### PR TITLE
Add once-daily leader-only background scan for stale git worktrees

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -86,6 +86,15 @@ import {
   isToastAllowed as _isToastAllowed,
 } from './insightsEngine';
 
+// --- Worktree background scan (once-daily, leader-only disk-usage scan) ---
+import {
+  shouldRunDailyWorktreeScan as _shouldRunDailyWorktreeScan,
+  shouldNotifyWorktreeFindings as _shouldNotifyWorktreeFindings,
+  formatBytesForNotification as _formatBytesForNotification,
+  sumWorktreeBytes as _sumWorktreeBytes,
+  type WorktreeBackgroundScanResult,
+} from './worktreeBackgroundScan';
+
 // --- Ecosystem adapter types & helpers ---
 import type { OpenCodeDataAccess } from '../../src/opencode';
 import type { CrushDataAccess } from '../../src/crush';
@@ -412,6 +421,13 @@ class CopilotTokenTracker implements vscode.Disposable {
 	private worktreeScanId: number = 0;
 	// Incremented on each cleanup start/cancel; an in-flight cleanup loop checks this to stop early
 	private worktreeCleanupId: number = 0;
+	// Incremented on each background worktree scan start/dispose; the in-flight drip scan checks this to stop early
+	private backgroundWorktreeScanId: number = 0;
+	// True while a daily background worktree scan is in flight in this window, to avoid starting a second one concurrently
+	private backgroundWorktreeScanRunning: boolean = false;
+	private static readonly WORKTREE_BG_SCAN_STARTED_KEY = 'worktrees.backgroundScan.startedAt';
+	private static readonly WORKTREE_BG_SCAN_RESULT_KEY = 'worktrees.backgroundScan.result';
+	private static readonly WORKTREE_BG_SCAN_NOTIFIED_BYTES_KEY = 'worktrees.backgroundScan.lastNotifiedBytes';
 	private logViewerPanel?: vscode.WebviewPanel;
 	private logViewerSessionFilePath: string = '';
 	private logViewerCurrentData?: SessionLogData;
@@ -710,6 +726,10 @@ class CopilotTokenTracker implements vscode.Disposable {
 		});
 		await Promise.all(workers);
 		return results;
