### PR TITLE
fix: resolve raw localization keys shown in UI (status bar, output channel, webview nav)

### DIFF
--- a/.github/instructions/vscode-extension.instructions.md
+++ b/.github/instructions/vscode-extension.instructions.md
@@ -73,6 +73,14 @@ The extension supports localization for all user-facing strings, including comma
 
 > ⚠️ **`package.nls*.json` files must be strict JSON** — VS Code's localization loader does not tolerate `//` comments or trailing commas. Don't add comments to these files even for section organization; use blank lines to group related keys instead.
 
+### Validating Localization
+
+Run `npm run validate:l10n` (script: `scripts/validate-l10n.mjs`) to detect broken localization before it ships: it strictly parses every `package.nls*.json`, checks that all `%key%` references in `package.json` and all `l10n.t('key')` calls in `src/**` resolve against `package.nls.json`, and verifies locale files cover every base key. With `--vsix <file>` it also validates the packaged VSIX contents. CI and the nightly pre-release workflow run this automatically after packaging.
+
+### Runtime Localization (Key-Based)
+
+`vscode.l10n.t()` only resolves through `l10n/bundle.l10n.<lang>.json` files (enabled by the `l10n` field in `package.json`); it **never reads `package.nls.json`** — that file is only used for static `%key%` references in `package.json`. On an English (default language) VS Code, `l10n.t('some.key')` returns the message argument unchanged, so key-based calls surface raw keys in the UI. This is why all extension code must localize runtime strings through `src/l10n.ts` (`import { t } from './l10n'` / the module-level `l10n` object in `extension.ts`) instead of calling `vscode.l10n.t()` directly. The helper treats `package.nls*.json` as the single source of truth: esbuild inlines the bundles into `dist/extension.js`, and `t()` resolves the key from the bundle matching `vscode.env.language` (falling back to English, then to the key itself with a one-time warning for genuinely missing keys). `vscode.l10n.t()` is still consulted first so real VS Code-provided translations take precedence if l10n bundles are ever shipped. Webviews additionally ignore localization entries whose value equals their key (`initializeWebviewLocalization` in `src/webview/shared/localization.ts`).
+
 ### Adding New Localizable Strings
 
 **For package.json entries** (commands, configuration, display names):
@@ -109,13 +117,12 @@ Example:
 ```
 
 **For runtime strings in TypeScript code**:
-Use the VS Code localization API:
+Use the resilient localization helper (see "Runtime Fallback" below):
 ```typescript
-import * as vscode from 'vscode';
-const l10n = vscode.l10n;
+import { t } from './l10n';
 
