### PR TITLE
Show untracked Copilot AIC usage and rename billing coverage title

### DIFF
--- a/visualstudio-extension/src/AIEngineeringFluency/webview/chart.js
+++ b/visualstudio-extension/src/AIEngineeringFluency/webview/chart.js
@@ -16186,78 +16186,113 @@ To suppress this warning, set window.${CONFIG_KEY} to true`);
     return button;
   }
 
+  // src/webview/shared/localization.ts
+  var DEFAULT_LOCALIZATION = {
+    "nav.btnRefresh": "Refresh",
+    "nav.btnDetails": "Details",
+    "nav.btnChart": "Chart",
+    "nav.btnUsage": "Usage Analysis",
+    "nav.btnDiagnostics": "Diagnostics",
+    "nav.btnMaturity": "Fluency Score",
+    "nav.btnDashboard": "Team Dashboard",
+    "nav.btnLevelViewer": "Level Viewer",
+    "nav.btnEnvironmental": "Environmental Impact",
+    "nav.btnEfficiency": "Efficiency"
+  };
+  var currentLocalization = { ...DEFAULT_LOCALIZATION };
+  function initializeWebviewLocalization(localization) {
+    currentLocalization = { ...DEFAULT_LOCALIZATION, ...localization };
+  }
+  function localize(key) {
+    return currentLocalization[key] || DEFAULT_LOCALIZATION[key] || key;
+  }
+  var currentLanguage = "en";
+  function setCurrentLanguage(language) {
+    currentLanguage = language;
+  }
+
   // src/webview/shared/buttonConfig.ts
-  var BUTTONS = {
+  var BUTTON_DEFS = {
     "btn-refresh": {
       id: "btn-refresh",
-      label: "Refresh",
+      labelKey: "nav.btnRefresh",
       icon: "refresh",
       appearance: "primary"
     },
     "btn-details": {
       id: "btn-details",
-      label: "Details",
+      labelKey: "nav.btnDetails",
       icon: "robot",
       iconColor: "#c37bff",
       appearance: "secondary"
     },
     "btn-chart": {
       id: "btn-chart",
-      label: "Chart",
+      labelKey: "nav.btnChart",
       icon: "graph-line",
       iconColor: "#60a5fa",
       appearance: "secondary"
     },
     "btn-usage": {
       id: "btn-usage",
-      label: "Usage Analysis",
+      labelKey: "nav.btnUsage",
       icon: "graph",
       iconColor: "#22d3ee",
       appearance: "secondary"
     },
     "btn-diagnostics": {
       id: "btn-diagnostics",
-      label: "Diagnostics",
+      labelKey: "nav.btnDiagnostics",
       icon: "search",
       iconColor: "#fb7185",
       appearance: "secondary"
     },
     "btn-maturity": {
       id: "btn-maturity",
-      label: "Fluency Score",
+      labelKey: "nav.btnMaturity",
       icon: "target",
       iconColor: "#fbbf24",
       appearance: "secondary"
     },
     "btn-dashboard": {
       id: "btn-dashboard",
-      label: "Team Dashboard",
+      labelKey: "nav.btnDashboard",
       icon: "organization",
       iconColor: "#818cf8",
       appearance: "secondary"
     },
     "btn-level-viewer": {
       id: "btn-level-viewer",
-      label: "Level Viewer",
+      labelKey: "nav.btnLevelViewer",
       icon: "list-tree",
       iconColor: "#94a3b8",
       appearance: "secondary"
     },
     "btn-environmental": {
       id: "btn-environmental",
-      label: "Environmental Impact",
+      labelKey: "nav.btnEnvironmental",
       icon: "globe",
       iconColor: "#4ade80",
       appearance: "secondary"
     },
     "btn-efficiency": {
       id: "btn-efficiency",
-      label: "Efficiency",
+      labelKey: "nav.btnEfficiency",
       icon: "dashboard",
       iconColor: "#f472b6",
       appearance: "secondary"
     }
   };
+  var BUTTONS = new Proxy({}, {
+    get(_target, prop) {
+      const def = BUTTON_DEFS[prop];
+      if (!def) {
+        return void 0;
+      }
+      const { labelKey, ...rest } = def;
+      return { ...rest, label: localize(labelKey) };
+    }
+  });
   var NAV_ORDER = [
     "btn-refresh",
     "btn-details",
@@ -16789,6 +16824,11 @@ body[data-vscode-theme-kind="vscode-high-contrast-light"] .title {
   // src/webview/chart/main.ts
   var vscode = acquireVsCodeApi();
   var initialData = getWindowData("__INITIAL_CHART__");
+  if (initialData?.localization) {
+    initializeWebviewLocalization(initialData.localization);
+    const language = initialData.localization["__language__"] || "en";
+    setCurrentLanguage(language);
+  }
   var chart;
   var Chart2;
   async function loadChartModule() {

--- a/visualstudio-extension/src/AIEngineeringFluency/webview/details.js
+++ b/visualstudio-extension/src/AIEngineeringFluency/webview/details.js
@@ -1695,15 +1695,41 @@ To suppress this warning, set window.${CONFIG_KEY} to true`);
       _modelNames[modelId] = pricing.displayNames[0];
     }
   }
