### PR TITLE
fix: stop posh-hook.ps1 from blocking shell startup on usage --json

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,10 +6,12 @@ All notable changes to the CLI (@rajbos/ai-engineering-fluency) will be document
 
 ### Features
 - Group models from user-configured custom endpoints (BYOK) under their own provider group (e.g. `Mistral (Custom)`) in the provider cost chart data
+- Add `--json` flag to `segment` command, so oh-my-posh/prompt hooks can get structured per-period token data from the fast, cached `segment` path instead of the uncached `usage --json` command
 
 ### Bug Fixes
 - Fix update sync-host-views skill paths after CopilotTokenTracker rename (#1398)
 - Fix modelSwitching cost model array initialization
+- Fix `posh-hook.ps1` reference hook blocking shell startup for 45-80+ seconds by calling `usage --json` synchronously; it now reads from a cache file and refreshes in a detached background process
 
 ### Maintenance
 - Added unit tests for error handling and CLI utilities (#1375)

--- a/cli/README.md
+++ b/cli/README.md
@@ -26,9 +26,10 @@ The `segment` command outputs a compact token usage string designed for use in s
 See [`../omp-segment/README.md`](../omp-segment/README.md) for full setup instructions.
 
 ```bash
-node dist/cli.js segment            # Use 15-minute cache (default)
-node dist/cli.js segment --refresh  # Force refresh, bypass cache
+node dist/cli.js segment              # Use 5-minute cache (default)
+node dist/cli.js segment --refresh    # Force refresh, bypass cache
 node dist/cli.js segment --hide-zero  # Output nothing when both counts are zero
+node dist/cli.js segment --json       # Structured JSON (today/month/30d) instead of the formatted string
 ```
 
 ## Requirements

--- a/cli/src/commands/segment.ts
+++ b/cli/src/commands/segment.ts
@@ -64,12 +64,66 @@ function writeSegmentCache(entry: SegmentCacheFile): void {
 	}
 }
 
+/** Structured JSON payload emitted by `--json`. Same fields whether served from cache or freshly computed. */
+export function buildJsonPayload(entry: SegmentCacheFile, cached: boolean): string {
+	return JSON.stringify({
+		today: entry.todayTokens,
+		month: entry.thisMonthTokens,
+		last30Days: entry.last30DaysTokens,
+		todayFormatted: formatTokens(entry.todayTokens),
+		monthFormatted: formatTokens(entry.thisMonthTokens),
+		last30DaysFormatted: formatTokens(entry.last30DaysTokens),
+		formatted: entry.formatted,
+		updatedAt: entry.updatedAt,
+		cached,
+	});
+}
+
+interface SegmentOptions {
+	ttl?: string;
+	refresh?: boolean;
+	hideZero?: boolean;
+	json?: boolean;
+}
+
+/** Write the final segment output (JSON or formatted string), unless --hide-zero suppresses it. */
+function emitSegment(entry: SegmentCacheFile, options: SegmentOptions, cached: boolean): void {
+	if (options.hideZero && entry.todayTokens === 0 && entry.last30DaysTokens === 0) {
+		return;
+	}
+	process.stdout.write(options.json ? buildJsonPayload(entry, cached) : entry.formatted);
+}
+
+/** Discover session files and compute today/month/30d token totals (cache-miss path). */
+async function computeSegmentEntry(): Promise<SegmentCacheFile> {
+	const files = await discoverSessionFiles();
+	let todayTokens = 0;
+	let thisMonthTokens = 0;
+	let last30DaysTokens = 0;
+
+	if (files.length > 0) {
+		const stats = await calculateDetailedStats(files);
+		todayTokens = stats.today.tokens;
+		thisMonthTokens = stats.month.tokens;
+		last30DaysTokens = stats.last30Days.tokens;
+	}
+
+	return {
+		updatedAt: new Date().toISOString(),
+		formatted: `${formatTokens(todayTokens)} today · ${formatTokens(thisMonthTokens)} month · ${formatTokens(last30DaysTokens)} 30d`,
+		todayTokens,
+		thisMonthTokens,
+		last30DaysTokens,
+	};
+}
+
 export const segmentCommand = new Command('segment')
 	.description('Output a compact token usage string for use in oh-my-posh prompt segments')
 	.option('--ttl <minutes>', `Segment cache TTL in minutes (default: ${DEFAULT_TTL_MINUTES})`, `${DEFAULT_TTL_MINUTES}`)
 	.option('--refresh', 'Force refresh — bypass the segment output cache')
 	.option('--hide-zero', 'Output nothing when both today and 30-day token counts are zero')
-	.action(async (options) => {
+	.option('--json', 'Output structured JSON (today/month/30d token counts) instead of the formatted string. Uses the same fast cache as the default output — recommended for custom prompt hooks (e.g. the PowerShell pre-prompt hook) instead of the uncached `usage --json` command.')
+	.action(async (options: SegmentOptions) => {
 		const parsedTtl = Number(options.ttl);
 		const ttl = Number.isFinite(parsedTtl) && parsedTtl >= 0 ? parsedTtl : DEFAULT_TTL_MINUTES;
 
@@ -77,48 +131,14 @@ export const segmentCommand = new Command('segment')
 		if (!options.refresh) {
 			const cached = readSegmentCache(ttl);
 			if (cached) {
-				if (options.hideZero && cached.todayTokens === 0 && cached.last30DaysTokens === 0) {
-					return;
-				}
-				process.stdout.write(cached.formatted);
+				emitSegment(cached, options, true);
 				return;
 			}
 		}
 
 		// Cache miss — discover files and compute stats
 		// (The preAction hook in cli.ts has already loaded the session file cache)
-		const files = await discoverSessionFiles();
-		let todayTokens = 0;
-		let thisMonthTokens = 0;
-		let last30DaysTokens = 0;
-
-		if (files.length > 0) {
-			const stats = await calculateDetailedStats(files);
-			todayTokens = stats.today.tokens;
-			thisMonthTokens = stats.month.tokens;
-			last30DaysTokens = stats.last30Days.tokens;
-		}
-
-		if (options.hideZero && todayTokens === 0 && last30DaysTokens === 0) {
-			writeSegmentCache({
-				updatedAt: new Date().toISOString(),
-				formatted: '',
-				todayTokens,
-				thisMonthTokens,
-				last30DaysTokens,
-			});
-			return;
-		}
-
-		const formatted = `${formatTokens(todayTokens)} today · ${formatTokens(thisMonthTokens)} month · ${formatTokens(last30DaysTokens)} 30d`;
-
-		writeSegmentCache({
-			updatedAt: new Date().toISOString(),
-			formatted,
-			todayTokens,
-			thisMonthTokens,
-			last30DaysTokens,
-		});
-
-		process.stdout.write(formatted);
+		const entry = await computeSegmentEntry();
+		writeSegmentCache(entry);
+		emitSegment(entry, options, false);
 	});

--- a/cli/src/test/segment.test.ts
+++ b/cli/src/test/segment.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Unit tests for the `segment --json` payload builder.
+ * Tests cli/src/commands/segment.ts
+ */
+
+import test from 'node:test';
+import * as assert from 'node:assert/strict';
+
+import { buildJsonPayload } from '../commands/segment';
+
+const sampleEntry = {
+	updatedAt: '2026-08-25T12:20:51.085Z',
+	formatted: '7.7M today · 12.3M month · 1.5B 30d',
+	todayTokens: 7_700_000,
+	thisMonthTokens: 12_300_000,
+	last30DaysTokens: 1_500_000_000,
+};
+
+test('buildJsonPayload includes raw and formatted token counts', () => {
+	const payload = JSON.parse(buildJsonPayload(sampleEntry, true));
+
+	assert.equal(payload.today, sampleEntry.todayTokens);
+	assert.equal(payload.month, sampleEntry.thisMonthTokens);
+	assert.equal(payload.last30Days, sampleEntry.last30DaysTokens);
+	assert.equal(payload.todayFormatted, '7.7M');
+	assert.equal(payload.monthFormatted, '12.3M');
+	assert.equal(payload.last30DaysFormatted, '1.5B');
+	assert.equal(payload.formatted, sampleEntry.formatted);
+	assert.equal(payload.updatedAt, sampleEntry.updatedAt);
+});
+
+test('buildJsonPayload reflects the cached flag passed in', () => {
+	const cachedPayload = JSON.parse(buildJsonPayload(sampleEntry, true));
+	const freshPayload = JSON.parse(buildJsonPayload(sampleEntry, false));
+
+	assert.equal(cachedPayload.cached, true);
+	assert.equal(freshPayload.cached, false);
+});
+
+test('buildJsonPayload handles zero token counts', () => {
+	const payload = JSON.parse(buildJsonPayload({
+		updatedAt: '2026-08-25T12:20:51.085Z',
+		formatted: '',
+		todayTokens: 0,
+		thisMonthTokens: 0,
+		last30DaysTokens: 0,
+	}, false));
+
+	assert.equal(payload.today, 0);
+	assert.equal(payload.todayFormatted, '0');
+});

--- a/omp-segment/README.md
+++ b/omp-segment/README.md
@@ -24,7 +24,9 @@ Two caches work together:
 
 > **Method 2 (env vars) warning:** Do **not** add a `"cache"` block to the env var segment in your OMP theme. OMP's segment cache stores the rendered string for the full duration — so if `Set-PoshContext` updates `$env:COPILOT_TOKENS_TODAY`, the prompt still shows the stale cached value until the OMP cache expires. Since `Set-PoshContext` already controls the refresh rate, the OMP cache only adds extra staleness here without any benefit.
 
-A session parsing run (cache miss) typically takes < 1 second.
+A session parsing run (cache miss) typically takes < 1 second, but **can take tens of seconds or more** on a machine with a large amount of accumulated session history, since a cache miss still re-parses every session file before returning. Always use `segment` (not `usage`, which has no output cache at all — see the warning below) and never call the CLI synchronously from something that runs on every prompt/shell start; [Method 2](#method-2-powershell-pre-prompt-hook--recommended) below reads from a local cache file instantly and refreshes it in a detached background process instead.
+
+> ⚠️ **Don't use `usage --json` for a prompt hook.** `usage` (unlike `segment`) has no output cache — it re-discovers and re-aggregates every session file on **every single call**. An earlier version of the Method 2 hook script called `usage --json` synchronously, which made every new terminal or profile reload hang for 45-80+ seconds on a machine with substantial session history. Use `segment --json` (see [Options Reference](#options-reference)) together with the background-refresh pattern in [`posh-hook.ps1`](./posh-hook.ps1) instead.
 
 ---
 
@@ -102,7 +104,18 @@ Open your theme JSON (or YAML/TOML) and add the following to a `segments` array 
 
 Use this if `{{ cmd }}` is not supported in your OMP version, or if you want more control over the output.
 
-### Step 1: Add the hook to your PowerShell profile
+> This hook never calls the CLI synchronously — it reads the last known values from a small on-disk cache file (instant) and refreshes that cache in a fully detached background process whenever it's stale. See the comment header in [`posh-hook.ps1`](./posh-hook.ps1) for why this matters: an earlier version of this hook called the uncached `usage --json` command directly, which could hang shell startup for 45-80+ seconds on machines with a lot of session history.
+
+### Step 1: Copy both files next to your PowerShell profile
+
+Copy [`Update-PoshContextCache.ps1`](./Update-PoshContextCache.ps1) into the same folder as your `$PROFILE` (the hook locates it via `$PSScriptRoot`, so it must sit next to the profile file itself, not just anywhere on `PATH`):
+
+```powershell
+# Find your profile's folder and copy the background-refresh worker there
+Copy-Item .\Update-PoshContextCache.ps1 -Destination (Split-Path $PROFILE.CurrentUserCurrentHost -Parent)
+```
+
+### Step 2: Add the hook to your PowerShell profile
 
 Copy the function from [`posh-hook.ps1`](./posh-hook.ps1) into your `$PROFILE`:
 
@@ -124,7 +137,7 @@ Without this, the segment shows empty values on the first prompt after every new
 
 Save the file.
 
-### Step 2: Add the environment-variable segment to your theme
+### Step 3: Add the environment-variable segment to your theme
 
 ```json
 {
@@ -138,7 +151,7 @@ Save the file.
 }
 ```
 
-The hook updates `$env:COPILOT_TOKENS_TODAY`, `$env:COPILOT_TOKENS_MONTH`, and `$env:COPILOT_TOKENS_30D` at most once every 5 minutes.
+The hook updates `$env:COPILOT_TOKENS_TODAY`, `$env:COPILOT_TOKENS_MONTH`, and `$env:COPILOT_TOKENS_30D` at most once every 5 minutes, from a background process that never blocks your prompt.
 
 ---
 
@@ -196,6 +209,10 @@ Options:
   --ttl <minutes>   Segment cache TTL in minutes (default: 5)
   --refresh         Force refresh — bypass the segment output cache
   --hide-zero       Output nothing when both token counts are zero
+  --json            Output structured JSON (today/month/30d, raw + formatted) instead of
+                     the formatted string. Uses the same fast cache — use this (not
+                     `usage --json`) if you need per-field values, e.g. for a custom
+                     prompt hook like posh-hook.ps1.
   --no-cache        Also bypass the underlying session file cache
   -h, --help        Show help
 ```
@@ -276,6 +293,7 @@ oh-my-posh init pwsh --config "$env:TEMP\test.omp.json" | Invoke-Expression
 | Prompt shows stale data even after refresh | OMP `cache` block on a Method 2 env var segment | **Remove** the `"cache"` block from the env var segment — OMP caches the rendered string, bypassing env var updates from `Set-PoshContext` |
 | Icon shows as a box / `?` | Not using a Nerd Font | Replace `\uec1e` with `🤖` or remove the icon |
 | Prompt slows down | OMP cache not set (Method 1 only) | Add `"cache": {"duration": "5m", "strategy": "session"}` to the `{{ cmd }}` segment |
+| New terminal / profile reload hangs for 45s+ | Method 2 hook calling `usage --json` synchronously (old version) | Update to the current [`posh-hook.ps1`](./posh-hook.ps1) + [`Update-PoshContextCache.ps1`](./Update-PoshContextCache.ps1), which read from a cache file and refresh in a detached background process instead |
 
 ---
 

--- a/omp-segment/Update-PoshContextCache.ps1
+++ b/omp-segment/Update-PoshContextCache.ps1
@@ -1,0 +1,58 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Background worker for the oh-my-posh PowerShell pre-prompt hook (posh-hook.ps1).
+
+.DESCRIPTION
+    Runs `ai-engineering-fluency segment --json` and writes the result atomically to the
+    cache file that Set-PoshContext (posh-hook.ps1) reads. This is launched detached via
+    Start-Process so it never blocks shell startup or prompt rendering.
+
+    Even though `segment` has its own 5-minute output cache, a cache MISS still re-parses
+    every session file, which can take anywhere from a few seconds to well over a minute
+    on a machine with a large session history. Running it here, out-of-process, means the
+    interactive shell never waits on it - it only ever reads the last known values from
+    the cache file (see posh-hook.ps1).
+
+    On failure, a placeholder ("?") entry is still written with a fresh timestamp, so a
+    broken or missing CLI doesn't get retried on every single prompt/shell launch.
+#>
+param(
+    [Parameter(Mandatory)][string]$CacheFile,
+    [Parameter(Mandatory)][string]$LockFile
+)
+
+# Ensure multi-byte characters (e.g. the "·" separator) survive the round-trip through
+# captured stdout, regardless of the console's default encoding.
+$OutputEncoding = [System.Text.UTF8Encoding]::new($false)
+[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
+
+try {
+    $json = ai-engineering-fluency segment --json
+    if ([string]::IsNullOrWhiteSpace($json)) { throw "empty output from 'ai-engineering-fluency segment --json'" }
+
+    # Validate it round-trips as JSON before trusting/caching it
+    $null = $json | ConvertFrom-Json
+}
+catch {
+    $json = @{
+        today               = 0
+        month               = 0
+        last30Days          = 0
+        todayFormatted      = "?"
+        monthFormatted      = "?"
+        last30DaysFormatted = "?"
+        formatted           = "?"
+        updatedAt           = [DateTime]::UtcNow.ToString("o")
+        cached              = $false
+    } | ConvertTo-Json
+}
+
+# Write to a temp file then rename, so the hook never reads a half-written file
+$cacheDir = Split-Path -Parent $CacheFile
+New-Item -Path $cacheDir -ItemType Directory -Force | Out-Null
+$tmp = "$CacheFile.tmp"
+$json | Set-Content -Path $tmp -Encoding utf8
+Move-Item -Path $tmp -Destination $CacheFile -Force
+
+Remove-Item -Path $LockFile -Force -ErrorAction SilentlyContinue

--- a/omp-segment/posh-hook.ps1
+++ b/omp-segment/posh-hook.ps1
@@ -1,53 +1,96 @@
 # oh-my-posh Pre-Prompt Hook (PowerShell)
 #
-# Alternative to the `cmd` approach: this hook runs the CLI before each prompt
-# and stores the results in environment variables that your oh-my-posh segment reads.
+# Alternative to the `cmd` approach: this hook reads cached token usage and stores it in
+# environment variables that your oh-my-posh segment reads.
 #
 # Use this if you prefer not to use the `{{ cmd "..." }}` template function,
 # or if you want more control over formatting.
 #
+# HOW IT WORKS (important - read this before wiring it up)
+# ----------------------------------------------------------
+# Set-PoshContext NEVER calls the CLI synchronously. It only ever reads the last known
+# values from a small on-disk cache file, so it is always fast and never blocks your
+# shell startup or prompt rendering.
+#
+# When that cache is missing or older than 5 minutes, it kicks off a *fully detached*
+# background process (Update-PoshContextCache.ps1) that calls
+# `ai-engineering-fluency segment --json` and writes the result back to the cache for
+# next time.
+#
+# This matters because `segment` has its own 5-minute output cache, but a cache MISS
+# still re-parses every session file - which can take anywhere from a few seconds to
+# well over a minute on a machine with a large session history. An earlier version of
+# this hook called `ai-engineering-fluency usage --json` directly and synchronously,
+# which has NO output cache at all and re-parses everything on every call - this made
+# every new terminal or profile reload hang for 45-80+ seconds on machines with a lot of
+# session history. Don't call the CLI synchronously from a pre-prompt hook - always
+# read-from-cache-then-refresh-in-the-background, as this script does.
+#
 # HOW TO USE
 # ----------
-# 1. Add this function to your PowerShell profile ($PROFILE).
-#    Open it with: notepad $PROFILE
+# 1. Copy Update-PoshContextCache.ps1 to the same folder as your PowerShell profile
+#    ($PROFILE), e.g. next to $PROFILE.CurrentUserCurrentHost.
 #
-# 2. Add the function below to your profile.
+# 2. Add the Set-PoshContext function below to your profile ($PROFILE).
+#    Open it with: notepad $PROFILE
 #
 # 3. Add the environment-variable segment to your oh-my-posh theme (see README.md).
 #
 # 4. Reload your profile: . $PROFILE
 
 function Set-PoshContext {
-    # Only refresh every 5 minutes to keep prompt fast.
-    $lastRun = if ($env:COPILOT_TOKEN_LAST_RUN) {
-        try { [DateTime]::Parse($env:COPILOT_TOKEN_LAST_RUN) } catch { [DateTime]::MinValue }
-    } else {
-        [DateTime]::MinValue
-    }
+    $cacheDir      = Join-Path $PSScriptRoot '.copilot-token-tracker'
+    $cacheFile     = Join-Path $cacheDir 'posh-hook-cache.json'
+    $lockFile      = Join-Path $cacheDir 'posh-hook-cache.lock'
+    $refreshScript = Join-Path $PSScriptRoot 'Update-PoshContextCache.ps1'
 
-    if (([DateTime]::UtcNow - $lastRun).TotalMinutes -lt 5) { return }
-
-    try {
-        $data   = ai-engineering-fluency usage --json | ConvertFrom-Json
-        $today  = [int]$data.today.tokens
-        $month  = [int]$data.month.tokens
-        $days30 = [int]$data.last30Days.tokens
-
-        function Format-Tokens([long]$n) {
-            if ($n -ge 1000000000) { return "{0:N1}B" -f ($n / 1000000000) }
-            if ($n -ge 1000000)    { return "{0:N1}M" -f ($n / 1000000) }
-            if ($n -ge 1000)       { return "{0:N1}K" -f ($n / 1000) }
-            return "$n"
+    # 1. Show the last known values instantly - this never blocks shell startup.
+    $lastRun = [DateTime]::MinValue
+    if (Test-Path $cacheFile) {
+        try {
+            $cache = Get-Content $cacheFile -Raw | ConvertFrom-Json
+            $env:COPILOT_TOKENS_TODAY = $cache.todayFormatted
+            $env:COPILOT_TOKENS_MONTH = $cache.monthFormatted
+            $env:COPILOT_TOKENS_30D   = $cache.last30DaysFormatted
         }
-
-        $env:COPILOT_TOKENS_TODAY   = Format-Tokens $today
-        $env:COPILOT_TOKENS_MONTH   = Format-Tokens $month
-        $env:COPILOT_TOKENS_30D     = Format-Tokens $days30
-        $env:COPILOT_TOKEN_LAST_RUN = [DateTime]::UtcNow.ToString("o")
+        catch {
+            $env:COPILOT_TOKENS_TODAY = "?"
+            $env:COPILOT_TOKENS_MONTH = "?"
+            $env:COPILOT_TOKENS_30D   = "?"
+        }
+        try {
+            # Get-Date (not [DateTime]::Parse) because ConvertFrom-Json may already
+            # hand back a [DateTime] object for ISO-8601 strings, not a plain string.
+            $lastRun = Get-Date $cache.updatedAt
+        }
+        catch {
+            $lastRun = [DateTime]::MinValue
+        }
     }
-    catch {
+    else {
         $env:COPILOT_TOKENS_TODAY = "?"
         $env:COPILOT_TOKENS_MONTH = "?"
         $env:COPILOT_TOKENS_30D   = "?"
     }
+
+    # 2. Refresh in a fully detached background process when the cache is stale.
+    #    See the header comment above for why this must never run synchronously.
+    if (([DateTime]::UtcNow - $lastRun).TotalMinutes -ge 5 -and -not (Test-Path $lockFile)) {
+        if (Test-Path $refreshScript) {
+            try {
+                New-Item -Path $cacheDir -ItemType Directory -Force | Out-Null
+                New-Item -Path $lockFile -ItemType File -Force | Out-Null
+                Start-Process -FilePath (Get-Process -Id $PID).Path `
+                    -ArgumentList @('-NoProfile', '-NonInteractive', '-WindowStyle', 'Hidden', '-File', $refreshScript, $cacheFile, $lockFile) `
+                    -WindowStyle Hidden -ErrorAction SilentlyContinue
+            }
+            catch {
+                Remove-Item -Path $lockFile -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
 }
+
+# Pre-populate token env vars so the first prompt render shows values
+# (instant - reads the cache, refreshes asynchronously in the background)
+Set-PoshContext


### PR DESCRIPTION
## Problem

The Method 2 oh-my-posh hook (`posh-hook.ps1`) called `ai-engineering-fluency usage --json` synchronously on every shell start / prompt render. `usage` has no output cache and always re-discovers and re-aggregates every session file, which can take 45-80+ seconds on a machine with a lot of session history. This blocks every new terminal and every profile reload.

I hit this myself, root-caused it in my own `$PROFILE`, and found the same anti-pattern documented as the "Recommended" method in this repo, so I'm fixing it here too.

## Changes

- **cli**: add a `--json` flag to the `segment` command so hooks can get structured per-period token data (today/month/30d, raw + formatted) from the existing fast, cached `segment` path instead of the uncached `usage --json` command.
- **omp-segment**: rewrite `posh-hook.ps1` so it never calls the CLI synchronously. `Set-PoshContext` now reads instantly from a small on-disk JSON cache and only spawns a fully detached background process (guarded by a lock file) to refresh it via `segment --json` when the cache is stale.
- **omp-segment**: add `Update-PoshContextCache.ps1`, the background worker script that performs the refresh and writes the cache atomically (temp file + rename), with a placeholder fallback on failure so a slow/broken CLI call doesn't get retried on every prompt.
- **docs**: update `omp-segment/README.md` and `cli/README.md` with the new `--json` option, a stronger performance warning contrasting `usage --json` (uncached) vs `segment` (cached), and a troubleshooting entry for the old blocking-hook symptom.
- **cli**: add unit tests for the new `--json` payload building logic.

## Testing

- `cli`: `npm run build`, `npm run test:unit` (26/26 passing), `npx eslint src` (no new warnings introduced).
- Manually smoke-tested `segment --json` and `segment` (no flag) output.
- End-to-end functional test of the new hook in an isolated profile: cold shell start is instant (~0.8s), background refresh process spawns and populates the cache correctly, warm reads return correct env vars, UTF-8 separator character renders correctly.

Note: even with the `--json` flag, a `segment --refresh` cache-miss can still take a long time on a machine with a lot of session history (confirmed ~68s on mine) — the background-refresh pattern in the hook is what actually fixes the blocking-startup problem, not just switching commands.
