### PR TITLE
ci: use --allow-all-tools instead of --allow-all in Copilot CLI workflows

### DIFF
--- a/.github/workflows/mutation-benchmark.yml
+++ b/.github/workflows/mutation-benchmark.yml
@@ -221,11 +221,14 @@ jobs:
         echo ""
         echo "=== Copilot CLI output ==="
 
+        # --allow-all-tools (not --allow-all): the agent only needs workspace
+        # file access and shell tools (gh), so don't grant --allow-all-paths
+        # or --allow-all-urls (least privilege).
         COPILOT_PROMPT_TEXT=$(cat /tmp/copilot-prompt.md)
         npx @github/copilot \
           -p "$COPILOT_PROMPT_TEXT" \
           --silent \
-          --allow-all \
+          --allow-all-tools \
           --add-dir "${GITHUB_WORKSPACE}" \
           --no-ask-user 2>&1 || {
             EXIT_CODE=$?

--- a/.github/workflows/sync-toolnames.yml
+++ b/.github/workflows/sync-toolnames.yml
@@ -110,11 +110,15 @@ jobs:
         cd "${GITHUB_WORKSPACE}/current-repo/"
         
         # Run gh copilot with the prompt using non-interactive mode
-        # Use -s/--silent for script-friendly output, -p for prompt, --allow-all for permissions
+        # Use -s/--silent for script-friendly output, -p for prompt,
+        # --allow-all-tools for tool permissions. Unlike --allow-all this does
+        # not grant --allow-all-paths/--allow-all-urls: file access stays
+        # confined to the workspace and the --add-dir paths below (least
+        # privilege), which covers everything this prompt needs.
         # Read the prompt into a variable for safer handling
         COPILOT_PROMPT_TEXT=$(cat /tmp/copilot-prompt.md)
         # > /tmp/copilot-output.txt
-        npx @github/copilot -p "$COPILOT_PROMPT_TEXT" --silent --allow-all --add-dir "${UPSTREAM_PATH}" --add-dir "${GITHUB_WORKSPACE}/current-repo" --no-ask-user  2>&1 || {
+        npx @github/copilot -p "$COPILOT_PROMPT_TEXT" --silent --allow-all-tools --add-dir "${UPSTREAM_PATH}" --add-dir "${GITHUB_WORKSPACE}/current-repo" --no-ask-user  2>&1 || {
           EXIT_CODE=$?
           echo "Warning: gh copilot command exited with code $EXIT_CODE, but continuing to check output"
           cat /tmp/copilot-output.txt 2>/dev/null || true


### PR DESCRIPTION
## Why

A review comment on another PR claimed `--allow-all-tools` is "likely an invalid flag" and that `--allow-all` should be used for consistency. That claim is incorrect: `copilot --help` confirms both flags exist, and `--allow-all` is shorthand for `--allow-all-tools --allow-all-paths --allow-all-urls`. For CI jobs that only need tool execution plus workspace file access, `--allow-all` over-grants. This PR switches the remaining two workflows to the narrower flag (least privilege).

## What changed

- **`.github/workflows/sync-toolnames.yml`**: `--allow-all` -> `--allow-all-tools`. The agent only reads/writes the workspace and the `--add-dir` paths (current repo + checked-out upstream repo) and runs shell/python; it never needs URL access or paths outside those directories.
- **`.github/workflows/mutation-benchmark.yml`**: `--allow-all` -> `--allow-all-tools`. The agent only reads the mutation report and TS sources in the workspace and runs `gh` via the shell tool, which `--allow-all-tools` covers.
- **`.github/workflows/pr-risk-review.yml`**: unchanged - it already uses `--allow-all-tools` together with explicit `--deny-tool` rules.

With `--no-ask-user` already set, any permission that is not granted is denied rather than prompted, so dropping `--allow-all-paths`/`--allow-all-urls` cannot hang these jobs.

## Validation

- `copilot --help` output confirming `--allow-all-tools` is a valid flag and `--allow-all` = `--allow-all-tools --allow-all-paths --allow-all-urls`
- YAML parse check on all three workflows
- `actionlint` clean on all three workflows

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>