+  var CUSTOM_PROVIDER_SUFFIX = " (Custom)";
+  function decodeSegment(segment) {
+    try {
+      return decodeURIComponent(segment);
+    } catch {
+      return segment;
+    }
+  }
+  function parseCustomProviderModel(model) {
+    const parts = model.split("/");
+    if (parts.length !== 3 || parts.some((part) => part.trim() === "")) {
+      return void 0;
+    }
+    return {
+      source: decodeSegment(parts[0]),
+      providerName: decodeSegment(parts[1]),
+      modelId: decodeSegment(parts[2])
+    };
+  }
+  function getCustomProviderGroup(model) {
+    const parsed = parseCustomProviderModel(model);
+    return parsed ? `${parsed.providerName}${CUSTOM_PROVIDER_SUFFIX}` : void 0;
+  }
+  function isCustomProviderGroup(group) {
+    return group.endsWith(CUSTOM_PROVIDER_SUFFIX);
+  }
   function getModelDisplayName(model) {
     if (_modelNames[model]) {
       return _modelNames[model];
     }
-    try {
-      return decodeURIComponent(model);
-    } catch {
-      return model;
+    const custom = parseCustomProviderModel(model);
+    if (custom) {
+      return _modelNames[custom.modelId] ?? custom.modelId;
     }
+    return decodeSegment(model);
   }
 
   // src/editorIcons.ts
@@ -1854,78 +1880,113 @@ To suppress this warning, set window.${CONFIG_KEY} to true`);
     return button;
   }
 
+  // src/webview/shared/localization.ts
+  var DEFAULT_LOCALIZATION = {
+    "nav.btnRefresh": "Refresh",
+    "nav.btnDetails": "Details",
+    "nav.btnChart": "Chart",
+    "nav.btnUsage": "Usage Analysis",
+    "nav.btnDiagnostics": "Diagnostics",
+    "nav.btnMaturity": "Fluency Score",
+    "nav.btnDashboard": "Team Dashboard",
+    "nav.btnLevelViewer": "Level Viewer",
+    "nav.btnEnvironmental": "Environmental Impact",
+    "nav.btnEfficiency": "Efficiency"
+  };
+  var currentLocalization = { ...DEFAULT_LOCALIZATION };
+  function initializeWebviewLocalization(localization) {
+    currentLocalization = { ...DEFAULT_LOCALIZATION, ...localization };
+  }
+  function localize(key) {
+    return currentLocalization[key] || DEFAULT_LOCALIZATION[key] || key;
+  }
+  var currentLanguage = "en";
+  function setCurrentLanguage(language) {
+    currentLanguage = language;
+  }
+
   // src/webview/shared/buttonConfig.ts
-  var BUTTONS = {
+  var BUTTON_DEFS = {
     "btn-refresh": {
       id: "btn-refresh",
-      label: "Refresh",
+      labelKey: "nav.btnRefresh",
       icon: "refresh",
       appearance: "primary"
     },
     "btn-details": {
       id: "btn-details",
-      label: "Details",
+      labelKey: "nav.btnDetails",
       icon: "robot",
       iconColor: "#c37bff",
       appearance: "secondary"
     },
     "btn-chart": {
       id: "btn-chart",
-      label: "Chart",
+      labelKey: "nav.btnChart",
       icon: "graph-line",
       iconColor: "#60a5fa",
       appearance: "secondary"
     },
     "btn-usage": {
       id: "btn-usage",
-      label: "Usage Analysis",
+      labelKey: "nav.btnUsage",
       icon: "graph",
       iconColor: "#22d3ee",
       appearance: "secondary"
     },
     "btn-diagnostics": {
       id: "btn-diagnostics",
-      label: "Diagnostics",
+      labelKey: "nav.btnDiagnostics",
       icon: "search",
       iconColor: "#fb7185",
       appearance: "secondary"
     },
     "btn-maturity": {
       id: "btn-maturity",
-      label: "Fluency Score",
+      labelKey: "nav.btnMaturity",
       icon: "target",
       iconColor: "#fbbf24",
       appearance: "secondary"
     },
     "btn-dashboard": {
       id: "btn-dashboard",
-      label: "Team Dashboard",
+      labelKey: "nav.btnDashboard",
       icon: "organization",
       iconColor: "#818cf8",
       appearance: "secondary"
     },
     "btn-level-viewer": {
       id: "btn-level-viewer",
-      label: "Level Viewer",
+      labelKey: "nav.btnLevelViewer",
       icon: "list-tree",
       iconColor: "#94a3b8",
       appearance: "secondary"
     },
     "btn-environmental": {
       id: "btn-environmental",
-      label: "Environmental Impact",
+      labelKey: "nav.btnEnvironmental",
       icon: "globe",
       iconColor: "#4ade80",
       appearance: "secondary"
     },
     "btn-efficiency": {
       id: "btn-efficiency",
-      label: "Efficiency",
+      labelKey: "nav.btnEfficiency",
       icon: "dashboard",
       iconColor: "#f472b6",
       appearance: "secondary"
     }
   };
+  var BUTTONS = new Proxy({}, {
+    get(_target, prop) {
+      const def = BUTTON_DEFS[prop];
+      if (!def) {
+        return void 0;
+      }
+      const { labelKey, ...rest } = def;
+      return { ...rest, label: localize(labelKey) };
+    }
+  });
   var NAV_ORDER = [
     "btn-refresh",
     "btn-details",
@@ -2323,6 +2384,9 @@ body[data-vscode-theme-kind="vscode-high-contrast-light"] .title {
     "MS Scout (Copilot CLI)"
   ]);
 
+  // ../src/tokenEstimation.ts
+  var NANO_AIU_TO_DOLLARS = 1 / 1e11;
+
   // ../src/chartDataBuilder.ts
   var MODEL_PROVIDER_PREFIXES = [
     ["anthropic", "Anthropic"],
@@ -2346,11 +2410,19 @@ body[data-vscode-theme-kind="vscode-high-contrast-light"] .title {
     ["raptor", "xAI"]
   ];
   function getModelBillingProvider(modelId) {
+    const customGroup = getCustomProviderGroup(modelId);
+    if (customGroup) {
+      return customGroup;
+    }
     const id = modelId.toLowerCase();
     const match = MODEL_PROVIDER_PREFIXES.find(([prefix]) => id.startsWith(prefix));
     return match ? match[1] : "Other";
   }
   function getBillingGroup(editor, modelId) {
+    const customGroup = getCustomProviderGroup(modelId);
+    if (customGroup) {
+      return customGroup;
+    }
     if (COPILOT_EDITOR_NAMES.has(editor)) {
       return "GitHub Copilot";
     }
@@ -2361,8 +2433,12 @@ body[data-vscode-theme-kind="vscode-high-contrast-light"] .title {
   var vscode = acquireVsCodeApi();
   var initialData = getWindowData("__INITIAL_DETAILS__");
   console.log("[CopilotTokenTracker] details webview loaded");
-  console.log("[CopilotTokenTracker] initialData:", initialData);
-  console.log("[CopilotTokenTracker] initialData:", initialData);
+  if (initialData?.localization) {
+    initializeWebviewLocalization(initialData.localization);
+    const language = initialData.localization["__language__"] || "en";
+    setCurrentLanguage(language);
+    console.log("[CopilotTokenTracker] Webview localization initialized for language:", language);
+  }
   var _initSort = initialData?.sortSettings;
   var editorSortKey = _initSort?.editor?.key ?? "name";
   var editorSortDir = _initSort?.editor?.dir ?? "asc";
@@ -2640,7 +2716,10 @@ body[data-vscode-theme-kind="vscode-high-contrast-light"] .title {
     "Other": "\u2754"
   };
   function getProviderIcon(provider) {
-    return PROVIDER_ICONS[provider] ?? "\u{1F4B5}";
+    if (PROVIDER_ICONS[provider]) {
+      return PROVIDER_ICONS[provider];
+    }
+    return isCustomProviderGroup(provider) ? "\u{1F9E9}" : "\u{1F4B5}";
   }
   function buildProviderCard(stats, provider) {
     const isExcluded = excludedProviders.has(provider);

--- a/visualstudio-extension/src/AIEngineeringFluency/webview/diagnostics.js
+++ b/visualstudio-extension/src/AIEngineeringFluency/webview/diagnostics.js
@@ -1572,78 +1572,113 @@ To suppress this warning, set window.${CONFIG_KEY} to true`);
     }
   });
 
