### PR TITLE
feat(cloud-agent): account-wide agent tasks with an hourly cached snapshot

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -74,6 +74,7 @@ Detailed documentation for individual features.
 | [features/THEMING_CHANGES.md](features/THEMING_CHANGES.md) | Light theme support implementation details |
 | [features/TOOL-CURATION.md](features/TOOL-CURATION.md) | Tool Curation — surface unused MCP servers and stale skills |
 | [features/MODEL-EFFICIENCY-COMPARISON.md](features/MODEL-EFFICIENCY-COMPARISON.md) | Models tab — compare two models, or one model across two periods |
+| [features/CLOUD-AGENT-COST.md](features/CLOUD-AGENT-COST.md) | Cloud Agent tab — per-repository AI credits, and the hourly cached snapshot behind it |
 
 ## Architecture Decision Records (ADR)
 

--- a/docs/features/CLOUD-AGENT-COST.md
+++ b/docs/features/CLOUD-AGENT-COST.md
@@ -1,0 +1,80 @@
+# Cloud Agent Cost — per-repository AI credits
+
+The **Cloud Agent** tab shows what Copilot's cloud agent cost, broken down per repository. This
+page explains where that data comes from, why it is the only per-repo cost we can get, and how the
+hourly snapshot works.
+
+## Why the agents API and not the billing API
+
+The extension already reads overall usage and quota from the Copilot internal API. That gives a
+total, not a breakdown: usage that happens outside an editor — cloud agent runs, Copilot code
+review — is billed to the *user*, never to a repository.
+
+GitHub's official billing endpoints do not close that gap for a normal user:
+
+| Endpoint | Per repo? | Usable here? |
+|---|---|---|
+| `/users/{user}/settings/billing/usage` | `repositoryName` field exists | Only for individually-purchased Copilot plans, and AI-credit usage is attributed to the user, not a repo. Needs a classic PAT — fine-grained tokens are rejected — so a VS Code auth session can't call it. |
+| `/users/{user}/settings/billing/ai_credit/usage` | No | Exact per-model credit totals, but no repository dimension at all. |
+| `/organizations/…` and `/enterprises/…` variants | Partly | Require org owner / billing manager / enterprise admin. |
+| `/orgs/{org}/copilot/metrics/reports/repos-1-day` | Yes, activity only | Per-repo pull request activity, no credits; org admin only. |
+| GraphQL | No | No AI-credit or premium-request fields exist. |
+
+What *is* available to any signed-in user is the **agent tasks API**, which reports billing units
+per session, and each session belongs to a repository:
+
+```
+GET /agents/tasks                  → the user's tasks across all repositories
+GET /agents/tasks/{task_id}        → sessions[], each with { model, usage: { type, amount } }
+GET /agents/repos/{owner}/{repo}/tasks[/{task_id}]  → the same, scoped to one repository
+```
+
+`usage.type` is `ai_credits` (amount in **nano-credits** — divide by 1,000,000,000) for sessions
+since June 2026, or `premium_requests` (a plain, possibly fractional count) for older ones. The
+live API has also been observed reporting the amount as `usage.credits`, so both spellings are
+read (see `readSessionUsage` in `vscode-extension/src/agentSessionsService.ts`).
+
+## Two sources, merged
+
+`collectAgentSessions()` combines:
+
+1. **Workspace repositories** — discovered from the git remotes of open folders. The repo-scoped
+   listing also surfaces tasks *other people* started in those repos.
+2. **The account-wide listing** (`/agents/tasks`) — tasks the signed-in user started anywhere,
+   including repos that are not checked out locally and ad-hoc sessions started from cloud chat
+   that have no repository at all. Those land in a "no repository (cloud chat)" row.
+
+Tasks are deduplicated by task ID before any detail call, so a task visible in both listings is
+counted once. Repositories found only through the account listing are labelled *(not in workspace)*.
+
+If the account-wide listing fails (for example, a token without the "Agent tasks" permission), the
+tab degrades to the workspace repositories and says so.
+
+## Cost control: one hourly snapshot, one window
+
+Collecting the data costs one list call per repository, one for the account, and one detail call
+per task, so it is deliberately rationed:
+
+- **Cached on disk** in the extension's global storage
+  (`agenttasks_<cacheId>.snapshot.json`), shared by every VS Code window of that edition —
+  see `vscode-extension/src/agentTasksCache.ts`.
+- **Refreshed at most once an hour** (`AGENT_TASKS_REFRESH_INTERVAL_MS`). Opening the tab renders
+  the snapshot immediately and never triggers an API call while it is fresh.
+- **Refreshed by a single window.** The refresh runs behind the `agenttasks` file lock, and is
+  kicked off from the leader-elected cache refresh cycle — so it also runs shortly after the
+  extension starts. Other windows read the snapshot the leader wrote; a heartbeat keeps the lock
+  alive so a slow API pass is never mistaken for a stale lock.
+- **Capped at `MAX_TASK_DETAILS_PER_REFRESH` detail calls** per pass, spent on the most recently
+  updated tasks. Repositories with tasks left over are flagged, and their totals are shown as
+  lower bounds.
+
+The tab always states how old the snapshot is and when the next refresh becomes due.
+
+## What is still missing
+
+- **Copilot code review** consumes AI credits charged to the reviewer or the PR author, with no
+  per-repo attribution anywhere in the API. Its Actions minutes *are* per repo (workflow path
+  `dynamic/agents/copilot-pull-request-reviewer`), which is a possible future addition.
+- **Actions minutes for cloud agent runs** are likewise not included in this tab yet.
+- **IDE chat and agent mode** have no repository dimension by construction; that usage is already
+  tracked from local session logs elsewhere in the extension.

