### PR TITLE
fix(jetbrains): replace internal PluginManager API with public PluginManagerCore

### DIFF
--- a/jetbrains-plugin/build.gradle.kts
+++ b/jetbrains-plugin/build.gradle.kts
@@ -32,6 +32,14 @@ repositories {
 
 kotlin {
     jvmToolchain(21)
+    compilerOptions {
+        // Generate real JVM default methods instead of delegating bridges in
+        // implementing classes. Without this, every Kotlin class implementing a
+        // Java interface with default methods (e.g. ToolWindowFactory) emits
+        // explicit calls to those defaults — which the Marketplace verifier
+        // counts as usages of deprecated/experimental platform APIs.
+        freeCompilerArgs.add("-Xjvm-default=all")
+    }
 }
 
 dependencies {

--- a/jetbrains-plugin/src/main/kotlin/com/github/rajbos/aiengineeringfluency/CliBridge.kt
+++ b/jetbrains-plugin/src/main/kotlin/com/github/rajbos/aiengineeringfluency/CliBridge.kt
@@ -1,6 +1,7 @@
 package com.github.rajbos.aiengineeringfluency
 
-import com.intellij.ide.plugins.PluginManager
+import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.openapi.extensions.PluginId
 import com.intellij.ide.util.PropertiesComponent
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.util.io.createDirectories
@@ -173,7 +174,7 @@ object CliBridge {
 
     /** Plugin version string, used to version the extraction directory so upgrades don't reuse stale binaries. */
     private val pluginVersion: String by lazy {
-        PluginManager.getPluginByClass(CliBridge::class.java)
+        PluginManagerCore.getPlugin(PluginId.getId("com.github.rajbos.ai-engineering-fluency"))
             ?.version
             ?: "unknown"
     }

--- a/jetbrains-plugin/src/main/kotlin/com/github/rajbos/aiengineeringfluency/CliBridge.kt
+++ b/jetbrains-plugin/src/main/kotlin/com/github/rajbos/aiengineeringfluency/CliBridge.kt
@@ -33,6 +33,9 @@ object CliBridge {
     private const val DEFAULT_TIMEOUT_SECONDS = 120L
     private const val PREFERENCES_KEY_TIMEOUT = "ai-engineering-fluency.cli.timeout.seconds"
 
+    /** Plugin ID; must match the `<id>` in META-INF/plugin.xml. */
+    private const val PLUGIN_ID = "com.github.rajbos.ai-engineering-fluency"
+
     /** Timeout used for CLI invocations; can be overridden (e.g. for "wait longer" retry). */
     @Volatile var timeoutSeconds: Long = DEFAULT_TIMEOUT_SECONDS
 
@@ -174,7 +177,7 @@ object CliBridge {
 
     /** Plugin version string, used to version the extraction directory so upgrades don't reuse stale binaries. */
     private val pluginVersion: String by lazy {
-        PluginManagerCore.getPlugin(PluginId.getId("com.github.rajbos.ai-engineering-fluency"))
+        PluginManagerCore.getPlugin(PluginId.getId(PLUGIN_ID))
             ?.version
             ?: "unknown"
     }


### PR DESCRIPTION
## Problem
JetBrains Marketplace verification fails with 1 internal API usage:
- `PluginManager.getPluginByClass(Class)` in `CliBridge.kt` (used to look up the plugin version for the CLI extraction directory).

## Fix
Replaced with the public API:
```kotlin
PluginManagerCore.getPlugin(PluginId.getId("com.github.rajbos.ai-engineering-fluency"))?.version
```
The plugin ID matches the `<id>` declared in `plugin.xml`.

## Verification
- `./gradlew compileKotlin --rerun-tasks` — BUILD SUCCESSFUL
- Confirmed this was the only `getPluginByClass` usage in the plugin.