+  // src/webview/shared/localization.ts
+  var DEFAULT_LOCALIZATION = {
+    "nav.btnRefresh": "Refresh",
+    "nav.btnDetails": "Details",
+    "nav.btnChart": "Chart",
+    "nav.btnUsage": "Usage Analysis",
+    "nav.btnDiagnostics": "Diagnostics",
+    "nav.btnMaturity": "Fluency Score",
+    "nav.btnDashboard": "Team Dashboard",
+    "nav.btnLevelViewer": "Level Viewer",
+    "nav.btnEnvironmental": "Environmental Impact",
+    "nav.btnEfficiency": "Efficiency"
+  };
+  var currentLocalization = { ...DEFAULT_LOCALIZATION };
+  function initializeWebviewLocalization(localization) {
+    currentLocalization = { ...DEFAULT_LOCALIZATION, ...localization };
+  }
+  function localize(key) {
+    return currentLocalization[key] || DEFAULT_LOCALIZATION[key] || key;
+  }
+  var currentLanguage = "en";
+  function setCurrentLanguage(language) {
+    currentLanguage = language;
+  }
+
   // src/webview/shared/buttonConfig.ts
-  var BUTTONS = {
+  var BUTTON_DEFS = {
     "btn-refresh": {
       id: "btn-refresh",
-      label: "Refresh",
+      labelKey: "nav.btnRefresh",
       icon: "refresh",
       appearance: "primary"
     },
     "btn-details": {
       id: "btn-details",
-      label: "Details",
+      labelKey: "nav.btnDetails",
       icon: "robot",
       iconColor: "#c37bff",
       appearance: "secondary"
     },
     "btn-chart": {
       id: "btn-chart",
-      label: "Chart",
+      labelKey: "nav.btnChart",
       icon: "graph-line",
       iconColor: "#60a5fa",
       appearance: "secondary"
     },
     "btn-usage": {
       id: "btn-usage",
-      label: "Usage Analysis",
+      labelKey: "nav.btnUsage",
       icon: "graph",
       iconColor: "#22d3ee",
       appearance: "secondary"
     },
     "btn-diagnostics": {
       id: "btn-diagnostics",
-      label: "Diagnostics",
+      labelKey: "nav.btnDiagnostics",
       icon: "search",
       iconColor: "#fb7185",
       appearance: "secondary"
     },
     "btn-maturity": {
       id: "btn-maturity",
-      label: "Fluency Score",
+      labelKey: "nav.btnMaturity",
       icon: "target",
       iconColor: "#fbbf24",
       appearance: "secondary"
     },
     "btn-dashboard": {
       id: "btn-dashboard",
-      label: "Team Dashboard",
+      labelKey: "nav.btnDashboard",
       icon: "organization",
       iconColor: "#818cf8",
       appearance: "secondary"
     },
     "btn-level-viewer": {
       id: "btn-level-viewer",
-      label: "Level Viewer",
+      labelKey: "nav.btnLevelViewer",
       icon: "list-tree",
       iconColor: "#94a3b8",
       appearance: "secondary"
     },
     "btn-environmental": {
       id: "btn-environmental",
-      label: "Environmental Impact",
+      labelKey: "nav.btnEnvironmental",
       icon: "globe",
       iconColor: "#4ade80",
       appearance: "secondary"
     },
     "btn-efficiency": {
       id: "btn-efficiency",
-      label: "Efficiency",
+      labelKey: "nav.btnEfficiency",
       icon: "dashboard",
       iconColor: "#f472b6",
       appearance: "secondary"
     }
   };
+  var BUTTONS = new Proxy({}, {
+    get(_target, prop) {
+      const def = BUTTON_DEFS[prop];
+      if (!def) {
+        return void 0;
+      }
+      const { labelKey, ...rest } = def;
+      return { ...rest, label: localize(labelKey) };
+    }
+  });
   var NAV_ORDER = [
     "btn-refresh",
     "btn-details",
@@ -3418,6 +3453,11 @@ This may take a few moments depending on the number of session files.
 The view will automatically update when data is ready.`;
   var vscode = acquireVsCodeApi();
   var initialData = getWindowData("__INITIAL_DIAGNOSTICS__");
+  if (initialData?.localization) {
+    initializeWebviewLocalization(initialData.localization);
+    const language = initialData.localization["__language__"] || "en";
+    setCurrentLanguage(language);
+  }
   var diagState = createViewStateManager(vscode, {
     activeTab: void 0,
     activeSubtab: void 0,

--- a/visualstudio-extension/src/AIEngineeringFluency/webview/environmental.js
+++ b/visualstudio-extension/src/AIEngineeringFluency/webview/environmental.js
@@ -1635,78 +1635,113 @@ To suppress this warning, set window.${CONFIG_KEY} to true`);
     return button;
   }
 
