### PR TITLE
fix(jetbrains): read plugin version from build-time resource, bump to 0.4.4

### DIFF
--- a/jetbrains-plugin/build.gradle.kts
+++ b/jetbrains-plugin/build.gradle.kts
@@ -10,6 +10,11 @@
 // `prepareBundledAssets` task below (or by the root build.ps1 orchestrator).
 
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
 
 plugins {
     // Pinned below CodeQL's Kotlin version ceiling: CodeQL (bundle 2.26.1, used by
@@ -97,6 +102,29 @@ intellijPlatform {
 // user's OS isn't covered.
 // ─────────────────────────────────────────────────────────────────────────────
 
+// Writes the plugin version into a classpath resource so runtime code can read
+// it without touching PluginManagerCore (flagged as internal API by the
+// Marketplace verifier). A typed task keeps this configuration-cache safe.
+abstract class GenerateVersionFileTask : DefaultTask() {
+    @get:Input
+    abstract val pluginVersion: Property<String>
+
+    @get:OutputDirectory
+    abstract val outputDir: DirectoryProperty
+
+    @TaskAction
+    fun generate() {
+        val dir = outputDir.get().asFile
+        dir.mkdirs()
+        dir.resolve("plugin-version.txt").writeText(pluginVersion.get())
+    }
+}
+
+val generatePluginVersionFile by tasks.registering(GenerateVersionFileTask::class) {
+    pluginVersion.set(providers.gradleProperty("pluginVersion"))
+    outputDir.set(layout.buildDirectory.dir("generated/plugin-version"))
+}
+
 val prepareBundledAssets by tasks.registering(Copy::class) {
     description = "Copy webview bundles, vscode-shim, and CLI binaries into plugin resources."
     group = "build"
@@ -146,6 +174,7 @@ sourceSets {
     main {
         resources {
             srcDir(prepareBundledAssets)
+            srcDir(generatePluginVersionFile)
         }
     }
 }

--- a/jetbrains-plugin/gradle.properties
+++ b/jetbrains-plugin/gradle.properties
@@ -3,7 +3,7 @@
 
 pluginGroup = com.github.rajbos
 pluginName = ai-engineering-fluency
-pluginVersion = 0.4.3
+pluginVersion = 0.4.4
 
 # Lowest IntelliJ Platform version we still load on (must match plugin.xml since-build).
 # 243 = 2024.3 release line.

--- a/jetbrains-plugin/src/main/kotlin/com/github/rajbos/aiengineeringfluency/CliBridge.kt
+++ b/jetbrains-plugin/src/main/kotlin/com/github/rajbos/aiengineeringfluency/CliBridge.kt
@@ -1,7 +1,5 @@
 package com.github.rajbos.aiengineeringfluency
 
-import com.intellij.ide.plugins.PluginManagerCore
-import com.intellij.openapi.extensions.PluginId
 import com.intellij.ide.util.PropertiesComponent
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.util.io.createDirectories
@@ -32,9 +30,6 @@ object CliBridge {
     private val log = Logger.getInstance(CliBridge::class.java)
     private const val DEFAULT_TIMEOUT_SECONDS = 120L
     private const val PREFERENCES_KEY_TIMEOUT = "ai-engineering-fluency.cli.timeout.seconds"
-
-    /** Plugin ID; must match the `<id>` in META-INF/plugin.xml. */
-    private const val PLUGIN_ID = "com.github.rajbos.ai-engineering-fluency"
 
     /** Timeout used for CLI invocations; can be overridden (e.g. for "wait longer" retry). */
     @Volatile var timeoutSeconds: Long = DEFAULT_TIMEOUT_SECONDS
@@ -177,8 +172,13 @@ object CliBridge {
 
     /** Plugin version string, used to version the extraction directory so upgrades don't reuse stale binaries. */
     private val pluginVersion: String by lazy {
-        PluginManagerCore.getPlugin(PluginId.getId(PLUGIN_ID))
-            ?.version
+        // Version is baked into a classpath resource at build time (see the
+        // generatePluginVersionFile task in build.gradle.kts). Reading the
+        // version from the plugin descriptor would require PluginManagerCore
+        // APIs that the Marketplace verifier flags as internal.
+        CliBridge::class.java.getResourceAsStream("/plugin-version.txt")
+            ?.bufferedReader()?.use { it.readText().trim() }
+            ?.takeIf { it.isNotBlank() }
             ?: "unknown"
     }
 


### PR DESCRIPTION
The 0.4.3 Marketplace verification still reports 1 internal API usage: PluginManagerCore.getPlugin(PluginId). This stops querying the platform for the plugin version entirely: a GenerateVersionFileTask bakes pluginVersion from gradle.properties into a plugin-version.txt classpath resource at build time, and CliBridge reads it from there. Also bumps pluginVersion 0.4.3 -> 0.4.4. Verified with buildPlugin + tests; the built jar contains /plugin-version.txt = 0.4.4.