### PR TITLE
Hide "selected providers" cost row when GitHub Copilot is the only provider

### DIFF
--- a/visualstudio-extension/src/AIEngineeringFluency/webview/details.js
+++ b/visualstudio-extension/src/AIEngineeringFluency/webview/details.js
@@ -2560,8 +2560,11 @@ body[data-vscode-theme-kind="vscode-high-contrast-light"] .title {
       { label: "Service overhead %", icon: "\u2601\uFE0F", color: "#90a4ae", today: serviceOverheadPct(stats.today), last30Days: serviceOverheadPct(stats.last30Days), month: serviceOverheadPct(stats.month), lastMonth: serviceOverheadPct(stats.lastMonth), projected: "\u2014" },
       { label: "Thinking tokens", icon: "\u{1F9E0}", color: "#a78bfa", today: formatCompact(stats.today.thinkingTokens || 0), last30Days: formatCompact(stats.last30Days.thinkingTokens || 0), month: formatCompact(stats.month.thinkingTokens || 0), lastMonth: formatCompact(stats.lastMonth.thinkingTokens || 0), projected: "\u2014" }
     ];
+    const selectedProvidersCostRows = isCopilotOnlyProviders(allProviders) ? [] : [
+      { label: "Estimated cost (selected providers)", labelTooltip: "Sum of estimated cost across the providers selected in the Cost by Provider filter below \u2014 GitHub Copilot uses UBB AI Credit rates, other providers use their own API pricing.", icon: "\u{1F4B5}", color: "#7ce38b", today: formatCost(totalCostForPeriod(stats.today, allProviders)), last30Days: formatCost(totalCostForPeriod(stats.last30Days, allProviders)), month: formatCost(totalCostForPeriod(stats.month, allProviders)), lastMonth: formatCost(totalCostForPeriod(stats.lastMonth, allProviders)), projected: formatCost(projections.projectedCost) }
+    ];
     const costRows = [
-      { label: "Estimated cost (selected providers)", labelTooltip: "Sum of estimated cost across the providers selected in the Cost by Provider filter below \u2014 GitHub Copilot uses UBB AI Credit rates, other providers use their own API pricing.", icon: "\u{1F4B5}", color: "#7ce38b", today: formatCost(totalCostForPeriod(stats.today, allProviders)), last30Days: formatCost(totalCostForPeriod(stats.last30Days, allProviders)), month: formatCost(totalCostForPeriod(stats.month, allProviders)), lastMonth: formatCost(totalCostForPeriod(stats.lastMonth, allProviders)), projected: formatCost(projections.projectedCost) },
+      ...selectedProvidersCostRows,
       { label: "Estimated cost (GitHub Copilot UBB)", labelTooltip: "Based on GitHub Copilot AI Credit rates (1 credit = $0.01) \u2014 this is what Copilot will bill you. UBB = Usage Based Billing.", icon: "\u{1F7E2}", color: "#7ce38b", today: formatCost(stats.today.estimatedCostCopilot ?? 0), last30Days: formatCost(stats.last30Days.estimatedCostCopilot ?? 0), month: formatCost(stats.month.estimatedCostCopilot ?? 0), lastMonth: formatCost(stats.lastMonth.estimatedCostCopilot ?? 0), projected: formatCost(projections.projectedCostCopilot ?? 0) }
     ];
     const activityRows = [
@@ -2727,6 +2730,9 @@ body[data-vscode-theme-kind="vscode-high-contrast-light"] .title {
       }
       return a3.localeCompare(b3);
     });
+  }
+  function isCopilotOnlyProviders(allProviders) {
+    return allProviders.every((p3) => p3 === "GitHub Copilot");
   }
   function includedProviders(allProviders) {
     return allProviders.filter((p3) => !excludedProviders.has(p3));

--- a/vscode-extension/src/webview/details/main.ts
+++ b/vscode-extension/src/webview/details/main.ts
@@ -398,8 +398,14 @@ function buildMetricsGroups(stats: DetailedStats, projections: Projections): Met
 		{ label: 'Service overhead %', icon: '☁️', color: '#90a4ae', today: serviceOverheadPct(stats.today), last30Days: serviceOverheadPct(stats.last30Days), month: serviceOverheadPct(stats.month), lastMonth: serviceOverheadPct(stats.lastMonth), projected: '—' },
 		{ label: 'Thinking tokens', icon: '🧠', color: '#a78bfa', today: formatCompact(stats.today.thinkingTokens || 0), last30Days: formatCompact(stats.last30Days.thinkingTokens || 0), month: formatCompact(stats.month.thinkingTokens || 0), lastMonth: formatCompact(stats.lastMonth.thinkingTokens || 0), projected: '—' },
 	];