+	}
+
+	private sleep(ms: number): Promise<void> {
+		return new Promise((resolve) => setTimeout(resolve, ms));
 	}
 
 	/**
@@ -2439,6 +2459,11 @@ class CopilotTokenTracker implements vscode.Disposable {
 		try { isLeader = await this.cacheManager.acquireRefreshLock(); }
 		catch (err) { this.warn(`Failed to acquire refresh lock, proceeding as leader: ${err}`); isLeader = true; }
 		this.startRefreshHeartbeat(isLeader);
+
+		// Piggyback the once-daily background worktree scan on the same leader election: only
+		// the window that won this refresh's leader lock may start it, and it runs detached
+		// (drip-throttled, can take far longer than this refresh cycle) so it never blocks it.
+		if (isLeader) { void this.maybeStartBackgroundWorktreeScan(); }
 
 		try {
 			return await this._runRefreshCore(silent, isLeader);
@@ -6629,6 +6654,13 @@ class CopilotTokenTracker implements vscode.Disposable {
 		void this.analysisPanel?.webview.postMessage({ command: 'switchTab', tab: 'tools', anchor: 'section-tool-curation' });
 	}
 
+	/** Opens the Usage Analysis panel, pushes the latest background worktree scan findings, and activates the Worktrees tab. */
+	public async showUsageAnalysisOnWorktreesTab(): Promise<void> {
+		await this.showUsageAnalysis();
+		this.postWorktreeBackgroundResults();
+		void this.analysisPanel?.webview.postMessage({ command: 'switchTab', tab: 'worktrees' });
+	}
+
 	private async _handleSuppressUnknownTool(toolName: string): Promise<void> {
 		this.analysisPanel?.webview.postMessage({ command: 'toolSuppressed', toolName });
 		const config = vscode.workspace.getConfiguration('aiEngineeringFluency');
@@ -9389,6 +9421,105 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString())}
   }
 
   /**
+   * Starts the once-daily background worktree scan if it's due and this window is the current
+   * refresh leader. A no-op most of the time (cheap timestamp check); when it does run, it runs
+   * detached from the caller so it never blocks the cache refresh that gated it.
+   */
+  private async maybeStartBackgroundWorktreeScan(): Promise<void> {
+    if (this.backgroundWorktreeScanRunning) { return; }
+    const startedAt = this.context.globalState.get<string>(CopilotTokenTracker.WORKTREE_BG_SCAN_STARTED_KEY);
+    if (!_shouldRunDailyWorktreeScan(startedAt, Date.now())) { return; }
+    const rootPaths = this.buildInitialWorktreeRoots();
+    if (rootPaths.length === 0) { return; }
+
+    this.backgroundWorktreeScanRunning = true;
+    const scanId = ++this.backgroundWorktreeScanId;
+    await this.context.globalState.update(CopilotTokenTracker.WORKTREE_BG_SCAN_STARTED_KEY, new Date().toISOString());
+    this.log(`🌳 Starting daily background worktree scan across ${rootPaths.length} root(s)`);
+    try {
+      await this.runBackgroundWorktreeScan(rootPaths, scanId);
+    } catch (err) {
+      this.warn(`Background worktree scan failed: ${err}`);
+    } finally {
+      this.backgroundWorktreeScanRunning = false;
+    }
+  }
+
+  /**
+   * Drip-scans the given roots at low concurrency with pacing delays between each worktree, so
+   * the scan can run unattended over the course of the day without contending with foreground
+   * disk activity. Reuses the same discovery/enrichment helpers as the interactive Worktrees tab
+   * scan, just with no webview to stream progress to and much gentler throttling.
+   */
+  private async runBackgroundWorktreeScan(rootPaths: string[], scanId: number): Promise<void> {
+    const excludeDirs = new Set(["node_modules", ".git", ".hg", ".svn", "packages", "vendor"]);
+    const isActive = () => scanId === this.backgroundWorktreeScanId;
+    const noop = () => { /* no webview open for this scan — findings are persisted instead */ };
+    const startTime = Date.now();
+
+    const discovered: WorktreeScanResult[] = [];
+    for (const root of rootPaths) {
+      if (!isActive()) { return; }
+      let isDirectory = false;
+      try { isDirectory = (await fs.promises.stat(root)).isDirectory(); } catch { isDirectory = false; }
+      if (!isDirectory) { continue; }
+
+      const gitMarkers: string[] = [];
+      await this.findGitMarkerFiles(root, excludeDirs, gitMarkers, isActive);
+      if (!isActive()) { return; }
+
+      discovered.push(...await this.discoverWorktreesFromMarkers(gitMarkers, root, isActive, noop, startTime, { concurrency: 1, throttleMs: 200 }));
+      if (!isActive()) { return; }
+      await this.sleep(500);
+    }
+
+    await this.enrichWorktrees(discovered, isActive, noop, startTime, { concurrency: 1, throttleMs: 400 });
+    if (!isActive()) { return; }
+
+    await this.finishBackgroundWorktreeScan(discovered);
+  }
+
+  /** Persists the completed background scan and decides whether to surface a findings notification. */
+  private async finishBackgroundWorktreeScan(discovered: WorktreeScanResult[]): Promise<void> {
+    const totalBytes = _sumWorktreeBytes(discovered);
+    const result: WorktreeBackgroundScanResult = {
+      scannedAt: new Date().toISOString(),
+      totalBytes,
+      worktreeCount: discovered.length,
+      worktrees: discovered,
+    };
+    await this.context.globalState.update(CopilotTokenTracker.WORKTREE_BG_SCAN_RESULT_KEY, result);
+    this.postWorktreeBackgroundResults();
+
+    const lastNotifiedBytes = this.context.globalState.get<number>(CopilotTokenTracker.WORKTREE_BG_SCAN_NOTIFIED_BYTES_KEY);
+    if (_shouldNotifyWorktreeFindings(totalBytes, lastNotifiedBytes)) {
+      await this.context.globalState.update(CopilotTokenTracker.WORKTREE_BG_SCAN_NOTIFIED_BYTES_KEY, totalBytes);
+      this.showWorktreeFindingsNotification(totalBytes, discovered.length);
+    }
+    this.log(`🌳 Background worktree scan complete: ${discovered.length} worktree(s), ${_formatBytesForNotification(totalBytes)}`);
+  }
+
+  /** Native notification pointing the user at the Worktrees tab findings. Fire-and-forget. */
+  private showWorktreeFindingsNotification(totalBytes: number, count: number): void {
+    const sizeLabel = _formatBytesForNotification(totalBytes);
+    void (async () => {
+      const choice = await vscode.window.showInformationMessage(
+        `We found ${sizeLabel} of data hidden in ${count} git worktree${count === 1 ? "" : "s"} that might no longer be needed.`,
+        "Show Me",
+      );
+      if (choice === "Show Me") { await this.showUsageAnalysisOnWorktreesTab(); }
+    })();
+  }
+
+  /** Sends the persisted background scan result to the Usage Analysis webview, if it's open. */
+  private postWorktreeBackgroundResults(): void {
+    if (!this.analysisPanel) { return; }
+    const result = this.context.globalState.get<WorktreeBackgroundScanResult>(CopilotTokenTracker.WORKTREE_BG_SCAN_RESULT_KEY);
+    if (!result) { return; }
+    void this.analysisPanel.webview.postMessage({ command: "worktreeBackgroundResults", ...result });
+  }
+
+  /**
    * Resolve .git markers to unique worktree roots (cheap, sequential) then fetch cheap git
    * metadata concurrently, streaming each worktree to the webview as soon as it is known.
    */