-// Use l10n.t() with the same key from package.nls.json
-const message = l10n.t('command.myCommand.message');
+// Use t() with the same key from package.nls.json
+const message = t('command.myCommand.message');
 ```
 
 ### Webview Localization

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,10 @@ jobs:
     - name: Create VSIX package
       working-directory: vscode-extension
       run: npx vsce package
+
+    - name: Validate localization bundle in VSIX
+      working-directory: vscode-extension
+      run: npm run validate:l10n -- --vsix "$(find . -maxdepth 1 -name 'ai-engineering-fluency-*.vsix' | head -n 1)"
       
     - name: Upload VSIX package
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/vscode-nightly-prerelease.yml
+++ b/.github/workflows/vscode-nightly-prerelease.yml
@@ -125,6 +125,11 @@ jobs:
         npx vsce package --pre-release \
           --baseImagesUrl https://raw.githubusercontent.com/rajbos/ai-engineering-fluency/main/vscode-extension
 
+    - name: Validate localization bundle in VSIX
+      if: steps.check_changes.outputs.has_changes == 'true'
+      working-directory: vscode-extension
+      run: npm run validate:l10n -- --vsix "$(find . -maxdepth 1 -name 'ai-engineering-fluency-*.vsix' | head -n 1)"
+
     - name: Get VSIX filename
       if: steps.check_changes.outputs.has_changes == 'true'
       id: vsix

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -513,6 +513,7 @@
     "watch-tests": "tsc -p tsconfig.tests.json -w",
     "pretest": "tsc --noEmit && eslint src ../src && node ../scripts/prepare-test-output.js && tsc -p tsconfig.tests.json",
     "check-types": "tsc --noEmit",
+    "validate:l10n": "node scripts/validate-l10n.mjs",
     "lint": "eslint src ../src",
     "lint:report": "eslint src ../src --format json",
     "lint:css": "stylelint \"src/webview/**/*.css\"",

--- a/vscode-extension/scripts/validate-l10n.mjs
+++ b/vscode-extension/scripts/validate-l10n.mjs
@@ -1,0 +1,209 @@
+#!/usr/bin/env node
+/**
+ * Localization validation for the VS Code extension.
+ *
+ * Detects the failure mode where VS Code shows raw localization keys
+ * (e.g. "statusBar.loadingText", "nav.btnRefresh") instead of translated
+ * text:
+ *
+ *   1. package.nls.json must parse as strict JSON (VS Code's l10n loader
+ *      does not tolerate comments or trailing commas).
+ *   2. Every %key% reference in package.json must exist in package.nls.json.
+ *   3. Every l10n.t('key') call in src/** must exist in package.nls.json.
+ *   4. Every locale file (package.nls.<locale>.json) must parse strictly and
+ *      contain every key from the base bundle.
+ *   5. --vsix mode: the packaged VSIX must contain extension/package.nls.json
+ *      whose strict-parsed contents satisfy the packaged package.json's
+ *      %key% references.
+ *
+ * Usage:
+ *   node scripts/validate-l10n.mjs
+ *   node scripts/validate-l10n.mjs --vsix path/to/ai-engineering-fluency-x.y.z.vsix
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import zlib from 'node:zlib';
+import { fileURLToPath } from 'node:url';
+
+const extRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const errors = [];
+const warnings = [];
+
+function strictParseJson(content, label) {
+	try {
+		return JSON.parse(content);
+	} catch (err) {
+		errors.push(`${label}: not strict JSON — ${err.message}`);
+		return null;
+	}
+}
+
+function collectStringValues(value, out = []) {
+	if (typeof value === 'string') {
+		out.push(value);
+	} else if (Array.isArray(value)) {
+		for (const item of value) { collectStringValues(item, out); }
+	} else if (value && typeof value === 'object') {
+		for (const item of Object.values(value)) { collectStringValues(item, out); }
+	}
+	return out;
+}
+
+function extractPercentKeys(jsonValue) {
+	const keys = new Set();
+	for (const s of collectStringValues(jsonValue)) {
+		for (const match of s.matchAll(/%([A-Za-z0-9_.-]+)%/g)) {
+			keys.add(match[1]);
+		}
+	}
+	return keys;
+}
+
+function extractCodeKeys(dir) {
+	const keys = new Set();
+	const pattern = /(?:vscode\.)?l10n\.t\(\s*['"]([^'"]+)['"]/g;
+	for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+		const full = path.join(dir, entry.name);
+		if (entry.isDirectory()) {
+			for (const k of extractCodeKeys(full)) { keys.add(k); }
+		} else if (entry.name.endsWith('.ts')) {
+			const content = fs.readFileSync(full, 'utf8');
+			for (const match of content.matchAll(pattern)) {
+				keys.add(match[1]);
+			}
+		}
+	}
+	return keys;
+}
+
+function checkKeysAgainstBundle(keys, bundle, sourceLabel, bundleLabel) {
+	for (const key of keys) {
+		if (!(key in bundle)) {
+			errors.push(`${sourceLabel} references key '${key}' which is missing from ${bundleLabel}`);
+		}
+	}
+}
+
+function validateSourceTree() {
+	const basePath = path.join(extRoot, 'package.nls.json');
+	const base = strictParseJson(fs.readFileSync(basePath, 'utf8'), 'package.nls.json');
+	if (!base) { return null; }
+
+	// Locale files must parse strictly and cover every base key.
+	for (const file of fs.readdirSync(extRoot)) {
+		if (!/^package\.nls\..+\.json$/.test(file)) { continue; }
+		const locale = strictParseJson(fs.readFileSync(path.join(extRoot, file), 'utf8'), file);
+		if (!locale) { continue; }
+		for (const key of Object.keys(base)) {
+			if (!(key in locale)) {
+				errors.push(`${file}: missing translation for key '${key}'`);
+			}
+		}
+		for (const key of Object.keys(locale)) {
+			if (!(key in base)) {
+				warnings.push(`${file}: key '${key}' has no entry in package.nls.json`);
+			}
+		}
+	}
+
+	// %key% references in package.json must resolve.
+	const pkg = JSON.parse(fs.readFileSync(path.join(extRoot, 'package.json'), 'utf8'));
+	checkKeysAgainstBundle(extractPercentKeys(pkg), base, 'package.json', 'package.nls.json');
+
+	// l10n.t('key') calls in TypeScript sources must resolve.
+	checkKeysAgainstBundle(extractCodeKeys(path.join(extRoot, 'src')), base, 'TypeScript sources', 'package.nls.json');
+
+	return base;
+}
+
+/** Minimal ZIP reader: enough to list entries and extract stored/deflate files from a VSIX. */
+function readZipEntries(filePath) {
+	const buf = fs.readFileSync(filePath);
+	let eocd = -1;
+	for (let i = buf.length - 22; i >= Math.max(0, buf.length - 65557); i--) {
+		if (buf.readUInt32LE(i) === 0x06054b50) { eocd = i; break; }
+	}
+	if (eocd < 0) { throw new Error('not a ZIP file (no end-of-central-directory record)'); }
+	const count = buf.readUInt16LE(eocd + 10);
+	let offset = buf.readUInt32LE(eocd + 16);
+	const entries = new Map();
+	for (let i = 0; i < count; i++) {
+		if (buf.readUInt32LE(offset) !== 0x02014b50) { break; }
+		const nameLen = buf.readUInt16LE(offset + 28);
+		const extraLen = buf.readUInt16LE(offset + 30);
+		const commentLen = buf.readUInt16LE(offset + 32);
+		const name = buf.toString('utf8', offset + 46, offset + 46 + nameLen);
+		entries.set(name, {
+			method: buf.readUInt16LE(offset + 10),
+			compressedSize: buf.readUInt32LE(offset + 20),
+			localOffset: buf.readUInt32LE(offset + 42)
+		});
+		offset += 46 + nameLen + extraLen + commentLen;
+	}
+	return { buf, entries };
+}
+
+function extractZipEntryText(buf, entry) {
+	const o = entry.localOffset;
+	const nameLen = buf.readUInt16LE(o + 26);
+	const extraLen = buf.readUInt16LE(o + 28);
+	const start = o + 30 + nameLen + extraLen;
+	const data = buf.subarray(start, start + entry.compressedSize);
+	if (entry.method === 0) { return data.toString('utf8'); }
+	if (entry.method === 8) { return zlib.inflateRawSync(data).toString('utf8'); }
+	throw new Error(`unsupported ZIP compression method ${entry.method}`);
+}
+
+function validateVsix(vsixPath, baseKeys) {
+	if (!fs.existsSync(vsixPath)) {
+		errors.push(`--vsix: file not found: ${vsixPath}`);
+		return;
+	}
+	let zip;
+	try {
+		zip = readZipEntries(vsixPath);
+	} catch (err) {
+		errors.push(`--vsix: failed to read ${vsixPath} — ${err.message}`);
+		return;
+	}
+	const nlsEntry = zip.entries.get('extension/package.nls.json');
+	const pkgEntry = zip.entries.get('extension/package.json');
+	if (!nlsEntry) {
+		errors.push('VSIX is missing extension/package.nls.json — VS Code would show raw localization keys at runtime');
+	}
+	if (!pkgEntry) {
+		errors.push('VSIX is missing extension/package.json');
+	}
+	if (!nlsEntry || !pkgEntry) { return; }
+
+	const packagedNls = strictParseJson(extractZipEntryText(zip.buf, nlsEntry), 'VSIX extension/package.nls.json');
+	const packagedPkg = strictParseJson(extractZipEntryText(zip.buf, pkgEntry), 'VSIX extension/package.json');
+	if (!packagedNls || !packagedPkg) { return; }
+
+	checkKeysAgainstBundle(extractPercentKeys(packagedPkg), packagedNls, 'packaged package.json', 'packaged package.nls.json');
+	for (const key of baseKeys) {
+		if (!(key in packagedNls)) {
+			errors.push(`packaged package.nls.json lost key '${key}' that exists in the source bundle`);
+		}
+	}
+}
+
+function main() {
+	const vsixIndex = process.argv.indexOf('--vsix');
+	const vsixPath = vsixIndex >= 0 ? process.argv[vsixIndex + 1] : undefined;
+
+	const base = validateSourceTree();
+	if (vsixPath && base) {
+		validateVsix(path.resolve(vsixPath), Object.keys(base));
+	}
+
+	for (const warning of warnings) { console.warn(`⚠️  ${warning}`); }
+	if (errors.length > 0) {
+		for (const error of errors) { console.error(`❌ ${error}`); }
+		console.error(`\n${errors.length} localization error(s) found.`);
+		process.exit(1);
+	}
+	console.log(`✅ Localization validation passed (${base ? Object.keys(base).length : 0} keys in package.nls.json${vsixPath ? ', VSIX contents verified' : ''}).`);
+}
+
+main();

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -5,8 +5,10 @@ import * as path from 'path';
 import * as os from 'os';
 import * as childProcess from 'child_process';
 
-// Localization support
-const l10n = vscode.l10n;
+// Localization support (key-based resolver over package.nls*.json — see l10n.ts
+// for why vscode.l10n.t() cannot be used directly with key-based strings)
+import { t as l10nT } from './l10n';
+const l10n = { t: l10nT };
 
 // --- JSON data files ---
 import tokenEstimatorsData from '../../src/tokenEstimators.json';
@@ -1329,13 +1331,13 @@ class CopilotTokenTracker implements vscode.Disposable {
 			} catch { /* Ignore git errors in dev mode */ }
 			this.initializeCrashDebugLog(context);
 		}
-		this.outputChannel = vscode.window.createOutputChannel(vscode.l10n.t('outputChannelName'));
+		this.outputChannel = vscode.window.createOutputChannel(l10n.t('outputChannelName'));
 		context.subscriptions.push(this.outputChannel);
 		this.log('Constructor called');
 		const version = context.extension.packageJSON?.version ?? 'unknown';
 		const mode = context.extensionMode === vscode.ExtensionMode.Development ? 'Development'
 			: context.extensionMode === vscode.ExtensionMode.Test ? 'Test' : 'Production';
-		let startupInfo = vscode.l10n.t('startupInfo', version, mode, CopilotTokenTracker.CACHE_VERSION);
+		let startupInfo = l10n.t('startupInfo', version, mode, CopilotTokenTracker.CACHE_VERSION);
 		if (context.extensionMode === vscode.ExtensionMode.Development) {
 			try {
 				const sha = childProcess.execSync('git rev-parse --short HEAD', {
@@ -1398,15 +1400,15 @@ class CopilotTokenTracker implements vscode.Disposable {
 
 	private initializeStatusBar(): void {
 		this.statusBarItem = vscode.window.createStatusBarItem('ai-engineering-fluency', vscode.StatusBarAlignment.Right, 102);
-		this.statusBarItem.name = vscode.l10n.t("statusBar.name");
-		this.setStatusBarText(vscode.l10n.t("statusBar.loadingText"));
-		this.statusBarItem.tooltip = vscode.l10n.t("statusBar.tooltip");
+		this.statusBarItem.name = l10n.t("statusBar.name");
+		this.setStatusBarText(l10n.t("statusBar.loadingText"));
+		this.statusBarItem.tooltip = l10n.t("statusBar.tooltip");
 		this.statusBarItem.command = 'aiEngineeringFluency.showDetails';
 		this.statusBarItem.show();
 
 		// Separate insights badge — hidden until there are new insights
 		this.insightsStatusBarItem = vscode.window.createStatusBarItem('ai-engineering-fluency-insights', vscode.StatusBarAlignment.Right, 101);
-		this.insightsStatusBarItem.name = vscode.l10n.t("statusBar.name") + " — Insights";
+		this.insightsStatusBarItem.name = l10n.t("statusBar.name") + " — Insights";
 		this.insightsStatusBarItem.command = 'aiEngineeringFluency.openInsightsTab';
 		// starts hidden; shown in refreshStatusBarInsightBadge when count > 0
 
@@ -1713,7 +1715,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			this.insightsStatusBarItem.text = `💡 ${label}`;
 			const tooltip = new vscode.MarkdownString();
 			tooltip.isTrusted = false;
-			tooltip.appendMarkdown(`**${vscode.l10n.t('aiFluencyInsights')}** — ${label} waiting for you\n\n`);
+			tooltip.appendMarkdown(`**${l10n.t('aiFluencyInsights')}** — ${label} waiting for you\n\n`);
 			if (this._topInsightTitle) {
 				tooltip.appendMarkdown(`${this._topInsightTitle}\n\n`);
 			}
@@ -2486,8 +2488,8 @@ class CopilotTokenTracker implements vscode.Disposable {
 			return await this._runRefreshCore(silent, isLeader);
 		} catch (error) {
 			this.error('Error updating token stats:', error);
-			this.setStatusBarText(vscode.l10n.t('statusBar.tokenError'));
-			this.statusBarItem.tooltip = vscode.l10n.t('statusBar.errorTooltip');
+			this.setStatusBarText(l10n.t('statusBar.tokenError'));
+			this.statusBarItem.tooltip = l10n.t('statusBar.errorTooltip');
 			return undefined;
 		} finally {
 			this.stopRefreshHeartbeat();
@@ -2632,7 +2634,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 				// changes, to avoid needless status-bar relayout on every callback.
 				if (percentage !== lastPercentage) {
 					lastPercentage = percentage;
-					this.setStatusBarText(vscode.l10n.t('statusBar.analyzingLogs', percentage.toString()));
+					this.setStatusBarText(l10n.t('statusBar.analyzingLogs', percentage.toString()));
 				}
 			}
 			if (!parsingStepNotified) {
@@ -2680,7 +2682,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 	private updateStatusBarAndTooltip(detailedStats: DetailedStats): void {
 		this._lastDetailedStats = detailedStats;
 		if (detailedStats.today.sessions === 0 && detailedStats.last30Days.sessions === 0) {
-			this.setStatusBarText(vscode.l10n.t('statusBar.noSessionData'));
+			this.setStatusBarText(l10n.t('statusBar.noSessionData'));
 		} else {
 			this.setStatusBarText(this.buildStatusBarText(detailedStats));
 		}
@@ -2826,22 +2828,22 @@ class CopilotTokenTracker implements vscode.Disposable {
 		const tooltip = new vscode.MarkdownString();
 		tooltip.isTrusted = true;
 		tooltip.supportThemeIcons = false;
-		tooltip.appendMarkdown(`#### ${vscode.l10n.t('tooltip.title')}`);
+		tooltip.appendMarkdown(`#### ${l10n.t('tooltip.title')}`);
 		tooltip.appendMarkdown('\n---\n');
 		const secondaryPeriod = tooltipSecondaryPeriod(this.getStatusBarShowTokensSetting(), this.getStatusBarShowCostSetting());
 		const secondaryStats = secondaryPeriod === 'currentMonth' ? detailedStats.month : detailedStats.last30Days;
