### PR TITLE
fix: friendly names and cost attribution for model ID variants

### DIFF
--- a/src/modelPricing.json
+++ b/src/modelPricing.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "description": "Model pricing data - costs per million tokens. Each model has direct provider/API pricing at the top level (used as a reference); models billed through GitHub Copilot AI Credits also include a `copilotPricing` block reflecting GitHub's published per-token rates (1 AI credit = $0.01).",
   "metadata": {
-    "lastUpdated": "2026-08-25",
+    "lastUpdated": "2026-08-30",
     "sources": [
       {
         "name": "OpenAI API Pricing",
@@ -424,7 +424,7 @@
       "category": "Claude models (Anthropic)",
       "tier": "standard",
       "displayNames": [
-        "Claude Sonnet 4.6 (alternate format)"
+        "Claude Sonnet 4.6"
       ],
       "copilotPricing": {
         "inputCostPerMillion": 3.0,
@@ -976,6 +976,15 @@
       "tier": "unknown",
       "displayNames": [
         "Devstral Medium"
+      ]
+    },
+    "devstral-latest": {
+      "inputCostPerMillion": 0.4,
+      "outputCostPerMillion": 2.0,
+      "category": "Mistral models",
+      "tier": "unknown",
+      "displayNames": [
+        "Devstral 2"
       ]
     },
     "pixtral-large-2411": {

--- a/src/tokenEstimation.ts
+++ b/src/tokenEstimation.ts
@@ -5,7 +5,7 @@
 import type { ModelUsage, ModelPricing, ContextReferenceUsage, TokenEstimator } from './types';
 import { toLocalDayKey } from './utils/dayKeys';
 import type { CopilotCliOtelSessionUsage } from './copilotCliOtel';
-import { parseCustomProviderModel } from './webview/shared/modelUtils';
+import { getModelLookupCandidates } from './webview/shared/modelUtils';
 
 /** Minimum request shape needed by getModelFromRequest. */
 interface ModelRequestSource {
@@ -1123,7 +1123,7 @@ export function applyDelta(state: unknown, delta: unknown): unknown {
 
 export function getModelTier(modelId: string, modelPricing: { [key: string]: ModelPricing } = {}): 'standard' | 'premium' | 'unknown' {
 	// Look up the explicit `tier` field from modelPricing.json.
-	const pricingInfo = modelPricing[modelId];
+	const pricingInfo = _lookupModelPricing(modelId, modelPricing);
 	if (pricingInfo?.tier) {
 		return pricingInfo.tier;
 	}
@@ -1172,7 +1172,7 @@ export interface LongContextInfo {
  * parseable threshold — i.e. the model is billed at a single (default) rate.
  */
 export function getLongContextInfo(modelId: string, modelPricing: { [key: string]: ModelPricing } = {}): LongContextInfo | null {
-	let pricing: ModelPricing | undefined = modelPricing[modelId];
+	let pricing: ModelPricing | undefined = _lookupModelPricing(modelId, modelPricing);
 	if (!pricing) {
 		const id = modelId.toLowerCase();
 		for (const [key, value] of Object.entries(modelPricing)) {
@@ -1202,7 +1202,7 @@ function _costBucketFromPricing(pricing: ModelPricing): 'low' | 'medium' | 'high
 }
 
 export function getModelCostBucket(modelId: string, modelPricing: { [key: string]: ModelPricing } = {}): 'low' | 'medium' | 'high' | 'unknown' {
-	const pricingInfo = modelPricing[modelId];
+	const pricingInfo = _lookupModelPricing(modelId, modelPricing);
 	if (pricingInfo) { return _costBucketFromPricing(pricingInfo); }
 	for (const [key, value] of Object.entries(modelPricing)) {
 		if (modelId.includes(key) || key.includes(modelId)) { return _costBucketFromPricing(value); }
@@ -1211,16 +1211,22 @@ export function getModelCostBucket(modelId: string, modelPricing: { [key: string
 }
 
 /**
- * Resolves the pricing entry for a model served by a user-configured custom endpoint,
- * e.g. `customendpoint/Mistral/mistral-medium-latest` → the `mistral-medium-latest` rates.
- * Returns undefined for plain model ids and for endpoint models with no pricing entry.
+ * Resolves the pricing entry for a raw model id by trying the normalized
+ * candidates from getModelLookupCandidates — handles `copilot/` prefixes,
+ * custom-endpoint ids (`customendpoint/<provider>/<model id>`), org-scoped
+ * Copilot catalog ids (`<uuid>/<model id>`), and dash/dot version variants
+ * (`claude-opus-4-8` → `claude-opus-4.8`).
+ * Returns undefined when no candidate has a pricing entry.
  */
-function _pricingForCustomEndpointModel(
+function _lookupModelPricing(
 	model: string,
 	modelPricing: { [key: string]: ModelPricing }
 ): ModelPricing | undefined {
-	const custom = parseCustomProviderModel(model);
-	return custom ? modelPricing[custom.modelId] : undefined;
+	for (const candidate of getModelLookupCandidates(model)) {
+		const entry = modelPricing[candidate];
+		if (entry) { return entry; }
+	}
+	return undefined;
 }
 
 /**
@@ -1262,9 +1268,9 @@ export function calculateEstimatedCost(
 	for (const [model, usage] of Object.entries(modelUsage)) {
 		// No pricing entry → model still appears in usage breakdowns (via modelUsage)
 		// but contributes $0 to cost. Do NOT fall back to another model's rates.
-		// Custom-endpoint ids (`customendpoint/<provider>/<model id>`) are priced by their
-		// model-id part — the same model, just reached through a user-configured endpoint.
-		const baseEntry = modelPricing[model] ?? _pricingForCustomEndpointModel(model, modelPricing);
+		// Prefixed/variant ids (custom endpoints, org-UUID catalog ids, dash/dot
+		// version variants) are priced by their resolved canonical id.
+		const baseEntry = _lookupModelPricing(model, modelPricing);
 		if (!baseEntry) {
 			continue;
 		}

--- a/src/webview/shared/modelUtils.ts
+++ b/src/webview/shared/modelUtils.ts
@@ -62,6 +62,39 @@ export function parseCustomProviderModel(model: string): CustomProviderModel | u
     };
 }
 
+/** Matches a leading `<uuid>/` prefix, e.g. org-scoped Copilot model catalog ids. */
+const UUID_PREFIX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\//i;
+
+/**
+ * Returns candidate model ids to try when looking up a raw model id in the
+ * pricing JSON, most specific first. Handles the id variants seen in session
+ * logs that all refer to the same underlying model:
+ *
+ * - `copilot/` prefix stripping
+ * - custom-endpoint ids (`<source>/<provider>/<model>`) → the model part
+ * - org-scoped Copilot catalog ids (`<uuid>/<model>`) → the model part
+ * - dash-separated version numbers (`claude-opus-4-8` → `claude-opus-4.8`),
+ *   applied to each of the above
+ */
+export function getModelLookupCandidates(model: string): string[] {
+	const candidates: string[] = [];
+	const add = (id: string) => { if (id && !candidates.includes(id)) { candidates.push(id); } };
+	const addWithVersionVariant = (id: string) => {
+		add(id);
+		// Some logs emit version numbers dash-separated (claude-opus-4-8) where the
+		// pricing JSON uses dots (claude-opus-4.8). Only convert the first
+		// digit-dash-digit run so date suffixes (…-4-5-20251001) stay intact.
+		add(id.replace(/(\d+)-(\d+)(?=-|$)/, '$1.$2'));
+	};
+
+	const base = model.replace(/^copilot\//, '');
+	addWithVersionVariant(base);
+	const custom = parseCustomProviderModel(base);
+	if (custom) { addWithVersionVariant(custom.modelId); }
+	if (UUID_PREFIX.test(base)) { addWithVersionVariant(base.replace(UUID_PREFIX, '')); }
+	return candidates;
+}
+
 /**
  * Returns the provider group for a custom-endpoint model — the user-chosen provider
  * name marked as custom, e.g. `Mistral (Custom)` for
@@ -85,14 +118,19 @@ export function isCustomProviderGroup(group: string): boolean {
  * Custom-endpoint ids are reduced to their model part (the user-chosen provider
  * name is surfaced separately as a provider group), so
  * `customendpoint/Mistral/mistral-medium-latest` displays as the friendly name of
- * `mistral-medium-latest`.
+ * `mistral-medium-latest`. Org-scoped catalog ids (`<uuid>/model`) and
+ * dash/dot version variants are resolved via `getModelLookupCandidates`.
  *
  * If the model ID is not in the pricing JSON, it falls back to URI-decoding
- * the raw ID (e.g. unify-chat-provider names contain %20-encoded segments).
+ * the raw ID (e.g. unify-chat-provider names contain %20-encoded segments),
+ * with known prefix forms (custom endpoint, org UUID) stripped.
  */
 export function getModelDisplayName(model: string): string {
-    if (_modelNames[model]) { return _modelNames[model]; }
+    for (const candidate of getModelLookupCandidates(model)) {
+    	if (_modelNames[candidate]) { return _modelNames[candidate]; }
+    }
     const custom = parseCustomProviderModel(model);
-    if (custom) { return _modelNames[custom.modelId] ?? custom.modelId; }
+    if (custom) { return custom.modelId; }
+    if (UUID_PREFIX.test(model)) { return model.replace(UUID_PREFIX, ''); }
     return decodeSegment(model);
 }

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-engineering-fluency",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-engineering-fluency",
-      "version": "0.17.2",
+      "version": "0.17.3",
       "dependencies": {
         "@azure/arm-resources": "^8.0.0",
         "@azure/arm-resources-subscriptions": "^3.0.0",
@@ -45,7 +45,7 @@
         "typescript": "^5.9.3"
       },
       "engines": {
-        "vscode": "^1.125.0"
+        "vscode": "^1.134.0"
       }
     },
     "node_modules/@asamuzakjp/css-color": {

--- a/vscode-extension/test/unit/tokenEstimation.test.ts
+++ b/vscode-extension/test/unit/tokenEstimation.test.ts
@@ -277,6 +277,26 @@ test('calculateEstimatedCost: custom-endpoint model with an unpriced model part 
         assert.equal(calculateEstimatedCost(modelUsage, pricing), 0);
 });
 
+test('calculateEstimatedCost: prices an org-UUID-prefixed catalog model from its model-ID part', () => {
+        const modelUsage = { '83a386ed-9f05-4fd9-83d4-f453d20c994c/mistral-medium-latest': { inputTokens: 1_000_000, outputTokens: 1_000_000, sessions: 0} };
+        const pricing = { 'mistral-medium-latest': { inputCostPerMillion: 0.4, outputCostPerMillion: 2.0 } };
+        const cost = calculateEstimatedCost(modelUsage, pricing);
+        assert.ok(Math.abs(cost - 2.4) < 1e-9);
+});
+
+test('calculateEstimatedCost: prices a dash-separated version id from its dotted pricing key', () => {
+        const modelUsage = { 'claude-opus-4-8': { inputTokens: 1_000_000, outputTokens: 1_000_000, sessions: 0} };
+        const pricing = { 'claude-opus-4.8': { inputCostPerMillion: 5.0, outputCostPerMillion: 25.0 } };
+        const cost = calculateEstimatedCost(modelUsage, pricing);
+        assert.ok(Math.abs(cost - 30.0) < 1e-9);
+});
+
+test('calculateEstimatedCost: UUID-prefixed model with an unpriced model part stays $0', () => {
+        const modelUsage = { '83a386ed-9f05-4fd9-83d4-f453d20c994c/some-private-model': { inputTokens: 1_000_000, outputTokens: 1_000_000, sessions: 0} };
+        const pricing = { 'mistral-medium-latest': { inputCostPerMillion: 0.4, outputCostPerMillion: 2.0 } };
+        assert.equal(calculateEstimatedCost(modelUsage, pricing), 0);
+});
+
 test('calculateEstimatedCost: copilot source uses copilotPricing block when present', () => {
         const modelUsage = { 'gpt-x': { inputTokens: 1_000_000, outputTokens: 1_000_000, sessions: 0} };
         const pricing = {

--- a/vscode-extension/test/unit/webview-utils.test.ts
+++ b/vscode-extension/test/unit/webview-utils.test.ts
@@ -54,6 +54,34 @@ test('getModelDisplayName: resolves the friendly name of a custom-endpoint model
 	assert.equal(getModelDisplayName('customendpoint/Mistral/gpt-4o'), 'GPT-4o');
 });
 
+test('getModelDisplayName: resolves dash-separated version ids to the dotted pricing key', () => {
+	assert.equal(getModelDisplayName('claude-opus-4-8'), 'Claude Opus 4.8');
+	assert.equal(getModelDisplayName('claude-sonnet-4-6'), 'Claude Sonnet 4.6');
+	assert.equal(getModelDisplayName('claude-haiku-4-5-20251001'), 'Claude Haiku 4.5 (2025-10-01)');
+});
+
+test('getModelDisplayName: resolves org-UUID-prefixed catalog ids to the friendly name of the model part', () => {
+	assert.equal(
+		getModelDisplayName('83a386ed-9f05-4fd9-83d4-f453d20c994c/mistral-medium-latest'),
+		'Mistral Medium 3.5'
+	);
+	assert.equal(
+		getModelDisplayName('83a386ed-9f05-4fd9-83d4-f453d20c994c/codestral-latest'),
+		'Codestral'
+	);
+	assert.equal(
+		getModelDisplayName('83a386ed-9f05-4fd9-83d4-f453d20c994c/devstral-latest'),
+		'Devstral 2'
+	);
+});
+
+test('getModelDisplayName: strips the org-UUID prefix for unknown catalog models', () => {
+	assert.equal(
+		getModelDisplayName('83a386ed-9f05-4fd9-83d4-f453d20c994c/some-private-model'),
+		'some-private-model'
+	);
+});
+
 // ── parseCustomProviderModel ────────────────────────────────────────────
 
 test('parseCustomProviderModel: splits a three-part custom-endpoint ID', () => {


### PR DESCRIPTION
## Why

The AI Usage Analysis views showed raw model IDs instead of friendly names for several real-world ID variants, and those same models silently contributed $0 to cost attribution:

- `claude-opus-4-8` - session logs emit the dash-separated version, but `modelPricing.json` only had the dotted key `claude-opus-4.8`, so exact-key lookup missed (display and cost).
- `83a386ed-.../mistral-medium-latest` - org-scoped Copilot model catalog IDs (`<uuid>/<model>`) did not match the 3-part custom-endpoint parser, so they displayed raw and priced at $0.
- "Claude Sonnet 4.6 (alternate format)" - a previous band-aid for the same dash/dot problem added a duplicate pricing key with a confusing display name.
- `devstral-latest` had no pricing entry at all.

## Approach

- New shared `getModelLookupCandidates()` in `src/webview/shared/modelUtils.ts` produces lookup candidates for a raw model ID: strips the `copilot/` prefix, resolves 3-part custom-endpoint IDs to their model part, strips org-UUID catalog prefixes, and maps the first dash-separated version run to dots (`claude-opus-4-8` -> `claude-opus-4.8`, while date suffixes like `claude-haiku-4-5-20251001` stay intact).
- `getModelDisplayName()` now tries all candidates; unknown UUID-prefixed models display without the GUID instead of the full raw string.
- `src/tokenEstimation.ts` replaces the custom-endpoint-only pricing lookup with `_lookupModelPricing()` (same candidates), wired into `calculateEstimatedCost`, `getModelCostBucket`, `getModelTier`, and `getLongContextInfo`. This fixes the $0-cost bug in both the extension and the CLI (shared code path).
- `modelPricing.json`: `claude-sonnet-4-6` display name is now plain "Claude Sonnet 4.6" (the duplicate key is kept - same pricing - for exact-key lookups elsewhere); added `devstral-latest` ("Devstral 2", $0.40/$2.00 per M tokens).

## Notes for reviewers

- `MistralMedium3.5` showing raw in the views is user-controlled free text (the model part of a `customendpoint/Mistral/...` BYOK registration), so it is intentionally left as-is.
- The committed Visual Studio copy of `modelPricing.json` is a build artifact refreshed from the dist build via the `sync-host-views` flow; not hand-edited here.

## Validation

- Extension: lint clean (3 pre-existing warnings), full unit suite green (286 tests incl. 8 new cases covering UUID prefixes, dash/dot variants, and $0-cost regressions).
- CLI: build + tests green.