@@ -9398,7 +9529,10 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString())}
     isActive: () => boolean,
     send: (msg: Record<string, unknown>) => void,
     startTime: number,
+    options?: { concurrency?: number; throttleMs?: number },
   ): Promise<WorktreeScanResult[]> {
+    const concurrency = options?.concurrency ?? 8;
+    const throttleMs = options?.throttleMs ?? 0;
     const foundRoots: string[] = [];
     const worktreeRoots: string[] = [];
     let checked = 0;
@@ -9419,7 +9553,8 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString())}
       if (!isActive()) { return; }
       discovered.push(result);
       send({ command: "worktreeFound", worktree: result });
-    }, 8);
+      if (throttleMs) { await this.sleep(throttleMs); }
+    }, concurrency);
     return discovered;
   }
 
@@ -9432,7 +9567,10 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString())}
     isActive: () => boolean,
     send: (msg: Record<string, unknown>) => void,
     startTime: number,
+    options?: { concurrency?: number; throttleMs?: number },
   ): Promise<void> {
+    const concurrency = options?.concurrency ?? 4;
+    const throttleMs = options?.throttleMs ?? 0;
     const total = worktrees.length;
     if (total === 0) { return; }
     send({ command: "worktreeEnrichStarted", total, elapsedMs: Date.now() - startTime });
@@ -9445,6 +9583,11 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString())}
         this.getWorktreePushedStatus(worktreePath),
       ]);
       if (!isActive()) { return; }
+      // Patch the caller's own objects (not just the webview, which tracks its own copy from
+      // the message below) so callers without a webview — the background scan — still end up
+      // with fully-enriched results in `worktrees` once this resolves.
+      const target = worktrees.find((w) => w.path === worktreePath);
+      if (target) { target.files = stats.files; target.folders = stats.folders; target.bytes = stats.bytes; target.pushed = pushed; }
       enriched++;
       send({ command: "worktreeEnriched", path: worktreePath, files: stats.files, folders: stats.folders, bytes: stats.bytes, pushed });
       const now = Date.now();
@@ -9452,7 +9595,8 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString())}
         lastPost = now;
         send({ command: "worktreeEnrichProgress", enriched, total, elapsedMs: now - startTime });
       }
-    }, 4);
+      if (throttleMs) { await this.sleep(throttleMs); }
+    }, concurrency);
   }
 
 
@@ -10732,6 +10876,7 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString())}
       copilotApiBalance: this._buildCopilotApiBalance(),
       monthBillingGroupCosts: this.lastDetailedStats?.month.billingGroupCosts ?? null,
       worktreeScanRoots: this.buildInitialWorktreeRoots(),