-		const secondaryLabel = secondaryPeriod === 'currentMonth' ? vscode.l10n.t('tooltip.currentMonthLabel') : vscode.l10n.t('tooltip.last30DaysLabel');
+		const secondaryLabel = secondaryPeriod === 'currentMonth' ? l10n.t('tooltip.currentMonthLabel') : l10n.t('tooltip.last30DaysLabel');
 		// Trailing &nbsp; padding on the "Today" column widens it a bit, giving the two
 		// value columns visual breathing room without VS Code table cell CSS to lean on.
 		const pad = (cell: string) => `${cell}&nbsp;&nbsp;&nbsp;&nbsp;`;
 		const grams = (n: number) => `${n.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} grams`;
 		const liters = (n: number) => `${n.toLocaleString(undefined, { minimumFractionDigits: 3, maximumFractionDigits: 3 })} liters`;
-		tooltip.appendMarkdown(`|  | 📅 ${vscode.l10n.t('tooltip.todayLabel')} | 📊 ${secondaryLabel} |\n|:---|:---|:---|\n`);
-		tooltip.appendMarkdown(`| ${vscode.l10n.t('tooltip.tokensLabel')} : | ${pad(detailedStats.today.tokens.toLocaleString())} | ${secondaryStats.tokens.toLocaleString()} |\n`);
-		tooltip.appendMarkdown(`| ${vscode.l10n.t('tooltip.copilotCostLabel')} : | ${pad(`$ ${(detailedStats.today.estimatedCostCopilot ?? 0).toFixed(2)}`)} | $ ${(secondaryStats.estimatedCostCopilot ?? 0).toFixed(2)} |\n`);
-		tooltip.appendMarkdown(`| ${vscode.l10n.t('tooltip.allProvidersCostLabel')} : | ${pad(`$ ${this.sumBillingGroupCosts(detailedStats.today.billingGroupCosts).toFixed(2)}`)} | $ ${this.sumBillingGroupCosts(secondaryStats.billingGroupCosts).toFixed(2)} |\n`);
-		tooltip.appendMarkdown(`| ${vscode.l10n.t('tooltip.co2Label')} : | ${pad(grams(detailedStats.today.co2))} | ${grams(secondaryStats.co2)} |\n`);
-		tooltip.appendMarkdown(`| ${vscode.l10n.t('tooltip.waterLabel')} : | ${pad(liters(detailedStats.today.waterUsage))} | ${liters(secondaryStats.waterUsage)} |\n`);
+		tooltip.appendMarkdown(`|  | 📅 ${l10n.t('tooltip.todayLabel')} | 📊 ${secondaryLabel} |\n|:---|:---|:---|\n`);
+		tooltip.appendMarkdown(`| ${l10n.t('tooltip.tokensLabel')} : | ${pad(detailedStats.today.tokens.toLocaleString())} | ${secondaryStats.tokens.toLocaleString()} |\n`);
+		tooltip.appendMarkdown(`| ${l10n.t('tooltip.copilotCostLabel')} : | ${pad(`$ ${(detailedStats.today.estimatedCostCopilot ?? 0).toFixed(2)}`)} | $ ${(secondaryStats.estimatedCostCopilot ?? 0).toFixed(2)} |\n`);
+		tooltip.appendMarkdown(`| ${l10n.t('tooltip.allProvidersCostLabel')} : | ${pad(`$ ${this.sumBillingGroupCosts(detailedStats.today.billingGroupCosts).toFixed(2)}`)} | $ ${this.sumBillingGroupCosts(secondaryStats.billingGroupCosts).toFixed(2)} |\n`);
+		tooltip.appendMarkdown(`| ${l10n.t('tooltip.co2Label')} : | ${pad(grams(detailedStats.today.co2))} | ${grams(secondaryStats.co2)} |\n`);
+		tooltip.appendMarkdown(`| ${l10n.t('tooltip.waterLabel')} : | ${pad(liters(detailedStats.today.waterUsage))} | ${liters(secondaryStats.waterUsage)} |\n`);
 		tooltip.appendMarkdown('\n---\n');
 		this.appendProviderCostSection(tooltip, detailedStats);
 		return tooltip;
