### PR TITLE
test: add unit coverage for billing other-sessions row

### DIFF
--- a/vscode-extension/src/webview/usage/billingCoverage.ts
+++ b/vscode-extension/src/webview/usage/billingCoverage.ts
@@ -1,0 +1,62 @@
+/**
+ * Pure helpers for the "AI Billing Coverage" provider-cost table in the usage panel.
+ * Extracted from main.ts (no DOM / CSS dependencies) so they can be unit-tested in Node.js.
+ *
+ * billingOtherSessionsCostUsd() computes the Copilot spend the API reports but the extension
+ * has no local session data for (github.com/copilot web chat, cloud agent, review agent, or a
+ * different device/environment). billingExtGroupCostsHtml() renders the extension-tracked
+ * provider→cost table, injecting an "other sessions" row when that gap exceeds the display
+ * threshold.
+ */
+
+import { escapeHtml, formatFixed } from '../shared/formatUtils';
+import type { CopilotApiBalance } from './billingStatsSanitizer';
+
+/** Cost of Copilot usage the API reports but the extension has no local session data for
+ *  (github.com/copilot web chat, cloud agent, review agent, or a different device/environment). */
+export function billingOtherSessionsCostUsd(groupCosts: Record<string, number>, api: CopilotApiBalance | null | undefined): number {
+	if (!api) { return 0; }
+	const copilotCostUsd = groupCosts['GitHub Copilot'] ?? 0;
+	return Math.max(0, (api.usedAiCredits * 0.01) - copilotCostUsd);
+}
+
+export function billingExtGroupCostsHtml(groupCosts: Record<string, number>, api: CopilotApiBalance | null | undefined): string {
+	const otherSessionsCostUsd = billingOtherSessionsCostUsd(groupCosts, api);
+	const hasLocalCopilotRow = 'GitHub Copilot' in groupCosts;
+	const totalCostUsd = Object.values(groupCosts).reduce((s, v) => s + v, 0) + otherSessionsCostUsd;
+	const otherSessionsRowHtml = otherSessionsCostUsd > 0.001
+		? `<tr>
+			<td style="padding:4px 8px; font-size:12px; color:var(--text-secondary);">GitHub Copilot - other sessions (remote or different environment)</td>
+			<td style="padding:4px 8px; font-size:12px; color:var(--text-secondary); text-align:right;">$${formatFixed(otherSessionsCostUsd, 2)}</td>
+		</tr>`
+		: '';
+	const rows = Object.entries(groupCosts)
+		.sort(([, a], [, b]) => b - a)
+		.map(([group, cost]) => {
+			const label = group === 'GitHub Copilot' ? 'GitHub Copilot - local sessions' : group;
+			return `
+				<tr>
+					<td style="padding:4px 8px; font-size:12px; color:var(--text-primary);">${escapeHtml(label)}</td>
+					<td style="padding:4px 8px; font-size:12px; color:var(--text-primary); text-align:right;">$${formatFixed(cost, 2)}</td>
+				</tr>${group === 'GitHub Copilot' ? otherSessionsRowHtml : ''}`;
+		}).join('') + (hasLocalCopilotRow ? '' : otherSessionsRowHtml);
+	return `
+		<div style="margin-bottom:12px;">
+			<div style="font-size:12px; font-weight:600; color:var(--text-secondary); margin-bottom:6px;">Extension tracked (this calendar month, IDE sessions only)</div>
+			<table style="width:100%; border-collapse:collapse; border:1px solid var(--border-subtle); border-radius:6px; overflow:hidden;">
+				<thead>
+					<tr style="background:var(--bg-tertiary);">
+						<th style="padding:6px 8px; text-align:left; font-size:11px; color:var(--text-secondary); font-weight:600;">Provider</th>
+						<th style="padding:6px 8px; text-align:right; font-size:11px; color:var(--text-secondary); font-weight:600;">Estimated cost</th>
+					</tr>
+				</thead>
+				<tbody>${rows}</tbody>
+				<tfoot>
+					<tr style="border-top:1px solid var(--border-color);">
+						<td style="padding:6px 8px; font-size:12px; font-weight:600; color:var(--text-primary);">Total</td>
+						<td style="padding:6px 8px; font-size:12px; font-weight:600; color:var(--text-primary); text-align:right;">$${formatFixed(totalCostUsd, 2)}</td>
+					</tr>
+				</tfoot>
+			</table>
+		</div>`;
+}

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -18,6 +18,7 @@ import { deriveModelEfficiencyRates, computeEfficiencyLowUsageThreshold } from '
 import type { ModelPricing, ModelEfficiencyUsage, ModelEfficiencyCounters } from '../../../../src/types';
 import { sanitizeCustomizationMatrix } from './customizationSanitizer';
 import { applyBillingFields, type CopilotApiBalance } from './billingStatsSanitizer';
