### PR TITLE
fix(ci): fall back to pinned Node version when .nvmrc is missing in Copilot setup steps

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -40,10 +40,24 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      # Copilot code review runs these setup steps against the PR head checkout,
+      # which can be an old branch that predates the root .nvmrc file. Resolve the
+      # version with a fallback so setup-node never fails on a missing file.
+      # Keep the fallback in sync with .nvmrc.
+      - name: Resolve Node.js version
+        id: node-version
+        run: |
+          if [ -f .nvmrc ]; then
+            echo "version=$(tr -d '[:space:]' < .nvmrc)" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::.nvmrc not found in this checkout (stale branch?) - falling back to Node 24"
+            echo "version=24" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version-file: ".nvmrc"
+          node-version: ${{ steps.node-version.outputs.version }}
           cache: "npm"
           cache-dependency-path: "**/package-lock.json"
 


### PR DESCRIPTION
## Problem

On PR #1863, Copilot code review posted a comment that a custom setup step failed:

> One or more custom setup steps configured for this repository failed during this Copilot code review run:
> `Set up Node.js`

The [workflow run](https://github.com/rajbos/ai-engineering-fluency/actions/runs/33084731722) shows:

```
##[error]The specified node version file at: /home/runner/work/ai-engineering-fluency/ai-engineering-fluency/.nvmrc does not exist
```

**Root cause:** Copilot code review runs `copilot-setup-steps.yml` against the *PR head checkout*. That PR branch predated the commit that added the root `.nvmrc` file (`7e4c9d02`), so `actions/setup-node` with `node-version-file: ".nvmrc"` failed hard. Any review of a stale branch older than `.nvmrc` hits this.

## Fix

Resolve the Node version in a shell step before `setup-node`:

- Read `.nvmrc` when it exists (single source of truth preserved).
- Otherwise emit a warning annotation and fall back to Node 24 (matching the current `.nvmrc`, with a comment to keep them in sync).

This makes the setup steps robust regardless of which historical ref Copilot happens to review.

## Validation

- YAML parses cleanly (step list and `with:` block verified programmatically).
- The workflow triggers on changes to itself, so the `Copilot Setup Steps` run on this PR validates the change end-to-end.