-	const costRows: MetricRow[] = [
+	// With GitHub Copilot as the only provider the "selected providers" row is just a
+	// duplicate of the Copilot UBB row below it, so drop it — same reasoning as the
+	// "Cost by Provider" panel hiding itself when there is nothing to compare.
+	const selectedProvidersCostRows: MetricRow[] = isCopilotOnlyProviders(allProviders) ? [] : [
 		{ label: 'Estimated cost (selected providers)', labelTooltip: 'Sum of estimated cost across the providers selected in the Cost by Provider filter below — GitHub Copilot uses UBB AI Credit rates, other providers use their own API pricing.', icon: '💵', color: '#7ce38b', today: formatCost(totalCostForPeriod(stats.today, allProviders)), last30Days: formatCost(totalCostForPeriod(stats.last30Days, allProviders)), month: formatCost(totalCostForPeriod(stats.month, allProviders)), lastMonth: formatCost(totalCostForPeriod(stats.lastMonth, allProviders)), projected: formatCost(projections.projectedCost) },
+	];
+	const costRows: MetricRow[] = [
+		...selectedProvidersCostRows,
 		{ label: 'Estimated cost (GitHub Copilot UBB)', labelTooltip: 'Based on GitHub Copilot AI Credit rates (1 credit = $0.01) — this is what Copilot will bill you. UBB = Usage Based Billing.', icon: '🟢', color: '#7ce38b', today: formatCost(stats.today.estimatedCostCopilot ?? 0), last30Days: formatCost(stats.last30Days.estimatedCostCopilot ?? 0), month: formatCost(stats.month.estimatedCostCopilot ?? 0), lastMonth: formatCost(stats.lastMonth.estimatedCostCopilot ?? 0), projected: formatCost(projections.projectedCostCopilot ?? 0) },
 	];
 	const activityRows: MetricRow[] = [
@@ -593,6 +599,15 @@ if (a === 'GitHub Copilot') { return -1; }
 if (b === 'GitHub Copilot') { return 1; }
 return a.localeCompare(b);
 });
+}
+
+/**
+ * Whether GitHub Copilot is the only provider in play — either it is the single billing
+ * group seen, or there is no billing-group breakdown at all (older cached stats, which
+ * fall back to the Copilot-only estimate).
+ */
+function isCopilotOnlyProviders(allProviders: string[]): boolean {
+	return allProviders.every(p => p === 'GitHub Copilot');
 }
 
 /** Providers currently selected (not filtered out) from the given full provider list. */


### PR DESCRIPTION
## What

On the details page the "Cost by Provider" hero panel already hides itself when there is only one provider to look at, but the **Cost** group in the Key Metrics table below it still showed two rows:

- `Estimated cost (selected providers)`
- `Estimated cost (GitHub Copilot UBB)`

When GitHub Copilot is the only billing group in play those two rows are identical, so the "selected providers" row is now dropped and only the Copilot UBB row remains.

## How

- `vscode-extension/src/webview/details/main.ts`: new `isCopilotOnlyProviders()` helper; `buildMetricsGroups()` includes the "selected providers" row only when a non-Copilot provider exists. `Array.every` returns `true` for an empty list, so this also covers stats with no billing-group breakdown at all (older cached data), where the row falls back to the Copilot-only estimate and duplicates the UBB row anyway.
- `visualstudio-extension/src/AIEngineeringFluency/webview/details.js`: refreshed the committed Visual Studio bundle from a fresh `dist` build so the VS host does not go stale. Only the `details` bundle was refreshed — other bundles were left untouched to keep the change surgical.

## Behavior

| Providers seen | Cost group rows |
|---|---|
| GitHub Copilot only (or no breakdown) | `Estimated cost (GitHub Copilot UBB)` |
| Copilot + Anthropic/Google/… | `Estimated cost (selected providers)` + `Estimated cost (GitHub Copilot UBB)` (unchanged) |
| Non-Copilot provider only | `Estimated cost (selected providers)` + `Estimated cost (GitHub Copilot UBB)` (unchanged — the rows are not equivalent there) |

## Verification

- `npm run compile` (tsc + eslint + esbuild) — clean, only the two pre-existing complexity warnings in `extension.ts`.
- `npm run test:node` — all suites pass, zero failures.
- `node .github/skills/sync-host-views/sync-host-views.js` — `details` no longer stale against dist.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GaJ3jMJcoEA1YkLDLD1Bqz)_