@@ -2861,12 +2863,12 @@ class CopilotTokenTracker implements vscode.Disposable {
 		const providers = Object.keys(monthCosts).sort((a, b) => (monthCosts[b] ?? 0) - (monthCosts[a] ?? 0));
 		if (providers.length === 0) { return; }
 		const totalCost = this.sumBillingGroupCosts(monthCosts);
-		tooltip.appendMarkdown(`💰 ${vscode.l10n.t('tooltip.costsByProvider')}  \n`);
+		tooltip.appendMarkdown(`💰 ${l10n.t('tooltip.costsByProvider')}  \n`);
 		tooltip.appendMarkdown(`|  |  |  |\n|---|---|---|\n`);
 		const { budget, source } = this.getEffectiveMonthlyBudgetWithSource();
 		if (budget > 0) {
 			this.appendCopilotBudgetRow(tooltip, monthCosts['GitHub Copilot'] ?? 0, budget);
-			tooltip.appendMarkdown(`| **${vscode.l10n.t('tooltip.shareOfTotalSpend')}** |  |  |\n`);
+			tooltip.appendMarkdown(`| **${l10n.t('tooltip.shareOfTotalSpend')}** |  |  |\n`);
 		}
 		for (const provider of providers) {
 			const cost = monthCosts[provider] ?? 0;
@@ -2875,7 +2877,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			tooltip.appendMarkdown(`| ${provider} | $${cost.toFixed(2)} | ${barCell} |\n`);
 		}
 		if (budget > 0) {
-			tooltip.appendMarkdown(`\n*${vscode.l10n.t('tooltip.budgetFromSource', source)}*\n`);
+			tooltip.appendMarkdown(`\n*${l10n.t('tooltip.budgetFromSource', source)}*\n`);
 		}
 	}
 