+import { billingExtGroupCostsHtml } from './billingCoverage';
 import { sanitizeAgentSessionsData, toSafeNumber, toSafeHttpUrl, type AgentSessionsResult } from './agentSessionsSanitizer';
 
 type ModelSwitchingAnalysis = BaseModelSwitchingAnalysis & {
@@ -3520,55 +3521,6 @@ function _billingApiBalanceHtml(api: CopilotApiBalance, copilotCostUsd: number):
 		</div>`;
 }
 
-/** Cost of Copilot usage the API reports but the extension has no local session data for
- *  (github.com/copilot web chat, cloud agent, review agent, or a different device/environment). */
-function _billingOtherSessionsCostUsd(groupCosts: Record<string, number>, api: CopilotApiBalance | null | undefined): number {
-	if (!api) { return 0; }
-	const copilotCostUsd = groupCosts['GitHub Copilot'] ?? 0;
-	return Math.max(0, (api.usedAiCredits * 0.01) - copilotCostUsd);
-}
-
-function _billingExtGroupCostsHtml(groupCosts: Record<string, number>, api: CopilotApiBalance | null | undefined): string {
-	const otherSessionsCostUsd = _billingOtherSessionsCostUsd(groupCosts, api);
-	const hasLocalCopilotRow = 'GitHub Copilot' in groupCosts;
-	const totalCostUsd = Object.values(groupCosts).reduce((s, v) => s + v, 0) + otherSessionsCostUsd;
-	const otherSessionsRowHtml = otherSessionsCostUsd > 0.001
-		? `<tr>
-			<td style="padding:4px 8px; font-size:12px; color:var(--text-secondary);">GitHub Copilot - other sessions (remote or different environment)</td>
-			<td style="padding:4px 8px; font-size:12px; color:var(--text-secondary); text-align:right;">$${formatFixed(otherSessionsCostUsd, 2)}</td>
-		</tr>`
-		: '';
-	const rows = Object.entries(groupCosts)
-		.sort(([, a], [, b]) => b - a)
-		.map(([group, cost]) => {
-			const label = group === 'GitHub Copilot' ? 'GitHub Copilot - local sessions' : group;
-			return `
-				<tr>
-					<td style="padding:4px 8px; font-size:12px; color:var(--text-primary);">${escapeHtml(label)}</td>
-					<td style="padding:4px 8px; font-size:12px; color:var(--text-primary); text-align:right;">$${formatFixed(cost, 2)}</td>
-				</tr>${group === 'GitHub Copilot' ? otherSessionsRowHtml : ''}`;
-		}).join('') + (hasLocalCopilotRow ? '' : otherSessionsRowHtml);
-	return `
-		<div style="margin-bottom:12px;">
-			<div style="font-size:12px; font-weight:600; color:var(--text-secondary); margin-bottom:6px;">Extension tracked (this calendar month, IDE sessions only)</div>
-			<table style="width:100%; border-collapse:collapse; border:1px solid var(--border-subtle); border-radius:6px; overflow:hidden;">
-				<thead>
-					<tr style="background:var(--bg-tertiary);">
-						<th style="padding:6px 8px; text-align:left; font-size:11px; color:var(--text-secondary); font-weight:600;">Provider</th>
-						<th style="padding:6px 8px; text-align:right; font-size:11px; color:var(--text-secondary); font-weight:600;">Estimated cost</th>
-					</tr>
-				</thead>
-				<tbody>${rows}</tbody>
-				<tfoot>
-					<tr style="border-top:1px solid var(--border-color);">
-						<td style="padding:6px 8px; font-size:12px; font-weight:600; color:var(--text-primary);">Total</td>
-						<td style="padding:6px 8px; font-size:12px; font-weight:600; color:var(--text-primary); text-align:right;">$${formatFixed(totalCostUsd, 2)}</td>
-					</tr>
-				</tfoot>
-			</table>
-		</div>`;
-}
-
 function _billingCoverageAnalysisHtml(api: CopilotApiBalance | null | undefined, copilotCostUsd: number, nonCopilotCostUsd: number): string {
 	if (!api) {
 		return `
@@ -3612,7 +3564,7 @@ function buildBillingComparisonSectionHtml(stats: UsageAnalysisStats): string {
 	const nonCopilotCostUsd = totalCostUsd - copilotCostUsd;
 
 	const apiHtml = api ? _billingApiBalanceHtml(api, copilotCostUsd) : '';
-	const extHtml = groupCosts && Object.keys(groupCosts).length > 0 ? _billingExtGroupCostsHtml(groupCosts, api) : '';
+	const extHtml = groupCosts && Object.keys(groupCosts).length > 0 ? billingExtGroupCostsHtml(groupCosts, api) : '';
 	const deltaHtml = _billingCoverageAnalysisHtml(api, copilotCostUsd, nonCopilotCostUsd);
 
 	return `

--- a/vscode-extension/test/unit/webview-billing-coverage.test.ts
+++ b/vscode-extension/test/unit/webview-billing-coverage.test.ts
@@ -1,0 +1,106 @@
+import { describe, test } from 'node:test';
+import * as assert from 'node:assert/strict';
+import {
+	billingOtherSessionsCostUsd,
+	billingExtGroupCostsHtml,
+} from '../../src/webview/usage/billingCoverage';
+import type { CopilotApiBalance } from '../../src/webview/usage/billingStatsSanitizer';
+import { setFormatLocale } from '../../src/webview/shared/formatUtils';
+
+// Lock the locale so cost assertions ("$4.00") don't depend on the machine's default locale.
+setFormatLocale('en-US');
+
+// ── Coverage for the "other sessions" billing row (PR #1872) ──────────────────
+//
+// The AI Billing Coverage table shows what the extension tracks locally versus what the
+// Copilot API reports across all channels. The gap between the two is rendered as a
+// "GitHub Copilot - other sessions" row. These tests lock in the two behaviors that
+// would otherwise regress silently:
+//   - the Math.max(0, ...) clamp in billingOtherSessionsCostUsd (API reporting *less*
+//     than the locally tracked cost must not produce a negative row), and
+//   - the api-null guard (no API quota snapshot yet → no other-sessions row, no crash).
+
+function makeApi(usedAiCredits: number): CopilotApiBalance {
+	return {
+		budgetUsd: 39,
+		budgetAiCredits: 3900,
+		remainingAiCredits: 3900 - usedAiCredits,
+		usedAiCredits,
+		pctAvailable: ((3900 - usedAiCredits) / 3900) * 100,
+	};
+}
+
+describe('billingOtherSessionsCostUsd', () => {
+	test('returns 0 when api is null or undefined', () => {
+		const groupCosts = { 'GitHub Copilot': 5 };
+		assert.equal(billingOtherSessionsCostUsd(groupCosts, null), 0);
+		assert.equal(billingOtherSessionsCostUsd(groupCosts, undefined), 0);
+	});
+
+	test('clamps to 0 when the API reports less than the local GitHub Copilot cost', () => {
+		// API reports $4.00 used, but local sessions already account for $5.00.
+		const groupCosts = { 'GitHub Copilot': 5 };
+		assert.equal(billingOtherSessionsCostUsd(groupCosts, makeApi(400)), 0);
+	});
+
+	test('returns the positive difference when the API reports more than locally tracked', () => {
+		// API reports $10.00 used, local sessions account for $6.00 → $4.00 elsewhere.
+		const groupCosts = { 'GitHub Copilot': 6 };
+		assert.equal(billingOtherSessionsCostUsd(groupCosts, makeApi(1000)), 4);
+	});
+
+	test('treats a missing GitHub Copilot key as 0 local cost', () => {
+		// API reports $10.00 used, no local Copilot sessions at all → full $10.00 elsewhere.
+		const groupCosts = { 'Claude Code': 3 };
+		assert.equal(billingOtherSessionsCostUsd(groupCosts, makeApi(1000)), 10);
+	});
+
+	test('returns 0 when api reports zero usage', () => {
+		assert.equal(billingOtherSessionsCostUsd({}, makeApi(0)), 0);
+	});
+});
+
+describe('billingExtGroupCostsHtml', () => {
+	test('includes the other-sessions row when the gap exceeds the display threshold', () => {
+		// API reports $10.00 used, local Copilot cost $6.00 → $4.00 gap.
+		const html = billingExtGroupCostsHtml({ 'GitHub Copilot': 6 }, makeApi(1000));
+		assert.ok(html.includes('GitHub Copilot - other sessions'), 'expected the other-sessions row');
+		assert.ok(html.includes('$4.00'), 'expected the gap cost in the row');
+	});
+
+	test('omits the other-sessions row when the gap is at or below the display threshold', () => {
+		// Zero gap: API reports exactly the locally tracked $6.00.
+		assert.ok(
+			!billingExtGroupCostsHtml({ 'GitHub Copilot': 6 }, makeApi(600)).includes('other sessions'),
+			'did not expect the other-sessions row for a zero gap',
+		);
+		// Positive gap below the 0.001 threshold: API reports $6.0005 used.
+		assert.ok(
+			!billingExtGroupCostsHtml({ 'GitHub Copilot': 6 }, makeApi(600.05)).includes('other sessions'),
+			'did not expect the other-sessions row for a sub-threshold gap',
+		);
+	});
+
+	test('total includes the other-sessions cost', () => {
+		// $6.00 local Copilot + $3.00 Claude Code + $4.00 other sessions → $13.00 total.
+		const html = billingExtGroupCostsHtml(
+			{ 'GitHub Copilot': 6, 'Claude Code': 3 },
+			makeApi(1000),
+		);
+		assert.ok(html.includes('$13.00'), 'expected the total to include the other-sessions cost');
+	});
+
+	test('renders the other-sessions row when there is no local Copilot row', () => {
+		const html = billingExtGroupCostsHtml({ 'Claude Code': 3 }, makeApi(1000));
+		assert.ok(html.includes('GitHub Copilot - other sessions'), 'expected the other-sessions row');
+		assert.ok(!html.includes('GitHub Copilot - local sessions'), 'did not expect a local Copilot row');
+		assert.ok(html.includes('$13.00'), 'expected the total to include the other-sessions cost');
+	});
+
+	test('api-null path renders without the other-sessions row and without crashing', () => {
+		const html = billingExtGroupCostsHtml({ 'GitHub Copilot': 6 }, null);
+		assert.ok(!html.includes('other sessions'), 'did not expect the other-sessions row');
+		assert.ok(html.includes('GitHub Copilot - local sessions'), 'expected the local Copilot row');
+		assert.ok(html.includes('$6.00'), 'expected the total to equal the local cost only');
+	});
+});


### PR DESCRIPTION
## Summary

Adds unit test coverage for the billing-row functions introduced in #1872 (`_billingOtherSessionsCostUsd()` / `_billingExtGroupCostsHtml()`), addressing the agent-review finding **"No test coverage for the new billing row"** — the `Math.max(0, ...)` clamp and the api-null guard would otherwise regress silently.

## Changes

- **Extract** the two private functions from `vscode-extension/src/webview/usage/main.ts` into a new pure module `vscode-extension/src/webview/usage/billingCoverage.ts` (next to `billingStatsSanitizer.ts`, following the established pattern for unit-testable webview code). `main.ts` now calls the extracted helpers — behavior is identical.
- **Add** `vscode-extension/test/unit/webview-billing-coverage.test.ts` (node:test + node:assert/strict, matching the existing webview-*.test.ts style) covering:
  - `billingOtherSessionsCostUsd`: returns 0 when api is null/undefined; clamps to 0 when API-reported spend is below the local 'GitHub Copilot' group cost; returns the positive difference when the API reports more; treats a missing 'GitHub Copilot' key as 0 local cost; zero-usage API.
  - `billingExtGroupCostsHtml`: renders the 'other sessions' row only above the 0.001 display threshold; total includes the other-sessions cost; renders the row when there is no local Copilot row; api-null path renders without the row and without crashing.

## Validation

- `npm run compile-tests` ✔
- `node --require ./out/vscode-extension/test/unit/vscode-shim-register.js --test out/vscode-extension/test/unit/webview-billing-coverage.test.js` — 10/10 pass ✔
- `npx tsc --noEmit -p vscode-extension` ✔
- eslint on changed files ✔

## Stacked PR

⚠️ This PR is **stacked on #1873** (`rajbos-workflow-test-coverage-check`) — base is set to that branch so the diff stays clean. It changes both source and tests, so the new test-coverage companion check from #1873 passes. Merge after #1873.