+      worktreeBackgroundScan: this.context.globalState.get<WorktreeBackgroundScanResult>(CopilotTokenTracker.WORKTREE_BG_SCAN_RESULT_KEY) ?? null,
     }).replace(/</g, "\\u003c");
   }
 
@@ -10771,6 +10916,8 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString())}
     if (this.updateInterval) {
       clearInterval(this.updateInterval);
     }
+    // Stop any in-flight background worktree scan from doing further disk I/O once disposed.
+    this.backgroundWorktreeScanId++;
     this.stopRefreshHeartbeat();
     if (this._followerResyncTimer) {
       clearTimeout(this._followerResyncTimer);

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -279,7 +279,8 @@ function traceCurationOnce(key: string, stage: string, details?: Record<string, 
 	traceCuration(stage, details);
 }
 
-type InitialUsageData = UsageAnalysisStats & { customizationMatrix?: WorkspaceCustomizationMatrix | null; missedPotential?: MissedPotentialWorkspace[]; worktreeScanRoots?: string[] };
+type WorktreeBackgroundScanData = { scannedAt: string; totalBytes: number; worktreeCount: number; worktrees: unknown[] };
+type InitialUsageData = UsageAnalysisStats & { customizationMatrix?: WorkspaceCustomizationMatrix | null; missedPotential?: MissedPotentialWorkspace[]; worktreeScanRoots?: string[]; worktreeBackgroundScan?: WorktreeBackgroundScanData | null };
 const initialData = getWindowData<InitialUsageData>('__INITIAL_USAGE__');
 let hygieneMatrixState: WorkspaceCustomizationMatrix | null = null;
 const repoAnalysisState = new Map<string, RepoAnalysisRecord>();
@@ -327,7 +328,14 @@ type WorktreeScanStatus = {
 
 // Worktree discovery tab state
 let worktreeRoots: string[] = initialData?.worktreeScanRoots ? [...initialData.worktreeScanRoots] : [];
-let worktreeResults: WorktreeResult[] = [];
+let worktreeResults: WorktreeResult[] = initialData?.worktreeBackgroundScan
+	? initialData.worktreeBackgroundScan.worktrees.map(sanitizeWorktreeResult)
+	: [];
+// Set when worktreeResults reflects the once-daily background scan rather than a live/manual
+// scan the user just ran — used to show a "found automatically" banner instead of empty state.
+let worktreeBackgroundScanMeta: { scannedAt: string; totalBytes: number } | null = initialData?.worktreeBackgroundScan
+	? { scannedAt: initialData.worktreeBackgroundScan.scannedAt, totalBytes: initialData.worktreeBackgroundScan.totalBytes }
+	: null;
 let worktreeScanInProgress = false;
 let worktreeScanStatus: WorktreeScanStatus = { root: "", checked: 0, total: 0, foundCount: 0, elapsedMs: 0 };
 let worktreeScanError: string | null = null;
@@ -1514,6 +1522,7 @@ function startWorktreeScan(): void {
 	if (worktreeRoots.length === 0 || worktreeScanInProgress || worktreeCleanupInProgress) { return; }
 	worktreeScanInProgress = true;
 	worktreeResults = [];
+	worktreeBackgroundScanMeta = null;
 	worktreeScanError = null;
 	worktreeScanStatus = { root: "", checked: 0, total: 0, foundCount: 0, elapsedMs: 0 };
 	worktreeCleanupLog = [];
@@ -1842,6 +1851,21 @@ function handleWorktreeScanCancelled(): void {
 	updateWorktreeControls();
 }
 
+/**
+ * Populates the Worktrees tab from the once-daily background scan (see extension.ts
+ * `postWorktreeBackgroundResults`), sent either in the initial payload or live when the
+ * notification's "Show Me" action reveals an already-open panel. Ignored while a live/manual
+ * scan or cleanup is in flight so it can't clobber what the user is actively watching.
+ */
+function handleWorktreeBackgroundResults(message: any): void {
+	if (worktreeScanInProgress || worktreeCleanupInProgress) { return; }
+	const worktrees = Array.isArray(message.worktrees) ? message.worktrees : [];
+	worktreeResults = worktrees.map(sanitizeWorktreeResult);
+	worktreeBackgroundScanMeta = { scannedAt: String(message.scannedAt ?? ""), totalBytes: numField(message.totalBytes) };
+	updateWorktreeControls();
+	updateWorktreeResults();
+}
+
 /** Dispatches worktree-tab messages via static, literal command comparisons (no dynamic method lookup). */
 const _worktreeMessageHandlers: Record<string, (message: any) => void> = {
 	worktreeRootPicked: handleWorktreeRootPicked,
@@ -1859,6 +1883,7 @@ const _worktreeMessageHandlers: Record<string, (message: any) => void> = {
 	worktreeDeleted: handleWorktreeDeleted,
 	worktreeScanComplete: () => handleWorktreeScanComplete(),
 	worktreeScanCancelled: () => handleWorktreeScanCancelled(),
+	worktreeBackgroundResults: handleWorktreeBackgroundResults,
 	cleanupDeclined: () => handleCleanupDeclined(),
 	cleanupStarted: handleCleanupStarted,
 	cleanupWorktreeResult: handleCleanupWorktreeResult,
@@ -3146,6 +3171,15 @@ function renderWorktreeProgress(): string {
 	return _renderWorktreeScanningProgress(s, seconds);
 }
 
+/** Banner noting that the visible results came from the once-daily automatic scan, not one the user just ran. */
+function renderWorktreeBackgroundScanBanner(): string {
+	if (!worktreeBackgroundScanMeta || worktreeScanInProgress || worktreeResults.length === 0) { return ""; }
+	const when = escapeHtml(new Date(worktreeBackgroundScanMeta.scannedAt).toLocaleString());
+	const size = formatFileSize(worktreeBackgroundScanMeta.totalBytes);
+	const count = worktreeResults.length;
+	return `<div class="info-box" style="margin-top: 12px;"><div>🌳 Found automatically by the daily background scan: ${size} across ${count} worktree${count === 1 ? "" : "s"}, last checked ${when}. Scan again for the latest.</div></div>`;
+}
+
 function renderWorktreeControls(): string {
 	return `
     <div class="section">
@@ -3166,6 +3200,7 @@ function renderWorktreeControls(): string {
         <button class="button" id="btn-scan-worktrees" ${worktreeScanInProgress || worktreeCleanupInProgress || worktreeRoots.length === 0 ? "disabled" : ""}>🔍 Scan for Worktrees</button>
         ${worktreeScanInProgress ? '<button class="button secondary" id="btn-cancel-worktree-scan">✕ Cancel</button>' : ""}
       </div>
+      ${renderWorktreeBackgroundScanBanner()}
       ${worktreeScanError ? `<div class="info-box" style="margin-top: 12px; border-color: #d97706; background: rgba(217,119,6,0.08);"><div>⚠️ ${escapeHtml(worktreeScanError)}</div></div>` : ""}
       <div id="worktree-progress-area">${renderWorktreeProgress()}</div>
     </div>`;

--- a/vscode-extension/src/worktreeBackgroundScan.ts
+++ b/vscode-extension/src/worktreeBackgroundScan.ts
@@ -1,0 +1,99 @@
+/**
+ * Worktree background scan — pure decision logic for the once-daily, leader-only disk-usage
+ * scan of git worktrees.
+ *
+ * All VS Code API calls (leader election via cacheManager, the drip-throttled disk walk, the
+ * native "found X of stale worktree data" notification) live in `extension.ts`
+ * (`CopilotTokenTracker.maybeStartBackgroundWorktreeScan` and friends). This module only holds
+ * the parts that are pure functions of their inputs, so they can be unit-tested directly,
+ * following the same pattern as `insightsEngine.ts`.
+ */
+
+/** One worktree's findings, as persisted after the background scan completes. */
+export interface WorktreeBackgroundScanEntry {
+	path: string;
+	repoLabel: string;
+	branch: string;
+	lastCommit: string;
+	lastCommitDate: string | null;
+	pushed: "yes" | "no" | "?";
+	files: number;
+	folders: number;
+	bytes: number;
+}
+
+/** Aggregate + per-worktree findings from the most recently completed background scan. */
+export interface WorktreeBackgroundScanResult {
+	/** ISO timestamp of when this scan completed. */
+	scannedAt: string;
+	totalBytes: number;
+	worktreeCount: number;
+	worktrees: WorktreeBackgroundScanEntry[];
+}
+
+/** How often the background scan is allowed to run, at most once per day. */
+export const WORKTREE_BACKGROUND_SCAN_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+/** Minimum stale-worktree footprint before we bother the user with a notification at all. */
+export const WORKTREE_SCAN_NOTIFY_MIN_BYTES = 200 * 1024 * 1024; // 200 MB
+
+/** Re-notify once the total has drifted by at least this fraction since the last notification. */
+export const WORKTREE_SCAN_NOTIFY_DELTA_RATIO = 0.1;
+
+/**
+ * Whether it's time to kick off another daily background scan: never run before, or the
+ * interval has elapsed since the last one started. Gated on when the scan *started* (not
+ * completed) so a scan interrupted by a window closing mid-drip isn't immediately re-triggered
+ * by the next window to become leader.
+ */
+export function shouldRunDailyWorktreeScan(
+	lastRunStartedAt: string | undefined,
+	now: number,
+	intervalMs: number = WORKTREE_BACKGROUND_SCAN_INTERVAL_MS,
+): boolean {
+	if (!lastRunStartedAt) { return true; }
+	const startedMs = Date.parse(lastRunStartedAt);
+	if (!Number.isFinite(startedMs)) { return true; }
+	return now - startedMs >= intervalMs;
+}
+
+/**
+ * Whether a just-completed scan's total should surface a notification: the total must clear the
+ * minimum footprint, and either this is the first notification ever or the total has moved by at
+ * least `deltaRatio` since the last total the user was actually notified about.
+ */
+export function shouldNotifyWorktreeFindings(
+	totalBytes: number,
+	lastNotifiedBytes: number | undefined,
+	minBytes: number = WORKTREE_SCAN_NOTIFY_MIN_BYTES,
+	deltaRatio: number = WORKTREE_SCAN_NOTIFY_DELTA_RATIO,
+): boolean {
+	if (totalBytes < minBytes) { return false; }
+	if (lastNotifiedBytes === undefined || lastNotifiedBytes <= 0) { return true; }
+	const delta = Math.abs(totalBytes - lastNotifiedBytes) / lastNotifiedBytes;
+	return delta >= deltaRatio;
+}
+
+/**
+ * Human-readable byte size for notification text (e.g. "1.3 GB", "450 MB"). Kept separate from
+ * the webview's `formatFileSize` (in `webview/shared/formatUtils.ts`), which pulls in
+ * browser-only dependencies not safe to import from the extension host.
+ */
+export function formatBytesForNotification(bytes: number): string {
+	if (!Number.isFinite(bytes) || bytes < 0) { return "0 B"; }
+	if (bytes < 1024) { return `${bytes} B`; }
+	const units = ["KB", "MB", "GB", "TB"];
+	let value = bytes / 1024;
+	let unitIndex = 0;
+	while (value >= 1024 && unitIndex < units.length - 1) {
+		value /= 1024;
+		unitIndex++;
+	}
+	const decimals = value < 10 ? 1 : 0;
+	return `${value.toFixed(decimals)} ${units[unitIndex]}`;
+}
+
+/** Sum of known (non-negative) bytes across scanned worktrees; entries still pending (-1) contribute 0. */
+export function sumWorktreeBytes(worktrees: { bytes: number }[]): number {
+	return worktrees.reduce((sum, w) => sum + (w.bytes > 0 ? w.bytes : 0), 0);
+}

--- a/vscode-extension/test/unit/worktreeBackgroundScan.test.ts
+++ b/vscode-extension/test/unit/worktreeBackgroundScan.test.ts
@@ -1,0 +1,114 @@
+import test from 'node:test';
+import * as assert from 'node:assert/strict';
+import {
+	shouldRunDailyWorktreeScan,
+	shouldNotifyWorktreeFindings,
+	formatBytesForNotification,
+	sumWorktreeBytes,
+	WORKTREE_BACKGROUND_SCAN_INTERVAL_MS,
+	WORKTREE_SCAN_NOTIFY_MIN_BYTES,
+} from '../../src/worktreeBackgroundScan';
+
+// ---------------------------------------------------------------------------
+// shouldRunDailyWorktreeScan
+// ---------------------------------------------------------------------------
+
+test('shouldRunDailyWorktreeScan: never run before -> true', () => {
+	assert.equal(shouldRunDailyWorktreeScan(undefined, Date.now()), true);
+});
+
+test('shouldRunDailyWorktreeScan: unparseable timestamp -> true (treat as never run)', () => {
+	assert.equal(shouldRunDailyWorktreeScan('not-a-date', Date.now()), true);
+});
+
+test('shouldRunDailyWorktreeScan: less than a day since last run -> false', () => {
+	const now = Date.parse('2026-08-21T12:00:00Z');
+	const startedAt = new Date(now - 2 * 60 * 60 * 1000).toISOString(); // 2h ago
+	assert.equal(shouldRunDailyWorktreeScan(startedAt, now), false);
+});
+
+test('shouldRunDailyWorktreeScan: exactly one interval since last run -> true', () => {
+	const now = Date.parse('2026-08-21T12:00:00Z');
+	const startedAt = new Date(now - WORKTREE_BACKGROUND_SCAN_INTERVAL_MS).toISOString();
+	assert.equal(shouldRunDailyWorktreeScan(startedAt, now), true);
+});
+
+test('shouldRunDailyWorktreeScan: more than a day since last run -> true', () => {
+	const now = Date.parse('2026-08-21T12:00:00Z');
+	const startedAt = new Date(now - 25 * 60 * 60 * 1000).toISOString();
+	assert.equal(shouldRunDailyWorktreeScan(startedAt, now), true);
+});
+
+test('shouldRunDailyWorktreeScan: respects a custom interval', () => {
+	const now = Date.parse('2026-08-21T12:00:00Z');
+	const startedAt = new Date(now - 30 * 60 * 1000).toISOString(); // 30 min ago
+	assert.equal(shouldRunDailyWorktreeScan(startedAt, now, 60 * 60 * 1000), false); // 1h interval
+	assert.equal(shouldRunDailyWorktreeScan(startedAt, now, 15 * 60 * 1000), true); // 15min interval
+});
+
+// ---------------------------------------------------------------------------
+// shouldNotifyWorktreeFindings
+// ---------------------------------------------------------------------------
+
+test('shouldNotifyWorktreeFindings: below the minimum footprint -> never notifies', () => {
+	assert.equal(shouldNotifyWorktreeFindings(WORKTREE_SCAN_NOTIFY_MIN_BYTES - 1, undefined), false);
+	assert.equal(shouldNotifyWorktreeFindings(1024, 500), false);
+});
+
+test('shouldNotifyWorktreeFindings: first time above the minimum -> notifies', () => {
+	assert.equal(shouldNotifyWorktreeFindings(WORKTREE_SCAN_NOTIFY_MIN_BYTES, undefined), true);
+});
+
+test('shouldNotifyWorktreeFindings: small delta from last-notified baseline -> does not renotify', () => {
+	const baseline = 1_000_000_000; // 1 GB
+	const smallGrowth = baseline * 1.05; // 5%
+	assert.equal(shouldNotifyWorktreeFindings(smallGrowth, baseline), false);
+});
+
+test('shouldNotifyWorktreeFindings: >= 10% growth from last-notified baseline -> renotifies', () => {
+	const baseline = 1_000_000_000; // 1 GB
+	const bigGrowth = baseline * 1.1; // exactly 10%
+	assert.equal(shouldNotifyWorktreeFindings(bigGrowth, baseline), true);
+});
+
+test('shouldNotifyWorktreeFindings: >= 10% shrink from last-notified baseline also renotifies', () => {
+	const baseline = 1_000_000_000;
+	const shrunk = baseline * 0.85; // -15%
+	assert.equal(shouldNotifyWorktreeFindings(shrunk, baseline), true);
+});
+
+test('shouldNotifyWorktreeFindings: a zero/negative baseline is treated like "never notified"', () => {
+	assert.equal(shouldNotifyWorktreeFindings(WORKTREE_SCAN_NOTIFY_MIN_BYTES, 0), true);
+});
+
+// ---------------------------------------------------------------------------
+// formatBytesForNotification
+// ---------------------------------------------------------------------------
+
+test('formatBytesForNotification: bytes below 1024 stay in B', () => {
+	assert.equal(formatBytesForNotification(512), '512 B');
+});
+
+test('formatBytesForNotification: scales through KB/MB/GB', () => {
+	assert.equal(formatBytesForNotification(1024), '1.0 KB');
+	assert.equal(formatBytesForNotification(450 * 1024 * 1024), '450 MB');
+	assert.equal(formatBytesForNotification(1.3 * 1024 * 1024 * 1024), '1.3 GB');
+});
+
+test('formatBytesForNotification: negative/NaN inputs fall back to "0 B"', () => {
+	assert.equal(formatBytesForNotification(-5), '0 B');
+	assert.equal(formatBytesForNotification(NaN), '0 B');
+});
+
+// ---------------------------------------------------------------------------
+// sumWorktreeBytes
+// ---------------------------------------------------------------------------
+
+test('sumWorktreeBytes: sums only known (non-negative) byte counts', () => {
+	const total = sumWorktreeBytes([{ bytes: 100 }, { bytes: -1 }, { bytes: 250 }]);
+	assert.equal(total, 350);
+});
+
+test('sumWorktreeBytes: empty list -> 0', () => {
+	assert.equal(sumWorktreeBytes([]), 0);
+});


### PR DESCRIPTION
## Summary

- Adds a once-daily, leader-only background scan of known git worktree roots, so stale worktree disk usage is discovered without the user having to open the Worktrees tab and click "Scan".
- The scan piggybacks on the existing cache-refresh leader election (`cacheManager.acquireRefreshLock`) so only one VS Code window runs it, and runs detached from that refresh cycle — it can take far longer than a single 5-minute tick.
- It's throttled well below the interactive scan (concurrency 1 with pacing delays between each worktree, plus a pause between roots) so it "drips" through the disk instead of thrashing it.
- When the scan finds a meaningful amount of stale data (≥200 MB), or the total has drifted by ≥10% since the last time the user was notified, a native VS Code notification appears: *"We found X of data hidden in N git worktree(s) that might no longer be needed."* Clicking **Show Me** opens the Usage Analysis panel directly on the Worktrees tab, pre-populated with the findings (no rescan needed).
- Findings are persisted in `globalState` so they also show up automatically the next time the Worktrees tab is opened, even without a notification click.

## Implementation notes

- New pure module `vscode-extension/src/worktreeBackgroundScan.ts` holds the decision logic (daily cadence check, 10%-delta notify check, byte formatting) with no VS Code API dependency, so it's directly unit-testable (see `test/unit/worktreeBackgroundScan.test.ts`).
- `discoverWorktreesFromMarkers` / `enrichWorktrees` in `extension.ts` gained optional `{ concurrency, throttleMs }` options (defaulting to the existing interactive-scan values, so the manual Worktrees tab scan is unchanged) and now mutate the discovered `WorktreeScanResult` objects directly during enrichment, since the background scan has no webview to stream progress messages to.
- A new `worktreeBackgroundResults` webview message and matching `main.ts` handler populate the Worktrees tab's existing results table/banner from the persisted background scan, reusing all existing rendering code.

## Test plan

- [x] `npm ci && npm run compile` — clean, 0 errors/0 new warnings (2 pre-existing unrelated complexity warnings confirmed present on `main` too).
- [x] `npm run test:node` — all 95 test files pass, including the new `worktreeBackgroundScan.test.js`.
- [ ] Manual verification in a real VS Code window (not done — agents must not launch a real editor instance per repo policy).

---
_Generated by [Claude Code](https://claude.ai/code/session_01LffVjnYaxno4QUAujPLKxE)_