@@ -3128,7 +3130,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 				if (r.mtime >= todayStart.getTime()) { todayTokens += r.tokens; }
 			}
 		} catch (error) {
-			this.error(vscode.l10n.t('error.calculatingTokenUsage'), error);
+			this.error(l10n.t('error.calculatingTokenUsage'), error);
 		}
 
 		return {
@@ -3315,7 +3317,6 @@ class CopilotTokenTracker implements vscode.Disposable {
 	 * This provides localized button labels and other UI strings for webview panels.
 	 */
 	private getWebviewLocalization(): Record<string, string> {
-		const l10n = vscode.l10n;
 		const language = vscode.env.language;
 		
 		// Return navigation button labels and other webview-localizable strings
@@ -3442,7 +3443,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			parts.push(`$(credit-card) ${this.buildCostParts(showCost, stats).join(' | ')}`);
 		}
 
-        return parts.length > 0 ? parts.join('  ') : `$(symbol-numeric) ${vscode.l10n.t('statusBar.defaultText')}`;
+        return parts.length > 0 ? parts.join('  ') : `$(symbol-numeric) ${l10n.t('statusBar.defaultText')}`;
 	}
 
 	private refreshOpenPanelsForSettingChange(): void {
@@ -6449,7 +6450,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 		// Create a small webview panel
 		this.detailsPanel = vscode.window.createWebviewPanel(
 			'copilotTokenDetails',
-			vscode.l10n.t('aiEngineeringFluency'),
+			l10n.t('aiEngineeringFluency'),
 			{
 				viewColumn: vscode.ViewColumn.One,
 				preserveFocus: true
@@ -6494,7 +6495,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 		if (!stats) {
 			this.log('No cached stats — showing loading screen while calculating...');
 			this._detailsPanelIsLoading = true;
-			this.statusBarItem.tooltip = vscode.l10n.t('statusBar.loadingInPanel');
+			this.statusBarItem.tooltip = l10n.t('statusBar.loadingInPanel');
 			this.detailsPanel.webview.html = this.getLoadingHtml(this.detailsPanel.webview);
 
 			stats = await this.updateTokenStats();
@@ -7475,7 +7476,7 @@ Return ONLY the JSON object, no markdown formatting, no explanations.`;
 		const maturityData = await this.calculateMaturityScores(true);
 		const isDebugMode = this.context.extensionMode === vscode.ExtensionMode.Development;
 		this.maturityPanel = vscode.window.createWebviewPanel(
-			'copilotMaturity', vscode.l10n.t('pptxTitle'),
+			'copilotMaturity', l10n.t('pptxTitle'),
 			{ viewColumn: vscode.ViewColumn.One, preserveFocus: true },
 			{ enableScripts: true, retainContextWhenHidden: false, localResourceRoots: [vscode.Uri.joinPath(this.extensionUri, 'dist', 'webview')] }
 		);
@@ -7552,7 +7553,7 @@ Return ONLY the JSON object, no markdown formatting, no explanations.`;
 			const evidenceList = c.evidence.length > 0 ? c.evidence.map(e => `- ✅ ${e}`).join('\n') : '- No significant activity detected';
 			return `<h2>${c.icon} ${c.category} — Stage ${c.stage}</h2>\n\n${evidenceList}`;
 		}).join('\n\n');
-		const body = `<h2>${vscode.l10n.t('fluencyScoreFeedbackTitle')}</h2>\n\n**Overall Stage:** ${scores.overallLabel}\n\n${categorySections}\n\n<h2>Feedback</h2>\n<!-- Describe your feedback or suggestion here -->\n`;
+		const body = `<h2>${l10n.t('fluencyScoreFeedbackTitle')}</h2>\n\n**Overall Stage:** ${scores.overallLabel}\n\n${categorySections}\n\n<h2>Feedback</h2>\n<!-- Describe your feedback or suggestion here -->\n`;
 		const issueUrl = `https://github.com/rajbos/ai-engineering-fluency/issues/new?title=${encodeURIComponent('Fluency Score Feedback')}&body=${encodeURIComponent(body)}&labels=${encodeURIComponent('fluency-score')}`;
 		await vscode.env.openExternal(vscode.Uri.parse(issueUrl));
 	}
@@ -7693,7 +7694,7 @@ private async shareTextToSocialPlatform(shareText: string, platform: 'linkedin' 
     const buffer = Buffer.from(base64Match[1], 'base64');
     await vscode.workspace.fs.writeFile(uri, buffer);
 
-    const shareText = vscode.l10n.t('shareText');
+    const shareText = l10n.t('shareText');
     await vscode.env.clipboard.writeText(shareText);
     await vscode.env.openExternal(vscode.Uri.parse(platformUrl));
 
@@ -7779,7 +7780,7 @@ private async shareTextToSocialPlatform(shareText: string, platform: 'linkedin' 
 
   private pdfAddPage(pdf: any, imgData: string, pageIndex: number, totalPages: number, pageWidth: number, pageHeight: number, margin: number): void {
     pdf.setFontSize(8); pdf.setTextColor(128, 128, 128);
-    pdf.text(vscode.l10n.t('pdfReportTitle', (pageIndex + 1).toString(), totalPages.toString()), margin, 7);
+    pdf.text(l10n.t('pdfReportTitle', (pageIndex + 1).toString(), totalPages.toString()), margin, 7);
     pdf.text(new Date().toLocaleDateString(), pageWidth - margin, 7, { align: "right" });
     const availW = pageWidth - 2 * margin;
     const availH = pageHeight - 2 * margin - 5;
@@ -7789,7 +7790,7 @@ private async shareTextToSocialPlatform(shareText: string, platform: 'linkedin' 
     const x = margin + (availW - drawW) / 2; const y = margin + 5 + (availH - drawH) / 2;
     pdf.addImage(imgData, "PNG", x, y, drawW, drawH);
     pdf.setFontSize(8); pdf.setTextColor(128, 128, 128);
-    pdf.text(vscode.l10n.t('pdfGeneratedBy'), pageWidth / 2, pageHeight - 5, { align: "center" });
+    pdf.text(l10n.t('pdfGeneratedBy'), pageWidth / 2, pageHeight - 5, { align: "center" });
   }
 
   private async exportFluencyScorePptx(images: { label: string; dataUrl: string }[]): Promise<void> {
@@ -7799,8 +7800,8 @@ private async shareTextToSocialPlatform(shareText: string, platform: 'linkedin' 
       const uri = await vscode.window.showSaveDialog({ defaultUri: vscode.Uri.file("copilot-fluency-score.pptx"), filters: { "PowerPoint Presentation": ["pptx"] }, title: "Export Fluency Score as PowerPoint" });
       if (!uri) { return; }
       const pptx = new PptxGenJS();
-      pptx.layout = "LAYOUT_WIDE"; pptx.author = vscode.l10n.t('pptxAuthor');
-      pptx.subject = vscode.l10n.t('pptxSubject'); pptx.title = vscode.l10n.t('pptxTitle');
+      pptx.layout = "LAYOUT_WIDE"; pptx.author = l10n.t('pptxAuthor');
+      pptx.subject = l10n.t('pptxSubject'); pptx.title = l10n.t('pptxTitle');
       const slideW = 13.33; const slideH = 7.5;
       const maxW = slideW - 0.8; const maxH = slideH - 1.0;
       for (const img of images) { this.pptxAddImageSlide(pptx, img.dataUrl, slideW, slideH, maxW, maxH); }
@@ -7836,7 +7837,7 @@ private async shareTextToSocialPlatform(shareText: string, platform: 'linkedin' 
     const { w: imgW, h: imgH } = this.pptxGetImageSize(dataUrl, maxW, maxH);
     const x = (slideW - imgW) / 2; const y = (slideH - 1.0 - imgH) / 2 + 0.1;
     slide.addImage({ data: dataUrl, x, y, w: imgW, h: imgH });
-    slide.addText(vscode.l10n.t('pptxGeneratedBy'), { x: 0, y: 7.0, w: 13.33, h: 0.4, fontSize: 8, color: "808080", align: "center" });
+    slide.addText(l10n.t('pptxGeneratedBy'), { x: 0, y: 7.0, w: 13.33, h: 0.4, fontSize: 8, color: "808080", align: "center" });
   }
 
   public async showFluencyLevelViewer(): Promise<void> {
@@ -8017,7 +8018,7 @@ private async shareTextToSocialPlatform(shareText: string, platform: 'linkedin' 
 			<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 			${buildCspMeta(webview, nonce)}
 			${getCodiconStylesheetTag(webview, this.extensionUri)}
-			<title>${vscode.l10n.t('pptxTitle')}</title>
+			<title>${l10n.t('pptxTitle')}</title>
 		</head>
 		<body>
 			<div id="root"></div>
@@ -8830,7 +8831,7 @@ private async shareTextToSocialPlatform(shareText: string, platform: 'linkedin' 
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 ${buildCspMeta(webview, nonce)}
-<title>${vscode.l10n.t('htmlTitleLoading')}</title>
+<title>${l10n.t('htmlTitleLoading')}</title>
 <style>
 ${this.getLoadingHtmlCssBase()}
 ${this.getLoadingHtmlCssSteps()}
@@ -8886,7 +8887,7 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString())}
 			<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 			${buildCspMeta(webview, nonce)}
 			${getCodiconStylesheetTag(webview, this.extensionUri)}
-			<title>${vscode.l10n.t('htmlTitle')}</title>
+			<title>${l10n.t('htmlTitle')}</title>
 		</head>
 		<body>
 			<div id="root"></div>
@@ -8916,7 +8917,7 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString())}
   }
 
   private buildDiagReportHeader(report: string[]): void {
-    report.push("=".repeat(70)); report.push(vscode.l10n.t('diagnosticReportTitle')); report.push("=".repeat(70)); report.push("");
+    report.push("=".repeat(70)); report.push(l10n.t('diagnosticReportTitle')); report.push("=".repeat(70)); report.push("");
   }
 
   private buildDiagReportExtensionInfo(report: string[]): void {
@@ -9036,7 +9037,7 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString())}
       if (sessionFiles.length > 0) { await this.appendSessionFileListing(report, sessionFiles); }
       else { this.appendNoSessionFilesMessage(report); }
       report.push("");
-    } catch (error) { report.push(vscode.l10n.t('error.calculatingTokenUsageStatistics') + `: ${error}`); report.push(""); }
+    } catch (error) { report.push(l10n.t('error.calculatingTokenUsageStatistics') + `: ${error}`); report.push(""); }
   }
 
   private buildDiagReportFooter(report: string[]): void {
@@ -9199,7 +9200,7 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString())}
       await vscode.commands.executeCommand("aiEngineeringFluency.configureBackend");
     } catch {
       void (async () => {
-        const choice = await vscode.window.showInformationMessage(vscode.l10n.t('backendConfigMessage'), "Open Settings");
+        const choice = await vscode.window.showInformationMessage(l10n.t('backendConfigMessage'), "Open Settings");
         if (choice === "Open Settings") { void vscode.commands.executeCommand("workbench.action.openSettings", "aiEngineeringFluency.backend"); }
       })();
     }
