### PR TITLE
ci: add test-coverage companion check to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,38 @@ permissions:
   contents: read
 
 jobs:
+  # Deterministic guard against "new source logic without test changes" — the
+  # class of finding the agent-review Test Expert agent would otherwise have to
+  # catch with an LLM. Fails the PR when production source under
+  # vscode-extension/src/, cli/src/ or src/ changes without any test file
+  # changing too. Escape hatch: put [skip-test-check] in the PR body.
+  test-coverage-check:
+    name: Test coverage companion check
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+    - name: Harden the runner (Block all outbound calls except allowed)
+      uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+      with:
+        egress-policy: block
+        allowed-endpoints: >
+          github.com:443
+          productionresultssa*.blob.core.windows.net:443
+          results-receiver.actions.githubusercontent.com:443
+
+    - name: Checkout code
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        fetch-depth: 0
+
+    - name: Check source changes come with test changes
+      env:
+        BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        PR_BODY: ${{ github.event.pull_request.body }}
+      shell: bash
+      run: bash .github/workflows/scripts/check-test-coverage.sh
+
   build:
     runs-on: ubuntu-latest
     

--- a/.github/workflows/scripts/check-test-coverage.sh
+++ b/.github/workflows/scripts/check-test-coverage.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Deterministic "test coverage companion" check.
+#
+# Catches the class of review finding "new source logic added without any test
+# changes" without needing an LLM: if a PR touches production source files but
+# no test files, the change ships without CI-visible test coverage updates and
+# this job fails.
+#
+# Inputs (env):
+#   BASE_SHA  — PR base sha (falls back to HEAD^ like compute-diff.sh)
+#   HEAD_SHA  — PR head sha (falls back to HEAD)
+#   PR_BODY   — PR body text; if it contains the marker [skip-test-check] the
+#               check passes with a warning (documented escape hatch for
+#               changes that genuinely cannot be unit-tested, e.g. pure
+#               HTML/layout tweaks in webview code).
+#
+# Classification rules:
+#   SOURCE: *.ts/*.tsx/*.js/*.cjs/*.mjs under vscode-extension/src/, cli/src/,
+#           or the shared src/ folder.
+#   TEST:   any path containing /test/, /tests/ or /__tests__/, or a filename
+#           containing .test. or .spec. — in any directory of the repo.
+set -euo pipefail
+
+BASE_SHA="${BASE_SHA:-}"
+HEAD_SHA="${HEAD_SHA:-}"
+PR_BODY="${PR_BODY:-}"
+
+if [ -z "$HEAD_SHA" ]; then
+  HEAD_SHA="$(git rev-parse HEAD)"
+fi
+
+if [ -z "$BASE_SHA" ]; then
+  BASE_SHA="$(git rev-parse "${HEAD_SHA}^" 2>/dev/null || true)"
+fi
+
+if [ -z "$BASE_SHA" ]; then
+  echo "No base commit available; nothing to check. PASS."
+  exit 0
+fi
+
+CHANGED_FILES="$(git diff --name-only "${BASE_SHA}...${HEAD_SHA}" \
+  || git diff --name-only "${BASE_SHA}" "${HEAD_SHA}")"
+
+if [ -z "$CHANGED_FILES" ]; then
+  echo "Empty changeset; nothing to check. PASS."
+  exit 0
+fi
+
+is_test_file() {
+  case "$1" in
+    */test/*|*/tests/*|*/__tests__/*|test/*|tests/*) return 0 ;;
+  esac
+  case "$(basename "$1")" in
+    *.test.*|*.spec.*) return 0 ;;
+  esac
+  return 1
+}
+
+is_source_file() {
+  case "$1" in
+    vscode-extension/src/*|cli/src/*|src/*) ;;
+    *) return 1 ;;
+  esac
+  case "$1" in
+    *.ts|*.tsx|*.js|*.cjs|*.mjs) return 0 ;;
+  esac
+  return 1
+}
+
+SOURCE_FILES=""
+TEST_FILES=""
+while IFS= read -r file; do
+  [ -z "$file" ] && continue
+  if is_test_file "$file"; then
+    TEST_FILES="${TEST_FILES}${file}"$'\n'
+  elif is_source_file "$file"; then
+    SOURCE_FILES="${SOURCE_FILES}${file}"$'\n'
+  fi
+done <<< "$CHANGED_FILES"
+
+if [ -z "$SOURCE_FILES" ]; then
+  echo "No production source files changed. PASS."
+  exit 0
+fi
+
+if [ -n "$TEST_FILES" ]; then
+  echo "Source files changed together with test files. PASS."
+  echo "Test files touched:"
+  printf '%s' "$TEST_FILES" | sed 's/^/  - /'
+  exit 0
+fi
+
+if [[ "$PR_BODY" == *"[skip-test-check]"* ]]; then
+  echo "::warning::Source files changed without test changes, but the PR body contains [skip-test-check]; passing."
+  exit 0
+fi
+
+cat <<EOF
+::error::Source files changed but no test files were added or modified.
+
+Source files without a test-file companion change:
+$(printf '%s' "$SOURCE_FILES" | sed 's/^/  - /')
+
+Add or update tests covering this change, or — if the change genuinely cannot
+be unit-tested — add the marker [skip-test-check] to the PR body explaining why.
+EOF
+exit 1

--- a/vscode-extension/src/webview/usage/billingCoverage.ts
+++ b/vscode-extension/src/webview/usage/billingCoverage.ts
@@ -1,0 +1,62 @@
+/**
+ * Pure helpers for the "AI Billing Coverage" provider-cost table in the usage panel.
+ * Extracted from main.ts (no DOM / CSS dependencies) so they can be unit-tested in Node.js.
+ *
+ * billingOtherSessionsCostUsd() computes the Copilot spend the API reports but the extension
+ * has no local session data for (github.com/copilot web chat, cloud agent, review agent, or a
+ * different device/environment). billingExtGroupCostsHtml() renders the extension-tracked
+ * provider→cost table, injecting an "other sessions" row when that gap exceeds the display
+ * threshold.
+ */
+
+import { escapeHtml, formatFixed } from '../shared/formatUtils';
+import type { CopilotApiBalance } from './billingStatsSanitizer';
+
+/** Cost of Copilot usage the API reports but the extension has no local session data for
+ *  (github.com/copilot web chat, cloud agent, review agent, or a different device/environment). */
+export function billingOtherSessionsCostUsd(groupCosts: Record<string, number>, api: CopilotApiBalance | null | undefined): number {
+	if (!api) { return 0; }
+	const copilotCostUsd = groupCosts['GitHub Copilot'] ?? 0;
+	return Math.max(0, (api.usedAiCredits * 0.01) - copilotCostUsd);
+}
+
+export function billingExtGroupCostsHtml(groupCosts: Record<string, number>, api: CopilotApiBalance | null | undefined): string {
+	const otherSessionsCostUsd = billingOtherSessionsCostUsd(groupCosts, api);
+	const hasLocalCopilotRow = 'GitHub Copilot' in groupCosts;
+	const totalCostUsd = Object.values(groupCosts).reduce((s, v) => s + v, 0) + otherSessionsCostUsd;
+	const otherSessionsRowHtml = otherSessionsCostUsd > 0.001
+		? `<tr>
+			<td style="padding:4px 8px; font-size:12px; color:var(--text-secondary);">GitHub Copilot - other sessions (remote or different environment)</td>
+			<td style="padding:4px 8px; font-size:12px; color:var(--text-secondary); text-align:right;">$${formatFixed(otherSessionsCostUsd, 2)}</td>
+		</tr>`
+		: '';
+	const rows = Object.entries(groupCosts)
+		.sort(([, a], [, b]) => b - a)
+		.map(([group, cost]) => {
+			const label = group === 'GitHub Copilot' ? 'GitHub Copilot - local sessions' : group;
+			return `
+				<tr>
+					<td style="padding:4px 8px; font-size:12px; color:var(--text-primary);">${escapeHtml(label)}</td>
+					<td style="padding:4px 8px; font-size:12px; color:var(--text-primary); text-align:right;">$${formatFixed(cost, 2)}</td>
+				</tr>${group === 'GitHub Copilot' ? otherSessionsRowHtml : ''}`;
+		}).join('') + (hasLocalCopilotRow ? '' : otherSessionsRowHtml);
+	return `
+		<div style="margin-bottom:12px;">
+			<div style="font-size:12px; font-weight:600; color:var(--text-secondary); margin-bottom:6px;">Extension tracked (this calendar month, IDE sessions only)</div>
+			<table style="width:100%; border-collapse:collapse; border:1px solid var(--border-subtle); border-radius:6px; overflow:hidden;">
+				<thead>
+					<tr style="background:var(--bg-tertiary);">
+						<th style="padding:6px 8px; text-align:left; font-size:11px; color:var(--text-secondary); font-weight:600;">Provider</th>
+						<th style="padding:6px 8px; text-align:right; font-size:11px; color:var(--text-secondary); font-weight:600;">Estimated cost</th>
+					</tr>
+				</thead>
+				<tbody>${rows}</tbody>
+				<tfoot>
+					<tr style="border-top:1px solid var(--border-color);">
+						<td style="padding:6px 8px; font-size:12px; font-weight:600; color:var(--text-primary);">Total</td>
+						<td style="padding:6px 8px; font-size:12px; font-weight:600; color:var(--text-primary); text-align:right;">$${formatFixed(totalCostUsd, 2)}</td>
+					</tr>
+				</tfoot>
+			</table>
+		</div>`;
+}

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -18,6 +18,7 @@ import { deriveModelEfficiencyRates, computeEfficiencyLowUsageThreshold } from '
 import type { ModelPricing, ModelEfficiencyUsage, ModelEfficiencyCounters } from '../../../../src/types';
 import { sanitizeCustomizationMatrix } from './customizationSanitizer';
 import { applyBillingFields, type CopilotApiBalance } from './billingStatsSanitizer';
+import { billingExtGroupCostsHtml } from './billingCoverage';
 import { sanitizeAgentSessionsData, toSafeNumber, toSafeHttpUrl, type AgentSessionsResult } from './agentSessionsSanitizer';
 
 type ModelSwitchingAnalysis = BaseModelSwitchingAnalysis & {
@@ -3520,55 +3521,6 @@ function _billingApiBalanceHtml(api: CopilotApiBalance, copilotCostUsd: number):
 		</div>`;
 }
 
-/** Cost of Copilot usage the API reports but the extension has no local session data for
- *  (github.com/copilot web chat, cloud agent, review agent, or a different device/environment). */
-function _billingOtherSessionsCostUsd(groupCosts: Record<string, number>, api: CopilotApiBalance | null | undefined): number {
-	if (!api) { return 0; }
-	const copilotCostUsd = groupCosts['GitHub Copilot'] ?? 0;
-	return Math.max(0, (api.usedAiCredits * 0.01) - copilotCostUsd);
-}
-
-function _billingExtGroupCostsHtml(groupCosts: Record<string, number>, api: CopilotApiBalance | null | undefined): string {
-	const otherSessionsCostUsd = _billingOtherSessionsCostUsd(groupCosts, api);
-	const hasLocalCopilotRow = 'GitHub Copilot' in groupCosts;
-	const totalCostUsd = Object.values(groupCosts).reduce((s, v) => s + v, 0) + otherSessionsCostUsd;
-	const otherSessionsRowHtml = otherSessionsCostUsd > 0.001
-		? `<tr>
-			<td style="padding:4px 8px; font-size:12px; color:var(--text-secondary);">GitHub Copilot - other sessions (remote or different environment)</td>
-			<td style="padding:4px 8px; font-size:12px; color:var(--text-secondary); text-align:right;">$${formatFixed(otherSessionsCostUsd, 2)}</td>
-		</tr>`
-		: '';
-	const rows = Object.entries(groupCosts)
-		.sort(([, a], [, b]) => b - a)
-		.map(([group, cost]) => {
-			const label = group === 'GitHub Copilot' ? 'GitHub Copilot - local sessions' : group;
-			return `
-				<tr>
-					<td style="padding:4px 8px; font-size:12px; color:var(--text-primary);">${escapeHtml(label)}</td>
-					<td style="padding:4px 8px; font-size:12px; color:var(--text-primary); text-align:right;">$${formatFixed(cost, 2)}</td>
-				</tr>${group === 'GitHub Copilot' ? otherSessionsRowHtml : ''}`;
-		}).join('') + (hasLocalCopilotRow ? '' : otherSessionsRowHtml);
-	return `
-		<div style="margin-bottom:12px;">
-			<div style="font-size:12px; font-weight:600; color:var(--text-secondary); margin-bottom:6px;">Extension tracked (this calendar month, IDE sessions only)</div>
-			<table style="width:100%; border-collapse:collapse; border:1px solid var(--border-subtle); border-radius:6px; overflow:hidden;">
-				<thead>
-					<tr style="background:var(--bg-tertiary);">
-						<th style="padding:6px 8px; text-align:left; font-size:11px; color:var(--text-secondary); font-weight:600;">Provider</th>
-						<th style="padding:6px 8px; text-align:right; font-size:11px; color:var(--text-secondary); font-weight:600;">Estimated cost</th>
-					</tr>
-				</thead>
-				<tbody>${rows}</tbody>
-				<tfoot>
-					<tr style="border-top:1px solid var(--border-color);">
-						<td style="padding:6px 8px; font-size:12px; font-weight:600; color:var(--text-primary);">Total</td>
-						<td style="padding:6px 8px; font-size:12px; font-weight:600; color:var(--text-primary); text-align:right;">$${formatFixed(totalCostUsd, 2)}</td>
-					</tr>
-				</tfoot>
-			</table>
-		</div>`;
-}
-
 function _billingCoverageAnalysisHtml(api: CopilotApiBalance | null | undefined, copilotCostUsd: number, nonCopilotCostUsd: number): string {
 	if (!api) {
 		return `
@@ -3612,7 +3564,7 @@ function buildBillingComparisonSectionHtml(stats: UsageAnalysisStats): string {
 	const nonCopilotCostUsd = totalCostUsd - copilotCostUsd;
 
 	const apiHtml = api ? _billingApiBalanceHtml(api, copilotCostUsd) : '';
-	const extHtml = groupCosts && Object.keys(groupCosts).length > 0 ? _billingExtGroupCostsHtml(groupCosts, api) : '';
+	const extHtml = groupCosts && Object.keys(groupCosts).length > 0 ? billingExtGroupCostsHtml(groupCosts, api) : '';
 	const deltaHtml = _billingCoverageAnalysisHtml(api, copilotCostUsd, nonCopilotCostUsd);
 
 	return `

--- a/vscode-extension/test/unit/webview-billing-coverage.test.ts
+++ b/vscode-extension/test/unit/webview-billing-coverage.test.ts
@@ -1,0 +1,106 @@
+import { describe, test } from 'node:test';
+import * as assert from 'node:assert/strict';
+import {
+	billingOtherSessionsCostUsd,
+	billingExtGroupCostsHtml,
+} from '../../src/webview/usage/billingCoverage';
+import type { CopilotApiBalance } from '../../src/webview/usage/billingStatsSanitizer';
+import { setFormatLocale } from '../../src/webview/shared/formatUtils';
+
+// Lock the locale so cost assertions ("$4.00") don't depend on the machine's default locale.
+setFormatLocale('en-US');
+
+// ── Coverage for the "other sessions" billing row (PR #1872) ──────────────────
+//
+// The AI Billing Coverage table shows what the extension tracks locally versus what the
+// Copilot API reports across all channels. The gap between the two is rendered as a
+// "GitHub Copilot - other sessions" row. These tests lock in the two behaviors that
+// would otherwise regress silently:
+//   - the Math.max(0, ...) clamp in billingOtherSessionsCostUsd (API reporting *less*
+//     than the locally tracked cost must not produce a negative row), and
+//   - the api-null guard (no API quota snapshot yet → no other-sessions row, no crash).
+
+function makeApi(usedAiCredits: number): CopilotApiBalance {
+	return {
+		budgetUsd: 39,
+		budgetAiCredits: 3900,
+		remainingAiCredits: 3900 - usedAiCredits,
+		usedAiCredits,
+		pctAvailable: ((3900 - usedAiCredits) / 3900) * 100,
+	};
+}
+
+describe('billingOtherSessionsCostUsd', () => {
+	test('returns 0 when api is null or undefined', () => {
+		const groupCosts = { 'GitHub Copilot': 5 };
+		assert.equal(billingOtherSessionsCostUsd(groupCosts, null), 0);
+		assert.equal(billingOtherSessionsCostUsd(groupCosts, undefined), 0);
+	});
+
+	test('clamps to 0 when the API reports less than the local GitHub Copilot cost', () => {
+		// API reports $4.00 used, but local sessions already account for $5.00.
+		const groupCosts = { 'GitHub Copilot': 5 };
+		assert.equal(billingOtherSessionsCostUsd(groupCosts, makeApi(400)), 0);
+	});
+
+	test('returns the positive difference when the API reports more than locally tracked', () => {
+		// API reports $10.00 used, local sessions account for $6.00 → $4.00 elsewhere.
+		const groupCosts = { 'GitHub Copilot': 6 };
+		assert.equal(billingOtherSessionsCostUsd(groupCosts, makeApi(1000)), 4);
+	});
+
+	test('treats a missing GitHub Copilot key as 0 local cost', () => {
+		// API reports $10.00 used, no local Copilot sessions at all → full $10.00 elsewhere.
+		const groupCosts = { 'Claude Code': 3 };
+		assert.equal(billingOtherSessionsCostUsd(groupCosts, makeApi(1000)), 10);
+	});
+
+	test('returns 0 when api reports zero usage', () => {
+		assert.equal(billingOtherSessionsCostUsd({}, makeApi(0)), 0);
+	});
+});
+
+describe('billingExtGroupCostsHtml', () => {
+	test('includes the other-sessions row when the gap exceeds the display threshold', () => {
+		// API reports $10.00 used, local Copilot cost $6.00 → $4.00 gap.
+		const html = billingExtGroupCostsHtml({ 'GitHub Copilot': 6 }, makeApi(1000));
+		assert.ok(html.includes('GitHub Copilot - other sessions'), 'expected the other-sessions row');
+		assert.ok(html.includes('$4.00'), 'expected the gap cost in the row');
+	});
+
+	test('omits the other-sessions row when the gap is at or below the display threshold', () => {
+		// Zero gap: API reports exactly the locally tracked $6.00.
+		assert.ok(
+			!billingExtGroupCostsHtml({ 'GitHub Copilot': 6 }, makeApi(600)).includes('other sessions'),
+			'did not expect the other-sessions row for a zero gap',
+		);
+		// Positive gap below the 0.001 threshold: API reports $6.0005 used.
+		assert.ok(
+			!billingExtGroupCostsHtml({ 'GitHub Copilot': 6 }, makeApi(600.05)).includes('other sessions'),
+			'did not expect the other-sessions row for a sub-threshold gap',
+		);
+	});
+
+	test('total includes the other-sessions cost', () => {
+		// $6.00 local Copilot + $3.00 Claude Code + $4.00 other sessions → $13.00 total.
+		const html = billingExtGroupCostsHtml(
+			{ 'GitHub Copilot': 6, 'Claude Code': 3 },
+			makeApi(1000),
+		);
+		assert.ok(html.includes('$13.00'), 'expected the total to include the other-sessions cost');
+	});
+
+	test('renders the other-sessions row when there is no local Copilot row', () => {
+		const html = billingExtGroupCostsHtml({ 'Claude Code': 3 }, makeApi(1000));
+		assert.ok(html.includes('GitHub Copilot - other sessions'), 'expected the other-sessions row');
+		assert.ok(!html.includes('GitHub Copilot - local sessions'), 'did not expect a local Copilot row');
+		assert.ok(html.includes('$13.00'), 'expected the total to include the other-sessions cost');
+	});
+
+	test('api-null path renders without the other-sessions row and without crashing', () => {
+		const html = billingExtGroupCostsHtml({ 'GitHub Copilot': 6 }, null);
+		assert.ok(!html.includes('other sessions'), 'did not expect the other-sessions row');
+		assert.ok(html.includes('GitHub Copilot - local sessions'), 'expected the local Copilot row');
+		assert.ok(html.includes('$6.00'), 'expected the total to equal the local cost only');
+	});
+});


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/scripts/check-test-coverage.sh`, a deterministic check that fails a PR when production source under `vscode-extension/src/`, `cli/src/`, or `src/` changes without any test file (anywhere matching `test/`, `tests/`, `__tests__/`, `*.test.*`, `*.spec.*`) changing too.
- Wires it into `ci.yml` as a PR-only job (`test-coverage-check`).

## Why
The agent-review Test Expert keeps flagging "no test coverage for the new code" with an LLM after the fact — e.g. PR #1872 ("No test coverage for the new billing row" for `_billingOtherSessionsCostUsd()`/`_billingExtGroupCostsHtml()`). This check catches that class of finding deterministically, before review.

## Escape hatch
Changes that genuinely cannot be unit-tested (e.g. pure HTML/layout tweaks in webview code) can put `[skip-test-check]` in the PR body; the job then passes with a warning.

## Verification (run locally against real history)
- PR #1872's exact changeset (`39f05964^..39f05964`, source-only) → **fails** with the file list ✅
- Same range + `[skip-test-check]` in body → passes with warning ✅
- Workflow-only commit (`1713bbb5`) → passes (no production source) ✅
- `c98fba1d` (src + tests together) → passes ✅

## Follow-up
A stacked PR will add the missing test coverage for the billing-row functions from #1872.

🤖 Generated with [GitHub Copilot](https://github.com/features/copilot)