### PR TITLE
feat(sharing-server): expose a composable app factory and publish to npm

### DIFF
--- a/.github/workflows/sharing-server-deploy.yml
+++ b/.github/workflows/sharing-server-deploy.yml
@@ -147,7 +147,9 @@ jobs:
             } >> "$GITHUB_OUTPUT"
           fi
 
-  # ── Type-check & unit tests ───────────────────────────────────────────────────
+  # ── Type-check, unit tests & library build ───────────────────────────────────
+  # The server is also consumed as an npm library by downstream servers, so a broken
+  # lib/ build must fail here rather than at publish time.
   test:
     name: Type-check & unit tests
     runs-on: ubuntu-latest
@@ -178,6 +180,26 @@ jobs:
       - name: Run unit tests
         working-directory: sharing-server
         run: npm test
+
+      - name: Build library (lib/)
+        working-directory: sharing-server
+        run: npm run build:lib
+
+      - name: Verify the published entry point loads
+        working-directory: sharing-server
+        run: |
+          node -e "
+            const api = require('./lib/index.js');
+            for (const name of ['createApp', 'startServer', 'registerSchemaExtension', 'requireBearerAuth', 'getDb']) {
+              if (typeof api[name] !== 'function') {
+                throw new Error('Missing export: ' + name);
+              }
+            }
+            if (typeof api.createApp().fetch !== 'function') {
+              throw new Error('createApp() did not return a Hono app');
+            }
+            console.log('Package entry point OK');
+          "
 
   # ── Build & push container image to GHCR ─────────────────────────────────────
   build:

