### PR TITLE
chore(jetbrains): bump plugin version to 0.4.3

### DIFF
--- a/jetbrains-plugin/gradle.properties
+++ b/jetbrains-plugin/gradle.properties
@@ -3,7 +3,7 @@
 
 pluginGroup = com.github.rajbos
 pluginName = ai-engineering-fluency
-pluginVersion = 0.4.2
+pluginVersion = 0.4.3
 
 # Lowest IntelliJ Platform version we still load on (must match plugin.xml since-build).
 # 243 = 2024.3 release line.


### PR DESCRIPTION
Bumps \pluginVersion\ in \jetbrains-plugin/gradle.properties\ from 0.4.2 → 0.4.3 so the next publish includes the Marketplace verification fixes from #1841 (internal API usage + deprecated/experimental API warnings).