@@ -9210,7 +9211,7 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString())}
       await vscode.commands.executeCommand("aiEngineeringFluency.configureTeamServer");
     } catch {
       void (async () => {
-        const choice = await vscode.window.showInformationMessage(vscode.l10n.t('teamServerConfigMessage'), "Open Settings");
+        const choice = await vscode.window.showInformationMessage(l10n.t('teamServerConfigMessage'), "Open Settings");
         if (choice === "Open Settings") { void vscode.commands.executeCommand("workbench.action.openSettings", "aiEngineeringFluency.backend.sharingServer"); }
       })();
     }
@@ -10917,7 +10918,7 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString())}
 			<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 			${buildCspMeta(webview, nonce)}
 			${getCodiconStylesheetTag(webview, this.extensionUri)}
-			<title>${vscode.l10n.t('htmlTitleChart')}</title>
+			<title>${l10n.t('htmlTitleChart')}</title>
 		</head>
 		<body>
 			<div id="root"></div>
@@ -11189,7 +11190,7 @@ async function checkForLegacyExtensionConflict(context: vscode.ExtensionContext)
     return;
   }
   const choice = await vscode.window.showWarningMessage(
-    vscode.l10n.t('cleanupWarning') + vscode.l10n.t('cleanupMessage'),
+    l10n.t('cleanupWarning') + l10n.t('cleanupMessage'),
     'Remove Old Extension',
     'Dismiss'
   );