--- a/.github/workflows/sharing-server-publish.yml
+++ b/.github/workflows/sharing-server-publish.yml
@@ -1,0 +1,230 @@
+name: Sharing Server - Publish to npm
+
+# Publishes the sharing server as a library so downstream servers can compose it
+# (createApp / startServer / registerSchemaExtension) instead of forking the repo.
+#
+# Uses npm trusted publishing (OIDC) — same as cli-publish.yml — so no NPM_TOKEN
+# secret is needed. Configure the trusted publisher for @rajbos/copilot-sharing-server
+# on npmjs.com pointing at this repository and this workflow file.
+on:
+  workflow_dispatch:
+    inputs:
+      version_bump:
+        description: 'Version bump type'
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+      dry_run:
+        description: 'Dry run (do not actually publish)'
+        required: false
+        default: false
+        type: boolean
+
+  push:
+    tags:
+      - 'sharing-server/v*' # Tag push: publish to npm + create GitHub release
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish sharing server to npm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write      # push the version bump branch, open the PR, create the release
+      pull-requests: write # open the version bump PR
+      id-token: write      # required for OIDC authentication to the npm registry
+    defaults:
+      run:
+        working-directory: sharing-server
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run type checking
+        run: npm run check-types
+
+      - name: Build library (lib/)
+        run: npm run build:lib
+
+      - name: Build server bundle (dist/)
+        run: npm run build:production
+
+      - name: Verify the published entry point loads
+        # Catches a broken exports map or a missing lib/ file before publishing.
+        run: |
+          node -e "
+            const api = require('./lib/index.js');
+            for (const name of ['createApp', 'startServer', 'registerSchemaExtension', 'requireBearerAuth', 'getDb']) {
+              if (typeof api[name] !== 'function') {
+                throw new Error('Missing export: ' + name);
+              }
+            }
+            const app = api.createApp();
+            if (typeof app.fetch !== 'function') {
+              throw new Error('createApp() did not return a Hono app');
+            }
+            console.log('Package entry point OK');
+          "
+
+      - name: Determine trigger type
+        id: trigger_type
+        working-directory: .
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          GIT_REF: ${{ github.ref }}
+        run: |
+          if [[ "$EVENT_NAME" == "push" && "$GIT_REF" == refs/tags/sharing-server/v* ]]; then
+            echo "is_tag=true" >> "$GITHUB_OUTPUT"
+            TAG_VERSION=${GIT_REF#refs/tags/sharing-server/v}
+            echo "tag_version=$TAG_VERSION" >> "$GITHUB_OUTPUT"
+            echo "Triggered by tag push: sharing-server/v$TAG_VERSION"
+          else
+            echo "is_tag=false" >> "$GITHUB_OUTPUT"
+            echo "tag_version=" >> "$GITHUB_OUTPUT"
+            echo "Triggered by workflow_dispatch"
+          fi
+
+      - name: Bump version (workflow_dispatch only)
+        if: steps.trigger_type.outputs.is_tag != 'true'
+        run: npm version ${{ inputs.version_bump }} --no-git-tag-version
+
+      - name: Verify version matches tag (tag trigger only)
+        if: steps.trigger_type.outputs.is_tag == 'true'
+        env:
+          TAG_VERSION: ${{ steps.trigger_type.outputs.tag_version }}
+        run: |
+          PACKAGE_VERSION=$(node -p 'require("./package.json").version')
+          if [ "$PACKAGE_VERSION" != "$TAG_VERSION" ]; then
+            echo "❌ Version mismatch!"
+            echo "  package.json: $PACKAGE_VERSION"
+            echo "  tag:          $TAG_VERSION"
+            echo "Please ensure the version in sharing-server/package.json matches the pushed tag."
+            exit 1
+          fi
+          echo "✅ Version check passed: $PACKAGE_VERSION"
+
+      - name: Get version
+        id: version
+        run: echo "version=$(node -p 'require("./package.json").version')" >> "$GITHUB_OUTPUT"
+
+      - name: Check if version is already published
+        id: check_published
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          PACKAGE_NAME=$(node -p 'require("./package.json").name')
+          echo "Checking npm registry for ${PACKAGE_NAME}@${VERSION}..."
+          if npm view "${PACKAGE_NAME}@${VERSION}" version 2>&1; then
+            echo "Version ${VERSION} is already published to npm. Skipping publish."
+            echo "already_published=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Version ${VERSION} is not yet published. Proceeding with publish."
+            echo "already_published=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish to npm
+        if: ${{ !inputs.dry_run && steps.check_published.outputs.already_published != 'true' }}
+        run: NODE_AUTH_TOKEN="" npm publish --access public
+
+      - name: Dry run publish
+        if: ${{ inputs.dry_run }}
+        run: NODE_AUTH_TOKEN="" npm publish --access public --dry-run
+
+      - name: Commit version bump and create PR
+        if: ${{ !inputs.dry_run && steps.check_published.outputs.already_published != 'true' && steps.trigger_type.outputs.is_tag != 'true' }}
+        working-directory: .
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "sharing-server/bump-version-v${VERSION}"
+          git add sharing-server/package.json sharing-server/package-lock.json
+          git commit -m "chore(sharing-server): bump version to v${VERSION}"
+          git push origin "sharing-server/bump-version-v${VERSION}"
+          gh pr create \
+            --title "chore(sharing-server): bump version to v${VERSION}" \
+            --body "Automated version bump after publishing \`@rajbos/copilot-sharing-server@${VERSION}\` to npm." \
+            --base main \
+            --head "sharing-server/bump-version-v${VERSION}"
+
+      - name: Generate release notes
+        if: ${{ !inputs.dry_run && steps.check_published.outputs.already_published != 'true' && steps.trigger_type.outputs.is_tag == 'true' }}
+        working-directory: .
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          TAG_NAME="sharing-server/v${VERSION}"
+          if gh api "repos/${{ github.repository }}/releases/generate-notes" \
+            -f tag_name="${TAG_NAME}" \
+            --jq '.body' > /tmp/release_notes.md 2>/dev/null && [ -s /tmp/release_notes.md ]; then
+            echo "✅ Generated release notes from merged PRs"
+          else
+            echo "Sharing server v${VERSION}" > /tmp/release_notes.md
+          fi
+
+      - name: Create GitHub release
+        if: ${{ !inputs.dry_run && steps.check_published.outputs.already_published != 'true' && steps.trigger_type.outputs.is_tag == 'true' }}
+        working-directory: .
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          TAG_NAME="sharing-server/v${VERSION}"
+          gh release create "$TAG_NAME" \
+            --title "Sharing server v${VERSION}" \
+            --notes-file /tmp/release_notes.md
+          echo "✅ GitHub release created: $TAG_NAME"
+
+      - name: Summary
+        working-directory: .
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          ALREADY_PUBLISHED: ${{ steps.check_published.outputs.already_published }}
+          IS_TAG: ${{ steps.trigger_type.outputs.is_tag }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          {
+            if [ "$ALREADY_PUBLISHED" = "true" ]; then
+              echo "## Sharing Server Publish Skipped ⏭️"
+              echo ""
+              echo "Version **v${VERSION}** is already published to npm."
+            else
+              echo "## Sharing Server Published 📦"
+              echo ""
+              echo "- **Version:** v${VERSION}"
+              echo "- **Dry run:** ${DRY_RUN}"
+              echo ""
+              if [ "$DRY_RUN" = "false" ]; then
+                echo "Consume with: \`npm install @rajbos/copilot-sharing-server@${VERSION}\`"
+                echo ""
+                if [ "$IS_TAG" = "true" ]; then
+                  echo "A GitHub release has been created: sharing-server/v${VERSION}"
+                else
+                  echo "A PR has been opened to merge the version bump back to main."
+                fi
+              fi
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/sharing-server-publish.yml
+++ b/.github/workflows/sharing-server-publish.yml
@@ -4,7 +4,7 @@ name: Sharing Server - Publish to npm
 # (createApp / startServer / registerSchemaExtension) instead of forking the repo.
 #
 # Uses npm trusted publishing (OIDC) — same as cli-publish.yml — so no NPM_TOKEN
-# secret is needed. Configure the trusted publisher for @rajbos/copilot-sharing-server
+# secret is needed. Configure the trusted publisher for @rajbos/ai-engineering-fluency-sharing-server
 # on npmjs.com pointing at this repository and this workflow file.
 on:
   workflow_dispatch:
@@ -165,7 +165,7 @@ jobs:
           git push origin "sharing-server/bump-version-v${VERSION}"
           gh pr create \
             --title "chore(sharing-server): bump version to v${VERSION}" \
-            --body "Automated version bump after publishing \`@rajbos/copilot-sharing-server@${VERSION}\` to npm." \
+            --body "Automated version bump after publishing \`@rajbos/ai-engineering-fluency-sharing-server@${VERSION}\` to npm." \
             --base main \
             --head "sharing-server/bump-version-v${VERSION}"
 
@@ -218,7 +218,7 @@ jobs:
               echo "- **Dry run:** ${DRY_RUN}"
               echo ""
               if [ "$DRY_RUN" = "false" ]; then
-                echo "Consume with: \`npm install @rajbos/copilot-sharing-server@${VERSION}\`"
+                echo "Consume with: \`npm install @rajbos/ai-engineering-fluency-sharing-server@${VERSION}\`"
                 echo ""
                 if [ "$IS_TAG" = "true" ]; then
                   echo "A GitHub release has been created: sharing-server/v${VERSION}"

--- a/sharing-server/.gitignore
+++ b/sharing-server/.gitignore
@@ -3,3 +3,4 @@ dist/
 data/
 *.db
 .env
+lib/

--- a/sharing-server/README.md
+++ b/sharing-server/README.md
@@ -230,7 +230,7 @@ import {
 	registerSchemaExtension,
 	requireBearerAuth,
 	getDb,
-} from '@rajbos/copilot-sharing-server';
+} from '@rajbos/ai-engineering-fluency-sharing-server';
 import { Hono } from 'hono';
 
 // Runs before the first getDb(), so the table exists at startup.

--- a/sharing-server/README.md
+++ b/sharing-server/README.md
@@ -217,6 +217,72 @@ uploads are safe and idempotent.
 | Per IP (all requests) | 200 requests / minute |
 | Per user (uploads) | 100 upload requests / hour |
 
+## Extending this server
+
+This server is also published as a library so you can build a customised server on top of
+it without forking. Import `createApp` and `startServer`, mount your own routes and
+register your own tables:
+
+```ts
+import {
+	createApp,
+	startServer,
+	registerSchemaExtension,
+	requireBearerAuth,
+	getDb,
+} from '@rajbos/copilot-sharing-server';
+import { Hono } from 'hono';
+
+// Runs before the first getDb(), so the table exists at startup.
+registerSchemaExtension('my-metrics', (db) => {
+	db.exec(`CREATE TABLE IF NOT EXISTS my_metrics (
+		id           INTEGER PRIMARY KEY,
+		user_id      INTEGER NOT NULL REFERENCES users(id),
+		dataset_id   TEXT NOT NULL DEFAULT 'default',
+		day          TEXT NOT NULL,
+		workspace_id TEXT NOT NULL,
+		machine_id   TEXT NOT NULL,
+		metrics_json TEXT NOT NULL,
+		UNIQUE(user_id, dataset_id, day, workspace_id, machine_id)
+	)`);
+});
+
+const routes = new Hono();
+routes.post('/upload', requireBearerAuth, async (c) => {
+	const user = c.get('user');
+	// … store rows for user.id …
+	return c.json({ ok: true });
+});
+
+const app = createApp({
+	healthExtra: () => ({ edition: 'my-company' }),
+	extend: (a) => a.route('/api/mine', routes),
+});
+
+await startServer(app);
+```
+
+### Extension points
+
+| Export | Purpose |
+|---|---|
+| `createApp({ extend })` | Register routes **before** the built-in ones. Because Hono matches in registration order, this also lets you override a built-in path. |
+| `createApp({ healthExtra })` | Merge extra fields into `/health`. |
+| `createApp({ mountApi, mountDashboard })` | Opt out of the built-in route groups. |
+| `registerSchemaExtension(name, fn)` | Add tables/indexes/migrations. Call before the first `getDb()`. |
+| `requireBearerAuth` | Authenticate with the same GitHub token as `/api/upload`, so your rows share the same `user_id`. |
+| `startServer(app, opts)` | Backup/restore, DB init with retry, periodic backup, graceful shutdown. |
+
+### Guidance
+
+- **Add tables, don't widen `usage_uploads`.** Keeping downstream tables separate means
+  core migrations and your migrations never conflict.
+- **Join on `(user_id, dataset_id, day, workspace_id, machine_id)`** — the natural rollup
+  key — and use a `LEFT JOIN`, since upload ordering between clients is not guaranteed.
+- **Upsert on that key** so a re-upload of the same day replaces rather than duplicates.
+- **Reuse `requireBearerAuth`.** A separate auth scheme would produce a different
+  `user_id` and make the two datasets impossible to join.
+
 ## Security
 
 - **Bearer token auth** — the extension sends your GitHub OAuth token. The server

--- a/sharing-server/package-lock.json
+++ b/sharing-server/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@rajbos/copilot-sharing-server",
+  "name": "@rajbos/ai-engineering-fluency-sharing-server",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@rajbos/copilot-sharing-server",
+      "name": "@rajbos/ai-engineering-fluency-sharing-server",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {

--- a/sharing-server/package.json
+++ b/sharing-server/package.json
@@ -4,6 +4,31 @@
   "description": "Self-hosted sharing server for AI Engineering Fluency — accepts daily usage uploads from VS Code via GitHub OAuth tokens",
   "license": "MIT",
   "author": "RobBos",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "default": "./lib/index.js"
+    },
+    "./db": {
+      "types": "./lib/db.d.ts",
+      "default": "./lib/db.js"
+    },
+    "./auth": {
+      "types": "./lib/auth.d.ts",
+      "default": "./lib/auth.js"
+    },
+    "./session": {
+      "types": "./lib/session.d.ts",
+      "default": "./lib/session.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "lib",
+    "README.md"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/rajbos/ai-engineering-fluency.git",
@@ -12,6 +37,8 @@
   "scripts": {
     "build": "node esbuild.js",
     "build:production": "node esbuild.js --production",
+    "build:lib": "tsc -p tsconfig.lib.json",
+    "prepack": "npm run build:lib",
     "start": "node --env-file=.env dist/server.js",
     "dev": "node --env-file=.env --watch dist/server.js",
     "serve": "node esbuild.js && node --env-file=.env --watch dist/server.js",
@@ -23,6 +50,14 @@
   "dependencies": {
     "@hono/node-server": "^2.1.1",
     "hono": "^4.13.3"
+  },
+  "peerDependencies": {
+    "chart.js": "^4.4.7"
+  },
+  "peerDependenciesMeta": {
+    "chart.js": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@types/node": "^26.2.0",

--- a/sharing-server/package.json
+++ b/sharing-server/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@rajbos/copilot-sharing-server",
+  "name": "@rajbos/ai-engineering-fluency-sharing-server",
   "version": "0.1.0",
   "description": "Self-hosted sharing server for AI Engineering Fluency — accepts daily usage uploads from VS Code via GitHub OAuth tokens",
   "license": "MIT",

--- a/sharing-server/src/app.ts
+++ b/sharing-server/src/app.ts
@@ -1,0 +1,91 @@
+import { Hono } from 'hono';
+import fs from 'node:fs';
+import path from 'node:path';
+import { api } from './routes/api.js';
+import { dashboard } from './routes/dashboard.js';
+
+export interface CreateAppOptions {
+	/**
+	 * Called before the built-in routes are mounted. Because Hono resolves routes in
+	 * registration order, anything registered here takes precedence over the built-in
+	 * `/api` and dashboard routes — which is how a downstream server overrides a page
+	 * or an endpoint without forking this package.
+	 */
+	extend?: (app: Hono) => void;
+	/** Extra fields merged into the `/health` response, e.g. a downstream version stamp. */
+	healthExtra?: () => Record<string, unknown>;
+	/** Mount the built-in `/api` routes. Default: true. */
+	mountApi?: boolean;
+	/** Mount the built-in dashboard and OAuth routes. Default: true. */
+	mountDashboard?: boolean;
+	/**
+	 * Directory holding static assets such as `icon.png`. Defaults to the `images/`
+	 * folder next to the bundle. A downstream server that bundles to its own `dist/`
+	 * can point this at the OSS package's copy.
+	 */
+	imagesDir?: string;
+}
+
+/**
+ * Build the sharing-server Hono application.
+ *
+ * Exported so downstream servers (e.g. a vendor-specific deployment) can compose extra
+ * routes and tables on top of this one instead of maintaining a fork:
+ *
+ * ```ts
+ * const app = createApp({ extend: (a) => a.route('/api/vendor', vendorRoutes) });
+ * await startServer(app);
+ * ```
+ */
+export function createApp(options: CreateAppOptions = {}): Hono {
+	const app = new Hono();
+
+	// Serve the product icon used by the dashboard header. The icon is copied into
+	// dist/images/ at build time so the bundled server remains self-contained.
+	const iconPath = path.join(options.imagesDir ?? path.join(__dirname, 'images'), 'icon.png');
+	app.get('/icon.png', (c) => {
+		if (!fs.existsSync(iconPath)) {
+			return c.body('Icon not found', 404, { 'Content-Type': 'text/plain' });
+		}
+		const icon = fs.readFileSync(iconPath);
+		return c.body(icon, 200, {
+			'Content-Type': 'image/png',
+			'Cache-Control': 'public, max-age=86400',
+		});
+	});
+
+	// Health check — no auth required
+	app.get('/health', (c) => c.json({
+		status: 'ok',
+		timestamp: new Date().toISOString(),
+		version: {
+			sha:    process.env.DEPLOY_SHA    ?? 'unknown',
+			branch: process.env.DEPLOY_BRANCH ?? 'unknown',
+			date:   process.env.DEPLOY_DATE   ?? 'unknown',
+		},
+		...(options.healthExtra?.() ?? {}),
+	}));
+
+	options.extend?.(app);
+
+	// API routes (bearer token auth)
+	if (options.mountApi !== false) {
+		app.route('/api', api);
+	}
+
+	// Dashboard + auth routes (session cookie)
+	if (options.mountDashboard !== false) {
+		app.route('/', dashboard);
+	}
+
+	// 404 fallback
+	app.notFound((c) => c.json({ error: 'Not found' }, 404));
+
+	// Log unhandled errors so they appear in container logs (ACA / Docker)
+	app.onError((err, c) => {
+		console.error(`[${new Date().toISOString()}] Unhandled error on ${c.req.method} ${c.req.path}:`, err);
+		return c.text('Internal Server Error', 500);
+	});
+
+	return app;
+}

--- a/sharing-server/src/app.ts
+++ b/sharing-server/src/app.ts
@@ -6,10 +6,10 @@ import { dashboard } from './routes/dashboard.js';
 
 export interface CreateAppOptions {
 	/**
-	 * Called before the built-in routes are mounted. Because Hono resolves routes in
-	 * registration order, anything registered here takes precedence over the built-in
-	 * `/api` and dashboard routes — which is how a downstream server overrides a page
-	 * or an endpoint without forking this package.
+	 * Called before any built-in route is mounted. Because Hono resolves routes in
+	 * registration order, anything registered here takes precedence over every
+	 * built-in route (`/health`, `/icon.png`, `/api` and the dashboard) — which is how
+	 * a downstream server overrides a page or an endpoint without forking this package.
 	 */
 	extend?: (app: Hono) => void;
 	/** Extra fields merged into the `/health` response, e.g. a downstream version stamp. */
@@ -40,6 +40,10 @@ export interface CreateAppOptions {
 export function createApp(options: CreateAppOptions = {}): Hono {
 	const app = new Hono();
 
+	// Registered first so downstream routes take precedence over every built-in
+	// route below — Hono resolves in registration order.
+	options.extend?.(app);
+
 	// Serve the product icon used by the dashboard header. The icon is copied into
 	// dist/images/ at build time so the bundled server remains self-contained.
 	const iconPath = path.join(options.imagesDir ?? path.join(__dirname, 'images'), 'icon.png');
@@ -65,8 +69,6 @@ export function createApp(options: CreateAppOptions = {}): Hono {
 		},
 		...(options.healthExtra?.() ?? {}),
 	}));
-
-	options.extend?.(app);
 
 	// API routes (bearer token auth)
 	if (options.mountApi !== false) {

--- a/sharing-server/src/db.ts
+++ b/sharing-server/src/db.ts
@@ -108,8 +108,8 @@ export function getDb(): DatabaseSync {
 		if (!existsSync(dataDir)) {
 			mkdirSync(dataDir, { recursive: true });
 		}
-		// Open first, then configure — only assign _db once fully initialized so
-		// that a failed startup causes the next request to retry initialization.
+		// Open first, then configure. `_db` is assigned only after the core schema is in
+		// place, so a failed startup leaves it unset and the next request retries.
 		const db = new DatabaseSync(dbPath);
 		try {
 			db.exec('PRAGMA busy_timeout = 5000');
@@ -117,9 +117,16 @@ export function getDb(): DatabaseSync {
 			db.exec('PRAGMA journal_mode = WAL');
 			db.exec('PRAGMA foreign_keys = ON');
 			initSchema(db);
-			runSchemaExtensions(db);
+			// Publish the handle *before* running downstream extensions. An extension is
+			// handed `db` directly, but it may call a query helper that reaches for
+			// getDb() itself; with `_db` still unset that would re-enter this branch and
+			// open a second handle to the same file (recursing until it blows up).
 			_db = db;
+			runSchemaExtensions(db);
 		} catch (err) {
+			// Roll back the publish so a failed extension does not leave a half-built
+			// database in place for the next caller.
+			_db = undefined;
 			try { db.close(); } catch { /* ignore */ }
 			throw err;
 		}
@@ -245,6 +252,10 @@ const _schemaExtensions = new Map<string, SchemaExtension>();
  *
  * Call this before the first `getDb()`. If the database is already open the extension is
  * applied immediately. Registering the same `name` twice is a no-op.
+ *
+ * The extension receives the database handle directly, and may also call `getDb()` (or a
+ * helper that does) — during initialization that returns this same handle rather than
+ * opening a second one.
  */
 export function registerSchemaExtension(name: string, fn: SchemaExtension): void {
 	if (_schemaExtensions.has(name)) return;

--- a/sharing-server/src/db.ts
+++ b/sharing-server/src/db.ts
@@ -117,6 +117,7 @@ export function getDb(): DatabaseSync {
 			db.exec('PRAGMA journal_mode = WAL');
 			db.exec('PRAGMA foreign_keys = ON');
 			initSchema(db);
+			runSchemaExtensions(db);
 			_db = db;
 		} catch (err) {
 			try { db.close(); } catch { /* ignore */ }
@@ -228,6 +229,44 @@ function initSchema(db: DatabaseSync): void {
 		.all() as unknown as Array<{ name: string }>;
 	if (!userCols.some(c => c.name === 'fluency_score_json')) {
 		db.exec('ALTER TABLE users ADD COLUMN fluency_score_json TEXT');
+	}
+}
+
+export type SchemaExtension = (db: DatabaseSync) => void;
+
+const _schemaExtensions = new Map<string, SchemaExtension>();
+
+/**
+ * Register additional schema (tables, indexes, migrations) owned by a downstream server.
+ *
+ * Downstream tables live alongside the core ones instead of widening `usage_uploads`, so
+ * core migrations and downstream migrations stay independent. Join downstream rows onto
+ * core rows on `(user_id, dataset_id, day, workspace_id, machine_id)` at read time.
+ *
+ * Call this before the first `getDb()`. If the database is already open the extension is
+ * applied immediately. Registering the same `name` twice is a no-op.
+ */
+export function registerSchemaExtension(name: string, fn: SchemaExtension): void {
+	if (_schemaExtensions.has(name)) return;
+	_schemaExtensions.set(name, fn);
+	if (_db) {
+		applySchemaExtension(_db, name, fn);
+	}
+}
+
+function applySchemaExtension(db: DatabaseSync, name: string, fn: SchemaExtension): void {
+	try {
+		fn(db);
+		console.log(`[db] Applied schema extension "${name}"`);
+	} catch (err) {
+		console.error(`[db] Schema extension "${name}" failed:`, err);
+		throw err;
+	}
+}
+
+function runSchemaExtensions(db: DatabaseSync): void {
+	for (const [name, fn] of _schemaExtensions) {
+		applySchemaExtension(db, name, fn);
 	}
 }
 

--- a/sharing-server/src/index.ts
+++ b/sharing-server/src/index.ts
@@ -1,10 +1,10 @@
 /**
- * Public entry point for `@rajbos/copilot-sharing-server`.
+ * Public entry point for `@rajbos/ai-engineering-fluency-sharing-server`.
  *
  * Downstream servers compose this package instead of forking it:
  *
  * ```ts
- * import { createApp, startServer, registerSchemaExtension, requireBearerAuth } from '@rajbos/copilot-sharing-server';
+ * import { createApp, startServer, registerSchemaExtension, requireBearerAuth } from '@rajbos/ai-engineering-fluency-sharing-server';
  *
  * registerSchemaExtension('vendor', (db) => db.exec(`CREATE TABLE IF NOT EXISTS ...`));
  *

--- a/sharing-server/src/index.ts
+++ b/sharing-server/src/index.ts
@@ -1,0 +1,74 @@
+/**
+ * Public entry point for `@rajbos/copilot-sharing-server`.
+ *
+ * Downstream servers compose this package instead of forking it:
+ *
+ * ```ts
+ * import { createApp, startServer, registerSchemaExtension, requireBearerAuth } from '@rajbos/copilot-sharing-server';
+ *
+ * registerSchemaExtension('vendor', (db) => db.exec(`CREATE TABLE IF NOT EXISTS ...`));
+ *
+ * const app = createApp({ extend: (a) => a.route('/api/vendor', vendorRoutes) });
+ * await startServer(app);
+ * ```
+ */
+
+export { createApp, type CreateAppOptions } from './app.js';
+export {
+	startServer,
+	initDbWithRetry,
+	registerShutdownHandlers,
+	type StartServerOptions,
+} from './lifecycle.js';
+
+// Built-in route apps, so a downstream server can remount them under a different path.
+export { api } from './routes/api.js';
+export { dashboard } from './routes/dashboard.js';
+
+// Auth — reuse so downstream endpoints authenticate the *same* user as core uploads.
+// This is what makes the two datasets joinable on `user_id`.
+export {
+	requireBearerAuth,
+	validateGitHubToken,
+	checkIpRateLimit,
+	checkUploadRateLimit,
+	type AuthVariables,
+} from './auth.js';
+
+export {
+	COOKIE_NAME,
+	OAUTH_STATE_COOKIE,
+	SESSION_MAX_AGE,
+	encodeSession,
+	decodeSession,
+	makeClaims,
+	type SessionClaims,
+} from './session.js';
+
+export {
+	getDb,
+	closeDb,
+	registerSchemaExtension,
+	restoreFromBackup,
+	backupToAzureFiles,
+	syncAdminLogins,
+	upsertUser,
+	getUserById,
+	getUserByGithubId,
+	upsertUpload,
+	deleteUploadsForDays,
+	getUploadsForUser,
+	getAllUsers,
+	getAllUploads,
+	upsertUserFluencyScore,
+	getUserFluencyScore,
+	getAdminUserSummaries,
+	getAdminDailyTotals,
+	type SchemaExtension,
+	type UserRow,
+	type UserUsageSummary,
+	type AdminDailyRow,
+	type UploadRow,
+	type AdminUploadRow,
+	type UploadEntry,
+} from './db.js';

--- a/sharing-server/src/lifecycle.ts
+++ b/sharing-server/src/lifecycle.ts
@@ -32,8 +32,21 @@ export async function initDbWithRetry(maxAttempts = 20): Promise<void> {
 	}
 }
 
-/** Back up the DB to Azure Files then close cleanly on SIGTERM/SIGINT. */
+/**
+ * Back up the DB to Azure Files then close cleanly on SIGTERM/SIGINT.
+ *
+ * Idempotent: as a library this may be called both by a downstream app and by
+ * `startServer`, and registering twice would double-run the backup on shutdown and
+ * leak listeners (`MaxListenersExceededWarning`) across multiple servers in a test run.
+ */
+let shutdownHandlersRegistered = false;
+
 export function registerShutdownHandlers(): void {
+	if (shutdownHandlersRegistered) {
+		return;
+	}
+	shutdownHandlersRegistered = true;
+
 	function shutdown(signal: string): void {
 		console.log(`Received ${signal}, backing up database and exiting...`);
 		backupToAzureFiles();

--- a/sharing-server/src/lifecycle.ts
+++ b/sharing-server/src/lifecycle.ts
@@ -1,0 +1,84 @@
+import { serve } from '@hono/node-server';
+import type { Hono } from 'hono';
+import { getDb, closeDb, restoreFromBackup, backupToAzureFiles, syncAdminLogins } from './db.js';
+import { BACKUP_INTERVAL_MS } from './config.js';
+
+export interface StartServerOptions {
+	/** Port to listen on. Defaults to `PORT` env var, then 3000. */
+	port?: number;
+	/** Interval between Azure Files backups in ms. Defaults to `BACKUP_INTERVAL_MS`. Set to 0 to disable. */
+	backupIntervalMs?: number;
+	/** Extra work to run after the database is initialised but before listening. */
+	onReady?: () => void | Promise<void>;
+}
+
+/** Open the database, retrying with backoff — Azure Files restore can lag behind container start. */
+export async function initDbWithRetry(maxAttempts = 20): Promise<void> {
+	for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+		try {
+			getDb();
+			console.log(`[db] Initialised successfully (attempt ${attempt})`);
+			return;
+		} catch (err) {
+			if (attempt < maxAttempts) {
+				const delay = Math.min(attempt * 5_000, 30_000);
+				console.warn(`[db] Init attempt ${attempt}/${maxAttempts} failed: ${err}. Retrying in ${delay}ms…`);
+				await new Promise(r => setTimeout(r, delay));
+			} else {
+				console.error('[db] All init attempts exhausted:', err);
+				throw err;
+			}
+		}
+	}
+}
+
+/** Back up the DB to Azure Files then close cleanly on SIGTERM/SIGINT. */
+export function registerShutdownHandlers(): void {
+	function shutdown(signal: string): void {
+		console.log(`Received ${signal}, backing up database and exiting...`);
+		backupToAzureFiles();
+		closeDb();
+		process.exit(0);
+	}
+	process.on('SIGTERM', () => shutdown('SIGTERM'));
+	process.on('SIGINT',  () => shutdown('SIGINT'));
+}
+
+/**
+ * Boot the full server lifecycle: restore backup, open the database, register shutdown
+ * handlers and start listening. Downstream servers call this with their own composed app.
+ */
+export async function startServer(app: Hono, options: StartServerOptions = {}): Promise<void> {
+	const port = options.port ?? parseInt(process.env.PORT ?? '3000', 10);
+
+	registerShutdownHandlers();
+
+	// Restore database from Azure Files backup before opening SQLite.
+	// SQLite runs on local container disk (/tmp/db) to avoid Azure Files SMB
+	// locking issues. Azure Files is used only as a backup/restore store.
+	restoreFromBackup();
+	await initDbWithRetry();
+	syncAdminLogins();
+
+	const backupIntervalMs = options.backupIntervalMs ?? BACKUP_INTERVAL_MS;
+	if (backupIntervalMs > 0) {
+		// Periodic backup in case of unexpected SIGKILL.
+		setInterval(() => backupToAzureFiles(), backupIntervalMs).unref();
+	}
+
+	await options.onReady?.();
+
+	const org = process.env.ALLOWED_GITHUB_ORG;
+	const adminLogins = process.env.ADMIN_GITHUB_LOGINS;
+	serve({ fetch: app.fetch, port }, (info) => {
+		console.log(`Token Tracker sharing server listening on port ${info.port}`);
+		if (org) {
+			console.log(`  Access restricted to members of GitHub org: ${org}`);
+		} else {
+			console.log('  Access: open to any GitHub user (set ALLOWED_GITHUB_ORG to restrict)');
+		}
+		if (adminLogins) {
+			console.log(`  Admin logins (ADMIN_GITHUB_LOGINS): ${adminLogins}`);
+		}
+	});
+}

--- a/sharing-server/src/routes/dashboard.ts
+++ b/sharing-server/src/routes/dashboard.ts
@@ -1,7 +1,8 @@
 import { Hono } from 'hono';
 import { getCookie, setCookie, deleteCookie } from 'hono/cookie';
 import { readFileSync } from 'fs';
-import { join } from 'path';
+import { join, dirname } from 'path';
+import { createRequire } from 'module';
 import {
 	encodeSession, decodeSession, makeClaims,
 	COOKIE_NAME, OAUTH_STATE_COOKIE, SESSION_MAX_AGE,
@@ -24,15 +25,35 @@ const DEPLOY_DATE   = process.env.DEPLOY_DATE   ?? 'unknown';
 
 // Load Chart.js UMD bundle once at startup.
 // Bundled build: esbuild.js copies it next to dist/server.js.
-// Library build: fall back to resolving chart.js from node_modules, since a downstream
-// server consuming this package has its own dist/ layout.
+// Library build: locate chart.js through Node's own resolution, since a downstream
+// server consuming this package has its own dist/ layout and may run from any cwd.
+
+/**
+ * Resolve chart.js's UMD bundle via Node module resolution.
+ *
+ * chart.js ships an `exports` map that refuses both `chart.js/dist/*` and
+ * `chart.js/package.json`, so neither can be resolved directly. The package root
+ * *is* resolvable though, so we resolve that and walk to its sibling UMD file.
+ * Resolution starts from this module's location, which means it finds chart.js
+ * whether it is a direct dependency or hoisted into a parent node_modules — and,
+ * unlike a cwd-based guess, it does not depend on where the process was started.
+ */
+function resolveChartJsUmd(): string | undefined {
+	try {
+		const require_ = createRequire(__filename);
+		// e.g. <root>/node_modules/chart.js/dist/chart.cjs → <root>/node_modules/chart.js/dist
+		return join(dirname(require_.resolve('chart.js')), 'chart.umd.min.js');
+	} catch {
+		return undefined;
+	}
+}
+
 const _chartJsCode: string = (() => {
 	const candidates = [
 		process.env.CHART_JS_PATH,
 		join(__dirname, 'chart.min.js'),
 		join(__dirname, '..', 'chart.min.js'),
-		// Library consumers: chart.js does not export its dist files, so read it directly.
-		join(process.cwd(), 'node_modules', 'chart.js', 'dist', 'chart.umd.min.js'),
+		resolveChartJsUmd(),
 	].filter((p): p is string => Boolean(p));
 
 	for (const candidate of candidates) {
@@ -40,7 +61,13 @@ const _chartJsCode: string = (() => {
 			return readFileSync(candidate, 'utf-8');
 		} catch { /* try next candidate */ }
 	}
-	return '/* chart.js not bundled — run npm run build in sharing-server/ */';
+	console.warn(
+		'[dashboard] Chart.js not found — charts will not render. ' +
+		'Run `npm run build` in sharing-server/, or if you are consuming this package as a ' +
+		'library, install the optional peer dependency (`npm install chart.js`) or point ' +
+		'CHART_JS_PATH at a chart.umd.min.js file.',
+	);
+	return '/* chart.js not found — see the server log for how to provide it */';
 })();
 
 // ── Auth ─────────────────────────────────────────────────────────────────────

--- a/sharing-server/src/routes/dashboard.ts
+++ b/sharing-server/src/routes/dashboard.ts
@@ -22,14 +22,25 @@ const DEPLOY_SHA    = process.env.DEPLOY_SHA    ?? 'unknown';
 const DEPLOY_BRANCH = process.env.DEPLOY_BRANCH ?? 'unknown';
 const DEPLOY_DATE   = process.env.DEPLOY_DATE   ?? 'unknown';
 
-// Load Chart.js UMD bundle once at startup — copied to dist/ by esbuild.js
-// eslint-disable-next-line @typescript-eslint/no-require-imports
+// Load Chart.js UMD bundle once at startup.
+// Bundled build: esbuild.js copies it next to dist/server.js.
+// Library build: fall back to resolving chart.js from node_modules, since a downstream
+// server consuming this package has its own dist/ layout.
 const _chartJsCode: string = (() => {
-	try {
-		return readFileSync(join(__dirname, 'chart.min.js'), 'utf-8');
-	} catch {
-		return '/* chart.js not bundled — run npm run build in sharing-server/ */';
+	const candidates = [
+		process.env.CHART_JS_PATH,
+		join(__dirname, 'chart.min.js'),
+		join(__dirname, '..', 'chart.min.js'),
+		// Library consumers: chart.js does not export its dist files, so read it directly.
+		join(process.cwd(), 'node_modules', 'chart.js', 'dist', 'chart.umd.min.js'),
+	].filter((p): p is string => Boolean(p));
+
+	for (const candidate of candidates) {
+		try {
+			return readFileSync(candidate, 'utf-8');
+		} catch { /* try next candidate */ }
 	}
+	return '/* chart.js not bundled — run npm run build in sharing-server/ */';
 })();
 
 // ── Auth ─────────────────────────────────────────────────────────────────────

--- a/sharing-server/src/server.ts
+++ b/sharing-server/src/server.ts
@@ -1,112 +1,13 @@
-import { serve } from '@hono/node-server';
-import { Hono } from 'hono';
-import fs from 'node:fs';
-import path from 'node:path';
-import { api } from './routes/api.js';
-import { dashboard } from './routes/dashboard.js';
-import { getDb, closeDb, restoreFromBackup, backupToAzureFiles, syncAdminLogins } from './db.js';
-import { BACKUP_INTERVAL_MS } from './config.js';
+/**
+ * Standalone entry point for the OSS sharing server.
+ *
+ * Kept deliberately thin: all reusable pieces live in `app.ts` / `lifecycle.ts` so a
+ * downstream server can import them from the package root (see `index.ts`).
+ */
+import { createApp } from "./app.js";
+import { startServer } from "./lifecycle.js";
 
-const app = new Hono();
-
-// Serve the product icon used by the dashboard header. The icon is copied into
-// dist/images/ at build time so the bundled server remains self-contained.
-const iconPath = path.join(__dirname, 'images', 'icon.png');
-app.get('/icon.png', (c) => {
-	if (!fs.existsSync(iconPath)) {
-		return c.body('Icon not found', 404, { 'Content-Type': 'text/plain' });
-	}
-	const icon = fs.readFileSync(iconPath);
-	return c.body(icon, 200, {
-		'Content-Type': 'image/png',
-		'Cache-Control': 'public, max-age=86400',
-	});
-});
-
-// Health check — no auth required
-app.get('/health', (c) => c.json({
-	status: 'ok',
-	timestamp: new Date().toISOString(),
-	version: {
-		sha:    process.env.DEPLOY_SHA    ?? 'unknown',
-		branch: process.env.DEPLOY_BRANCH ?? 'unknown',
-		date:   process.env.DEPLOY_DATE   ?? 'unknown',
-	},
-}));
-
-// API routes (Bearer GitHub token auth)
-app.route('/api', api);
-
-// Dashboard + auth routes (session cookie)
-app.route('/', dashboard);
-
-// 404 fallback
-app.notFound((c) => c.json({ error: 'Not found' }, 404));
-
-// Log unhandled errors so they appear in container logs (ACA / Docker)
-app.onError((err, c) => {
-	console.error(`[${new Date().toISOString()}] Unhandled error on ${c.req.method} ${c.req.path}:`, err);
-	return c.text('Internal Server Error', 500);
-});
-
-// Backup DB to Azure Files then close cleanly on shutdown.
-// Azure Files is the persistence layer; SQLite runs on local container disk.
-function shutdown(signal: string): void {
-	console.log(`Received ${signal}, backing up database and exiting...`);
-	backupToAzureFiles();
-	closeDb();
-	process.exit(0);
-}
-process.on('SIGTERM', () => shutdown('SIGTERM'));
-process.on('SIGINT',  () => shutdown('SIGINT'));
-
-async function initDbWithRetry(maxAttempts = 20): Promise<void> {
-	for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-		try {
-			getDb();
-			console.log(`[db] Initialised successfully (attempt ${attempt})`);
-			return;
-		} catch (err) {
-			if (attempt < maxAttempts) {
-				const delay = Math.min(attempt * 5_000, 30_000);
-				console.warn(`[db] Init attempt ${attempt}/${maxAttempts} failed: ${err}. Retrying in ${delay}ms…`);
-				await new Promise(r => setTimeout(r, delay));
-			} else {
-				console.error('[db] All init attempts exhausted:', err);
-				throw err;
-			}
-		}
-	}
-}
-
-const PORT = parseInt(process.env.PORT ?? '3000', 10);
-
-async function main(): Promise<void> {
-	// Restore database from Azure Files backup before opening SQLite.
-	// SQLite runs on local container disk (/tmp/db) to avoid Azure Files SMB
-	// locking issues. Azure Files is used only as a backup/restore store.
-	restoreFromBackup();
-	await initDbWithRetry();
-	syncAdminLogins();
-	// Periodic backup every 5 minutes in case of unexpected SIGKILL.
-	setInterval(() => backupToAzureFiles(), BACKUP_INTERVAL_MS).unref();
-
-	const org = process.env.ALLOWED_GITHUB_ORG;
-	const adminLogins = process.env.ADMIN_GITHUB_LOGINS;
-	serve({ fetch: app.fetch, port: PORT }, (info) => {
-		console.log(`Token Tracker sharing server listening on port ${info.port}`);
-		if (org) {
-			console.log(`  Access restricted to members of GitHub org: ${org}`);
-		} else {
-			console.log('  Access: open to any GitHub user (set ALLOWED_GITHUB_ORG to restrict)');
-		}
-		if (adminLogins) {
-			console.log(`  Admin logins (ADMIN_GITHUB_LOGINS): ${adminLogins}`);
-		}
-	});
-}
-
-main().catch(err => {
-	console.error('Fatal startup error:', err);
+startServer(createApp()).catch(err => {
+	console.error("Fatal startup error:", err);
 	process.exit(1);
 });

--- a/sharing-server/src/test/app.test.ts
+++ b/sharing-server/src/test/app.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Unit tests for the library composition surface added so downstream servers can
+ * build on this package instead of forking it:
+ *  - createApp: health payload, healthExtra merging, extend-before-builtins
+ *    precedence, and the mountApi / mountDashboard toggles
+ *  - registerShutdownHandlers: idempotency, so repeated calls (or several
+ *    servers in one process) do not stack duplicate signal listeners
+ *
+ * No database or network access is required: only routes that avoid the DB are
+ * exercised, so these tests stay fast and hermetic.
+ */
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { Hono } from 'hono';
+import { createApp } from '../app.js';
+import { registerShutdownHandlers } from '../lifecycle.js';
+
+describe('createApp', () => {
+	test('serves /health without auth', async () => {
+		const res = await createApp().request('/health');
+		assert.equal(res.status, 200);
+		const body = await res.json() as Record<string, unknown>;
+		assert.equal(body.status, 'ok');
+		assert.ok(body.version, 'expected a version stamp');
+	});
+
+	test('merges healthExtra into the health payload', async () => {
+		const app = createApp({ healthExtra: () => ({ edition: 'downstream' }) });
+		const body = await (await app.request('/health')).json() as Record<string, unknown>;
+		assert.equal(body.edition, 'downstream');
+		// Core fields must survive the merge.
+		assert.equal(body.status, 'ok');
+	});
+
+	test('mounts extend routes and can add new paths', async () => {
+		const app = createApp({
+			extend: (a) => { a.get('/api/vendor/ping', (c) => c.text('pong')); },
+		});
+		const res = await app.request('/api/vendor/ping');
+		assert.equal(res.status, 200);
+		assert.equal(await res.text(), 'pong');
+	});
+
+	test('extend runs before built-in routes so downstream can override them', async () => {
+		// This ordering is the contract that lets a downstream server replace a
+		// built-in page without forking; Hono resolves in registration order.
+		const app = createApp({
+			extend: (a) => { a.get('/health', (c) => c.text('overridden')); },
+		});
+		assert.equal(await (await app.request('/health')).text(), 'overridden');
+	});
+
+	test('honours mountApi: false and mountDashboard: false', async () => {
+		const app = createApp({ mountApi: false, mountDashboard: false });
+		// With both unmounted, previously-served paths fall through to the 404 handler.
+		const res = await app.request('/dashboard');
+		assert.equal(res.status, 404);
+		assert.deepEqual(await res.json(), { error: 'Not found' });
+	});
+
+	test('returns a Hono instance', () => {
+		assert.ok(createApp() instanceof Hono);
+	});
+});
+
+describe('registerShutdownHandlers', () => {
+	test('is idempotent across repeated calls', () => {
+		// startServer() calls this too, so a downstream app that also calls it (or a
+		// test run that starts several servers) must not stack duplicate handlers
+		// that would double-run the backup and emit MaxListenersExceededWarning.
+		const before = {
+			SIGTERM: process.listenerCount('SIGTERM'),
+			SIGINT:  process.listenerCount('SIGINT'),
+		};
+
+		registerShutdownHandlers();
+		const afterFirst = {
+			SIGTERM: process.listenerCount('SIGTERM'),
+			SIGINT:  process.listenerCount('SIGINT'),
+		};
+
+		for (let i = 0; i < 5; i++) {
+			registerShutdownHandlers();
+		}
+		const afterMany = {
+			SIGTERM: process.listenerCount('SIGTERM'),
+			SIGINT:  process.listenerCount('SIGINT'),
+		};
+
+		assert.equal(afterFirst.SIGTERM, before.SIGTERM + 1);
+		assert.equal(afterFirst.SIGINT,  before.SIGINT + 1);
+		assert.deepEqual(afterMany, afterFirst, 'repeated calls must not add listeners');
+	});
+});

--- a/sharing-server/src/test/schemaExtension.test.ts
+++ b/sharing-server/src/test/schemaExtension.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Unit tests for the schema-extension hook that lets a downstream server add its own
+ * tables without forking this package:
+ *  - extensions run during getDb() and receive a usable handle
+ *  - an extension (or a helper it calls) may call getDb() re-entrantly and gets the
+ *    same handle back, rather than recursively opening new ones
+ *  - registering the same name twice is a no-op
+ *  - registering after the database is open applies immediately
+ *  - a failing extension does not leave a half-initialised database behind
+ *
+ * Uses a real node:sqlite database in a temp directory via LOCAL_DATA_DIR.
+ */
+import { test, describe, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+let tempDir: string;
+
+before(() => {
+	tempDir = mkdtempSync(join(tmpdir(), 'schema-ext-test-'));
+	process.env.LOCAL_DATA_DIR = tempDir;
+});
+
+after(async () => {
+	// Close the handle first: on Windows the open SQLite file blocks rmSync with EPERM.
+	const { closeDb } = await import('../db.js');
+	closeDb();
+	rmSync(tempDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 50 });
+});
+
+describe('registerSchemaExtension', () => {
+	beforeEach(async () => {
+		const { closeDb } = await import('../db.js');
+		closeDb();
+	});
+
+	test('runs the extension during getDb() with a usable handle', async () => {
+		const { getDb, registerSchemaExtension, closeDb } = await import('../db.js');
+		closeDb();
+
+		let received: unknown;
+		registerSchemaExtension('ext-basic', (db) => {
+			received = db;
+			db.exec('CREATE TABLE IF NOT EXISTS ext_basic (id INTEGER PRIMARY KEY)');
+		});
+
+		const db = getDb();
+		assert.equal(received, db, 'extension should receive the live handle');
+		// The table must really exist, not just have been "executed".
+		db.exec('INSERT INTO ext_basic (id) VALUES (1)');
+		assert.equal(db.prepare('SELECT COUNT(*) AS n FROM ext_basic').get()!.n, 1);
+	});
+
+	test('tolerates an extension that calls getDb() re-entrantly', async () => {
+		// A downstream extension is handed `db`, but may call a query helper that
+		// reaches for getDb() itself. If getDb() had not published the handle before
+		// running extensions, this recursed and opened a new SQLite handle each time.
+		const { getDb, registerSchemaExtension, closeDb } = await import('../db.js');
+		closeDb();
+
+		let depth = 0;
+		let maxDepth = 0;
+		let invocations = 0;
+		let innerHandle: unknown;
+		registerSchemaExtension('ext-reentrant', () => {
+			// Track nesting depth rather than a raw count: this extension stays
+			// registered for the rest of the suite and runs on every later getDb(),
+			// but it must never be *nested* inside itself.
+			depth++;
+			maxDepth = Math.max(maxDepth, depth);
+			invocations++;
+			try {
+				innerHandle = getDb();
+			} finally {
+				depth--;
+			}
+		});
+
+		invocations = 0;
+		maxDepth = 0;
+		const outer = getDb();
+		assert.equal(maxDepth, 1, 'extension re-entered itself — getDb() is recursing');
+		assert.equal(invocations, 1, 'extension should run exactly once');
+		assert.equal(innerHandle, outer, 're-entrant getDb() must return the same handle');
+	});
+
+	test('ignores a duplicate registration of the same name', async () => {
+		const { getDb, registerSchemaExtension, closeDb } = await import('../db.js');
+		closeDb();
+
+		let count = 0;
+		registerSchemaExtension('ext-dupe', () => { count++; });
+		registerSchemaExtension('ext-dupe', () => { count += 100; });
+
+		count = 0;
+		getDb();
+		assert.equal(count, 1, 'only the first registration should apply');
+	});
+
+	test('applies immediately when registered after the database is open', async () => {
+		const { getDb, registerSchemaExtension, closeDb } = await import('../db.js');
+		closeDb();
+
+		getDb();
+		let applied = false;
+		registerSchemaExtension('ext-late', (db) => {
+			applied = true;
+			db.exec('CREATE TABLE IF NOT EXISTS ext_late (id INTEGER PRIMARY KEY)');
+		});
+		assert.ok(applied, 'late registration should apply against the open database');
+	});
+
+	test('does not leave a half-initialised database when an extension throws', async () => {
+		const { getDb, registerSchemaExtension, closeDb } = await import('../db.js');
+		closeDb();
+
+		let attempts = 0;
+		let shouldThrow = true;
+		registerSchemaExtension('ext-throws', () => {
+			attempts++;
+			if (shouldThrow) {
+				shouldThrow = false;
+				throw new Error('boom');
+			}
+		});
+
+		attempts = 0;
+		assert.throws(() => getDb(), /boom/);
+		// The failed handle must have been rolled back, so the next call retries
+		// initialisation rather than handing out a partially-built database.
+		const db = getDb();
+		assert.equal(attempts, 2, 'second getDb() should re-run initialisation');
+		assert.ok(db, 'retry should succeed once the extension stops throwing');
+	});
+});

--- a/sharing-server/tsconfig.lib.json
+++ b/sharing-server/tsconfig.lib.json
@@ -1,0 +1,13 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"module": "CommonJS",
+		"moduleResolution": "node",
+		"outDir": "lib",
+		"declaration": true,
+		"declarationMap": true,
+		"sourceMap": true
+	},
+	"include": ["src/**/*.ts"],
+	"exclude": ["node_modules", "dist", "lib"]
+}


### PR DESCRIPTION
Makes the sharing server consumable as a library so downstream editions can compose it instead of forking it.

- `createApp({ extend, healthExtra, mountApi, mountDashboard })` returns the Hono app; `extend` runs before built-in routes so downstream can override a path.
- `registerSchemaExtension(name, fn)` lets downstream servers create their own tables, applied inside `getDb()` right after `initSchema`. Downstream data stays in downstream tables, so migrations stay independent.
- `startServer` / `initDbWithRetry` / `registerShutdownHandlers` lifecycle helpers.
- New `src/index.ts` public entry point. `src/server.ts` is now a ~6-line entry; standalone behaviour is unchanged.

Packaging: dual build (esbuild bundle for the container + `build:lib` producing CommonJS/declarations in `lib/`), an `exports` map, and `chart.js` as an optional peer dependency with multi-candidate resolution. The package is deliberately not `type: module`, which would break the CJS bundle.

CI: new `sharing-server-publish.yml` using npm OIDC trusted publishing (no NPM_TOKEN), triggered by a `sharing-server/v*` tag or workflow_dispatch. `sharing-server-deploy.yml` gains a `verify` job that `build` depends on.

Naming: npm package is `@rajbos/ai-engineering-fluency-sharing-server`. The GHCR image name is intentionally left as `copilot-sharing-server` so existing deployments keep working.

Verified: check-types, build:lib and the bundled build pass; standalone `/health` and `/dashboard` return 200; and the packed tarball was installed into a downstream consumer that type-checked, built and booted against it.

Note: the first npm publish must be done manually with a token, since npm has no pending-publisher concept.