### PR TITLE
fix(usage): stop Repository PRs and Cloud Agent tabs hanging on Loading

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1837,33 +1837,34 @@ class CopilotTokenTracker implements vscode.Disposable {
 
 	/** Load PR stats for all discovered GitHub repos and send results to the analysis panel. */
 	private async loadRepoPrStats(): Promise<void> {
-		if (!this.analysisPanel) { return; }
+		const panel = this.analysisPanel;
+		if (!panel) { return; }
 
 		const since = new Date();
 		since.setDate(since.getDate() - 30);
 		this.log('🔎 Loading repository PR stats (last 30 days)…');
 		try {
-			await this.collectAndPublishRepoPrStats(since);
+			await this.collectAndPublishRepoPrStats(panel, since);
 		} catch (err) {
 			// Guarantee a post-back on every failure path — otherwise the webview stays on
 			// "Loading…" forever and dispatch() dedup silently swallows every retry.
+			// Post via the captured panel: this.analysisPanel may have been disposed mid-flight
+			// (postMessage on a disposed webview resolves false instead of throwing).
 			this.error('Failed to load repository PR stats', err);
 			const result: RepoPrStatsResult = {
 				repos: [], authenticated: !this._githubSignedOutByUser, since: since.toISOString(),
 				error: err instanceof Error ? err.message : String(err),
 			};
 			this._lastRepoPrStats = result;
-			this.analysisPanel.webview.postMessage({ command: 'repoPrStatsLoaded', data: result });
+			void panel.webview.postMessage({ command: 'repoPrStatsLoaded', data: result });
 		}
 	}
 
-	private async collectAndPublishRepoPrStats(since: Date): Promise<void> {
-		if (!this.analysisPanel) { return; }
-
+	private async collectAndPublishRepoPrStats(panel: vscode.WebviewPanel, since: Date): Promise<void> {
 		if (this._githubSignedOutByUser) {
 			const result: RepoPrStatsResult = { repos: [], authenticated: false, since: since.toISOString() };
 			this._lastRepoPrStats = result;
-			this.analysisPanel.webview.postMessage({ command: 'repoPrStatsLoaded', data: result });
+			void panel.webview.postMessage({ command: 'repoPrStatsLoaded', data: result });
 			return;
 		}
 
@@ -1871,7 +1872,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 		if (!session) {
 			const result: RepoPrStatsResult = { repos: [], authenticated: false, since: since.toISOString() };
 			this._lastRepoPrStats = result;
-			this.analysisPanel.webview.postMessage({ command: 'repoPrStatsLoaded', data: result });
+			void panel.webview.postMessage({ command: 'repoPrStatsLoaded', data: result });
 			return;
 		}
 
@@ -1886,7 +1887,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 		const discoveryStart = Date.now();
 		const repos = await discoverGitHubRepos(workspacePaths, getConfiguredGitHubEnterpriseUri());
 		this.log(`🔎 Discovered ${repos.length} GitHub repo(s) across ${workspacePaths.length} workspace path(s) in ${((Date.now() - discoveryStart) / 1000).toFixed(1)}s`);
-		this.analysisPanel.webview.postMessage({ command: 'repoPrStatsProgress', total: repos.length, done: 0 });
+		void panel.webview.postMessage({ command: 'repoPrStatsProgress', total: repos.length, done: 0 });
 
 		const results: RepoPrInfo[] = [];
 		for (let i = 0; i < repos.length; i++) {
@@ -1894,12 +1895,12 @@ class CopilotTokenTracker implements vscode.Disposable {
 			const { prs, error } = await fetchRepoPrs(owner, repo, session.accessToken, since);
 			const stats = this.collectAiPrStats(prs, error, session.account.label);
 			results.push({ owner, repo, repoUrl: `https://github.com/${owner}/${repo}`, ...stats, error });
-			this.analysisPanel.webview.postMessage({ command: 'repoPrStatsProgress', total: repos.length, done: i + 1 });
+			void panel.webview.postMessage({ command: 'repoPrStatsProgress', total: repos.length, done: i + 1 });
 		}
 
 		const result: RepoPrStatsResult = { repos: results, authenticated: true, since: since.toISOString() };
 		this._lastRepoPrStats = result;
-		this.analysisPanel.webview.postMessage({ command: 'repoPrStatsLoaded', data: result });
+		void panel.webview.postMessage({ command: 'repoPrStatsLoaded', data: result });
 	}
 
 	/** Classify one PR, pushing any AI detail rows and returning its contribution to the counters. */

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1841,6 +1841,24 @@ class CopilotTokenTracker implements vscode.Disposable {
 
 		const since = new Date();
 		since.setDate(since.getDate() - 30);
+		this.log('🔎 Loading repository PR stats (last 30 days)…');
+		try {
+			await this.collectAndPublishRepoPrStats(since);
+		} catch (err) {
+			// Guarantee a post-back on every failure path — otherwise the webview stays on
+			// "Loading…" forever and dispatch() dedup silently swallows every retry.
+			this.error('Failed to load repository PR stats', err);
+			const result: RepoPrStatsResult = {
+				repos: [], authenticated: !this._githubSignedOutByUser, since: since.toISOString(),
+				error: err instanceof Error ? err.message : String(err),
+			};
+			this._lastRepoPrStats = result;
+			this.analysisPanel.webview.postMessage({ command: 'repoPrStatsLoaded', data: result });
+		}
+	}
+
+	private async collectAndPublishRepoPrStats(since: Date): Promise<void> {
+		if (!this.analysisPanel) { return; }
 
 		if (this._githubSignedOutByUser) {
 			const result: RepoPrStatsResult = { repos: [], authenticated: false, since: since.toISOString() };
@@ -1865,7 +1883,9 @@ class CopilotTokenTracker implements vscode.Disposable {
 		}
 
 		const workspacePaths = this._buildWorkspacePaths();
-		const repos = discoverGitHubRepos(workspacePaths, getConfiguredGitHubEnterpriseUri());
+		const discoveryStart = Date.now();
+		const repos = await discoverGitHubRepos(workspacePaths, getConfiguredGitHubEnterpriseUri());
+		this.log(`🔎 Discovered ${repos.length} GitHub repo(s) across ${workspacePaths.length} workspace path(s) in ${((Date.now() - discoveryStart) / 1000).toFixed(1)}s`);
 		this.analysisPanel.webview.postMessage({ command: 'repoPrStatsProgress', total: repos.length, done: 0 });
 
 		const results: RepoPrInfo[] = [];
@@ -1973,7 +1993,17 @@ class CopilotTokenTracker implements vscode.Disposable {
 	private async loadAgentSessions(): Promise<void> {
 		if (!this.analysisPanel) { return; }
 		const since = this.agentSessionsSince();
+		this.log('🤖 Loading cloud agent sessions…');
+		try {
+			await this.collectAndPublishAgentSessions(since);
+		} catch (err) {
+			// Guarantee a post-back on every failure path so the webview never hangs on "Loading…".
+			this.error('Failed to load cloud agent sessions', err);
+			this.publishAgentSessions(this._lastAgentSessionsData ?? this.buildEmptyAgentSessionsResult(since, !this._githubSignedOutByUser));
+		}
+	}
 
+	private async collectAndPublishAgentSessions(since: Date): Promise<void> {
 		if (this._githubSignedOutByUser) {
 			this.publishAgentSessions(this.buildEmptyAgentSessionsResult(since, false));
 			return;
@@ -2048,7 +2078,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 	 * repos that aren't checked out here, and ad-hoc cloud chat tasks with no repository at all).
 	 */
 	private async refreshAgentSessionsSnapshot(token: string, since: Date, cachePath: string): Promise<void> {
-		const workspaceRepos = discoverGitHubRepos(this._buildWorkspacePaths(), getConfiguredGitHubEnterpriseUri());
+		const workspaceRepos = await discoverGitHubRepos(this._buildWorkspacePaths(), getConfiguredGitHubEnterpriseUri());
 		this.log(`🤖 Refreshing cloud agent snapshot (${workspaceRepos.length} workspace repo(s) + account-wide tasks)`);
 
 		const result = await collectAgentSessions({

--- a/vscode-extension/src/githubPrService.ts
+++ b/vscode-extension/src/githubPrService.ts
@@ -466,10 +466,11 @@ function buildGitHubRemotePattern(enterpriseUri?: string): RegExp {
 		try { enterpriseHost = new URL(enterpriseUri).host; } catch { /* ignore invalid URI — fall back to github.com only */ }
 	}
 	const hostAlternation = enterpriseHost ? `github\\.com|${escapeRegExp(enterpriseHost)}` : 'github\\.com';
-	// Anchored at the start of the remote URL so a host mention later in the string
-	// (e.g. https://evil.example.com/github.com/o/r) can never match (CodeQL js/regex/missing-regexp-anchor).
-	// Accepts https://host/o/r(.git), ssh://[git@]host/o/r and the scp-like git@host:o/r forms.
-	return new RegExp(`^(?:(?:https?|ssh):\\/\\/(?:[^@/\\s]+@)?|[^@/\\s]+@)(?:${hostAlternation})[:/]([^/]+)\\/([^/\\s]+?)(?:\\.git)?$`, 'i');
+	// Anchored with literal scheme prefixes so neither arbitrary text nor a host mention later
+	// in the string can match (CodeQL js/regex/missing-regexp-anchor). Accepts the remote forms
+	// git actually produces for GitHub hosts: https://host/o/r(.git), ssh://git@host/o/r and the
+	// scp-like git@host:o/r. Userinfo other than git@ is intentionally not supported.
+	return new RegExp(`^(?:https:\\/\\/|http:\\/\\/|ssh:\\/\\/git@|git@)(?:${hostAlternation})[:/]([^/]+)\\/([^/\\s]+?)(?:\\.git)?$`, 'i');
 }
 
 /**

--- a/vscode-extension/src/githubPrService.ts
+++ b/vscode-extension/src/githubPrService.ts
@@ -451,26 +451,54 @@ export async function fetchRepoPrs(
 	return { prs: allPrs };
 }
 
-/** Escape a string for safe embedding inside a regular expression. */
-function escapeRegExp(value: string): string {
-	return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
 /** Maximum number of concurrent `git remote` probes during repo discovery. */
 const DISCOVERY_CONCURRENCY = 8;
 
-/** Build the remote-URL matcher for github.com plus an optional enterprise host. */
-function buildGitHubRemotePattern(enterpriseUri?: string): RegExp {
-	let enterpriseHost: string | undefined;
+/** Anchored matcher for the scp-like remote form `git@host:owner/repo(.git)` (a `/` separator after the host is also accepted). */
+const SCP_LIKE_REMOTE_PATTERN = /^git@([^:/]+)[:/]([^/]+)\/([^/\s]+?)(?:\.git)?$/i;
+
+/** Collect the accepted GitHub hosts: github.com plus an optional enterprise host. */
+function buildGitHubHosts(enterpriseUri?: string): Set<string> {
+	const hosts = new Set<string>(['github.com']);
 	if (enterpriseUri) {
-		try { enterpriseHost = new URL(enterpriseUri).host; } catch { /* ignore invalid URI — fall back to github.com only */ }
+		try {
+			const enterpriseHost = new URL(enterpriseUri).host.toLowerCase();
+			if (enterpriseHost) { hosts.add(enterpriseHost); }
+		} catch { /* ignore invalid URI — fall back to github.com only */ }
 	}
-	const hostAlternation = enterpriseHost ? `github\\.com|${escapeRegExp(enterpriseHost)}` : 'github\\.com';
-	// Anchored with literal scheme prefixes so neither arbitrary text nor a host mention later
-	// in the string can match (CodeQL js/regex/missing-regexp-anchor). Accepts the remote forms
-	// git actually produces for GitHub hosts: https://host/o/r(.git), ssh://git@host/o/r and the
-	// scp-like git@host:o/r. Userinfo other than git@ is intentionally not supported.
-	return new RegExp(`^(?:https:\\/\\/|http:\\/\\/|ssh:\\/\\/git@|git@)(?:${hostAlternation})[:/]([^/]+)\\/([^/\\s]+?)(?:\\.git)?$`, 'i');
+	return hosts;
+}
+
+/** Strip a trailing `.git` suffix from a repo name, matching git's own remote handling. */
+function stripGitSuffix(repo: string): string {
+	return repo.toLowerCase().endsWith('.git') ? repo.slice(0, -'.git'.length) : repo;
+}
+
+/**
+ * Extract owner/repo from a git remote URL when its host is one of `hosts`.
+ * Accepts the remote forms git actually produces for GitHub hosts:
+ * https://host/o/r(.git), ssh://git@host/o/r and the scp-like git@host:o/r.
+ * Parsed with `new URL()` where possible (no unanchored host regex) with an
+ * anchored fallback for the scp-like form, which is not a valid URL.
+ */
+function parseGitHubRemote(remote: string, hosts: Set<string>): { owner: string; repo: string } | undefined {
+	try {
+		const url = new URL(remote);
+		if ((url.protocol === 'https:' || url.protocol === 'http:' || url.protocol === 'ssh:') && hosts.has(url.host.toLowerCase())) {
+			const segments = url.pathname.split('/').filter((segment) => segment.length > 0);
+			if (segments.length === 2) {
+				return { owner: segments[0], repo: stripGitSuffix(segments[1]) };
+			}
+		}
+		return undefined;
+	} catch {
+		// Not a URL — fall through to the scp-like form below.
+	}
+	const match = SCP_LIKE_REMOTE_PATTERN.exec(remote);
+	if (match && hosts.has(match[1].toLowerCase())) {
+		return { owner: match[2], repo: match[3] };
+	}
+	return undefined;
 }
 
 /**
@@ -501,7 +529,7 @@ function getGitRemoteOrigin(cwd: string): Promise<string | undefined> {
  * slowest handful of `git` calls rather than the sum of all of them.
  */
 export async function discoverGitHubRepos(workspacePaths: string[], enterpriseUri?: string): Promise<{ owner: string; repo: string }[]> {
-	const remotePattern = buildGitHubRemotePattern(enterpriseUri);
+	const gitHubHosts = buildGitHubHosts(enterpriseUri);
 	const uniquePaths = [...new Set(workspacePaths)];
 	const remotes = new Array<string | undefined>(uniquePaths.length);
 	let nextIndex = 0;
@@ -521,12 +549,12 @@ export async function discoverGitHubRepos(workspacePaths: string[], enterpriseUr
 	const repos: { owner: string; repo: string }[] = [];
 	for (const remote of remotes) {
 		if (!remote) { continue; }
-		const match = remote.match(remotePattern);
-		if (!match) { continue; }
-		const key = `${match[1]}/${match[2]}`.toLowerCase();
+		const parsed = parseGitHubRemote(remote, gitHubHosts);
+		if (!parsed) { continue; }
+		const key = `${parsed.owner}/${parsed.repo}`.toLowerCase();
 		if (seen.has(key)) { continue; }
 		seen.add(key);
-		repos.push({ owner: match[1], repo: match[2] });
+		repos.push(parsed);
 	}
 	return repos;
 }

--- a/vscode-extension/src/githubPrService.ts
+++ b/vscode-extension/src/githubPrService.ts
@@ -466,7 +466,10 @@ function buildGitHubRemotePattern(enterpriseUri?: string): RegExp {
 		try { enterpriseHost = new URL(enterpriseUri).host; } catch { /* ignore invalid URI — fall back to github.com only */ }
 	}
 	const hostAlternation = enterpriseHost ? `github\\.com|${escapeRegExp(enterpriseHost)}` : 'github\\.com';
-	return new RegExp(`(?:${hostAlternation})[:/]([^/]+)\\/([^/\\s]+?)(?:\\.git)?$`, 'i');
+	// Anchored at the start of the remote URL so a host mention later in the string
+	// (e.g. https://evil.example.com/github.com/o/r) can never match (CodeQL js/regex/missing-regexp-anchor).
+	// Accepts https://host/o/r(.git), ssh://[git@]host/o/r and the scp-like git@host:o/r forms.
+	return new RegExp(`^(?:(?:https?|ssh):\\/\\/(?:[^@/\\s]+@)?|[^@/\\s]+@)(?:${hostAlternation})[:/]([^/]+)\\/([^/\\s]+?)(?:\\.git)?$`, 'i');
 }
 
 /**

--- a/vscode-extension/src/githubPrService.ts
+++ b/vscode-extension/src/githubPrService.ts
@@ -34,6 +34,8 @@ export type RepoPrStatsResult = {
 	repos: RepoPrInfo[];
 	authenticated: boolean;
 	since: string; // ISO date string
+	/** Set when the collection itself failed (not a per-repo error) — the panel shows this instead of hanging on "Loading…". */
+	error?: string;
 };
 
 // ---------------------------------------------------------------------------
@@ -454,6 +456,35 @@ function escapeRegExp(value: string): string {
 	return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+/** Maximum number of concurrent `git remote` probes during repo discovery. */
+const DISCOVERY_CONCURRENCY = 8;
+
+/** Build the remote-URL matcher for github.com plus an optional enterprise host. */
+function buildGitHubRemotePattern(enterpriseUri?: string): RegExp {
+	let enterpriseHost: string | undefined;
+	if (enterpriseUri) {
+		try { enterpriseHost = new URL(enterpriseUri).host; } catch { /* ignore invalid URI — fall back to github.com only */ }
+	}
+	const hostAlternation = enterpriseHost ? `github\\.com|${escapeRegExp(enterpriseHost)}` : 'github\\.com';
+	return new RegExp(`(?:${hostAlternation})[:/]([^/]+)\\/([^/\\s]+?)(?:\\.git)?$`, 'i');
+}
+
+/**
+ * Read the `origin` remote of one path, resolving to undefined on any failure. Async with a
+ * hard timeout — unlike execSync this never blocks the extension host, which matters when the
+ * customization matrix contributes hundreds of workspace paths (a sync probe per path would
+ * freeze the host for minutes and leave every webview stuck on "Loading…").
+ */
+function getGitRemoteOrigin(cwd: string): Promise<string | undefined> {
+	return new Promise((resolve) => {
+		childProcess.execFile(
+			'git', ['remote', 'get-url', 'origin'],
+			{ cwd, encoding: 'utf8', timeout: 3000, windowsHide: true },
+			(error, stdout) => resolve(error ? undefined : String(stdout ?? '').trim()),
+		);
+	});
+}
+
 /**
  * Discover GitHub repos from workspace paths using git remote.
  * Deduplicates by owner/repo so each GitHub repo is only fetched once.
@@ -461,33 +492,37 @@ function escapeRegExp(value: string): string {
  * Always matches github.com remotes; when `enterpriseUri` is configured (the
  * `github-enterprise.uri` setting), remotes on that host (e.g. a `tenant.ghe.com`
  * or on-prem GitHub Enterprise Server) are recognized too.
+ *
+ * Probes run with bounded concurrency so a large workspace-path list costs the
+ * slowest handful of `git` calls rather than the sum of all of them.
  */
-export function discoverGitHubRepos(workspacePaths: string[], enterpriseUri?: string): { owner: string; repo: string }[] {
+export async function discoverGitHubRepos(workspacePaths: string[], enterpriseUri?: string): Promise<{ owner: string; repo: string }[]> {
+	const remotePattern = buildGitHubRemotePattern(enterpriseUri);
+	const uniquePaths = [...new Set(workspacePaths)];
+	const remotes = new Array<string | undefined>(uniquePaths.length);
+	let nextIndex = 0;
+	const worker = async (): Promise<void> => {
+		while (nextIndex < uniquePaths.length) {
+			const i = nextIndex++;
+			try {
+				remotes[i] = await getGitRemoteOrigin(uniquePaths[i]);
+			} catch {
+				remotes[i] = undefined; // Not a git repo or no remote — skip
+			}
+		}
+	};
+	await Promise.all(Array.from({ length: Math.min(DISCOVERY_CONCURRENCY, uniquePaths.length) }, worker));
+
 	const seen = new Set<string>();
 	const repos: { owner: string; repo: string }[] = [];
-	let enterpriseHost: string | undefined;
-	if (enterpriseUri) {
-		try { enterpriseHost = new URL(enterpriseUri).host; } catch { /* ignore invalid URI — fall back to github.com only */ }
-	}
-	const hostAlternation = enterpriseHost ? `github\\.com|${escapeRegExp(enterpriseHost)}` : 'github\\.com';
-	const remotePattern = new RegExp(`(?:${hostAlternation})[:/]([^/]+)\\/([^/\\s]+?)(?:\\.git)?$`, 'i');
-	for (const workspacePath of workspacePaths) {
-		try {
-			const remote = childProcess.execSync('git remote get-url origin', {
-				cwd: workspacePath,
-				encoding: 'utf8',
-				timeout: 3000,
-				stdio: ['pipe', 'pipe', 'pipe'],
-			}).trim();
-			const match = remote.match(remotePattern);
-			if (!match) { continue; }
-			const key = `${match[1]}/${match[2]}`.toLowerCase();
-			if (seen.has(key)) { continue; }
-			seen.add(key);
-			repos.push({ owner: match[1], repo: match[2] });
-		} catch {
-			// Not a git repo or no remote — skip
-		}
+	for (const remote of remotes) {
+		if (!remote) { continue; }
+		const match = remote.match(remotePattern);
+		if (!match) { continue; }
+		const key = `${match[1]}/${match[2]}`.toLowerCase();
+		if (seen.has(key)) { continue; }
+		seen.add(key);
+		repos.push({ owner: match[1], repo: match[2] });
 	}
 	return repos;
 }

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -618,6 +618,7 @@ type RepoPrStatsResult = {
   repos: RepoPrInfo[];
   authenticated: boolean;
   since: string;
+  error?: string;
 };
 
 const EFFORT_DISPLAY_NAMES: Record<string, string> = {
@@ -1944,6 +1945,7 @@ function sanitizeRepoPrStatsData(input: unknown): RepoPrStatsResult {
 	return {
 		authenticated: Boolean(src.authenticated),
 		since: typeof src.since === 'string' || typeof src.since === 'number' ? src.since : Date.now(),
+		error: typeof src.error === 'string' ? escapeHtml(src.error) : undefined,
 		repos: repos.map((repo) => {
 			const r = (repo && typeof repo === 'object') ? (repo as Record<string, unknown>) : {};
 			const aiDetails = Array.isArray(r.aiDetails) ? r.aiDetails : [];
@@ -2023,6 +2025,14 @@ function renderRepoPrRow(r: RepoPrInfo, cell: string, cellCenter: string): strin
 
 function renderReposPrContent(data: RepoPrStatsResult): string {
 	const sinceDate = escapeHtml(new Date(data.since).toLocaleDateString());
+	if (data.error) {
+		return `
+			<div style="margin-top:12px; padding:12px; background:var(--bg-tertiary); border:1px solid var(--border-color); border-radius:6px; font-size:12px; color:var(--text-secondary);">
+				<strong>⚠️ Failed to load repository PR activity</strong><br/>
+				${data.error}<br/>
+				Switch to another tab and back to retry — details are in the extension Output channel.
+			</div>`;
+	}
 	if (!data.authenticated) {
 		return `
 			<div style="margin-top:12px; padding:12px; background:var(--bg-tertiary); border:1px solid var(--border-color); border-radius:6px; font-size:12px; color:var(--text-secondary);">

--- a/vscode-extension/test/unit/githubPrService.test.ts
+++ b/vscode-extension/test/unit/githubPrService.test.ts
@@ -421,3 +421,13 @@ test('discoverGitHubRepos: does not match a github.com mention inside another ho
 		fs.rmSync(dir, { recursive: true, force: true });
 	}
 });
+
+test('discoverGitHubRepos: matches an ssh://git@ remote', async () => {
+	const dir = makeGitRepoWithRemote('ssh://git@github.com/rajbos/ai-engineering-fluency.git');
+	try {
+		const repos = await discoverGitHubRepos([dir]);
+		assert.deepEqual(repos, [{ owner: 'rajbos', repo: 'ai-engineering-fluency' }]);
+	} finally {
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+});

--- a/vscode-extension/test/unit/githubPrService.test.ts
+++ b/vscode-extension/test/unit/githubPrService.test.ts
@@ -411,3 +411,13 @@ test('discoverGitHubRepos: deduplicates repos reachable from multiple workspace 
 		fs.rmSync(dir, { recursive: true, force: true });
 	}
 });
+
+test('discoverGitHubRepos: does not match a github.com mention inside another host\'s URL', async () => {
+	const dir = makeGitRepoWithRemote('https://evil.example.com/github.com/rajbos/not-a-match.git');
+	try {
+		const repos = await discoverGitHubRepos([dir]);
+		assert.deepEqual(repos, []);
+	} finally {
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+});

--- a/vscode-extension/test/unit/githubPrService.test.ts
+++ b/vscode-extension/test/unit/githubPrService.test.ts
@@ -340,51 +340,73 @@ function makeGitRepoWithRemote(remoteUrl: string): string {
 	return dir;
 }
 
-test('discoverGitHubRepos: matches a github.com remote', () => {
+test('discoverGitHubRepos: matches a github.com remote', async () => {
 	const dir = makeGitRepoWithRemote('https://github.com/rajbos/ai-engineering-fluency.git');
 	try {
-		const repos = discoverGitHubRepos([dir]);
+		const repos = await discoverGitHubRepos([dir]);
 		assert.deepEqual(repos, [{ owner: 'rajbos', repo: 'ai-engineering-fluency' }]);
 	} finally {
 		fs.rmSync(dir, { recursive: true, force: true });
 	}
 });
 
-test('discoverGitHubRepos: ignores a non-github.com remote when no enterprise URI is configured', () => {
+test('discoverGitHubRepos: ignores a non-github.com remote when no enterprise URI is configured', async () => {
 	const dir = makeGitRepoWithRemote('https://customer.ghe.com/rajbos/private-repo.git');
 	try {
-		const repos = discoverGitHubRepos([dir]);
+		const repos = await discoverGitHubRepos([dir]);
 		assert.deepEqual(repos, []);
 	} finally {
 		fs.rmSync(dir, { recursive: true, force: true });
 	}
 });
 
-test('discoverGitHubRepos: matches a GHE.com remote when the enterprise URI is configured', () => {
+test('discoverGitHubRepos: matches a GHE.com remote when the enterprise URI is configured', async () => {
 	const dir = makeGitRepoWithRemote('https://customer.ghe.com/rajbos/private-repo.git');
 	try {
-		const repos = discoverGitHubRepos([dir], 'https://customer.ghe.com');
+		const repos = await discoverGitHubRepos([dir], 'https://customer.ghe.com');
 		assert.deepEqual(repos, [{ owner: 'rajbos', repo: 'private-repo' }]);
 	} finally {
 		fs.rmSync(dir, { recursive: true, force: true });
 	}
 });
 
-test('discoverGitHubRepos: still matches github.com remotes when an enterprise URI is also configured', () => {
+test('discoverGitHubRepos: still matches github.com remotes when an enterprise URI is also configured', async () => {
 	const dir = makeGitRepoWithRemote('https://github.com/rajbos/ai-engineering-fluency.git');
 	try {
-		const repos = discoverGitHubRepos([dir], 'https://customer.ghe.com');
+		const repos = await discoverGitHubRepos([dir], 'https://customer.ghe.com');
 		assert.deepEqual(repos, [{ owner: 'rajbos', repo: 'ai-engineering-fluency' }]);
 	} finally {
 		fs.rmSync(dir, { recursive: true, force: true });
 	}
 });
 
-test('discoverGitHubRepos: matches an on-prem GitHub Enterprise Server remote via SSH form', () => {
+test('discoverGitHubRepos: matches an on-prem GitHub Enterprise Server remote via SSH form', async () => {
 	const dir = makeGitRepoWithRemote('git@github.acme-corp.com:rajbos/internal-tool.git');
 	try {
-		const repos = discoverGitHubRepos([dir], 'https://github.acme-corp.com');
+		const repos = await discoverGitHubRepos([dir], 'https://github.acme-corp.com');
 		assert.deepEqual(repos, [{ owner: 'rajbos', repo: 'internal-tool' }]);
+	} finally {
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+test('discoverGitHubRepos: skips non-git and missing paths without throwing', async () => {
+	const dir = makeGitRepoWithRemote('https://github.com/rajbos/ai-engineering-fluency.git');
+	const notARepo = fs.mkdtempSync(path.join(os.tmpdir(), 'discover-gh-notrepo-'));
+	try {
+		const repos = await discoverGitHubRepos([notARepo, path.join(os.tmpdir(), 'does-not-exist-xyz'), dir]);
+		assert.deepEqual(repos, [{ owner: 'rajbos', repo: 'ai-engineering-fluency' }]);
+	} finally {
+		fs.rmSync(dir, { recursive: true, force: true });
+		fs.rmSync(notARepo, { recursive: true, force: true });
+	}
+});
+
+test('discoverGitHubRepos: deduplicates repos reachable from multiple workspace paths', async () => {
+	const dir = makeGitRepoWithRemote('https://github.com/rajbos/ai-engineering-fluency.git');
+	try {
+		const repos = await discoverGitHubRepos([dir, dir]);
+		assert.deepEqual(repos, [{ owner: 'rajbos', repo: 'ai-engineering-fluency' }]);
 	} finally {
 		fs.rmSync(dir, { recursive: true, force: true });
 	}


### PR DESCRIPTION
## Problem

The **Repository PRs** and **Cloud Agent** tabs in Usage Analysis stayed on "Loading… (sign in with GitHub to see data)" forever, with no error and no sign of activity.

Root cause, confirmed against the extension Output log on a machine with ~300 known workspace paths:

- `discoverGitHubRepos` probed **every workspace path from the customization matrix** with a **synchronous `execSync`** (`git remote get-url origin`, up to 3 s timeout each), running before the first progress message was posted.
- Hundreds of blocking process spawns froze the extension-host main loop for minutes. The Repository PRs tab blocked inside discovery; the Cloud Agent tab's `loadAgentSessions` message couldn't even start because the event loop was busy. Both tabs looked dead, and `dispatch()`'s in-flight dedup silently swallowed every retry click.

## Fix

- **`githubPrService.ts`** — `discoverGitHubRepos` is now async: `execFile` probes with bounded concurrency (8 at a time, 3 s timeout each). Total cost is the slowest few probes instead of the sum of all of them. Also dedupes repeated workspace paths up front.
- **`extension.ts`**
  - `loadRepoPrStats` / `loadAgentSessions`: guarantee a post-back on **every** exit path (try/catch posting an error/empty result), so the webview can never hang on "Loading…" again.
  - Both loaders log entry and repo-discovery timing to the Output channel so the next "nothing happens" report is diagnosable from logs alone.
- **Webview** — a collection-level failure now renders an error box in the Repository PRs panel (with retry hint) instead of hanging silently.

## Validation

- `npm run compile` clean (only pre-existing warnings in unrelated files).
- `githubPrService` unit tests updated to async + 2 new tests (non-git/missing paths, duplicate paths): **39/39 pass**.
- `agentSessionsService`, `agentTasksCache`, `webview-agentSessionsSanitizer`: **52/52 pass**.