### PR TITLE
refactor: decompose _saveConfigAndActivate into focused private helpers

### DIFF
--- a/vscode-extension/src/backend/services/azureResourceService.ts
+++ b/vscode-extension/src/backend/services/azureResourceService.ts
@@ -440,7 +440,7 @@ export class AzureResourceService {
 		}
 	}
 
-	private async _saveConfigAndActivate(
+	private async _persistBackendConfig(
 		config: vscode.WorkspaceConfiguration,
 		subscriptionId: string,
 		rgResult: ResourceGroupResult,
@@ -463,8 +463,14 @@ export class AzureResourceService {
 		await config.update('backend.userIdentityMode', profile.userIdentityMode, vscode.ConfigurationTarget.Global);
 		await config.update('backend.authMode', authMode, vscode.ConfigurationTarget.Global);
 		await config.update('backend.enabled', true, vscode.ConfigurationTarget.Global);
+	}
 
-		const finalSettings = this.deps.getSettings();
+	/**
+	 * Verifies data-plane credentials and access. Returns false if activation should stop here
+	 * (either because no Storage Shared Key is set yet, or validation failed) — in both cases
+	 * the appropriate user-facing message and fallback side effects have already been handled.
+	 */
+	private async _activateDataPlaneAccess(finalSettings: BackendSettings): Promise<boolean> {
 		try {
 			const creds = await this.credentialService.getBackendDataPlaneCredentials(finalSettings);
 			if (!creds) {
@@ -473,33 +479,56 @@ export class AzureResourceService {
 				);
 				this.deps.startTimerIfEnabled();
 				await this.deps.updateTokenStats?.();
-				return;
+				return false;
 			}
 			await this.dataPlaneService.ensureTableExists(finalSettings, creds.tableCredential);
 			await this.dataPlaneService.validateAccess(finalSettings, creds.tableCredential);
+			return true;
 		} catch (e: unknown) {
 			vscode.window.showErrorMessage(`Backend sync configured, but access validation failed: ${safeStringifyError(e)}`);
-			return;
+			return false;
 		}
+	}
 
-		if (tableConfig.createEvents.startsWith('Yes')) {
-			try {
-				const creds = await this.credentialService.getBackendDataPlaneCredentials(finalSettings);
-				if (creds) {
-					const endpoint = getAzureTableStorageEndpoint(finalSettings.storageAccount);
-					const serviceClient = new TableServiceClient(endpoint, creds.tableCredential as any);
-					await serviceClient.createTable(finalSettings.eventsTable);
-					this.deps.log(`Created optional events table: ${finalSettings.eventsTable}`);
-				}
-			} catch (e) {
-				this.deps.log(`Optional events table creation failed (non-blocking): ${safeStringifyError(e)}`);
+	private async _createOptionalEventsTable(finalSettings: BackendSettings, tableConfig: TableConfig): Promise<void> {
+		if (!tableConfig.createEvents.startsWith('Yes')) { return; }
+		try {
+			const creds = await this.credentialService.getBackendDataPlaneCredentials(finalSettings);
+			if (creds) {
+				const endpoint = getAzureTableStorageEndpoint(finalSettings.storageAccount);
+				const serviceClient = new TableServiceClient(endpoint, creds.tableCredential as any);
+				await serviceClient.createTable(finalSettings.eventsTable);
+				this.deps.log(`Created optional events table: ${finalSettings.eventsTable}`);
 			}
+		} catch (e) {
+			this.deps.log(`Optional events table creation failed (non-blocking): ${safeStringifyError(e)}`);
 		}
+	}
 
+	private async _finalizeBackendActivation(): Promise<void> {
 		this.deps.startTimerIfEnabled();
 		await this.deps.syncToBackendStore(true);
 		await this.deps.updateTokenStats?.();
 		vscode.window.showInformationMessage('Backend sync configured. Initial sync completed (or queued).');
+	}
+
+	private async _saveConfigAndActivate(
+		config: vscode.WorkspaceConfiguration,
+		subscriptionId: string,
+		rgResult: ResourceGroupResult,
+		storageAccount: string,
+		tableConfig: TableConfig,
+		authMode: BackendAuthMode,
+		profile: SharingProfileResult
+	): Promise<void> {
+		await this._persistBackendConfig(config, subscriptionId, rgResult, storageAccount, tableConfig, authMode, profile);
+
+		const finalSettings = this.deps.getSettings();
+		if (!await this._activateDataPlaneAccess(finalSettings)) { return; }
+
+		await this._createOptionalEventsTable(finalSettings, tableConfig);
+
+		await this._finalizeBackendActivation();
 	}
 
 	/**


### PR DESCRIPTION
## Motivation

`AzureResourceService._saveConfigAndActivate` in `vscode-extension/src/backend/services/azureResourceService.ts` was flagged by ESLint's `max-lines-per-function` rule (61 lines, limit 50) — it mixed four distinct concerns (persisting config, verifying data-plane access, optionally creating an events table, and finalizing activation) in one method, adding cognitive overhead when reasoning about any single step.

## Extracted helpers

| Method | Responsibility |
|---|---|
| `_persistBackendConfig` | Writes all wizard-collected settings to `vscode.WorkspaceConfiguration` |
| `_activateDataPlaneAccess` | Resolves data-plane credentials and validates table access; returns `false` (after already showing the appropriate message/fallback) if activation should stop here |
| `_createOptionalEventsTable` | Creates the optional `usageEvents` table when the user opted in, non-blocking on failure |
| `_finalizeBackendActivation` | Starts the sync timer, runs the initial sync, refreshes stats, and shows the completion message |

`_saveConfigAndActivate` now just sequences these four calls, with an early-return guard on `_activateDataPlaneAccess`'s boolean result — matching the wizard's existing `if (!result) { return; }` pattern used elsewhere in this file.

No public/exported signatures changed; only this one source file was touched.

## Verification

- `tsc --noEmit` — clean
- `npm run test:node` — all unit tests pass (including `azureResourceService.test.ts` and `backend-azureResourceService-utils.test.ts`, which cover this file)
- `node esbuild.js --production` — production bundle builds successfully
- `eslint src/backend/services/azureResourceService.ts` — no warnings

No pre-existing warnings elsewhere in the codebase were touched by this change.

Co-authored-by: Claude <noreply@anthropic.com>