@@ -11198,7 +11199,7 @@ async function checkForLegacyExtensionConflict(context: vscode.ExtensionContext)
       await vscode.commands.executeCommand('workbench.extensions.uninstallExtension', LEGACY_EXTENSION_ID);
     } catch {
       vscode.window.showInformationMessage(
-        vscode.l10n.t('cleanupMessage2')
+        l10n.t('cleanupMessage2')
       );
     }
   } else if (choice === 'Dismiss') {
@@ -11326,7 +11327,7 @@ function registerViewCommands(context: vscode.ExtensionContext, tokenTracker: Co
     async () => {
       tokenTracker.log("Refresh command called");
       await tokenTracker.updateTokenStats();
-      vscode.window.showInformationMessage(vscode.l10n.t('dataRefreshed'));
+      vscode.window.showInformationMessage(l10n.t('dataRefreshed'));
     },
   );
 

--- a/vscode-extension/src/l10n.ts
+++ b/vscode-extension/src/l10n.ts
@@ -1,0 +1,77 @@
+/**
+ * Key-based localization for the extension's runtime strings.
+ *
+ * Why not call `vscode.l10n.t()` directly? That API only resolves through
+ * `l10n/bundle.l10n.<lang>.json` files (enabled via the `l10n` field in
+ * package.json). This extension keeps its strings in `package.nls.json`,
+ * which VS Code only consults for static `%key%` references in
+ * package.json — never for the runtime API. On an English (default
+ * language) VS Code, `l10n.t(key)` returns the message argument unchanged,
+ * so key-based calls like `l10n.t('statusBar.loadingText')` surface the raw
+ * key in the UI.
+ *
+ * This module makes the existing `package.nls*.json` files the single source
+ * of truth for runtime strings too: esbuild inlines them into the bundle and
+ * `t()` resolves keys from the bundle matching `vscode.env.language`,
+ * falling back to English and finally to the key itself.
+ *
+ * `vscode.l10n.t()` is still consulted first, so if proper l10n bundles are
+ * ever shipped, real VS Code-provided translations take precedence.
+ */
+import * as vscode from 'vscode';
+import englishBundleData from '../package.nls.json';
+import zhCnBundleData from '../package.nls.zh-cn.json';
+
+const ENGLISH_BUNDLE = englishBundleData as Record<string, string>;
+
+/** Locale id (lowercase, from the package.nls.<locale>.json filename) → bundle. */
+const LOCALE_BUNDLES: Record<string, Record<string, string>> = {
+	'zh-cn': zhCnBundleData as Record<string, string>
+};
+
+const missingKeyWarnings = new Set<string>();
+
+/** Replace {0}, {1}, ... placeholders, mirroring vscode.l10n.t() formatting. */
+function formatMessage(template: string, args: Array<string | number | boolean>): string {
+	return template.replace(/\{(\d+)\}/g, (match, index) => {
+		const i = Number(index);
+		return i < args.length ? String(args[i]) : match;
+	});
+}
+
+function resolveLocaleBundle(language: string): Record<string, string> | undefined {
+	const lang = (language || '').toLowerCase();
+	if (LOCALE_BUNDLES[lang]) {
+		return LOCALE_BUNDLES[lang];
+	}
+	// A bare language tag ('zh') may match a more specific bundle ('zh-cn'),
+	// but never the other way around ('zh-tw' must not get Simplified Chinese).
+	for (const locale of Object.keys(LOCALE_BUNDLES)) {
+		if (lang === locale.split('-')[0]) {
+			return LOCALE_BUNDLES[locale];
+		}
+	}
+	return undefined;
+}
+
+/**
+ * Look up a localized string by its package.nls.json key. Resolution order:
+ * VS Code's own l10n bundle (if one is ever provided), the inlined bundle for
+ * the current VS Code display language, the inlined English bundle, and
+ * finally the key itself for genuinely unknown keys (logged once per key).
+ */
+export function t(key: string, ...args: Array<string | number | boolean>): string {
+	const value = args.length > 0 ? vscode.l10n.t(key, ...args) : vscode.l10n.t(key);
+	if (value !== key) {
+		return value;
+	}
+	const template = resolveLocaleBundle(vscode.env.language)?.[key] ?? ENGLISH_BUNDLE[key];
+	if (template === undefined) {
+		if (!missingKeyWarnings.has(key)) {
+			missingKeyWarnings.add(key);
+			console.warn(`[ai-engineering-fluency] No localization found for key "${key}" — add it to package.nls.json.`);
+		}
+		return key;
+	}
+	return formatMessage(template, args);
+}

--- a/vscode-extension/src/webview/shared/localization.ts
+++ b/vscode-extension/src/webview/shared/localization.ts
@@ -42,9 +42,18 @@ let currentLocalization: WebviewLocalization = { ...DEFAULT_LOCALIZATION };
 /**
  * Initialize webview localization with strings from the extension.
  * This should be called when the webview receives its initial state/data.
+ * Entries whose value equals their key are raw localization keys passed
+ * through unresolved (bundle load failure on the extension side) — ignore
+ * them so the built-in defaults are used instead of showing raw keys.
  */
 export function initializeWebviewLocalization(localization: Partial<WebviewLocalization>): void {
-	currentLocalization = { ...DEFAULT_LOCALIZATION, ...localization } as WebviewLocalization;
+	const resolved: Record<string, string> = {};
+	for (const [key, value] of Object.entries(localization)) {
+		if (typeof value === 'string' && value !== key) {
+			resolved[key] = value;
+		}
+	}
+	currentLocalization = { ...DEFAULT_LOCALIZATION, ...resolved } as WebviewLocalization;
 }
 
 /**

--- a/vscode-extension/test/unit/l10n.test.ts
+++ b/vscode-extension/test/unit/l10n.test.ts
@@ -1,0 +1,64 @@
+import test from 'node:test';
+import * as assert from 'node:assert/strict';
+
+import * as vscode from 'vscode';
+import { t } from '../../src/l10n';
+
+const mock = (vscode as any).__mock;
+
+// The shim's default l10n.t returns the raw key — exactly what real VS Code
+// does for key-based calls on the default (English) display language.
+
+test('l10n: VS Code-provided bundle translation takes precedence', () => {
+	mock.setL10nBundle({ 'statusBar.loadingText': 'Chargement…' });
+	assert.equal(t('statusBar.loadingText'), 'Chargement…');
+	mock.setL10nBundle(null);
+});
+
+test('l10n: VS Code bundle args are passed through', () => {
+	mock.setL10nBundle({ 'statusBar.analyzingLogs': 'Analyse: {0}%' });
+	assert.equal(t('statusBar.analyzingLogs', '42'), 'Analyse: 42%');
+	mock.setL10nBundle(null);
+});
+
+test('l10n: resolves English from the inlined package.nls.json when VS Code returns the raw key', () => {
+	const value = t('statusBar.loadingText');
+	assert.notEqual(value, 'statusBar.loadingText');
+	assert.ok(value.includes('AI Fluency'), `expected English text, got: ${value}`);
+});
+
+test('l10n: inlined fallback formats {0} placeholders', () => {
+	assert.equal(t('statusBar.analyzingLogs', '42'), '$(loading~spin) Analyzing Logs: 42%');
+});
+
+test('l10n: resolves zh-cn strings when the display language is zh-cn', () => {
+	mock.setLanguage('zh-cn');
+	assert.equal(t('nav.btnRefresh'), '刷新');
+	mock.setLanguage('en');
+});
+
+test('l10n: bare language tag zh matches the zh-cn bundle', () => {
+	mock.setLanguage('zh');
+	assert.equal(t('nav.btnRefresh'), '刷新');
+	mock.setLanguage('en');
+});
+
+test('l10n: zh-tw does not get the Simplified Chinese bundle', () => {
+	mock.setLanguage('zh-tw');
+	assert.equal(t('nav.btnRefresh'), 'Refresh');
+	mock.setLanguage('en');
+});
+
+test('l10n: unknown key returns the key itself and warns once', () => {
+	const warnings: string[] = [];
+	const originalWarn = console.warn;
+	console.warn = (msg: unknown) => { warnings.push(String(msg)); };
+	try {
+		assert.equal(t('no.such.key.exists'), 'no.such.key.exists');
+		t('no.such.key.exists');
+	} finally {
+		console.warn = originalWarn;
+	}
+	assert.equal(warnings.length, 1);
+	assert.ok(warnings[0].includes('No localization found for key "no.such.key.exists"'));
+});

--- a/vscode-extension/test/unit/vscode-shim-register.ts
+++ b/vscode-extension/test/unit/vscode-shim-register.ts
@@ -14,6 +14,8 @@ type VscodeMockState = {
 	lastErrorMessages: string[];
 	nextPick: string | undefined;
 	extensions: Record<string, unknown>;
+	l10nBundle: Record<string, string> | null;
+	language: string;
 };
 
 const state: VscodeMockState = {
@@ -26,7 +28,9 @@ const state: VscodeMockState = {
 	lastWarningMessages: [],
 	lastErrorMessages: [],
 	nextPick: undefined,
-	extensions: {}
+	extensions: {},
+	l10nBundle: null,
+	language: 'en'
 };
 
 function normalizeGetKey(key: string): string {
@@ -95,6 +99,8 @@ function attachMock(target: any): void {
 			state.lastErrorMessages = [];
 			state.nextPick = undefined;
 			state.extensions = {};
+			state.l10nBundle = null;
+			state.language = 'en';
 		},
 		setConfig(values: ConfigStore): void {
 			state.config = { ...values };
@@ -116,6 +122,12 @@ function attachMock(target: any): void {
 		},
 		setClipboardThrow(shouldThrow: boolean): void {
 			state.clipboardThrow = shouldThrow;
+		},
+		setL10nBundle(bundle: Record<string, string> | null): void {
+			state.l10nBundle = bundle;
+		},
+		setLanguage(language: string): void {
+			state.language = language;
 		}
 	};
 
@@ -123,6 +135,20 @@ function attachMock(target: any): void {
 	target.ExtensionMode = target.ExtensionMode ?? { Production: 1, Development: 2, Test: 3 };
 	target.ProgressLocation = target.ProgressLocation ?? { Notification: 15 };
 	target.ViewColumn = target.ViewColumn ?? { Active: -1, Beside: -2, One: 1, Two: 2, Three: 3 };
+
+	// l10n mock: mirrors real VS Code behavior for key-based calls — without a
+	// bundle (the default) t() returns the raw key; setL10nBundle() simulates a
+	// loaded l10n/bundle.l10n.<lang>.json.
+	target.l10n = target.l10n ?? {
+		t: (key: string, ...args: Array<string | number | boolean>): string => {
+			const template = state.l10nBundle?.[key];
+			if (template === undefined) {
+				return key;
+			}
+			return template.replace(/\{(\d+)\}/g, (match, index) =>
+				Number(index) < args.length ? String(args[Number(index)]) : match);
+		}
+	};
 
 	// Add Uri class for tests
 	target.Uri = target.Uri ?? class Uri {
@@ -233,6 +259,11 @@ function attachMock(target: any): void {
 
 	target.env = target.env ?? {};
 	target.env.machineId = target.env.machineId ?? 'test-machine-id-0000000000000000';
+	Object.defineProperty(target.env, 'language', {
+		get() {
+			return state.language;
+		}
+	});
 	const clipboardImpl = {
 		async writeText(text: string): Promise<void> {
 			if (state.clipboardThrow) {


### PR DESCRIPTION
## Why

The extension UI was showing raw localization keys instead of text: the status bar read `statusBar.loadingText`, the Output channel was literally named `outputChannelName`, webview nav buttons showed `nav.btnRefresh` etc., and the panel tab title was `aiEngineeringFluency`. Reinstalling or switching between release/prerelease did not help.

Root cause (verified against VS Code's `extHostLocalizationService.ts`): **key-based `vscode.l10n.t()` calls can never resolve keys from `package.nls.json`.** That file is only consulted for static `%key%` references in `package.json`. At runtime, the l10n API returns the message argument unchanged on the default (English) display language, and for other languages only reads `l10n/bundle.l10n.<lang>.json` files (enabled via the `l10n` field in package.json, which this extension does not have). So every key-based `l10n.t('...')` call returned the raw key, in both release and prerelease builds.

## Fix

- New `vscode-extension/src/l10n.ts`: a key-based resolver that treats `package.nls*.json` as the single source of truth. esbuild inlines the bundles into `dist/extension.js`; `t()` resolves the key from the bundle matching `vscode.env.language` (zh-cn supported; bare `zh` matches, `zh-tw` correctly falls back to English), then English, then the key itself with a one-time warning for genuinely missing keys. `vscode.l10n.t()` is still consulted first, so real VS Code-provided translations would take precedence if l10n bundles ever ship.
- All ~60 call sites in `extension.ts` now route through the helper.
- Webview `initializeWebviewLocalization` ignores entries whose value equals their key (raw-key passthrough), so built-in defaults win.

## Detection

- New `vscode-extension/scripts/validate-l10n.mjs` (`npm run validate:l10n`): strictly parses all `package.nls*.json`, checks every `%key%` reference in `package.json` and every `l10n.t('key')` call in `src/**` against the base bundle, and verifies locale key parity. With `--vsix <file>` it also validates the packaged VSIX ships a complete, valid bundle (self-contained zip reader, no `unzip` dependency).
- Wired into `ci.yml` and `vscode-nightly-prerelease.yml` right after VSIX packaging, so a broken or incomplete localization bundle fails the build.

## Verification

- Validator run against a locally built VSIX and the published nightly VSIX `0.17.2026082501` (both pass; confirms the shipped artifacts were complete and the bug was the API usage, not packaging). Negative test: a VSIX with `package.nls.json` removed fails validation with exit 1.
- 8 new unit tests for the resolver (locale selection, bundle precedence, `{0}` placeholder formatting, missing-key warning); the vscode test shim gained `l10n` and `env.language` mocks.
- Full unit suite green (96 files, exit 0); production VSIX verified to contain both inlined bundles.

## Notes for reviewers

- `extension.ts` diff is large but purely mechanical (`vscode.l10n.t(` -> `l10n.t(`).
- `npm run compile` reports 3 pre-existing complexity warnings in code untouched by this PR.
- Docs updated in `.github/instructions/vscode-extension.instructions.md` (why the helper exists + how to validate).