+  // src/webview/shared/localization.ts
+  var DEFAULT_LOCALIZATION = {
+    "nav.btnRefresh": "Refresh",
+    "nav.btnDetails": "Details",
+    "nav.btnChart": "Chart",
+    "nav.btnUsage": "Usage Analysis",
+    "nav.btnDiagnostics": "Diagnostics",
+    "nav.btnMaturity": "Fluency Score",
+    "nav.btnDashboard": "Team Dashboard",
+    "nav.btnLevelViewer": "Level Viewer",
+    "nav.btnEnvironmental": "Environmental Impact",
+    "nav.btnEfficiency": "Efficiency"
+  };
+  var currentLocalization = { ...DEFAULT_LOCALIZATION };
+  function initializeWebviewLocalization(localization) {
+    currentLocalization = { ...DEFAULT_LOCALIZATION, ...localization };
+  }
+  function localize(key) {
+    return currentLocalization[key] || DEFAULT_LOCALIZATION[key] || key;
+  }
+  var currentLanguage = "en";
+  function setCurrentLanguage(language) {
+    currentLanguage = language;
+  }
+
   // src/webview/shared/buttonConfig.ts
-  var BUTTONS = {
+  var BUTTON_DEFS = {
     "btn-refresh": {
       id: "btn-refresh",
-      label: "Refresh",
+      labelKey: "nav.btnRefresh",
       icon: "refresh",
       appearance: "primary"
     },
     "btn-details": {
       id: "btn-details",
-      label: "Details",
+      labelKey: "nav.btnDetails",
       icon: "robot",
       iconColor: "#c37bff",
       appearance: "secondary"
     },
     "btn-chart": {
       id: "btn-chart",
-      label: "Chart",
+      labelKey: "nav.btnChart",
       icon: "graph-line",
       iconColor: "#60a5fa",
       appearance: "secondary"
     },
     "btn-usage": {
       id: "btn-usage",
-      label: "Usage Analysis",
+      labelKey: "nav.btnUsage",
       icon: "graph",
       iconColor: "#22d3ee",
       appearance: "secondary"
     },
     "btn-diagnostics": {
       id: "btn-diagnostics",
-      label: "Diagnostics",
+      labelKey: "nav.btnDiagnostics",
       icon: "search",
       iconColor: "#fb7185",
       appearance: "secondary"
     },
     "btn-maturity": {
       id: "btn-maturity",
-      label: "Fluency Score",
+      labelKey: "nav.btnMaturity",
       icon: "target",
       iconColor: "#fbbf24",
       appearance: "secondary"
     },
     "btn-dashboard": {
       id: "btn-dashboard",
-      label: "Team Dashboard",
+      labelKey: "nav.btnDashboard",
       icon: "organization",
       iconColor: "#818cf8",
       appearance: "secondary"
     },
     "btn-level-viewer": {
       id: "btn-level-viewer",
-      label: "Level Viewer",
+      labelKey: "nav.btnLevelViewer",
       icon: "list-tree",
       iconColor: "#94a3b8",
       appearance: "secondary"
     },
     "btn-environmental": {
       id: "btn-environmental",
-      label: "Environmental Impact",
+      labelKey: "nav.btnEnvironmental",
       icon: "globe",
       iconColor: "#4ade80",
       appearance: "secondary"
     },
     "btn-efficiency": {
       id: "btn-efficiency",
-      label: "Efficiency",
+      labelKey: "nav.btnEfficiency",
       icon: "dashboard",
       iconColor: "#f472b6",
       appearance: "secondary"
     }
   };
+  var BUTTONS = new Proxy({}, {
+    get(_target, prop) {
+      const def = BUTTON_DEFS[prop];
+      if (!def) {
+        return void 0;
+      }
+      const { labelKey, ...rest } = def;
+      return { ...rest, label: localize(labelKey) };
+    }
+  });
   var NAV_ORDER = [
     "btn-refresh",
     "btn-details",
@@ -2137,6 +2172,11 @@ body[data-vscode-theme-kind="vscode-high-contrast-light"] .title {
   var WATER_LITERS_DAILY_DRINKING = 2;
   var vscode = acquireVsCodeApi();
   var initialData = getWindowData("__INITIAL_ENVIRONMENTAL__");
+  if (initialData?.localization) {
+    initializeWebviewLocalization(initialData.localization);
+    const language = initialData.localization["__language__"] || "en";
+    setCurrentLanguage(language);
+  }
   function calculateProjection(last30DaysValue) {
     return last30DaysValue / 30 * 365.25;
   }

--- a/visualstudio-extension/src/AIEngineeringFluency/webview/maturity.js
+++ b/visualstudio-extension/src/AIEngineeringFluency/webview/maturity.js
@@ -9384,78 +9384,113 @@ To suppress this warning, set window.${CONFIG_KEY} to true`);
     }
   });
 
+  // src/webview/shared/localization.ts
+  var DEFAULT_LOCALIZATION = {
+    "nav.btnRefresh": "Refresh",
+    "nav.btnDetails": "Details",
+    "nav.btnChart": "Chart",
+    "nav.btnUsage": "Usage Analysis",
+    "nav.btnDiagnostics": "Diagnostics",
+    "nav.btnMaturity": "Fluency Score",
+    "nav.btnDashboard": "Team Dashboard",
+    "nav.btnLevelViewer": "Level Viewer",
+    "nav.btnEnvironmental": "Environmental Impact",
+    "nav.btnEfficiency": "Efficiency"
+  };
+  var currentLocalization = { ...DEFAULT_LOCALIZATION };
+  function initializeWebviewLocalization(localization) {
+    currentLocalization = { ...DEFAULT_LOCALIZATION, ...localization };
+  }
+  function localize(key) {
+    return currentLocalization[key] || DEFAULT_LOCALIZATION[key] || key;
+  }
+  var currentLanguage = "en";
+  function setCurrentLanguage(language) {
+    currentLanguage = language;
+  }
+
   // src/webview/shared/buttonConfig.ts
-  var BUTTONS = {
+  var BUTTON_DEFS = {
     "btn-refresh": {
       id: "btn-refresh",
-      label: "Refresh",
+      labelKey: "nav.btnRefresh",
       icon: "refresh",
       appearance: "primary"
     },
     "btn-details": {
       id: "btn-details",
-      label: "Details",
+      labelKey: "nav.btnDetails",
       icon: "robot",
       iconColor: "#c37bff",
       appearance: "secondary"
     },
     "btn-chart": {
       id: "btn-chart",
-      label: "Chart",
+      labelKey: "nav.btnChart",
       icon: "graph-line",
       iconColor: "#60a5fa",
       appearance: "secondary"
     },
     "btn-usage": {
       id: "btn-usage",
-      label: "Usage Analysis",
+      labelKey: "nav.btnUsage",
       icon: "graph",
       iconColor: "#22d3ee",
       appearance: "secondary"
     },
     "btn-diagnostics": {
       id: "btn-diagnostics",
-      label: "Diagnostics",
+      labelKey: "nav.btnDiagnostics",
       icon: "search",
       iconColor: "#fb7185",
       appearance: "secondary"
     },
     "btn-maturity": {
       id: "btn-maturity",
-      label: "Fluency Score",
+      labelKey: "nav.btnMaturity",
       icon: "target",
       iconColor: "#fbbf24",
       appearance: "secondary"
     },
     "btn-dashboard": {
       id: "btn-dashboard",
-      label: "Team Dashboard",
+      labelKey: "nav.btnDashboard",
       icon: "organization",
       iconColor: "#818cf8",
       appearance: "secondary"
     },
     "btn-level-viewer": {
       id: "btn-level-viewer",
-      label: "Level Viewer",
+      labelKey: "nav.btnLevelViewer",
       icon: "list-tree",
       iconColor: "#94a3b8",
       appearance: "secondary"
     },
     "btn-environmental": {
       id: "btn-environmental",
-      label: "Environmental Impact",
+      labelKey: "nav.btnEnvironmental",
       icon: "globe",
       iconColor: "#4ade80",
       appearance: "secondary"
     },
     "btn-efficiency": {
       id: "btn-efficiency",
-      label: "Efficiency",
+      labelKey: "nav.btnEfficiency",
       icon: "dashboard",
       iconColor: "#f472b6",
       appearance: "secondary"
     }
   };
+  var BUTTONS = new Proxy({}, {
+    get(_target, prop) {
+      const def = BUTTON_DEFS[prop];
+      if (!def) {
+        return void 0;
+      }
+      const { labelKey, ...rest } = def;
+      return { ...rest, label: localize(labelKey) };
+    }
+  });
   var NAV_ORDER = [
     "btn-refresh",
     "btn-details",
@@ -10829,6 +10864,11 @@ body[data-vscode-theme-kind="vscode-high-contrast-light"] .demo-step-active.demo
   };
   var vscode = acquireVsCodeApi();
   var initialData = getWindowData("__INITIAL_MATURITY__");
+  if (initialData?.localization) {
+    initializeWebviewLocalization(initialData.localization);
+    const language = initialData.localization["__language__"] || "en";
+    setCurrentLanguage(language);
+  }
   var demoModeActive = false;
   var demoStageOverrides = [];
   var demoPanelExpanded = false;

--- a/visualstudio-extension/src/AIEngineeringFluency/webview/usage.js
+++ b/visualstudio-extension/src/AIEngineeringFluency/webview/usage.js
@@ -1668,78 +1668,113 @@ To suppress this warning, set window.${CONFIG_KEY} to true`);
     return { wrapper, select };
   }
 
+  // src/webview/shared/localization.ts
+  var DEFAULT_LOCALIZATION = {
+    "nav.btnRefresh": "Refresh",
+    "nav.btnDetails": "Details",
+    "nav.btnChart": "Chart",
+    "nav.btnUsage": "Usage Analysis",
+    "nav.btnDiagnostics": "Diagnostics",
+    "nav.btnMaturity": "Fluency Score",
+    "nav.btnDashboard": "Team Dashboard",
+    "nav.btnLevelViewer": "Level Viewer",
+    "nav.btnEnvironmental": "Environmental Impact",
+    "nav.btnEfficiency": "Efficiency"
+  };
+  var currentLocalization = { ...DEFAULT_LOCALIZATION };
+  function initializeWebviewLocalization(localization) {
+    currentLocalization = { ...DEFAULT_LOCALIZATION, ...localization };
+  }
+  function localize(key) {
+    return currentLocalization[key] || DEFAULT_LOCALIZATION[key] || key;
+  }
+  var currentLanguage = "en";
+  function setCurrentLanguage(language) {
+    currentLanguage = language;
+  }
+
   // src/webview/shared/buttonConfig.ts
-  var BUTTONS = {
+  var BUTTON_DEFS = {
     "btn-refresh": {
       id: "btn-refresh",
-      label: "Refresh",
+      labelKey: "nav.btnRefresh",
       icon: "refresh",
       appearance: "primary"
     },
     "btn-details": {
       id: "btn-details",
-      label: "Details",
+      labelKey: "nav.btnDetails",
       icon: "robot",
       iconColor: "#c37bff",
       appearance: "secondary"
     },
     "btn-chart": {
       id: "btn-chart",
-      label: "Chart",
+      labelKey: "nav.btnChart",
       icon: "graph-line",
       iconColor: "#60a5fa",
       appearance: "secondary"
     },
     "btn-usage": {
       id: "btn-usage",
-      label: "Usage Analysis",
+      labelKey: "nav.btnUsage",
       icon: "graph",
       iconColor: "#22d3ee",
       appearance: "secondary"
     },
     "btn-diagnostics": {
       id: "btn-diagnostics",
-      label: "Diagnostics",
+      labelKey: "nav.btnDiagnostics",
       icon: "search",
       iconColor: "#fb7185",
       appearance: "secondary"
     },
     "btn-maturity": {
       id: "btn-maturity",
-      label: "Fluency Score",
+      labelKey: "nav.btnMaturity",
       icon: "target",
       iconColor: "#fbbf24",
       appearance: "secondary"
     },
     "btn-dashboard": {
       id: "btn-dashboard",
-      label: "Team Dashboard",
+      labelKey: "nav.btnDashboard",
       icon: "organization",
       iconColor: "#818cf8",
       appearance: "secondary"
     },
     "btn-level-viewer": {
       id: "btn-level-viewer",
-      label: "Level Viewer",
+      labelKey: "nav.btnLevelViewer",
       icon: "list-tree",
       iconColor: "#94a3b8",
       appearance: "secondary"
     },
     "btn-environmental": {
       id: "btn-environmental",
-      label: "Environmental Impact",
+      labelKey: "nav.btnEnvironmental",
       icon: "globe",
       iconColor: "#4ade80",
       appearance: "secondary"
     },
     "btn-efficiency": {
       id: "btn-efficiency",
-      label: "Efficiency",
+      labelKey: "nav.btnEfficiency",
       icon: "dashboard",
       iconColor: "#f472b6",
       appearance: "secondary"
     }
   };
+  var BUTTONS = new Proxy({}, {
+    get(_target, prop) {
+      const def = BUTTON_DEFS[prop];
+      if (!def) {
+        return void 0;
+      }
+      const { labelKey, ...rest } = def;
+      return { ...rest, label: localize(labelKey) };
+    }
+  });
   var NAV_ORDER = [
     "btn-refresh",
     "btn-details",
@@ -2243,15 +2278,33 @@ body[data-vscode-theme-kind="vscode-high-contrast-light"] .title {
       _modelNames[modelId] = pricing.displayNames[0];
     }
   }
+  function decodeSegment(segment) {
+    try {
+      return decodeURIComponent(segment);
+    } catch {
+      return segment;
+    }
+  }
+  function parseCustomProviderModel(model) {
+    const parts = model.split("/");
+    if (parts.length !== 3 || parts.some((part) => part.trim() === "")) {
+      return void 0;
+    }
+    return {
+      source: decodeSegment(parts[0]),
+      providerName: decodeSegment(parts[1]),
+      modelId: decodeSegment(parts[2])
+    };
+  }
   function getModelDisplayName(model) {
     if (_modelNames[model]) {
       return _modelNames[model];
     }
-    try {
-      return decodeURIComponent(model);
-    } catch {
-      return model;
+    const custom = parseCustomProviderModel(model);
+    if (custom) {
+      return _modelNames[custom.modelId] ?? custom.modelId;
     }
+    return decodeSegment(model);
   }
 
   // ../src/tokenEstimation.ts
@@ -2625,6 +2678,11 @@ body[data-vscode-theme-kind="vscode-high-contrast-light"] .title {
     traceCuration(stage, details);
   }
   var initialData = getWindowData("__INITIAL_USAGE__");
+  if (initialData?.localization) {
+    initializeWebviewLocalization(initialData.localization);
+    const language = initialData.localization["__language__"] || "en";
+    setCurrentLanguage(language);
+  }
   var hygieneMatrixState = null;
   var repoAnalysisState = /* @__PURE__ */ new Map();
   var selectedRepoPath = null;
@@ -2636,7 +2694,8 @@ body[data-vscode-theme-kind="vscode-high-contrast-light"] .title {
   var currentInsights = [];
   var currentCurationAnalysis = null;
   var worktreeRoots = initialData?.worktreeScanRoots ? [...initialData.worktreeScanRoots] : [];
-  var worktreeResults = [];
+  var worktreeResults = initialData?.worktreeBackgroundScan ? initialData.worktreeBackgroundScan.worktrees.map(sanitizeWorktreeResult) : [];
+  var worktreeBackgroundScanMeta = initialData?.worktreeBackgroundScan ? { scannedAt: initialData.worktreeBackgroundScan.scannedAt, totalBytes: initialData.worktreeBackgroundScan.totalBytes } : null;
   var worktreeScanInProgress = false;
   var worktreeScanStatus = { root: "", checked: 0, total: 0, foundCount: 0, elapsedMs: 0 };
   var worktreeScanError = null;
@@ -3676,6 +3735,7 @@ ${_renderMultiModelMixedCostSessions(switching)}
     }
     worktreeScanInProgress = true;
     worktreeResults = [];
+    worktreeBackgroundScanMeta = null;
     worktreeScanError = null;
     worktreeScanStatus = { root: "", checked: 0, total: 0, foundCount: 0, elapsedMs: 0 };
     worktreeCleanupLog = [];
@@ -4006,6 +4066,16 @@ ${_renderMultiModelMixedCostSessions(switching)}
     worktreeScanInProgress = false;
     updateWorktreeControls();
   }
+  function handleWorktreeBackgroundResults(message) {
+    if (worktreeScanInProgress || worktreeCleanupInProgress) {
+      return;
+    }
+    const worktrees = Array.isArray(message.worktrees) ? message.worktrees : [];
+    worktreeResults = worktrees.map(sanitizeWorktreeResult);
+    worktreeBackgroundScanMeta = { scannedAt: String(message.scannedAt ?? ""), totalBytes: numField(message.totalBytes) };
+    updateWorktreeControls();
+    updateWorktreeResults();
+  }
   var _worktreeMessageHandlers = {
     worktreeRootPicked: handleWorktreeRootPicked,
     worktreeRootsDiscovered: handleWorktreeRootsDiscovered,
@@ -4022,6 +4092,7 @@ ${_renderMultiModelMixedCostSessions(switching)}
     worktreeDeleted: handleWorktreeDeleted,
     worktreeScanComplete: () => handleWorktreeScanComplete(),
     worktreeScanCancelled: () => handleWorktreeScanCancelled(),
+    worktreeBackgroundResults: handleWorktreeBackgroundResults,
     cleanupDeclined: () => handleCleanupDeclined(),
     cleanupStarted: handleCleanupStarted,
     cleanupWorktreeResult: handleCleanupWorktreeResult,
@@ -5211,6 +5282,15 @@ ${_renderMultiModelMixedCostSessions(switching)}
     }
     return _renderWorktreeScanningProgress(s4, seconds);
   }
+  function renderWorktreeBackgroundScanBanner() {
+    if (!worktreeBackgroundScanMeta || worktreeScanInProgress || worktreeResults.length === 0) {
+      return "";
+    }
+    const when = escapeHtml(new Date(worktreeBackgroundScanMeta.scannedAt).toLocaleString());
+    const size = formatFileSize(worktreeBackgroundScanMeta.totalBytes);
+    const count = worktreeResults.length;
+    return `<div class="info-box" style="margin-top: 12px;"><div>\u{1F333} Found automatically by the daily background scan: ${size} across ${count} worktree${count === 1 ? "" : "s"}, last checked ${when}. Scan again for the latest.</div></div>`;
+  }
   function renderWorktreeControls() {
     return `
     <div class="section">
@@ -5231,6 +5311,7 @@ ${_renderMultiModelMixedCostSessions(switching)}
         <button class="button" id="btn-scan-worktrees" ${worktreeScanInProgress || worktreeCleanupInProgress || worktreeRoots.length === 0 ? "disabled" : ""}>\u{1F50D} Scan for Worktrees</button>
         ${worktreeScanInProgress ? '<button class="button secondary" id="btn-cancel-worktree-scan">\u2715 Cancel</button>' : ""}
       </div>
+      ${renderWorktreeBackgroundScanBanner()}
       ${worktreeScanError ? `<div class="info-box" style="margin-top: 12px; border-color: #d97706; background: rgba(217,119,6,0.08);"><div>\u26A0\uFE0F ${escapeHtml(worktreeScanError)}</div></div>` : ""}
       <div id="worktree-progress-area">${renderWorktreeProgress()}</div>
     </div>`;
@@ -5496,13 +5577,29 @@ ${_renderMultiModelMixedCostSessions(switching)}
 			</div>
 		</div>`;
   }
-  function _billingExtGroupCostsHtml(groupCosts) {
-    const totalCostUsd = Object.values(groupCosts).reduce((s4, v2) => s4 + v2, 0);
-    const rows = Object.entries(groupCosts).sort(([, a3], [, b3]) => b3 - a3).map(([group, cost]) => `
-			<tr>
-				<td style="padding:4px 8px; font-size:12px; color:var(--text-primary);">${escapeHtml(group)}</td>
-				<td style="padding:4px 8px; font-size:12px; color:var(--text-primary); text-align:right;">$${formatFixed(cost, 2)}</td>
-			</tr>`).join("");
+  function _billingOtherSessionsCostUsd(groupCosts, api) {
+    if (!api) {
+      return 0;
+    }
+    const copilotCostUsd = groupCosts["GitHub Copilot"] ?? 0;
+    return Math.max(0, api.usedAiCredits * 0.01 - copilotCostUsd);
+  }
+  function _billingExtGroupCostsHtml(groupCosts, api) {
+    const otherSessionsCostUsd = _billingOtherSessionsCostUsd(groupCosts, api);
+    const hasLocalCopilotRow = "GitHub Copilot" in groupCosts;
+    const totalCostUsd = Object.values(groupCosts).reduce((s4, v2) => s4 + v2, 0) + otherSessionsCostUsd;
+    const otherSessionsRowHtml = otherSessionsCostUsd > 1e-3 ? `<tr>
+			<td style="padding:4px 8px; font-size:12px; color:var(--text-secondary);">GitHub Copilot - other sessions (remote or different environment)</td>
+			<td style="padding:4px 8px; font-size:12px; color:var(--text-secondary); text-align:right;">$${formatFixed(otherSessionsCostUsd, 2)}</td>
+		</tr>` : "";
+    const rows = Object.entries(groupCosts).sort(([, a3], [, b3]) => b3 - a3).map(([group, cost]) => {
+      const label = group === "GitHub Copilot" ? "GitHub Copilot - local sessions" : group;
+      return `
+				<tr>
+					<td style="padding:4px 8px; font-size:12px; color:var(--text-primary);">${escapeHtml(label)}</td>
+					<td style="padding:4px 8px; font-size:12px; color:var(--text-primary); text-align:right;">$${formatFixed(cost, 2)}</td>
+				</tr>${group === "GitHub Copilot" ? otherSessionsRowHtml : ""}`;
+    }).join("") + (hasLocalCopilotRow ? "" : otherSessionsRowHtml);
     return `
 		<div style="margin-bottom:12px;">
 			<div style="font-size:12px; font-weight:600; color:var(--text-secondary); margin-bottom:6px;">Extension tracked (this calendar month, IDE sessions only)</div>
@@ -5561,12 +5658,12 @@ ${_renderMultiModelMixedCostSessions(switching)}
     const totalCostUsd = groupCosts ? Object.values(groupCosts).reduce((s4, v2) => s4 + v2, 0) : 0;
     const nonCopilotCostUsd = totalCostUsd - copilotCostUsd;
     const apiHtml = api ? _billingApiBalanceHtml(api, copilotCostUsd) : "";
-    const extHtml = groupCosts && Object.keys(groupCosts).length > 0 ? _billingExtGroupCostsHtml(groupCosts) : "";
+    const extHtml = groupCosts && Object.keys(groupCosts).length > 0 ? _billingExtGroupCostsHtml(groupCosts, api) : "";
     const deltaHtml = _billingCoverageAnalysisHtml(api, copilotCostUsd, nonCopilotCostUsd);
     return `
 		<div class="section">
-			<div class="section-title"><span>\u{1F4B3}</span><span>Copilot Billing Coverage</span></div>
-			<div class="section-subtitle">Compare what the GitHub Copilot API reports across all channels with what the extension can track from local IDE session logs.</div>
+			<div class="section-title"><span>\u{1F4B3}</span><span>AI Billing Coverage</span></div>
+			<div class="section-subtitle">Compare what the GitHub Copilot API reports across all channels with what the extension can track from local IDE session logs, alongside estimated costs from other AI providers.</div>
 			${apiHtml}
 			${extHtml}
 			${deltaHtml}
@@ -5574,7 +5671,7 @@ ${_renderMultiModelMixedCostSessions(switching)}
   }
   function buildActivityTabPanelHtml(stats, multiModelHtml, thinkingEffortHtml, sessionsSummaryHtml, todayTotalRefs, last30DaysTotalRefs) {
     const modelCostHtml = safeSectionHtml("Model Cost", () => buildModelCostSectionHtml(stats));
-    const billingComparisonHtml = safeSectionHtml("Copilot Billing Coverage", () => buildBillingComparisonSectionHtml(stats));
+    const billingComparisonHtml = safeSectionHtml("AI Billing Coverage", () => buildBillingComparisonSectionHtml(stats));
     const modeUsageHtml = safeSectionHtml("Interaction Modes", () => `
 			<div class="section">
 				<div class="section-title"><span>\u{1F3AF}</span><span>Interaction Modes</span></div>

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -3520,15 +3520,34 @@ function _billingApiBalanceHtml(api: CopilotApiBalance, copilotCostUsd: number):
 		</div>`;
 }
 
-function _billingExtGroupCostsHtml(groupCosts: Record<string, number>): string {
-	const totalCostUsd = Object.values(groupCosts).reduce((s, v) => s + v, 0);
+/** Cost of Copilot usage the API reports but the extension has no local session data for
+ *  (github.com/copilot web chat, cloud agent, review agent, or a different device/environment). */
+function _billingOtherSessionsCostUsd(groupCosts: Record<string, number>, api: CopilotApiBalance | null | undefined): number {
+	if (!api) { return 0; }
+	const copilotCostUsd = groupCosts['GitHub Copilot'] ?? 0;
+	return Math.max(0, (api.usedAiCredits * 0.01) - copilotCostUsd);
+}
+
+function _billingExtGroupCostsHtml(groupCosts: Record<string, number>, api: CopilotApiBalance | null | undefined): string {
+	const otherSessionsCostUsd = _billingOtherSessionsCostUsd(groupCosts, api);
+	const hasLocalCopilotRow = 'GitHub Copilot' in groupCosts;
+	const totalCostUsd = Object.values(groupCosts).reduce((s, v) => s + v, 0) + otherSessionsCostUsd;
+	const otherSessionsRowHtml = otherSessionsCostUsd > 0.001
+		? `<tr>
+			<td style="padding:4px 8px; font-size:12px; color:var(--text-secondary);">GitHub Copilot - other sessions (remote or different environment)</td>
+			<td style="padding:4px 8px; font-size:12px; color:var(--text-secondary); text-align:right;">$${formatFixed(otherSessionsCostUsd, 2)}</td>
+		</tr>`
+		: '';
 	const rows = Object.entries(groupCosts)
 		.sort(([, a], [, b]) => b - a)
-		.map(([group, cost]) => `
-			<tr>
-				<td style="padding:4px 8px; font-size:12px; color:var(--text-primary);">${escapeHtml(group)}</td>
-				<td style="padding:4px 8px; font-size:12px; color:var(--text-primary); text-align:right;">$${formatFixed(cost, 2)}</td>
-			</tr>`).join('');
+		.map(([group, cost]) => {
+			const label = group === 'GitHub Copilot' ? 'GitHub Copilot - local sessions' : group;
+			return `
+				<tr>
+					<td style="padding:4px 8px; font-size:12px; color:var(--text-primary);">${escapeHtml(label)}</td>
+					<td style="padding:4px 8px; font-size:12px; color:var(--text-primary); text-align:right;">$${formatFixed(cost, 2)}</td>
+				</tr>${group === 'GitHub Copilot' ? otherSessionsRowHtml : ''}`;
+		}).join('') + (hasLocalCopilotRow ? '' : otherSessionsRowHtml);
 	return `
 		<div style="margin-bottom:12px;">
 			<div style="font-size:12px; font-weight:600; color:var(--text-secondary); margin-bottom:6px;">Extension tracked (this calendar month, IDE sessions only)</div>
@@ -3593,13 +3612,13 @@ function buildBillingComparisonSectionHtml(stats: UsageAnalysisStats): string {
 	const nonCopilotCostUsd = totalCostUsd - copilotCostUsd;
 
 	const apiHtml = api ? _billingApiBalanceHtml(api, copilotCostUsd) : '';
-	const extHtml = groupCosts && Object.keys(groupCosts).length > 0 ? _billingExtGroupCostsHtml(groupCosts) : '';
+	const extHtml = groupCosts && Object.keys(groupCosts).length > 0 ? _billingExtGroupCostsHtml(groupCosts, api) : '';
 	const deltaHtml = _billingCoverageAnalysisHtml(api, copilotCostUsd, nonCopilotCostUsd);
 
 	return `
 		<div class="section">
-			<div class="section-title"><span>💳</span><span>Copilot Billing Coverage</span></div>
-			<div class="section-subtitle">Compare what the GitHub Copilot API reports across all channels with what the extension can track from local IDE session logs.</div>
+			<div class="section-title"><span>💳</span><span>AI Billing Coverage</span></div>
+			<div class="section-subtitle">Compare what the GitHub Copilot API reports across all channels with what the extension can track from local IDE session logs, alongside estimated costs from other AI providers.</div>
 			${apiHtml}
 			${extHtml}
 			${deltaHtml}
@@ -3618,7 +3637,7 @@ function buildActivityTabPanelHtml(
 	// shape it doesn't expect) renders an inline error card for that section only, instead of
 	// throwing out of this template literal and blanking the entire Activity tab.
 	const modelCostHtml = safeSectionHtml('Model Cost', () => buildModelCostSectionHtml(stats));
-	const billingComparisonHtml = safeSectionHtml('Copilot Billing Coverage', () => buildBillingComparisonSectionHtml(stats));
+	const billingComparisonHtml = safeSectionHtml('AI Billing Coverage', () => buildBillingComparisonSectionHtml(stats));
 	const modeUsageHtml = safeSectionHtml('Interaction Modes', () => `
 			<div class="section">
 				<div class="section-title"><span>🎯</span><span>Interaction Modes</span></div>


### PR DESCRIPTION
## Summary
- In the "Extension tracked" billing table, rename the `GitHub Copilot` row to `GitHub Copilot - local sessions`, and add a new row beneath it, `GitHub Copilot - other sessions (remote or different environment)`, showing the cost of AI Credit usage the Copilot API reports that the extension has no local session data for (e.g. `github.com/copilot` web chat, cloud agent, review agent, or a different device). Only the cost is shown for that row, no AIC count.
- Rename the section title from "Copilot Billing Coverage" to "AI Billing Coverage" and tweak the subtitle, since the section already shows estimated costs from non-Copilot providers (Anthropic, Mistral, etc), not just Copilot.
- Refresh the committed Visual Studio webview bundles (`chart`, `details`, `diagnostics`, `environmental`, `maturity`, `usage`) from a fresh `dist` build via the `sync-host-views` skill, so they pick up this change plus other source drift that hadn't been synced yet (e.g. webview localization support).

## Test plan
- [x] `npx tsc --noEmit -p vscode-extension` passes
- [x] `npx eslint vscode-extension/src/webview/usage/main.ts` passes
- [x] `npm run package` (vscode-extension) builds cleanly
- [x] `node .github/skills/sync-host-views/sync-host-views.js` reports the Visual Studio `usage` bundle in sync with `dist` after refresh
- [ ] Visual Studio build/tests (not runnable in this environment — no `dotnet` toolchain available)

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_0178zbQRAMqAvbfkX5hJRkFh

---
_Generated by [Claude Code](https://claude.ai/code/session_0178zbQRAMqAvbfkX5hJRkFh)_