--- a/src/types.ts
+++ b/src/types.ts
@@ -896,6 +896,9 @@ export interface SessionLogData {
 
 export type AgentSessionSource = 'cloud-agent' | 'cli-remote' | 'unknown';
 
+/** Where a repository row came from: workspace git remotes, the account-wide task list, or both. */
+export type AgentRepoDiscovery = 'workspace' | 'account' | 'both';
+
 export interface AgentRepoSummary {
   owner: string;
   repo: string;
@@ -903,14 +906,20 @@ export interface AgentRepoSummary {
   totalTasks: number;
   /** Total cloud-agent sessions across all scanned tasks. */
   totalSessions: number;
-  /** Sum of usage.credits for all cloud-agent sessions (0 when unavailable). */
+  /** Sum of session usage in whole AI credits for all cloud-agent sessions (0 when unavailable). */
   totalCredits: number;
+  /** Sum of premium requests for sessions billed before the June 2026 switch to AI credits. */
+  totalPremiumRequests: number;
   /** How many tasks we fetched full session details for. */
   tasksScanned: number;
   /** Total tasks found in the list API response (before the detail-fetch cap). */
   tasksTotal: number;
   /** True when the detail-fetch cap was reached — totals are conservative lower bounds. */
   partial: boolean;
+  /** How this repo was found. `account`-only rows are not open in any workspace folder. */
+  discovery: AgentRepoDiscovery;
+  /** True for the synthetic bucket of account tasks the API reported without a repository. */
+  unassigned?: boolean;
   error?: string;
 }
 
@@ -919,9 +928,19 @@ export interface AgentSessionsResult {
   totalTasks: number;
   totalSessions: number;
   totalCredits: number;
+  totalPremiumRequests: number;
   authenticated: boolean;
   since: string;
+  /** When the snapshot was fetched from GitHub; empty string when it has never been fetched. */
   fetchedAt: string;
+  /** True when the account-wide `/agents/tasks` listing succeeded (false → workspace repos only). */
+  accountTasksAvailable: boolean;
+  /** Why the account-wide listing was skipped or failed, when it was. */
+  accountTasksError?: string;
+  /** True when the task-detail budget was exhausted — totals are lower bounds. */
+  partial: boolean;
+  /** How often the snapshot is refreshed, so the UI can say when the next refresh is due. */
+  refreshIntervalMs?: number;
 }
 
 // Local summary type for customization files (mirrors webview/shared/contextRefUtils.ts)

--- a/vscode-extension/src/agentSessionsService.ts
+++ b/vscode-extension/src/agentSessionsService.ts
@@ -1,43 +1,33 @@
 import * as https from 'https';
 import { getGitHubApiEndpoints, buildGitHubApiHeaders } from './githubApiConfig';
+import type {
+	AgentRepoDiscovery,
+	AgentRepoSummary,
+	AgentSessionSource,
+	AgentSessionsResult,
+} from '../../src/types';
 
-export type AgentSessionSource = 'cloud-agent' | 'cli-remote' | 'unknown';
-
-export interface AgentRepoSummary {
-	owner: string;
-	repo: string;
-	/** Number of cloud-agent tasks found (tasks with at least one cloud-agent session). */
-	totalTasks: number;
-	/** Total cloud-agent sessions across all tasks. */
-	totalSessions: number;
-	/** Sum of usage.credits (converted from nano-credits to whole AI credits) for all cloud-agent sessions (0 when unavailable). */
-	totalCredits: number;
-	/** How many tasks we fetched full details for (may be less than tasksTotal when capped). */
-	tasksScanned: number;
-	/** Total tasks found in the list API before detail fetch cap. */
-	tasksTotal: number;
-	/** True when the detail fetch was capped — totals are a lower bound. */
-	partial: boolean;
-	error?: string;
-}
-
-export interface AgentSessionsResult {
-	repos: AgentRepoSummary[];
-	totalTasks: number;
-	totalSessions: number;
-	totalCredits: number;
-	authenticated: boolean;
-	since: string;
-	fetchedAt: string;
-}
+/**
+ * The shape of these results is shared with the webviews via `src/types.ts`; they are re-exported
+ * here so callers of this service keep importing them from one place.
+ */
+export type { AgentSessionSource, AgentRepoDiscovery, AgentRepoSummary, AgentSessionsResult };
 
 /** Maximum number of task detail fetches per repo to avoid API rate-limit spikes. */
 const MAX_TASKS_DETAIL_PER_REPO = 50;
 
 /**
+ * Maximum number of task-detail calls for one account-wide collection pass. Each task costs one
+ * request, so this caps a refresh at a few hundred calls even for very active accounts. Because
+ * the snapshot is only refreshed hourly by a single window, this stays far below GitHub's
+ * 5,000 req/hour primary rate limit.
+ */
+export const MAX_TASK_DETAILS_PER_REFRESH = 200;
+
+/**
  * Detect whether an agent session came from the GitHub Copilot cloud agent or a CLI/remote session.
  *
- * Heuristic from the undocumented agent API (may change):
+ * Heuristic from the agents API:
  *   cloud-agent: model field is non-empty (e.g. "sweagent-capi:claude-sonnet-4") OR usage field present
  *   cli-remote:  model field present but empty string
  *   unknown:     model field absent entirely
@@ -74,70 +64,29 @@ export interface FetchTaskPageOptions {
 	since?: string;
 }
 
+export interface FetchAccountTaskPageOptions {
+	token: string;
+	page: number;
+	archived: boolean;
+	since?: string;
+}
+
 export type FetchTaskPageFn = (options: FetchTaskPageOptions) => Promise<TaskPageResult>;
+
+export type FetchAccountTaskPageFn = (options: FetchAccountTaskPageOptions) => Promise<TaskPageResult>;
 
 export type FetchTaskDetailFn = (
 	owner: string, repo: string, taskId: string, token: string,
 ) => Promise<TaskDetailResult>;
 
-/** Fetch one page of agent tasks from the GitHub API. */
-export function fetchAgentTasksPage(
-	{ owner, repo, token, page, archived, since }: FetchTaskPageOptions,
-): Promise<TaskPageResult> {
-	return new Promise((resolve) => {
-		let queryParams = `per_page=100&page=${page}`;
-		if (archived) { queryParams += '&archived=true'; }
-		if (since) { queryParams += `&since=${encodeURIComponent(since)}`; }
+export type FetchAccountTaskDetailFn = (taskId: string, token: string) => Promise<TaskDetailResult>;
 
-		const { hostname, restPathPrefix } = getGitHubApiEndpoints();
-		const req = https.request(
-			{
-				hostname,
-				path: `${restPathPrefix}/agents/repos/${owner}/${repo}/tasks?${queryParams}`,
-				headers: buildGitHubApiHeaders(token),
-			},
-			(res) => {
-				let data = '';
-				res.on('data', (chunk) => (data += chunk));
-				res.on('end', () => {
-					const statusCode = res.statusCode ?? 0;
-					if (statusCode < 200 || statusCode >= 300) {
-						resolve({ tasks: [], statusCode, error: `HTTP ${statusCode}` });
-						return;
-					}
-					try {
-						const parsed = JSON.parse(data);
-						const tasks = Array.isArray(parsed?.tasks)
-							? parsed.tasks
-							: (Array.isArray(parsed) ? parsed : []);
-						resolve({ tasks, statusCode });
-					} catch (e) {
-						resolve({ tasks: [], statusCode, error: String(e) });
-					}
-				});
-			},
-		);
-		req.on('error', (e) => resolve({ tasks: [], error: e.message }));
-		req.setTimeout(15000, () => { req.destroy(new Error('Request timed out')); });
-		req.end();
-	});
-}
-
-/** Fetch session details for a single agent task. */
-export function fetchAgentTaskDetail(
-	owner: string,
-	repo: string,
-	taskId: string,
-	token: string,
-): Promise<TaskDetailResult> {
+/** GET a GitHub REST path and parse the JSON body, mapping transport/HTTP errors into the result. */
+function requestGitHubJson(path: string, token: string): Promise<{ body?: any; statusCode?: number; error?: string }> {
 	return new Promise((resolve) => {
 		const { hostname, restPathPrefix } = getGitHubApiEndpoints();
 		const req = https.request(
-			{
-				hostname,
-				path: `${restPathPrefix}/agents/repos/${owner}/${repo}/tasks/${encodeURIComponent(taskId)}`,
-				headers: buildGitHubApiHeaders(token),
-			},
+			{ hostname, path: `${restPathPrefix}${path}`, headers: buildGitHubApiHeaders(token) },
 			(res) => {
 				let data = '';
 				res.on('data', (chunk) => (data += chunk));
@@ -148,11 +97,9 @@ export function fetchAgentTaskDetail(
 						return;
 					}
 					try {
-						const parsed = JSON.parse(data);
-						const sessions = Array.isArray(parsed?.sessions) ? parsed.sessions : [];
-						resolve({ sessions, statusCode });
+						resolve({ body: JSON.parse(data), statusCode });
 					} catch (e) {
-						resolve({ error: String(e) });
+						resolve({ statusCode, error: String(e) });
 					}
 				});
 			},
@@ -161,6 +108,160 @@ export function fetchAgentTaskDetail(
 		req.setTimeout(15000, () => { req.destroy(new Error('Request timed out')); });
 		req.end();
 	});
+}
+
+/** Build the shared query string for both the repo-scoped and account-wide task listings. */
+function buildTaskListQuery(page: number, archived: boolean, since?: string): string {
+	let query = `per_page=100&page=${page}`;
+	if (archived) { query += '&is_archived=true'; }
+	if (since) { query += `&since=${encodeURIComponent(since)}`; }
+	return query;
+}
+
+/** Pull the `tasks` array out of a task-listing response, tolerating a bare array body. */
+function toTaskPageResult(result: { body?: any; statusCode?: number; error?: string }): TaskPageResult {
+	if (result.error) { return { tasks: [], statusCode: result.statusCode, error: result.error }; }
+	const parsed = result.body;
+	const tasks = Array.isArray(parsed?.tasks) ? parsed.tasks : (Array.isArray(parsed) ? parsed : []);
+	return { tasks, statusCode: result.statusCode };
+}
+
+/** Pull the `sessions` array out of a task-detail response. */
+function toTaskDetailResult(result: { body?: any; statusCode?: number; error?: string }): TaskDetailResult {
+	if (result.error) { return { statusCode: result.statusCode, error: result.error }; }
+	return { sessions: Array.isArray(result.body?.sessions) ? result.body.sessions : [], statusCode: result.statusCode };
+}
+
+/** Fetch one page of agent tasks for a single repository. */
+export async function fetchAgentTasksPage(
+	{ owner, repo, token, page, archived, since }: FetchTaskPageOptions,
+): Promise<TaskPageResult> {
+	const query = buildTaskListQuery(page, archived, since);
+	return toTaskPageResult(await requestGitHubJson(`/agents/repos/${owner}/${repo}/tasks?${query}`, token));
+}
+
+/**
+ * Fetch one page of agent tasks for the authenticated user across **all** repositories.
+ *
+ * This is the account-wide `/agents/tasks` endpoint: it surfaces tasks started from github.com
+ * (the agents page and cloud chat) in repos that are not checked out locally, which the
+ * repo-scoped listing can never see. Needs "Agent tasks" (read) on the token.
+ */
+export async function fetchAccountAgentTasksPage(
+	{ token, page, archived, since }: FetchAccountTaskPageOptions,
+): Promise<TaskPageResult> {
+	const query = buildTaskListQuery(page, archived, since);
+	return toTaskPageResult(await requestGitHubJson(`/agents/tasks?${query}`, token));
+}
+
+/** Fetch session details for a single agent task, scoped to its repository. */
+export async function fetchAgentTaskDetail(
+	owner: string,
+	repo: string,
+	taskId: string,
+	token: string,
+): Promise<TaskDetailResult> {
+	const path = `/agents/repos/${owner}/${repo}/tasks/${encodeURIComponent(taskId)}`;
+	return toTaskDetailResult(await requestGitHubJson(path, token));
+}
+
+/** Fetch session details for a task by ID alone — used for tasks with no resolvable repository. */
+export async function fetchAccountAgentTaskDetail(taskId: string, token: string): Promise<TaskDetailResult> {
+	return toTaskDetailResult(await requestGitHubJson(`/agents/tasks/${encodeURIComponent(taskId)}`, token));
+}
+
+// ---------------------------------------------------------------------------
+// Session usage parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * The agents API reports AI credits in nano-credits (1 credit = 1_000_000_000 nano-credits),
+ * e.g. a session costing 43.38 AI credits is reported as `43380350000`. Divide by this factor to
+ * get the whole-credit value shown in the UI (where 1 credit = $0.01).
+ */
+const NANO_CREDITS_PER_CREDIT = 1_000_000_000;
+
+/** Billing units consumed by a single agent session. */
+export interface SessionUsage {
+	/** Whole AI credits (nano-credits from the API, divided down). */
+	credits: number;
+	/** Premium requests, for sessions that ran before the June 2026 switch to AI credits. */
+	premiumRequests: number;
+}
+
+/**
+ * Read the billing units of one session.
+ *
+ * The documented shape is `usage: { type: 'ai_credits' | 'premium_requests', amount: number }`;
+ * the live API has also been observed reporting the amount as `usage.credits`, so both spellings
+ * are accepted. Premium-request amounts are whole/fractional requests — not nano units — so they
+ * are kept in their own bucket rather than being scaled down as if they were credits.
+ */
+export function readSessionUsage(session: any): SessionUsage {
+	const usage = session?.usage;
+	if (!usage || typeof usage !== 'object') { return { credits: 0, premiumRequests: 0 }; }
+	const raw = typeof usage.amount === 'number' ? usage.amount
+		: typeof usage.credits === 'number' ? usage.credits
+		: 0;
+	if (!Number.isFinite(raw) || raw <= 0) { return { credits: 0, premiumRequests: 0 }; }
+	if (usage.type === 'premium_requests') { return { credits: 0, premiumRequests: raw }; }
+	return { credits: raw / NANO_CREDITS_PER_CREDIT, premiumRequests: 0 };
+}
+
+// ---------------------------------------------------------------------------
+// Task → repository resolution
+// ---------------------------------------------------------------------------
+
+/** Extract `owner/repo` from a github.com-style URL, if it looks like a repository URL. */
+function repoFromUrl(url: unknown): { owner: string; repo: string } | undefined {
+	if (typeof url !== 'string') { return undefined; }
+	const match = /^https?:\/\/[^/]+\/([^/\s]+)\/([^/\s?#]+)/.exec(url);
+	if (!match) { return undefined; }
+	const [, owner, repo] = match;
+	// Task URLs on the agents page (github.com/copilot/agents/...) are not repository URLs.
+	if (owner === 'copilot') { return undefined; }
+	return { owner, repo: repo.replace(/\.git$/, '') };
+}
+
+/** Split an `owner/repo` full name, ignoring anything that is not exactly two non-empty parts. */
+function splitFullName(fullName: unknown): { owner: string; repo: string } | undefined {
+	if (typeof fullName !== 'string') { return undefined; }
+	const [owner, repo, ...rest] = fullName.split('/');
+	return owner && repo && rest.length === 0 ? { owner, repo } : undefined;
+}
+
+/** Pick the repo out of the repository object itself, across the spellings the API has used. */
+function repoFromRepositoryObject(repository: any, task: any): { owner: string; repo: string } | undefined {
+	const fromFullName = splitFullName(repository.full_name) ?? splitFullName(repository.nwo);
+	if (fromFullName) { return fromFullName; }
+
+	const ownerLogin = repository.owner?.login ?? task?.owner?.login;
+	if (typeof ownerLogin === 'string' && ownerLogin && typeof repository.name === 'string' && repository.name) {
+		return { owner: ownerLogin, repo: repository.name };
+	}
+	return repoFromUrl(repository.html_url);
+}
+
+/**
+ * Resolve the repository a task belongs to.
+ *
+ * The published schema only guarantees `repository.id`, while the live API returns richer repo
+ * objects, so every known spelling is tried before falling back to parsing the task's URLs.
+ * Returns undefined for tasks with no repository — e.g. ad-hoc sessions started from cloud chat
+ * before a repo is picked — which are grouped into their own bucket.
+ */
+export function resolveTaskRepo(task: any): { owner: string; repo: string } | undefined {
+	const repository = task?.repository;
+	if (repository && typeof repository === 'object') {
+		const resolved = repoFromRepositoryObject(repository, task);
+		if (resolved) { return resolved; }
+	}
+	return repoFromUrl(task?.html_url);
+}
+
+/** Stable map key for a repository summary; account tasks with no repo share the empty key. */
+export function repoKey(owner: string, repo: string): string {
+	return owner && repo ? `${owner.toLowerCase()}/${repo.toLowerCase()}` : '';
 }
 
 // ---------------------------------------------------------------------------
@@ -193,18 +294,41 @@ export async function fetchAgentSessionsForRepo(
 	const tasksTotal = allTasks.length;
 	const tasksToDetail = allTasks.slice(0, MAX_TASKS_DETAIL_PER_REPO);
 	const partial = tasksTotal > MAX_TASKS_DETAIL_PER_REPO;
-	const { totalTasks, totalSessions, totalCredits } = await aggregateTaskDetails(tasksToDetail, owner, repo, token, fetchTaskDetail);
+	const totals = await aggregateTaskDetails(tasksToDetail, owner, repo, token, fetchTaskDetail);
 
-	return { owner, repo, totalTasks, totalSessions, totalCredits, tasksScanned: tasksToDetail.length, tasksTotal, partial };
+	return {
+		owner, repo,
+		totalTasks: totals.totalTasks,
+		totalSessions: totals.totalSessions,
+		totalCredits: totals.totalCredits,
+		totalPremiumRequests: totals.totalPremiumRequests,
+		tasksScanned: tasksToDetail.length,
+		tasksTotal,
+		partial,
+		discovery: 'workspace',
+	};
+}
+
+/** An empty summary row for a repository, before any task totals are folded in. */
+export function emptyRepoSummary(owner: string, repo: string, discovery: AgentRepoDiscovery): AgentRepoSummary {
+	return {
+		owner, repo,
+		totalTasks: 0, totalSessions: 0, totalCredits: 0, totalPremiumRequests: 0,
+		tasksScanned: 0, tasksTotal: 0, partial: false,
+		discovery,
+	};
 }
 
 function buildTaskFetchError(owner: string, repo: string, statusCode: number | undefined): AgentRepoSummary {
-	const msg = statusCode === 404
-		? 'Copilot cloud agent not enabled or not accessible for this repo'
-		: statusCode === 403
-		? 'Access denied — check that your GitHub token has repo scope'
-		: `API error (HTTP ${statusCode ?? 'unknown'})`;
-	return { owner, repo, totalTasks: 0, totalSessions: 0, totalCredits: 0, tasksScanned: 0, tasksTotal: 0, partial: false, error: msg };
+	return { ...emptyRepoSummary(owner, repo, 'workspace'), error: describeTaskFetchError(statusCode) };
+}
+
+/** Human-readable reason for a failed task listing, based on the HTTP status. */
+export function describeTaskFetchError(statusCode: number | undefined): string {
+	if (statusCode === 404) { return 'Copilot cloud agent not enabled or not accessible for this repo'; }
+	if (statusCode === 403) { return 'Access denied — check that your GitHub token has repo scope'; }
+	if (statusCode === 401) { return 'GitHub sign-in expired — sign in again to refresh agent data'; }
+	return `API error (HTTP ${statusCode ?? 'unknown'})`;
 }
 
 async function fetchTasksForArchivedBatch(
@@ -237,18 +361,18 @@ async function fetchAllTasksForRepo(
 	return { allTasks };
 }
 
-/**
- * The GitHub agents API reports `usage.credits` in nano-credits (1 credit = 1_000_000_000 nano-credits),
- * e.g. a task costing 43.38 AI credits is reported as `43380350000`. Divide by this factor to get the
- * whole-credit value shown in the UI (where 1 credit = $0.01).
- */
-const NANO_CREDITS_PER_CREDIT = 1_000_000_000;
-
-function sumCloudSessionCredits(sessions: any[]): { tasks: number; sessions: number; credits: number } {
+/** Totals for the cloud-agent sessions of a single task. */
+function sumCloudSessionUsage(sessions: any[]): { tasks: number; sessions: number; credits: number; premiumRequests: number } {
 	const cloudSessions = sessions.filter(s => detectSessionSource(s) === 'cloud-agent');
-	if (cloudSessions.length === 0) { return { tasks: 0, sessions: 0, credits: 0 }; }
-	const rawCredits = cloudSessions.reduce((sum, s) => sum + (s.usage && typeof s.usage.credits === 'number' ? s.usage.credits : 0), 0);
-	return { tasks: 1, sessions: cloudSessions.length, credits: rawCredits / NANO_CREDITS_PER_CREDIT };
+	if (cloudSessions.length === 0) { return { tasks: 0, sessions: 0, credits: 0, premiumRequests: 0 }; }
+	let credits = 0;
+	let premiumRequests = 0;
+	for (const session of cloudSessions) {
+		const usage = readSessionUsage(session);
+		credits += usage.credits;
+		premiumRequests += usage.premiumRequests;
+	}
+	return { tasks: 1, sessions: cloudSessions.length, credits, premiumRequests };
 }
 
 async function aggregateTaskDetails(
@@ -257,21 +381,253 @@ async function aggregateTaskDetails(
 	repo: string,
 	token: string,
 	fetchTaskDetail: FetchTaskDetailFn,
-): Promise<{ totalTasks: number; totalSessions: number; totalCredits: number }> {
+): Promise<{ totalTasks: number; totalSessions: number; totalCredits: number; totalPremiumRequests: number }> {
 	let totalTasks = 0;
 	let totalSessions = 0;
 	let totalCredits = 0;
+	let totalPremiumRequests = 0;
 	const CONCURRENCY = 5;
 	for (let i = 0; i < tasksToDetail.length; i += CONCURRENCY) {
 		const batch = tasksToDetail.slice(i, i + CONCURRENCY);
 		const results = await Promise.all(batch.map(task => fetchTaskDetail(owner, repo, task.id, token)));
 		for (const { sessions } of results) {
 			if (!sessions || sessions.length === 0) { continue; }
-			const { tasks, sessions: s, credits } = sumCloudSessionCredits(sessions);
-			totalTasks += tasks;
-			totalSessions += s;
-			totalCredits += credits;
+			const totals = sumCloudSessionUsage(sessions);
+			totalTasks += totals.tasks;
+			totalSessions += totals.sessions;
+			totalCredits += totals.credits;
+			totalPremiumRequests += totals.premiumRequests;
 		}
 	}
-	return { totalTasks, totalSessions, totalCredits };
+	return { totalTasks, totalSessions, totalCredits, totalPremiumRequests };
+}
+
+// ---------------------------------------------------------------------------
+// Account-wide collection (workspace repos + /agents/tasks)
+// ---------------------------------------------------------------------------
+
+/** One task considered for a detail fetch, with the repository it was attributed to. */
+interface AgentTaskCandidate {
+	id: string;
+	key: string;
+	owner?: string;
+	repo?: string;
+	/** Sort key (most recent first) so the detail budget is spent on the newest tasks. */
+	sortAt: number;
+}
+
+export interface CollectAgentSessionsOptions {
+	token: string;
+	since: Date;
+	/** Repos discovered from workspace git remotes. Listed even when they report no tasks. */
+	workspaceRepos: { owner: string; repo: string }[];
+	fetchTaskPage?: FetchTaskPageFn;
+	fetchAccountTaskPage?: FetchAccountTaskPageFn;
+	fetchTaskDetail?: FetchTaskDetailFn;
+	fetchAccountTaskDetail?: FetchAccountTaskDetailFn;
+	/** Cap on task-detail calls for this pass (default MAX_TASK_DETAILS_PER_REFRESH). */
+	maxTaskDetails?: number;
+	/** Reports coarse progress (list calls + detail calls) so the panel can show a bar. */
+	onProgress?: (done: number, total: number) => void;
+}
+
+/** Timestamp used to spend the detail budget on the most recently active tasks first. */
+function taskSortAt(task: any): number {
+	const stamp = Date.parse(task?.updated_at ?? task?.created_at ?? '');
+	return Number.isFinite(stamp) ? stamp : 0;
+}
+
+/** Collect one archived/active slice of a task listing into `tasks`, deduplicating by task ID. */
+async function listTaskSlice(
+	fetchPage: (page: number, archived: boolean) => Promise<TaskPageResult>,
+	archived: boolean,
+	tasks: any[],
+	seen: Set<string>,
+): Promise<{ statusCode?: number; error?: string } | undefined> {
+	for (let page = 1; page <= 5; page++) {
+		const result = await fetchPage(page, archived);
+		if (result.error) { return { statusCode: result.statusCode, error: result.error }; }
+		for (const task of result.tasks) {
+			if (task?.id && !seen.has(task.id)) { seen.add(task.id); tasks.push(task); }
+		}
+		if (result.tasks.length < 100) { return undefined; }
+	}
+	return undefined;
+}
+
+/**
+ * Page through a task listing, active tasks first and then archived ones. Only a failure on the
+ * very first call is reported: once some tasks are in hand, a later page or the archived pass
+ * failing just means the snapshot is slightly short, which the per-repo `partial` flag covers.
+ */
+async function listAllTasks(
+	fetchPage: (page: number, archived: boolean) => Promise<TaskPageResult>,
+): Promise<{ tasks: any[]; statusCode?: number; error?: string }> {
+	const tasks: any[] = [];
+	const seen = new Set<string>();
+	const activeError = await listTaskSlice(fetchPage, false, tasks, seen);
+	if (activeError && tasks.length === 0) { return { tasks: [], ...activeError }; }
+	await listTaskSlice(fetchPage, true, tasks, seen);
+	return { tasks };
+}
+
+/** Ensure a row exists for this repo key, widening its discovery when seen from both sources. */
+function upsertRow(
+	rows: Map<string, AgentRepoSummary>, key: string, owner: string, repo: string, discovery: AgentRepoDiscovery,
+): AgentRepoSummary {
+	const existing = rows.get(key);
+	if (existing) {
+		if (existing.discovery !== discovery) { existing.discovery = 'both'; }
+		return existing;
+	}
+	const row: AgentRepoSummary = { ...emptyRepoSummary(owner, repo, discovery) };
+	if (!key) { row.unassigned = true; }
+	rows.set(key, row);
+	return row;
+}
+
+/** List tasks for every workspace repo, recording per-repo errors on their rows. */
+async function collectWorkspaceTasks(
+	options: CollectAgentSessionsOptions,
+	rows: Map<string, AgentRepoSummary>,
+	candidates: Map<string, AgentTaskCandidate>,
+	reportProgress: () => void,
+): Promise<void> {
+	const fetchTaskPage = options.fetchTaskPage ?? fetchAgentTasksPage;
+	const sinceStr = options.since.toISOString();
+	for (const { owner, repo } of options.workspaceRepos) {
+		const key = repoKey(owner, repo);
+		const row = upsertRow(rows, key, owner, repo, 'workspace');
+		const { tasks, statusCode, error } = await listAllTasks(
+			(page, archived) => fetchTaskPage({ owner, repo, token: options.token, page, archived, since: sinceStr }),
+		);
+		if (error) { row.error = describeTaskFetchError(statusCode); }
+		for (const task of tasks) {
+			if (!candidates.has(task.id)) { candidates.set(task.id, { id: task.id, key, owner, repo, sortAt: taskSortAt(task) }); }
+		}
+		reportProgress();
+	}
+}
+
+/** List the authenticated user's tasks across all repositories, adding any repos not seen yet. */
+async function collectAccountTasks(
+	options: CollectAgentSessionsOptions,
+	rows: Map<string, AgentRepoSummary>,
+	candidates: Map<string, AgentTaskCandidate>,
+): Promise<{ available: boolean; error?: string }> {
+	const fetchAccountPage = options.fetchAccountTaskPage ?? fetchAccountAgentTasksPage;
+	const sinceStr = options.since.toISOString();
+	const { tasks, statusCode, error } = await listAllTasks(
+		(page, archived) => fetchAccountPage({ token: options.token, page, archived, since: sinceStr }),
+	);
+	if (error) { return { available: false, error: describeTaskFetchError(statusCode) }; }
+
+	for (const task of tasks) {
+		const resolved = resolveTaskRepo(task);
+		const key = repoKey(resolved?.owner ?? '', resolved?.repo ?? '');
+		upsertRow(rows, key, resolved?.owner ?? '', resolved?.repo ?? '', 'account');
+		const existing = candidates.get(task.id);
+		if (existing) { continue; }
+		candidates.set(task.id, { id: task.id, key, owner: resolved?.owner, repo: resolved?.repo, sortAt: taskSortAt(task) });
+	}
+	return { available: true };
+}
+
+/** Fetch details for the selected tasks and fold their session totals into the repo rows. */
+async function foldTaskDetails(
+	selected: AgentTaskCandidate[],
+	options: CollectAgentSessionsOptions,
+	rows: Map<string, AgentRepoSummary>,
+	reportProgress: () => void,
+): Promise<void> {
+	const fetchTaskDetail = options.fetchTaskDetail ?? fetchAgentTaskDetail;
+	const fetchAccountTaskDetail = options.fetchAccountTaskDetail ?? fetchAccountAgentTaskDetail;
+	const CONCURRENCY = 5;
+	for (let i = 0; i < selected.length; i += CONCURRENCY) {
+		const batch = selected.slice(i, i + CONCURRENCY);
+		const details = await Promise.all(batch.map(candidate => (
+			candidate.owner && candidate.repo
+				? fetchTaskDetail(candidate.owner, candidate.repo, candidate.id, options.token)
+				: fetchAccountTaskDetail(candidate.id, options.token)
+		)));
+		batch.forEach((candidate, index) => {
+			reportProgress();
+			const row = rows.get(candidate.key);
+			const sessions = details[index]?.sessions;
+			if (!row || !sessions || sessions.length === 0) { return; }
+			const totals = sumCloudSessionUsage(sessions);
+			row.totalTasks += totals.tasks;
+			row.totalSessions += totals.sessions;
+			row.totalCredits += totals.credits;
+			row.totalPremiumRequests += totals.premiumRequests;
+		});
+	}
+}
+
+/** Order rows by cost, then activity, then name — with the "no repository" bucket last. */
+function sortRepoRows(rows: AgentRepoSummary[]): AgentRepoSummary[] {
+	return rows.sort((a, b) => {
+		if (Boolean(a.unassigned) !== Boolean(b.unassigned)) { return a.unassigned ? 1 : -1; }
+		if (b.totalCredits !== a.totalCredits) { return b.totalCredits - a.totalCredits; }
+		if (b.tasksTotal !== a.tasksTotal) { return b.tasksTotal - a.tasksTotal; }
+		return `${a.owner}/${a.repo}`.localeCompare(`${b.owner}/${b.repo}`);
+	});
+}
+
+/**
+ * Collect cloud-agent session stats for the authenticated user across both sources:
+ * the workspace's git remotes (which also surface tasks other people started in those repos) and
+ * the account-wide `/agents/tasks` listing (which surfaces tasks started from github.com in repos
+ * that aren't checked out locally, plus ad-hoc cloud chat tasks with no repository at all).
+ *
+ * Tasks are deduplicated by ID across both listings, so a task visible in both is counted once.
+ * The number of task-detail calls is capped: the newest tasks are detailed first and any repo with
+ * tasks left over is flagged `partial`, making its totals a lower bound.
+ */
+export async function collectAgentSessions(options: CollectAgentSessionsOptions): Promise<AgentSessionsResult> {
+	const rows = new Map<string, AgentRepoSummary>();
+	const candidates = new Map<string, AgentTaskCandidate>();
+	const maxDetails = options.maxTaskDetails ?? MAX_TASK_DETAILS_PER_REFRESH;
+
+	// Progress is reported over: one unit per workspace repo listing, one for the account listing,
+	// and one per task-detail call. The detail count is only known after listing, so the total is
+	// re-estimated as it grows rather than pretending to be exact up front.
+	let done = 0;
+	let total = options.workspaceRepos.length + 1;
+	const reportProgress = () => { done++; options.onProgress?.(done, Math.max(total, done)); };
+
+	await collectWorkspaceTasks(options, rows, candidates, reportProgress);
+	const account = await collectAccountTasks(options, rows, candidates);
+	reportProgress();
+
+	for (const candidate of candidates.values()) {
+		const row = rows.get(candidate.key);
+		if (row) { row.tasksTotal++; }
+	}
+
+	const ordered = Array.from(candidates.values()).sort((a, b) => b.sortAt - a.sortAt);
+	const selected = ordered.slice(0, maxDetails);
+	total += selected.length;
+	for (const candidate of selected) {
+		const row = rows.get(candidate.key);
+		if (row) { row.tasksScanned++; }
+	}
+	for (const row of rows.values()) { row.partial = row.tasksTotal > row.tasksScanned; }
+
+	await foldTaskDetails(selected, options, rows, reportProgress);
+
+	const repos = sortRepoRows(Array.from(rows.values()));
+	return {
+		repos,
+		totalTasks: repos.reduce((sum, r) => sum + r.totalTasks, 0),
+		totalSessions: repos.reduce((sum, r) => sum + r.totalSessions, 0),
+		totalCredits: repos.reduce((sum, r) => sum + r.totalCredits, 0),
+		totalPremiumRequests: repos.reduce((sum, r) => sum + r.totalPremiumRequests, 0),
+		authenticated: true,
+		since: options.since.toISOString(),
+		fetchedAt: new Date().toISOString(),
+		accountTasksAvailable: account.available,
+		accountTasksError: account.error,
+		partial: candidates.size > selected.length,
+	};
 }

--- a/vscode-extension/src/agentTasksCache.ts
+++ b/vscode-extension/src/agentTasksCache.ts
@@ -1,0 +1,124 @@
+/**
+ * Cross-window cache for the Copilot cloud-agent task snapshot.
+ *
+ * Collecting agent sessions costs a task-list call per repo plus one detail call per task, so it
+ * is deliberately expensive to refresh: the snapshot is written to a JSON file in the extension's
+ * global storage (shared by every VS Code window of this edition) and refreshed at most once an
+ * hour, by whichever window currently holds the agent-tasks lock. Every other window — and every
+ * panel open in between — reads this file instead of calling GitHub.
+ *
+ * The file I/O lives here; the freshness decisions are pure functions so they can be unit tested
+ * without touching disk, following the same split as `worktreeBackgroundScan.ts`.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import type { AgentSessionsResult } from './agentSessionsService';
+
+/** How often the agent-task snapshot may be refreshed from the GitHub API: once an hour. */
+export const AGENT_TASKS_REFRESH_INTERVAL_MS = 60 * 60 * 1000;
+
+/**
+ * Bumped whenever the shape of `AgentSessionsResult` changes in a way that would make an older
+ * snapshot render incorrectly. Snapshots from a different version are ignored (and refetched).
+ */
+export const AGENT_TASKS_CACHE_SCHEMA_VERSION = 2;
+
+/** On-disk envelope: the snapshot plus what it takes to decide whether it is still usable. */
+export interface AgentTasksCacheEnvelope {
+	schemaVersion: number;
+	/** When the snapshot was fetched from GitHub (ISO 8601). */
+	fetchedAt: string;
+	/** Start of the window the snapshot covers (ISO 8601), so a widened window invalidates it. */
+	since: string;
+	data: AgentSessionsResult;
+}
+
+/** Path of the shared snapshot file for this cache identifier (dev and prod are kept separate). */
+export function getAgentTasksCachePath(globalStoragePath: string, cacheIdentifier: string): string {
+	return path.join(globalStoragePath, `agenttasks_${cacheIdentifier}.snapshot.json`);
+}
+
+/**
+ * Whether a snapshot is still fresh enough to serve without calling GitHub. A missing or
+ * unparseable timestamp counts as stale, and so does one in the future by more than the interval
+ * (a clock change) so a bad timestamp can never pin the cache open forever.
+ */
+export function isAgentTasksSnapshotFresh(
+	fetchedAt: string | undefined,
+	now: number,
+	intervalMs: number = AGENT_TASKS_REFRESH_INTERVAL_MS,
+): boolean {
+	if (!fetchedAt) { return false; }
+	const fetchedMs = Date.parse(fetchedAt);
+	if (!Number.isFinite(fetchedMs)) { return false; }
+	const age = now - fetchedMs;
+	if (age < -intervalMs) { return false; }
+	return age < intervalMs;
+}
+
+/** Whether this envelope can be served as-is: right schema, same window, still fresh. */
+export function canServeAgentTasksSnapshot(
+	envelope: AgentTasksCacheEnvelope | undefined,
+	since: Date,
+	now: number,
+	intervalMs: number = AGENT_TASKS_REFRESH_INTERVAL_MS,
+): boolean {
+	if (!isAgentTasksEnvelopeUsable(envelope, since)) { return false; }
+	return isAgentTasksSnapshotFresh(envelope?.fetchedAt, now, intervalMs);
+}
+
+/**
+ * Whether an envelope may be shown at all (even when stale): a stale snapshot is still the best
+ * thing to render while the next hourly refresh is pending, but one from another schema version or
+ * covering a shorter window than asked for is not.
+ */
+export function isAgentTasksEnvelopeUsable(
+	envelope: AgentTasksCacheEnvelope | undefined,
+	since: Date,
+): boolean {
+	if (!envelope || envelope.schemaVersion !== AGENT_TASKS_CACHE_SCHEMA_VERSION) { return false; }
+	if (!envelope.data || !Array.isArray(envelope.data.repos)) { return false; }
+	const snapshotSince = Date.parse(envelope.since);
+	if (!Number.isFinite(snapshotSince)) { return false; }
+	// Tolerate a minute of drift: `since` is recomputed as "30 days ago" on every call.
+	return snapshotSince <= since.getTime() + 60_000;
+}
+
+/** When the next refresh becomes due, as an ISO timestamp (undefined when it is due now). */
+export function nextAgentTasksRefreshAt(
+	fetchedAt: string | undefined,
+	intervalMs: number = AGENT_TASKS_REFRESH_INTERVAL_MS,
+): string | undefined {
+	if (!fetchedAt) { return undefined; }
+	const fetchedMs = Date.parse(fetchedAt);
+	if (!Number.isFinite(fetchedMs)) { return undefined; }
+	return new Date(fetchedMs + intervalMs).toISOString();
+}
+
+/** Read the shared snapshot, returning undefined when it is missing or unreadable. */
+export async function readAgentTasksSnapshot(filePath: string): Promise<AgentTasksCacheEnvelope | undefined> {
+	try {
+		const raw = await fs.promises.readFile(filePath, 'utf8');
+		const parsed = JSON.parse(raw);
+		if (!parsed || typeof parsed !== 'object') { return undefined; }
+		return parsed as AgentTasksCacheEnvelope;
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * Write the shared snapshot. Writes to a temporary file first and renames it into place so a
+ * window reading concurrently never sees a half-written file.
+ */
+export async function writeAgentTasksSnapshot(filePath: string, envelope: AgentTasksCacheEnvelope): Promise<void> {
+	await fs.promises.mkdir(path.dirname(filePath), { recursive: true });
+	const tempPath = `${filePath}.${process.pid}.tmp`;
+	await fs.promises.writeFile(tempPath, JSON.stringify(envelope), 'utf8');
+	try {
+		await fs.promises.rename(tempPath, filePath);
+	} catch (err) {
+		await fs.promises.rm(tempPath, { force: true });
+		throw err;
+	}
+}

--- a/vscode-extension/src/cacheManager.ts
+++ b/vscode-extension/src/cacheManager.ts
@@ -125,7 +125,7 @@ export class CacheManager {
 			const now = Date.now();
 			let removedCount = 0;
 			for (const name of entries) {
-				if (!/^(cache|refresh)_dev-[0-9a-f]+\.(snapshot\.json|lock)$/.test(name)) { continue; }
+				if (!/^(cache|refresh|agenttasks)_dev-[0-9a-f]+\.(snapshot\.json|lock)$/.test(name)) { continue; }
 				const filePath = path.join(dir, name);
 				try {
 					const stat = await fs.promises.stat(filePath);
@@ -162,6 +162,17 @@ export class CacheManager {
 	}
 
 	/**
+	 * Get the path for the agent-tasks refresh lock file.
+	 * Held by the single window that refreshes the hourly Copilot cloud-agent snapshot from the
+	 * GitHub API, so the other windows never duplicate those API calls. Kept separate from the
+	 * cache-refresh leader lock because the two run on different schedules.
+	 */
+	getAgentTasksLockPath(): string {
+		const cacheId = this.getCacheIdentifier();
+		return path.join(this.context.globalStorageUri.fsPath, `agenttasks_${cacheId}.lock`);
+	}
+
+	/**
 	 * Acquire an exclusive file lock for cache writes.
 	 * Uses atomic file creation (O_EXCL / CREATE_NEW) to prevent concurrent writes
 	 * across multiple VS Code windows of the same edition.
@@ -169,6 +180,19 @@ export class CacheManager {
 	 */
 	async acquireCacheLock(): Promise<boolean> {
 		return this.acquireLock(this.getCacheLockPath());
+	}
+
+	/**
+	 * Try to become the window that refreshes the agent-tasks snapshot. Returns false when another
+	 * window is already refreshing it, in which case this window serves the shared snapshot.
+	 */
+	async acquireAgentTasksLock(): Promise<boolean> {
+		return this.acquireLock(this.getAgentTasksLockPath());
+	}
+
+	/** Release the agent-tasks refresh lock, but only if we own it. */
+	async releaseAgentTasksLock(): Promise<void> {
+		return this.releaseLock(this.getAgentTasksLockPath());
 	}
 
 	/**
@@ -186,7 +210,19 @@ export class CacheManager {
 	 * Returns true if the lock is still owned by us after the renew attempt.
 	 */
 	async renewRefreshLock(): Promise<boolean> {
-		const lockPath = this.getRefreshLockPath();
+		return this.renewLock(this.getRefreshLockPath());
+	}
+
+	/**
+	 * Renew (heartbeat) the agent-tasks lock so a slow GitHub API pass is not mistaken for a stale
+	 * lock by another window, which would let it duplicate the same API calls.
+	 */
+	async renewAgentTasksLock(): Promise<boolean> {
+		return this.renewLock(this.getAgentTasksLockPath());
+	}
+
+	/** Refresh a lock file's timestamp, but only while this window still owns it. */
+	private async renewLock(lockPath: string): Promise<boolean> {
 		try {
 			const content = await fs.promises.readFile(lockPath, 'utf-8');
 			const lock = JSON.parse(content);

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -242,7 +242,16 @@ import {
 	type RepoPrInfo,
 	type RepoPrStatsResult,
 } from './githubPrService';
-import { fetchAgentSessionsForRepo } from './agentSessionsService';
+import { collectAgentSessions } from './agentSessionsService';
+import {
+	AGENT_TASKS_CACHE_SCHEMA_VERSION,
+	AGENT_TASKS_REFRESH_INTERVAL_MS,
+	canServeAgentTasksSnapshot,
+	getAgentTasksCachePath,
+	isAgentTasksEnvelopeUsable,
+	readAgentTasksSnapshot,
+	writeAgentTasksSnapshot,
+} from './agentTasksCache';
 import { getConfiguredGitHubEnterpriseUri, getGitHubAuthProviderId } from './githubApiConfig';
 
 // --- View regression ---
@@ -634,8 +643,11 @@ class CopilotTokenTracker implements vscode.Disposable {
 	// Cached PR stats result for the repos tab
 	private _lastRepoPrStats?: RepoPrStatsResult;
 
-	// Cached cloud agent sessions result for the cloud agent tab
+	// Cached cloud agent sessions result for the cloud agent tab (mirrors the shared snapshot on disk)
 	private _lastAgentSessionsData?: AgentSessionsResult;
+
+	// True while this window is refreshing the shared cloud-agent snapshot from the GitHub API
+	private _agentSessionsRefreshInFlight = false;
 
 	// Tool name mapping - loaded from toolNames.json for friendly display names
 	private toolNameMap: { [key: string]: string } = toolNamesData as { [key: string]: string };
@@ -1779,9 +1791,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 				const result: RepoPrStatsResult = { repos: [], authenticated: false, since: since.toISOString() };
 				this._lastRepoPrStats = result;
 				this.analysisPanel.webview.postMessage({ command: 'repoPrStatsLoaded', data: result });
-				const agentResult: AgentSessionsResult = { repos: [], totalTasks: 0, totalSessions: 0, totalCredits: 0, authenticated: false, since: since.toISOString(), fetchedAt: new Date().toISOString() };
-				this._lastAgentSessionsData = agentResult;
-				this.analysisPanel.webview.postMessage({ command: 'agentSessionsLoaded', data: agentResult });
+				this.publishAgentSessions(this.buildEmptyAgentSessionsResult(since, false));
 			}
 		} catch (error) {
 			this.error('Failed to sign out from GitHub:', error);
@@ -1919,61 +1929,148 @@ class CopilotTokenTracker implements vscode.Disposable {
 			: { totalPrs, aiAuthoredPrs, aiReviewRequestedPrs, aiDetails };
 	}
 
+	/** Window the cloud-agent snapshot covers: the last 30 days, matching the other GitHub panels. */
+	private agentSessionsSince(): Date {
+		const since = new Date();
+		since.setDate(since.getDate() - 30);
+		return since;
+	}
+
+	/** Path of the cross-window cloud-agent snapshot shared by every window of this VS Code edition. */
+	private agentTasksCachePath(): string {
+		return getAgentTasksCachePath(this.context.globalStorageUri.fsPath, this.cacheManager.getCacheIdentifier());
+	}
+
+	/** An empty snapshot — `fetchedAt: ''` marks "never fetched", which the panel renders as pending. */
+	private buildEmptyAgentSessionsResult(since: Date, authenticated: boolean): AgentSessionsResult {
+		return {
+			repos: [], totalTasks: 0, totalSessions: 0, totalCredits: 0, totalPremiumRequests: 0,
+			authenticated, since: since.toISOString(), fetchedAt: '',
+			accountTasksAvailable: false, partial: false,
+		};
+	}
+
 	/**
-	 * Load Copilot cloud agent session stats for all discovered GitHub repos and send to the analysis panel.
-	 * Only cloud-agent sessions are counted — CLI/remote sessions that share the same task API are excluded
-	 * so they are not double-counted with the chat-session data already shown in "My Activity".
+	 * Remember and push a snapshot to the analysis panel, if one is open. The refresh interval is
+	 * stamped on here so the panel can show when the next refresh is due without duplicating the
+	 * cache policy.
+	 */
+	private publishAgentSessions(result: AgentSessionsResult): void {
+		const stamped: AgentSessionsResult = { ...result, refreshIntervalMs: AGENT_TASKS_REFRESH_INTERVAL_MS };
+		this._lastAgentSessionsData = stamped;
+		this.analysisPanel?.webview.postMessage({ command: 'agentSessionsLoaded', data: stamped });
+	}
+
+	/**
+	 * Show Copilot cloud agent session stats in the analysis panel.
+	 *
+	 * This never calls GitHub itself: it serves the shared hourly snapshot (see `agentTasksCache.ts`)
+	 * so opening the tab is instant and costs no API calls, then asks for a refresh, which only
+	 * happens if the snapshot is stale *and* this window wins the agent-tasks lock.
 	 */
 	private async loadAgentSessions(): Promise<void> {
 		if (!this.analysisPanel) { return; }
-
-		const since = new Date();
-		since.setDate(since.getDate() - 30);
+		const since = this.agentSessionsSince();
 
 		if (this._githubSignedOutByUser) {
-			const result: AgentSessionsResult = { repos: [], totalTasks: 0, totalSessions: 0, totalCredits: 0, authenticated: false, since: since.toISOString(), fetchedAt: new Date().toISOString() };
-			this._lastAgentSessionsData = result;
-			this.analysisPanel.webview.postMessage({ command: 'agentSessionsLoaded', data: result });
+			this.publishAgentSessions(this.buildEmptyAgentSessionsResult(since, false));
 			return;
 		}
 
 		const session = await vscode.authentication.getSession(getGitHubAuthProviderId(), ['read:user'], { silent: true });
 		if (!session) {
-			const result: AgentSessionsResult = { repos: [], totalTasks: 0, totalSessions: 0, totalCredits: 0, authenticated: false, since: since.toISOString(), fetchedAt: new Date().toISOString() };
-			this._lastAgentSessionsData = result;
-			this.analysisPanel.webview.postMessage({ command: 'agentSessionsLoaded', data: result });
+			this.publishAgentSessions(this.buildEmptyAgentSessionsResult(since, false));
 			return;
 		}
-
 		if (!this.githubSession) {
 			this.githubSession = session;
 			await this.context.globalState.update('github.authenticated', true);
 			await this.context.globalState.update('github.username', session.account.label);
 		}
 
-		const workspacePaths = this._buildWorkspacePaths();
-		const repos = discoverGitHubRepos(workspacePaths, getConfiguredGitHubEnterpriseUri());
-		this.analysisPanel.webview.postMessage({ command: 'agentSessionsProgress', total: repos.length, done: 0 });
-
-		const repoResults = [];
-		for (let i = 0; i < repos.length; i++) {
-			const { owner, repo } = repos[i];
-			const summary = await fetchAgentSessionsForRepo(owner, repo, session.accessToken, since);
-			repoResults.push(summary);
-			this.analysisPanel.webview.postMessage({ command: 'agentSessionsProgress', total: repos.length, done: i + 1 });
+		const snapshot = await readAgentTasksSnapshot(this.agentTasksCachePath());
+		if (isAgentTasksEnvelopeUsable(snapshot, since)) {
+			this.publishAgentSessions(snapshot!.data);
+		} else {
+			this.publishAgentSessions(this._lastAgentSessionsData ?? this.buildEmptyAgentSessionsResult(since, true));
 		}
 
-		const result: AgentSessionsResult = {
-			repos: repoResults,
-			totalTasks: repoResults.reduce((s, r) => s + r.totalTasks, 0),
-			totalSessions: repoResults.reduce((s, r) => s + r.totalSessions, 0),
-			totalCredits: repoResults.reduce((s, r) => s + r.totalCredits, 0),
-			authenticated: true,
-			since: since.toISOString(),
-			fetchedAt: new Date().toISOString(),
-		};
-		this._lastAgentSessionsData = result;
-		this.analysisPanel.webview.postMessage({ command: 'agentSessionsLoaded', data: result });
+		void this.maybeRefreshAgentSessions();
+	}
+
+	/**
+	 * Refresh the cloud-agent snapshot from the GitHub API, if it is due.
+	 *
+	 * Collecting it costs one task-list call per repo plus one detail call per task, so it is
+	 * deliberately rationed: at most once every AGENT_TASKS_REFRESH_INTERVAL_MS, and only in the
+	 * window that wins the agent-tasks lock — the other windows read that window's snapshot from
+	 * global storage instead of repeating the calls. Runs on extension start and on every cache
+	 * refresh cycle (both leader-gated), plus whenever the Cloud Agent tab is opened.
+	 */
+	private async maybeRefreshAgentSessions(): Promise<void> {
+		if (this._agentSessionsRefreshInFlight || this._githubSignedOutByUser) { return; }
+		const since = this.agentSessionsSince();
+		const cachePath = this.agentTasksCachePath();
+		if (canServeAgentTasksSnapshot(await readAgentTasksSnapshot(cachePath), since, Date.now())) { return; }
+
+		const session = await vscode.authentication.getSession(getGitHubAuthProviderId(), ['read:user'], { silent: true });
+		if (!session) { return; }
+
+		let acquired = false;
+		try { acquired = await this.cacheManager.acquireAgentTasksLock(); }
+		catch (err) { this.warn(`Failed to acquire agent tasks lock: ${err}`); }
+		if (!acquired) {
+			this.log('⏭️ Cloud agent refresh skipped — another window is refreshing the shared snapshot');
+			return;
+		}
+
+		this._agentSessionsRefreshInFlight = true;
+		// Heartbeat the lock: a slow API pass must not look stale to another window, which would
+		// let it start the same collection in parallel.
+		const heartbeat = setInterval(() => { void this.cacheManager.renewAgentTasksLock(); }, 60 * 1000);
+		try {
+			await this.refreshAgentSessionsSnapshot(session.accessToken, since, cachePath);
+		} catch (err) {
+			this.warn(`Cloud agent session refresh failed: ${err}`);
+		} finally {
+			clearInterval(heartbeat);
+			this._agentSessionsRefreshInFlight = false;
+			try { await this.cacheManager.releaseAgentTasksLock(); }
+			catch (err) { this.warn(`Failed to release agent tasks lock: ${err}`); }
+		}
+	}
+
+	/**
+	 * Collect the snapshot and publish it, combining the workspace repos (which also surface tasks
+	 * other people started there) with the account-wide task list (tasks started on github.com in
+	 * repos that aren't checked out here, and ad-hoc cloud chat tasks with no repository at all).
+	 */
+	private async refreshAgentSessionsSnapshot(token: string, since: Date, cachePath: string): Promise<void> {
+		const workspaceRepos = discoverGitHubRepos(this._buildWorkspacePaths(), getConfiguredGitHubEnterpriseUri());
+		this.log(`🤖 Refreshing cloud agent snapshot (${workspaceRepos.length} workspace repo(s) + account-wide tasks)`);
+
+		const result = await collectAgentSessions({
+			token,
+			since,
+			workspaceRepos,
+			onProgress: (done, total) => {
+				this.analysisPanel?.webview.postMessage({ command: 'agentSessionsProgress', total, done });
+			},
+		});
+
+		try {
+			await writeAgentTasksSnapshot(cachePath, {
+				schemaVersion: AGENT_TASKS_CACHE_SCHEMA_VERSION,
+				fetchedAt: result.fetchedAt,
+				since: result.since,
+				data: result,
+			});
+		} catch (err) {
+			this.warn(`Failed to write cloud agent snapshot: ${err}`);
+		}
+
+		this.log(`🤖 Cloud agent snapshot: ${result.repos.length} repo(s), ${result.totalTasks} task(s), ${result.totalCredits.toFixed(1)} credits`);
+		this.publishAgentSessions(result);
 	}
 
 	/** Collect workspace paths from the customization matrix and currently open VS Code workspace folders. */
@@ -2480,7 +2577,12 @@ class CopilotTokenTracker implements vscode.Disposable {
 		// Piggyback the once-daily background worktree scan on the same leader election: only
 		// the window that won this refresh's leader lock may start it, and it runs detached
 		// (drip-throttled, can take far longer than this refresh cycle) so it never blocks it.
-		if (isLeader) { void this.maybeStartBackgroundWorktreeScan(); }
+		// The hourly cloud-agent snapshot refresh rides along for the same reason: it is leader-only
+		// GitHub API work that must not hold up the parse, and this also gives it a run at startup.
+		if (isLeader) {
+			void this.maybeStartBackgroundWorktreeScan();
+			void this.maybeRefreshAgentSessions();
+		}
 
 		try {
 			return await this._runRefreshCore(silent, isLeader);

--- a/vscode-extension/src/webview/usage/agentSessionsSanitizer.ts
+++ b/vscode-extension/src/webview/usage/agentSessionsSanitizer.ts
@@ -14,17 +14,24 @@ import { escapeHtml } from '../shared/formatUtils';
  * `customizationSanitizer.ts` and `billingStatsSanitizer.ts` in this folder.
  */
 
+/** Where a repo row came from: workspace git remotes, the account-wide task list, or both. */
+export type AgentRepoDiscovery = 'workspace' | 'account' | 'both';
+
 export type AgentRepoSummary = {
 	owner: string;
 	repo: string;
-	/** Pre-validated safe https URL for this repo. */
+	/** Pre-validated safe https URL for this repo ('#' for the "no repository" bucket). */
 	repoUrl: string;
 	totalTasks: number;
 	totalSessions: number;
 	totalCredits: number;
+	totalPremiumRequests: number;
 	tasksScanned: number;
 	tasksTotal: number;
 	partial: boolean;
+	discovery: AgentRepoDiscovery;
+	/** True for the bucket of account tasks the API reported without a repository. */
+	unassigned: boolean;
 	error?: string;
 };
 
@@ -33,10 +40,25 @@ export type AgentSessionsResult = {
 	totalTasks: number;
 	totalSessions: number;
 	totalCredits: number;
+	totalPremiumRequests: number;
 	authenticated: boolean;
 	since: string;
+	/** ISO timestamp of the shared snapshot; empty when it has never been fetched. */
 	fetchedAt: string;
+	accountTasksAvailable: boolean;
+	accountTasksError?: string;
+	partial: boolean;
+	/** How often the extension refreshes the snapshot, used to show when the next refresh is due. */
+	refreshIntervalMs: number;
 };
+
+/** Fallback refresh cadence when a snapshot predates the extension stamping its own interval. */
+const DEFAULT_SNAPSHOT_REFRESH_INTERVAL_MS = 60 * 60 * 1000;
+
+/** Narrow an untrusted value to a known discovery source, defaulting to the workspace scan. */
+function toDiscovery(value: unknown): AgentRepoDiscovery {
+	return value === 'account' || value === 'both' ? value : 'workspace';
+}
 
 /** Coerces a value to a non-negative finite number, defaulting to 0. */
 export function toSafeNumber(value: unknown): number {
@@ -70,20 +92,29 @@ export function sanitizeAgentSessionsData(input: unknown): AgentSessionsResult {
 		totalTasks: toSafeNumber(src.totalTasks),
 		totalSessions: toSafeNumber(src.totalSessions),
 		totalCredits: toSafeNumber(src.totalCredits),
+		totalPremiumRequests: toSafeNumber(src.totalPremiumRequests),
+		accountTasksAvailable: Boolean(src.accountTasksAvailable),
+		refreshIntervalMs: toSafeNumber(src.refreshIntervalMs) || DEFAULT_SNAPSHOT_REFRESH_INTERVAL_MS,
+		accountTasksError: typeof src.accountTasksError === 'string' ? escapeHtml(src.accountTasksError) : undefined,
+		partial: Boolean(src.partial),
 		repos: repos.map((repo) => {
 			const r = (repo && typeof repo === 'object') ? (repo as Record<string, unknown>) : {};
 			const owner = escapeHtml(typeof r.owner === 'string' ? r.owner : '');
 			const repoName = escapeHtml(typeof r.repo === 'string' ? r.repo : '');
+			const unassigned = Boolean(r.unassigned) || !owner || !repoName;
 			return {
 				owner,
 				repo: repoName,
-				repoUrl: toSafeHttpUrl(`https://github.com/${owner}/${repoName}`),
+				repoUrl: unassigned ? '#' : toSafeHttpUrl(`https://github.com/${owner}/${repoName}`),
 				totalTasks: toSafeNumber(r.totalTasks),
 				totalSessions: toSafeNumber(r.totalSessions),
 				totalCredits: toSafeNumber(r.totalCredits),
+				totalPremiumRequests: toSafeNumber(r.totalPremiumRequests),
 				tasksScanned: toSafeNumber(r.tasksScanned),
 				tasksTotal: toSafeNumber(r.tasksTotal),
 				partial: Boolean(r.partial),
+				discovery: toDiscovery(r.discovery),
+				unassigned,
 				error: typeof r.error === 'string' ? escapeHtml(r.error) : undefined,
 			};
 		}),

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -3,7 +3,7 @@ import { el, setHtml } from '../shared/domUtils';
 import { createPeriodSelector, PERIOD_LABELS, type Period } from '../shared/periodSelector';
 import { navButtonsHtml } from '../shared/buttonConfig';
 import { ContextReferenceUsage, getTotalContextRefs } from '../shared/contextRefUtils';
-import { escapeHtml, formatCompact, formatCost, formatDurationShort, formatFileSize, formatFixed, formatNumber, formatPercent, safeSectionHtml, setFormatLocale } from '../shared/formatUtils';
+import { escapeHtml, formatCompact, formatCost, formatDurationShort, formatFileSize, formatFixed, formatNumber, formatPercent, getTimeSince, safeSectionHtml, setFormatLocale } from '../shared/formatUtils';
 import { wireExtensionPointButtons } from '../shared/extensionPoints';
 import { initializeWebviewLocalization, setCurrentLanguage } from '../shared/localization';
 import type { McpToolUsage, ModeUsage, ModelSwitchingAnalysis as BaseModelSwitchingAnalysis, ToolCallUsage } from '../shared/types';
@@ -18,7 +18,7 @@ import { deriveModelEfficiencyRates, computeEfficiencyLowUsageThreshold } from '
 import type { ModelPricing, ModelEfficiencyUsage, ModelEfficiencyCounters } from '../../../../src/types';
 import { sanitizeCustomizationMatrix } from './customizationSanitizer';
 import { applyBillingFields, type CopilotApiBalance } from './billingStatsSanitizer';
-import { sanitizeAgentSessionsData, toSafeNumber, toSafeHttpUrl, type AgentSessionsResult } from './agentSessionsSanitizer';
+import { sanitizeAgentSessionsData, toSafeNumber, toSafeHttpUrl, type AgentRepoSummary, type AgentSessionsResult } from './agentSessionsSanitizer';
 
 type ModelSwitchingAnalysis = BaseModelSwitchingAnalysis & {
 	minModelsPerSession: number;
@@ -2087,26 +2087,61 @@ function updateReposPrPanel(data: RepoPrStatsResult): void {
 // Cloud Agent Sessions tab
 // ---------------------------------------------------------------------------
 
+/** Label for one repo row: a link for real repos, a plain label for the "no repository" bucket. */
+function agentRepoLabelHtml(r: AgentRepoSummary): string {
+  const mono = "font-family:'Courier New',monospace; font-size:12px;";
+  if (r.unassigned) {
+    return `<span style="${mono} color:var(--text-secondary);" title="Tasks the agents API reported without a repository — typically ad-hoc sessions started from cloud chat">no repository (cloud chat)</span>`;
+  }
+  const link = `<a href="${r.repoUrl}" target="_blank" rel="noopener noreferrer" style="color:var(--link-color); ${mono}">${r.owner}/${r.repo}</a>`;
+  const accountOnly = r.discovery === 'account'
+    ? ` <span title="Found through your account-wide agent tasks — this repo is not open in any workspace folder" style="color:var(--text-muted); font-size:10px;">(not in workspace)</span>`
+    : '';
+  return `${link}${accountOnly}`;
+}
+
 function buildAgentSessionRows(data: AgentSessionsResult, cell: string, cellCenter: string): string {
   return data.repos.map((r) => {
     // r.owner, r.repo, r.repoUrl and r.error are pre-sanitized by sanitizeAgentSessionsData
-    const repoLink = `<a href="${r.repoUrl}" target="_blank" rel="noopener noreferrer" style="color:var(--link-color); font-family:'Courier New',monospace; font-size:12px;">${r.owner}/${r.repo}</a>`;
+    const label = agentRepoLabelHtml(r);
     if (r.error) {
       return `<tr>
-        <td style="${cell} font-family:'Courier New',monospace; font-size:12px;">${repoLink}</td>
+        <td style="${cell}">${label}</td>
         <td colspan="3" style="${cell} color:var(--text-secondary); font-style:italic; font-size:12px;">${r.error}</td>
       </tr>`;
     }
     const partialNote = r.partial
       ? ` <span title="Showing ${r.tasksScanned} of ${r.tasksTotal} tasks — capped to limit API usage" style="color:var(--text-muted); font-size:10px;">(${r.tasksScanned}/${r.tasksTotal} tasks scanned)</span>`
       : '';
+    const credits = r.totalCredits > 0
+      ? r.totalCredits.toFixed(1)
+      : r.totalPremiumRequests > 0 ? `${r.totalPremiumRequests.toFixed(1)} PR` : '—';
     return `<tr>
-      <td style="${cell} font-family:'Courier New',monospace; font-size:12px;">${repoLink}${partialNote}</td>
+      <td style="${cell}">${label}${partialNote}</td>
       <td style="${cellCenter} font-weight:600;">${r.totalTasks}</td>
       <td style="${cellCenter} font-weight:600;">${r.totalSessions}</td>
-      <td style="${cellCenter}">${r.totalCredits > 0 ? r.totalCredits.toFixed(1) : '—'}</td>
+      <td style="${cellCenter}">${credits}</td>
     </tr>`;
   }).join('');
+}
+
+/**
+ * Freshness line for the snapshot. The data is fetched at most once an hour, by whichever VS Code
+ * window holds the agent-tasks lock, so the panel always says how old what it shows is.
+ */
+function agentSnapshotFreshnessHtml(data: AgentSessionsResult): string {
+  const box = 'margin-bottom:12px; padding:8px 10px; background:var(--bg-tertiary); border:1px solid var(--border-color); border-radius:6px; font-size:11px; color:var(--text-secondary);';
+  if (!data.fetchedAt) {
+    return `<div style="${box}">🕒 <strong>Not fetched yet.</strong> The snapshot is refreshed hourly by the main VS Code window — it will appear here once that first refresh completes.</div>`;
+  }
+  const fetchedMs = Date.parse(data.fetchedAt);
+  const nextRefresh = Number.isFinite(fetchedMs)
+    ? new Date(fetchedMs + data.refreshIntervalMs).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+    : 'unknown';
+  return `<div style="${box}">
+    🕒 Updated <strong>${escapeHtml(getTimeSince(data.fetchedAt))}</strong> · next refresh after ${escapeHtml(nextRefresh)}.
+    Cached and refreshed at most once an hour, by a single VS Code window, to keep GitHub API usage low.
+  </div>`;
 }
 
 function renderAgentSessionsContent(data: AgentSessionsResult): string {
@@ -2118,9 +2153,9 @@ function renderAgentSessionsContent(data: AgentSessionsResult): string {
 			</div>`;
 	}
 	if (data.repos.length === 0) {
-		return `
+		return `${agentSnapshotFreshnessHtml(data)}
 			<div style="margin-top:12px; font-size:12px; color:var(--text-secondary);">
-				No GitHub repositories detected in your workspace folders.
+				No cloud agent tasks found — neither in your workspace repositories nor anywhere else in your account.
 			</div>`;
 	}
 
@@ -2133,32 +2168,42 @@ function renderAgentSessionsContent(data: AgentSessionsResult): string {
 			acc.tasks += r.totalTasks;
 			acc.sessions += r.totalSessions;
 			acc.credits += r.totalCredits;
+			acc.premiumRequests += r.totalPremiumRequests;
 		}
 		return acc;
-	}, { tasks: 0, sessions: 0, credits: 0 });
+	}, { tasks: 0, sessions: 0, credits: 0, premiumRequests: 0 });
 
 	const hasPartial = data.repos.some(r => r.partial && !r.error);
-
 	const rows = buildAgentSessionRows(data, cell, cellCenter);
+	const tile = 'background:var(--bg-tertiary); border:1px solid var(--border-color); border-radius:6px; padding:12px 20px; text-align:center; min-width:80px;';
 
 	return `
+		${agentSnapshotFreshnessHtml(data)}
 		<div style="margin-bottom:12px; display:flex; gap:24px; flex-wrap:wrap;">
-			<div style="background:var(--bg-tertiary); border:1px solid var(--border-color); border-radius:6px; padding:12px 20px; text-align:center; min-width:80px;">
+			<div style="${tile}">
 				<div style="font-size:22px; font-weight:700; color:var(--text-primary);">${summaryTotals.tasks}</div>
 				<div style="font-size:11px; color:var(--text-secondary); margin-top:2px;">Tasks</div>
 			</div>
-			<div style="background:var(--bg-tertiary); border:1px solid var(--border-color); border-radius:6px; padding:12px 20px; text-align:center; min-width:80px;">
+			<div style="${tile}">
 				<div style="font-size:22px; font-weight:700; color:var(--text-primary);">${summaryTotals.sessions}</div>
 				<div style="font-size:11px; color:var(--text-secondary); margin-top:2px;">Sessions</div>
 			</div>
-			<div style="background:var(--bg-tertiary); border:1px solid var(--border-color); border-radius:6px; padding:12px 20px; text-align:center; min-width:80px;">
+			<div style="${tile}">
 				<div style="font-size:22px; font-weight:700; color:var(--text-primary);">${summaryTotals.credits > 0 ? summaryTotals.credits.toFixed(1) : '—'}</div>
 				<div style="font-size:11px; color:var(--text-secondary); margin-top:2px;">AI Credits</div>
 			</div>
+			${summaryTotals.premiumRequests > 0 ? `
+			<div style="${tile}">
+				<div style="font-size:22px; font-weight:700; color:var(--text-primary);">${summaryTotals.premiumRequests.toFixed(1)}</div>
+				<div style="font-size:11px; color:var(--text-secondary); margin-top:2px;" title="Sessions that ran before the June 2026 switch to AI credits are billed in premium requests">Premium Requests</div>
+			</div>` : ''}
 		</div>
 		<div style="font-size:11px; color:var(--text-secondary); margin-bottom:12px;">
 			Showing cloud-agent sessions from ${sinceDate} to now.
-			${hasPartial ? '<strong>Note:</strong> Some repos were capped at 50 tasks — totals may be lower bounds. ' : ''}
+			${hasPartial ? '<strong>Note:</strong> Some repos were capped — totals are lower bounds. ' : ''}
+			${data.accountTasksAvailable
+				? ''
+				: `<strong>Account-wide tasks unavailable:</strong> ${data.accountTasksError ?? 'the /agents/tasks endpoint could not be read'} — only workspace repositories are shown.`}
 		</div>
 		<div class="customization-matrix-container">
 			<table class="customization-matrix" style="width:100%; border-collapse:collapse;">
@@ -2175,6 +2220,7 @@ function renderAgentSessionsContent(data: AgentSessionsResult): string {
 		</div>
 		<div style="margin-top:8px; font-size:10px; color:var(--text-muted); border-top:1px solid var(--border-subtle); padding-top:8px;">
 			ℹ️ <strong>No double-counting:</strong> These are cloud agent sessions only. CLI/remote sessions and local IDE chat sessions (shown in "My Activity") are excluded.<br/>
+			ℹ️ <strong>Two sources:</strong> your workspace repositories (which also surface tasks other people started there) plus your account-wide agent tasks, which cover repos you don't have open and ad-hoc cloud chat sessions. Tasks seen in both are counted once.<br/>
 			ℹ️ <strong>Action minutes</strong> (GitHub Actions compute used by the agent) are not shown here — they require additional per-branch API calls.
 		</div>`;
 }

--- a/vscode-extension/test/unit/agentSessionsService.test.ts
+++ b/vscode-extension/test/unit/agentSessionsService.test.ts
@@ -1,9 +1,13 @@
 import test from 'node:test';
 import * as assert from 'node:assert/strict';
 import {
+	collectAgentSessions,
 	detectSessionSource,
 	fetchAgentSessionsForRepo,
+	readSessionUsage,
+	resolveTaskRepo,
 	type AgentRepoSummary,
+	type FetchAccountTaskPageFn,
 	type FetchTaskPageFn,
 	type FetchTaskDetailFn,
 } from '../../src/agentSessionsService';
@@ -199,4 +203,261 @@ test('fetchAgentSessionsForRepo: handles detail fetch failure gracefully (skips 
 	assert.equal(result.totalSessions, 1);
 	assert.equal(result.totalCredits, 3);
 	assert.equal(result.error, undefined);
+});
+
+// ---------------------------------------------------------------------------
+// readSessionUsage — both API spellings of the billing units
+// ---------------------------------------------------------------------------
+
+test('readSessionUsage: reads the documented usage.amount in nano-credits', () => {
+	assert.deepEqual(
+		readSessionUsage({ usage: { type: 'ai_credits', amount: 43380350000 } }),
+		{ credits: 43.38035, premiumRequests: 0 },
+	);
+});
+
+test('readSessionUsage: reads the usage.credits spelling the live API has returned', () => {
+	assert.deepEqual(
+		readSessionUsage({ usage: { type: 'ai_credits', credits: 2_000_000_000 } }),
+		{ credits: 2, premiumRequests: 0 },
+	);
+});
+
+test('readSessionUsage: premium requests are counted as-is, never scaled like nano-credits', () => {
+	assert.deepEqual(
+		readSessionUsage({ usage: { type: 'premium_requests', amount: 1.5 } }),
+		{ credits: 0, premiumRequests: 1.5 },
+	);
+});
+
+test('readSessionUsage: missing, empty or non-numeric usage yields zero', () => {
+	assert.deepEqual(readSessionUsage({}), { credits: 0, premiumRequests: 0 });
+	assert.deepEqual(readSessionUsage({ usage: null }), { credits: 0, premiumRequests: 0 });
+	assert.deepEqual(readSessionUsage({ usage: { type: 'ai_credits' } }), { credits: 0, premiumRequests: 0 });
+	assert.deepEqual(readSessionUsage({ usage: { amount: 'lots' } }), { credits: 0, premiumRequests: 0 });
+});
+
+test('fetchAgentSessionsForRepo: keeps premium-request sessions out of the credit total', async () => {
+	const fetchPage: FetchTaskPageFn = async ({ page }) => (page === 1 ? { tasks: [makeTask('t1')] } : { tasks: [] });
+	const fetchDetail: FetchTaskDetailFn = async () => ({
+		sessions: [{ id: 's1', model: 'sweagent-capi:gpt-5.4', usage: { type: 'premium_requests', amount: 1.5 } }],
+	});
+	const result = await fetchAgentSessionsForRepo('owner', 'repo', 'token', SINCE, fetchPage, fetchDetail);
+	assert.equal(result.totalCredits, 0);
+	assert.equal(result.totalPremiumRequests, 1.5);
+});
+
+// ---------------------------------------------------------------------------
+// resolveTaskRepo — the repository a task is attributed to
+// ---------------------------------------------------------------------------
+
+test('resolveTaskRepo: reads full_name, nwo, owner+name, and repository html_url', () => {
+	assert.deepEqual(resolveTaskRepo({ repository: { full_name: 'octo/demo' } }), { owner: 'octo', repo: 'demo' });
+	assert.deepEqual(resolveTaskRepo({ repository: { nwo: 'octo/demo' } }), { owner: 'octo', repo: 'demo' });
+	assert.deepEqual(
+		resolveTaskRepo({ repository: { name: 'demo', owner: { login: 'octo' } } }),
+		{ owner: 'octo', repo: 'demo' },
+	);
+	assert.deepEqual(
+		resolveTaskRepo({ repository: { id: 1, html_url: 'https://github.com/octo/demo' } }),
+		{ owner: 'octo', repo: 'demo' },
+	);
+});
+
+test('resolveTaskRepo: falls back to the task html_url, and ignores agents-page URLs', () => {
+	assert.deepEqual(
+		resolveTaskRepo({ html_url: 'https://github.com/octo/demo/pull/7' }),
+		{ owner: 'octo', repo: 'demo' },
+	);
+	assert.equal(resolveTaskRepo({ html_url: 'https://github.com/copilot/agents/abc123' }), undefined);
+});
+
+test('resolveTaskRepo: returns undefined for a task with no resolvable repository', () => {
+	assert.equal(resolveTaskRepo({ id: 't1' }), undefined);
+	assert.equal(resolveTaskRepo({ repository: { id: 42 } }), undefined);
+	assert.equal(resolveTaskRepo(undefined), undefined);
+});
+
+// ---------------------------------------------------------------------------
+// collectAgentSessions — workspace repos merged with the account-wide task list
+// ---------------------------------------------------------------------------
+
+/** Task as returned by the account-wide listing, carrying its repository. */
+function makeAccountTask(id: string, fullName?: string, updatedAt = '2026-08-01T00:00:00Z'): any {
+	return {
+		id,
+		name: `Task ${id}`,
+		state: 'completed',
+		updated_at: updatedAt,
+		created_at: updatedAt,
+		...(fullName ? { repository: { full_name: fullName } } : {}),
+	};
+}
+
+const NO_TASKS: FetchTaskPageFn = async () => ({ tasks: [] });
+const NO_ACCOUNT_TASKS: FetchAccountTaskPageFn = async () => ({ tasks: [] });
+
+function firstPageOnly(tasks: any[]): (page: number) => { tasks: any[] } {
+	return (page: number) => (page === 1 ? { tasks } : { tasks: [] });
+}
+
+test('collectAgentSessions: finds account tasks in repos that are not open in the workspace', async () => {
+	const accountPage = firstPageOnly([makeAccountTask('a1', 'octo/remote-repo')]);
+	const result = await collectAgentSessions({
+		token: 'token',
+		since: SINCE,
+		workspaceRepos: [],
+		fetchTaskPage: NO_TASKS,
+		fetchAccountTaskPage: async ({ page, archived }) => (archived ? { tasks: [] } : accountPage(page)),
+		fetchTaskDetail: async () => ({ sessions: [makeSession('cloud-model', 4)] }),
+		fetchAccountTaskDetail: async () => ({ sessions: [] }),
+	});
+
+	assert.equal(result.accountTasksAvailable, true);
+	assert.equal(result.repos.length, 1);
+	assert.equal(result.repos[0].owner, 'octo');
+	assert.equal(result.repos[0].repo, 'remote-repo');
+	assert.equal(result.repos[0].discovery, 'account');
+	assert.equal(result.totalCredits, 4);
+});
+
+test('collectAgentSessions: a task in both listings is detailed once and marked as seen from both', async () => {
+	const shared = makeAccountTask('shared', 'octo/demo');
+	let detailCalls = 0;
+	const result = await collectAgentSessions({
+		token: 'token',
+		since: SINCE,
+		workspaceRepos: [{ owner: 'octo', repo: 'demo' }],
+		fetchTaskPage: async ({ page, archived }) => (!archived && page === 1 ? { tasks: [shared] } : { tasks: [] }),
+		fetchAccountTaskPage: async ({ page, archived }) => (!archived && page === 1 ? { tasks: [shared] } : { tasks: [] }),
+		fetchTaskDetail: async () => { detailCalls++; return { sessions: [makeSession('cloud-model', 7)] }; },
+		fetchAccountTaskDetail: async () => { detailCalls++; return { sessions: [] }; },
+	});
+
+	assert.equal(detailCalls, 1, 'the same task must not be detailed twice');
+	assert.equal(result.repos.length, 1);
+	assert.equal(result.repos[0].discovery, 'both');
+	assert.equal(result.repos[0].tasksTotal, 1);
+	assert.equal(result.totalCredits, 7);
+	assert.equal(result.totalTasks, 1);
+});
+
+test('collectAgentSessions: tasks with no repository land in their own bucket, detailed by ID', async () => {
+	let byIdCalls = 0;
+	const result = await collectAgentSessions({
+		token: 'token',
+		since: SINCE,
+		workspaceRepos: [],
+		fetchTaskPage: NO_TASKS,
+		fetchAccountTaskPage: async ({ page, archived }) =>
+			(!archived && page === 1 ? { tasks: [makeAccountTask('chat-1')] } : { tasks: [] }),
+		fetchTaskDetail: async () => ({ sessions: [] }),
+		fetchAccountTaskDetail: async () => { byIdCalls++; return { sessions: [makeSession('cloud-model', 1.5)] }; },
+	});
+
+	assert.equal(byIdCalls, 1, 'a task with no repo must be fetched through the account-wide detail endpoint');
+	assert.equal(result.repos.length, 1);
+	assert.equal(result.repos[0].unassigned, true);
+	assert.equal(result.repos[0].owner, '');
+	assert.equal(result.totalCredits, 1.5);
+});
+
+test('collectAgentSessions: workspace repos are listed even when they have no tasks', async () => {
+	const result = await collectAgentSessions({
+		token: 'token',
+		since: SINCE,
+		workspaceRepos: [{ owner: 'octo', repo: 'quiet' }],
+		fetchTaskPage: NO_TASKS,
+		fetchAccountTaskPage: NO_ACCOUNT_TASKS,
+		fetchTaskDetail: async () => ({ sessions: [] }),
+		fetchAccountTaskDetail: async () => ({ sessions: [] }),
+	});
+
+	assert.equal(result.repos.length, 1);
+	assert.equal(result.repos[0].discovery, 'workspace');
+	assert.equal(result.repos[0].tasksTotal, 0);
+	assert.equal(result.repos[0].partial, false);
+	assert.equal(result.partial, false);
+});
+
+test('collectAgentSessions: a failing account listing degrades to the workspace repos', async () => {
+	const result = await collectAgentSessions({
+		token: 'token',
+		since: SINCE,
+		workspaceRepos: [{ owner: 'octo', repo: 'demo' }],
+		fetchTaskPage: async ({ page, archived }) =>
+			(!archived && page === 1 ? { tasks: [makeTask('t1')] } : { tasks: [] }),
+		fetchAccountTaskPage: async () => ({ tasks: [], statusCode: 403, error: 'HTTP 403' }),
+		fetchTaskDetail: async () => ({ sessions: [makeSession('cloud-model', 2)] }),
+		fetchAccountTaskDetail: async () => ({ sessions: [] }),
+	});
+
+	assert.equal(result.accountTasksAvailable, false);
+	assert.ok(result.accountTasksError?.includes('Access denied'));
+	assert.equal(result.repos.length, 1);
+	assert.equal(result.totalCredits, 2);
+});
+
+test('collectAgentSessions: a failing repo listing shows an error row without failing the pass', async () => {
+	const result = await collectAgentSessions({
+		token: 'token',
+		since: SINCE,
+		workspaceRepos: [{ owner: 'octo', repo: 'denied' }],
+		fetchTaskPage: async () => ({ tasks: [], statusCode: 404, error: 'HTTP 404' }),
+		fetchAccountTaskPage: async ({ page, archived }) =>
+			(!archived && page === 1 ? { tasks: [makeAccountTask('a1', 'octo/other')] } : { tasks: [] }),
+		fetchTaskDetail: async () => ({ sessions: [makeSession('cloud-model', 1)] }),
+		fetchAccountTaskDetail: async () => ({ sessions: [] }),
+	});
+
+	const denied = result.repos.find(r => r.repo === 'denied');
+	assert.ok(denied?.error?.includes('not enabled') || denied?.error?.includes('not accessible'));
+	assert.ok(result.repos.some(r => r.repo === 'other'));
+});
+
+test('collectAgentSessions: the detail budget covers the newest tasks and flags the rest as partial', async () => {
+	const tasks = [
+		makeAccountTask('old', 'octo/demo', '2026-08-01T00:00:00Z'),
+		makeAccountTask('new', 'octo/demo', '2026-08-20T00:00:00Z'),
+	];
+	const detailed: string[] = [];
+	const result = await collectAgentSessions({
+		token: 'token',
+		since: SINCE,
+		workspaceRepos: [],
+		maxTaskDetails: 1,
+		fetchTaskPage: NO_TASKS,
+		fetchAccountTaskPage: async ({ page, archived }) => (!archived && page === 1 ? { tasks } : { tasks: [] }),
+		fetchTaskDetail: async (_owner, _repo, taskId) => {
+			detailed.push(taskId);
+			return { sessions: [makeSession('cloud-model', 1)] };
+		},
+		fetchAccountTaskDetail: async () => ({ sessions: [] }),
+	});
+
+	assert.deepEqual(detailed, ['new'], 'the most recently updated task is detailed first');
+	assert.equal(result.partial, true);
+	assert.equal(result.repos[0].partial, true);
+	assert.equal(result.repos[0].tasksTotal, 2);
+	assert.equal(result.repos[0].tasksScanned, 1);
+});
+
+test('collectAgentSessions: reports progress that never exceeds its own total', async () => {
+	const progress: { done: number; total: number }[] = [];
+	await collectAgentSessions({
+		token: 'token',
+		since: SINCE,
+		workspaceRepos: [{ owner: 'octo', repo: 'demo' }],
+		fetchTaskPage: async ({ page, archived }) =>
+			(!archived && page === 1 ? { tasks: [makeTask('t1')] } : { tasks: [] }),
+		fetchAccountTaskPage: NO_ACCOUNT_TASKS,
+		fetchTaskDetail: async () => ({ sessions: [makeSession('cloud-model', 1)] }),
+		fetchAccountTaskDetail: async () => ({ sessions: [] }),
+		onProgress: (done, total) => progress.push({ done, total }),
+	});
+
+	assert.ok(progress.length >= 3, 'one unit per repo listing, the account listing, and each detail call');
+	assert.ok(progress.every(p => p.done <= p.total), 'progress must never report more done than total');
+	const last = progress[progress.length - 1];
+	assert.equal(last.done, last.total);
 });

--- a/vscode-extension/test/unit/agentTasksCache.test.ts
+++ b/vscode-extension/test/unit/agentTasksCache.test.ts
@@ -1,0 +1,149 @@
+import test from 'node:test';
+import * as assert from 'node:assert/strict';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+	AGENT_TASKS_CACHE_SCHEMA_VERSION,
+	AGENT_TASKS_REFRESH_INTERVAL_MS,
+	canServeAgentTasksSnapshot,
+	getAgentTasksCachePath,
+	isAgentTasksEnvelopeUsable,
+	isAgentTasksSnapshotFresh,
+	nextAgentTasksRefreshAt,
+	readAgentTasksSnapshot,
+	writeAgentTasksSnapshot,
+	type AgentTasksCacheEnvelope,
+} from '../../src/agentTasksCache';
+import type { AgentSessionsResult } from '../../../src/types';
+
+const NOW = Date.parse('2026-08-29T12:00:00Z');
+const SINCE = new Date('2026-07-30T12:00:00Z');
+
+function makeResult(overrides: Partial<AgentSessionsResult> = {}): AgentSessionsResult {
+	return {
+		repos: [],
+		totalTasks: 0,
+		totalSessions: 0,
+		totalCredits: 0,
+		totalPremiumRequests: 0,
+		authenticated: true,
+		since: SINCE.toISOString(),
+		fetchedAt: new Date(NOW).toISOString(),
+		accountTasksAvailable: true,
+		partial: false,
+		...overrides,
+	};
+}
+
+function makeEnvelope(overrides: Partial<AgentTasksCacheEnvelope> = {}): AgentTasksCacheEnvelope {
+	return {
+		schemaVersion: AGENT_TASKS_CACHE_SCHEMA_VERSION,
+		fetchedAt: new Date(NOW).toISOString(),
+		since: SINCE.toISOString(),
+		data: makeResult(),
+		...overrides,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Freshness
+// ---------------------------------------------------------------------------
+
+test('isAgentTasksSnapshotFresh: a snapshot younger than the interval is fresh', () => {
+	const fetchedAt = new Date(NOW - 59 * 60 * 1000).toISOString();
+	assert.equal(isAgentTasksSnapshotFresh(fetchedAt, NOW), true);
+});
+
+test('isAgentTasksSnapshotFresh: a snapshot at or past the interval is stale', () => {
+	const exactly = new Date(NOW - AGENT_TASKS_REFRESH_INTERVAL_MS).toISOString();
+	const older = new Date(NOW - 3 * AGENT_TASKS_REFRESH_INTERVAL_MS).toISOString();
+	assert.equal(isAgentTasksSnapshotFresh(exactly, NOW), false);
+	assert.equal(isAgentTasksSnapshotFresh(older, NOW), false);
+});
+
+test('isAgentTasksSnapshotFresh: missing or unparseable timestamps are stale', () => {
+	assert.equal(isAgentTasksSnapshotFresh(undefined, NOW), false);
+	assert.equal(isAgentTasksSnapshotFresh('', NOW), false);
+	assert.equal(isAgentTasksSnapshotFresh('not-a-date', NOW), false);
+});
+
+test('isAgentTasksSnapshotFresh: a far-future timestamp (clock change) is stale, not pinned fresh', () => {
+	const future = new Date(NOW + 5 * AGENT_TASKS_REFRESH_INTERVAL_MS).toISOString();
+	assert.equal(isAgentTasksSnapshotFresh(future, NOW), false);
+});
+
+test('nextAgentTasksRefreshAt: one interval after the fetch, undefined without one', () => {
+	const fetchedAt = new Date(NOW).toISOString();
+	assert.equal(nextAgentTasksRefreshAt(fetchedAt), new Date(NOW + AGENT_TASKS_REFRESH_INTERVAL_MS).toISOString());
+	assert.equal(nextAgentTasksRefreshAt(undefined), undefined);
+	assert.equal(nextAgentTasksRefreshAt('nonsense'), undefined);
+});
+
+// ---------------------------------------------------------------------------
+// Envelope usability
+// ---------------------------------------------------------------------------
+
+test('isAgentTasksEnvelopeUsable: accepts a current-schema envelope covering the window', () => {
+	assert.equal(isAgentTasksEnvelopeUsable(makeEnvelope(), SINCE), true);
+});
+
+test('isAgentTasksEnvelopeUsable: rejects a snapshot written by another schema version', () => {
+	assert.equal(isAgentTasksEnvelopeUsable(makeEnvelope({ schemaVersion: 0 }), SINCE), false);
+});
+
+test('isAgentTasksEnvelopeUsable: rejects a snapshot covering a shorter window than asked for', () => {
+	const shorter = makeEnvelope({ since: new Date(SINCE.getTime() + 24 * 60 * 60 * 1000).toISOString() });
+	assert.equal(isAgentTasksEnvelopeUsable(shorter, SINCE), false);
+});
+
+test('isAgentTasksEnvelopeUsable: accepts a slightly older window (since is recomputed per call)', () => {
+	const drifted = makeEnvelope({ since: new Date(SINCE.getTime() - 30 * 1000).toISOString() });
+	assert.equal(isAgentTasksEnvelopeUsable(drifted, SINCE), true);
+});
+
+test('isAgentTasksEnvelopeUsable: rejects missing, malformed, and repo-less payloads', () => {
+	assert.equal(isAgentTasksEnvelopeUsable(undefined, SINCE), false);
+	assert.equal(isAgentTasksEnvelopeUsable(makeEnvelope({ since: 'garbage' }), SINCE), false);
+	assert.equal(isAgentTasksEnvelopeUsable({ ...makeEnvelope(), data: undefined as any }, SINCE), false);
+});
+
+test('canServeAgentTasksSnapshot: a usable but stale snapshot is not served without a refresh', () => {
+	const stale = makeEnvelope({ fetchedAt: new Date(NOW - 2 * AGENT_TASKS_REFRESH_INTERVAL_MS).toISOString() });
+	assert.equal(isAgentTasksEnvelopeUsable(stale, SINCE), true);
+	assert.equal(canServeAgentTasksSnapshot(stale, SINCE, NOW), false);
+	assert.equal(canServeAgentTasksSnapshot(makeEnvelope(), SINCE, NOW), true);
+});
+
+// ---------------------------------------------------------------------------
+// Disk round-trip
+// ---------------------------------------------------------------------------
+
+test('getAgentTasksCachePath: keeps dev and prod snapshots apart', () => {
+	assert.equal(getAgentTasksCachePath('/store', 'prod'), path.join('/store', 'agenttasks_prod.snapshot.json'));
+	assert.notEqual(getAgentTasksCachePath('/store', 'dev-abc'), getAgentTasksCachePath('/store', 'prod'));
+});
+
+test('writeAgentTasksSnapshot/readAgentTasksSnapshot: round-trips the snapshot', async () => {
+	const dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'agenttasks-'));
+	const filePath = getAgentTasksCachePath(path.join(dir, 'nested'), 'prod');
+	const envelope = makeEnvelope({ data: makeResult({ totalCredits: 43.4, totalTasks: 2 }) });
+
+	await writeAgentTasksSnapshot(filePath, envelope);
+	const readBack = await readAgentTasksSnapshot(filePath);
+
+	assert.deepEqual(readBack, envelope);
+	assert.deepEqual(await fs.promises.readdir(path.dirname(filePath)), [path.basename(filePath)]);
+	await fs.promises.rm(dir, { recursive: true, force: true });
+});
+
+test('readAgentTasksSnapshot: missing or corrupt files read as undefined, never throw', async () => {
+	const dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'agenttasks-'));
+	const missing = path.join(dir, 'nope.json');
+	const corrupt = path.join(dir, 'corrupt.json');
+	await fs.promises.writeFile(corrupt, '{ this is not json', 'utf8');
+
+	assert.equal(await readAgentTasksSnapshot(missing), undefined);
+	assert.equal(await readAgentTasksSnapshot(corrupt), undefined);
+	await fs.promises.rm(dir, { recursive: true, force: true });
+});

--- a/vscode-extension/test/unit/cacheManager-lock.test.ts
+++ b/vscode-extension/test/unit/cacheManager-lock.test.ts
@@ -129,3 +129,45 @@ test('releaseCacheLock: only releases own lock', async () => {
 	fs.unlinkSync(lockPath);
 });
 
+
+// ── Agent-tasks lock: only one window refreshes the hourly cloud-agent snapshot ────────
+
+test('acquireAgentTasksLock: uses its own lock file, separate from the refresh leader lock', async () => {
+	const { manager } = makeDirAndManager();
+	assert.notEqual(manager.getAgentTasksLockPath(), manager.getRefreshLockPath());
+	assert.ok(manager.getAgentTasksLockPath().includes('agenttasks_'));
+
+	assert.equal(await manager.acquireAgentTasksLock(), true);
+	assert.equal(await manager.acquireRefreshLock(), true, 'holding one lock must not block the other');
+
+	await manager.releaseAgentTasksLock();
+	await manager.releaseRefreshLock();
+});
+
+test('acquireAgentTasksLock: a second window is turned away while the lock is held, then let in', async () => {
+	const { manager } = makeDirAndManager();
+	await manager.acquireAgentTasksLock();
+
+	const lockPath = manager.getAgentTasksLockPath();
+	fs.writeFileSync(lockPath, JSON.stringify({ sessionId: 'other-window', pid: process.pid, timestamp: Date.now() }));
+	assert.equal(await manager.acquireAgentTasksLock(), false, 'a live lock from another window blocks the refresh');
+
+	fs.unlinkSync(lockPath);
+	assert.equal(await manager.acquireAgentTasksLock(), true);
+	await manager.releaseAgentTasksLock();
+});
+
+test('renewAgentTasksLock: refreshes our own timestamp and refuses to renew another window\'s lock', async () => {
+	const { manager } = makeDirAndManager();
+	await manager.acquireAgentTasksLock();
+	const lockPath = manager.getAgentTasksLockPath();
+	const before = JSON.parse(fs.readFileSync(lockPath, 'utf-8')).timestamp;
+
+	await new Promise(resolve => setTimeout(resolve, 5));
+	assert.equal(await manager.renewAgentTasksLock(), true);
+	const after = JSON.parse(fs.readFileSync(lockPath, 'utf-8')).timestamp;
+	assert.ok(after >= before, 'renewing should move the timestamp forward');
+
+	fs.writeFileSync(lockPath, JSON.stringify({ sessionId: 'other-window', pid: process.pid, timestamp: Date.now() }));
+	assert.equal(await manager.renewAgentTasksLock(), false, 'never renew a lock this window does not own');
+});

--- a/vscode-extension/test/unit/webview-agentSessionsSanitizer.test.ts
+++ b/vscode-extension/test/unit/webview-agentSessionsSanitizer.test.ts
@@ -1,0 +1,104 @@
+import test from 'node:test';
+import * as assert from 'node:assert/strict';
+import { sanitizeAgentSessionsData } from '../../src/webview/usage/agentSessionsSanitizer';
+
+// The cloud-agent snapshot crosses the extension-host → webview trust boundary: repo names come
+// from the GitHub API and end up interpolated into HTML, so every string is escaped here and every
+// number is coerced. These tests cover the fields added for the account-wide task listing.
+
+test('sanitizeAgentSessionsData: carries the snapshot freshness and account-listing status through', () => {
+	const result = sanitizeAgentSessionsData({
+		repos: [],
+		totalTasks: 3,
+		totalSessions: 4,
+		totalCredits: 12.5,
+		totalPremiumRequests: 1.5,
+		authenticated: true,
+		since: '2026-07-30T00:00:00Z',
+		fetchedAt: '2026-08-29T10:00:00Z',
+		accountTasksAvailable: true,
+		partial: true,
+	});
+
+	assert.equal(result.fetchedAt, '2026-08-29T10:00:00Z');
+	assert.equal(result.totalPremiumRequests, 1.5);
+	assert.equal(result.accountTasksAvailable, true);
+	assert.equal(result.partial, true);
+	assert.equal(result.accountTasksError, undefined);
+});
+
+test('sanitizeAgentSessionsData: defaults a never-fetched snapshot to an empty fetchedAt', () => {
+	const result = sanitizeAgentSessionsData({ authenticated: true });
+	assert.equal(result.fetchedAt, '');
+	assert.equal(result.accountTasksAvailable, false);
+	assert.equal(result.totalPremiumRequests, 0);
+	assert.deepEqual(result.repos, []);
+});
+
+test('sanitizeAgentSessionsData: escapes the account-listing error message', () => {
+	const result = sanitizeAgentSessionsData({
+		authenticated: true,
+		accountTasksError: '<img src=x onerror=alert(1)>',
+	});
+	assert.ok(!result.accountTasksError?.includes('<img'));
+	assert.ok(result.accountTasksError?.includes('&lt;img'));
+});
+
+test('sanitizeAgentSessionsData: keeps the discovery source, defaulting unknown values to workspace', () => {
+	const result = sanitizeAgentSessionsData({
+		authenticated: true,
+		repos: [
+			{ owner: 'octo', repo: 'a', discovery: 'account' },
+			{ owner: 'octo', repo: 'b', discovery: 'both' },
+			{ owner: 'octo', repo: 'c', discovery: 'something-else' },
+			{ owner: 'octo', repo: 'd' },
+		],
+	});
+
+	assert.deepEqual(result.repos.map(r => r.discovery), ['account', 'both', 'workspace', 'workspace']);
+});
+
+test('sanitizeAgentSessionsData: the repo-less bucket is marked unassigned and gets no repo link', () => {
+	const result = sanitizeAgentSessionsData({
+		authenticated: true,
+		repos: [
+			{ owner: '', repo: '', unassigned: true, totalCredits: 2 },
+			{ owner: 'octo', repo: 'demo', totalCredits: 1 },
+		],
+	});
+
+	assert.equal(result.repos[0].unassigned, true);
+	assert.equal(result.repos[0].repoUrl, '#');
+	assert.equal(result.repos[1].unassigned, false);
+	assert.equal(result.repos[1].repoUrl, 'https://github.com/octo/demo');
+});
+
+test('sanitizeAgentSessionsData: a repo row missing its name is treated as unassigned, not linked', () => {
+	const result = sanitizeAgentSessionsData({
+		authenticated: true,
+		repos: [{ owner: 'octo', repo: '' }],
+	});
+
+	assert.equal(result.repos[0].unassigned, true);
+	assert.equal(result.repos[0].repoUrl, '#');
+});
+
+test('sanitizeAgentSessionsData: escapes hostile repo names and coerces hostile numbers', () => {
+	const result = sanitizeAgentSessionsData({
+		authenticated: true,
+		repos: [{
+			owner: '<script>alert(1)</script>',
+			repo: '"onload="x',
+			totalCredits: -5,
+			totalPremiumRequests: 'lots',
+			tasksTotal: Number.NaN,
+		}],
+	});
+
+	const row = result.repos[0];
+	assert.ok(!row.owner.includes('<script>'));
+	assert.ok(!row.repo.includes('"'));
+	assert.equal(row.totalCredits, 0);
+	assert.equal(row.totalPremiumRequests, 0);
+	assert.equal(row.tasksTotal, 0);
+});


### PR DESCRIPTION
## Why

We have the overall usage cost from the Copilot internal API, but it cannot tell us **cost per repository** for usage outside an editor (cloud agent tasks, review agent). I researched every official GitHub option first; the short version:

| Option | Per repo? | Usable for a normal user? |
|---|---|---|
| `/users/{user}/settings/billing/usage` | has a `repositoryName` field | ❌ AI credits are attributed to the *user*, not a repo; only for individually-purchased plans; rejects fine-grained tokens (classic PAT only), so a VS Code auth session can't call it |
| `/users/{user}/settings/billing/ai_credit/usage` | ❌ no repo dimension | exact per-model totals only |
| `/organizations/…`, `/enterprises/…` billing | partly | needs org owner / billing manager / enterprise admin |
| `/orgs/{org}/copilot/metrics/reports/repos-1-day` | activity only, no credits | org admin only |
| GraphQL | ❌ | no AI-credit or premium-request fields exist |
| **agent tasks API** | ✅ per session, per repo | ✅ any signed-in user, "Agent tasks" read |

So this PR gets everything it can out of the agents API, and caches it hard.

## What changed

**Account-wide task discovery** — added the `/agents/tasks` listing (all repositories for the signed-in user) alongside the existing per-repo one, and merged the two in `collectAgentSessions()`:

- surfaces tasks started on github.com in repos that aren't checked out locally (previously invisible — repos came only from workspace git remotes)
- ad-hoc cloud chat tasks with no repository land in their own "no repository (cloud chat)" row
- tasks are deduplicated by ID across both listings, so a task visible in both is counted once
- repos found only through the account are labelled *(not in workspace)*; workspace repos are still listed even when they have no tasks
- a failing account listing degrades to the workspace repos and says so in the panel

**Correct billing units** — `readSessionUsage()` reads `usage.amount` + `usage.type` (the documented shape) as well as `usage.credits` (what the live API has been returning), and keeps `premium_requests` amounts in their own bucket instead of dividing them by 1e9 as if they were nano-credits.

**Hourly cached snapshot, one window** (`vscode-extension/src/agentTasksCache.ts`):

- the whole result is written to `agenttasks_<cacheId>.snapshot.json` in global storage, shared by every VS Code window of that edition
- refreshed at most once an hour, behind its own `agenttasks` file lock, so only one window ever makes the API calls; a heartbeat renews the lock so a slow pass isn't mistaken for a stale one
- the refresh is kicked off from the leader-elected cache refresh cycle (same election as the daily worktree scan), so it also runs shortly after the extension starts, and on every cycle thereafter — gated by the hourly check
- opening the Cloud Agent tab renders the snapshot instantly and costs no API calls; it only asks for a refresh, which no-ops while the snapshot is fresh
- capped at 200 task-detail calls per pass, spent on the most recently updated tasks; repos with tasks left over are flagged and their totals shown as lower bounds

**UI** — the panel now states how old the snapshot is and when the next refresh is due, shows a premium-requests tile when legacy sessions are in range, and explains the two sources.

## Testing

- `npm run pretest` (tsc + eslint) clean — the 3 remaining eslint warnings are pre-existing
- full unit suite: 97/97 test files pass
- new tests: `agentTasksCache.test.ts` (freshness, schema/window invalidation, clock-change guard, disk round-trip, corrupt-file handling), `webview-agentSessionsSanitizer.test.ts` (new fields, escaping, hostile input), plus `agentSessionsService.test.ts` cases for `readSessionUsage`, `resolveTaskRepo`, and `collectAgentSessions` (cross-source dedup, unassigned bucket, detail budget, degraded account listing), and `cacheManager-lock.test.ts` cases for the new lock

## Docs

`docs/features/CLOUD-AGENT-COST.md` records the API comparison above, the merge behaviour, the caching policy, and what is still missing (code-review credits have no per-repo attribution anywhere; its Actions minutes do, via the `dynamic/agents/copilot-pull-request-reviewer` workflow — a possible follow-up).

---
_Generated by [Claude Code](https://claude.ai/code/session_01746cqzNkJLzACQbky3juUZ)_