### PR TITLE
fix(claude-desktop): discover renamed claude-code-sessions directory

### DIFF
--- a/cli/src/analysis.ts
+++ b/cli/src/analysis.ts
@@ -122,6 +122,7 @@ export function getEditorSourceFromPath(filePath: string): string {
 	if (normalized.includes('/.kiro/sessions/cli/')) { return 'Kiro CLI'; }
 	if (normalized.includes('/kiro.kiroagent/workspace-sessions/')) { return 'Kiro'; }
 	if (normalized.includes('/.continue/sessions/')) { return 'Continue'; }
+	if (normalized.includes('/claude-code-sessions/')) { return 'Claude Desktop Cowork'; }
 	if (normalized.includes('/local-agent-mode-sessions/')) { return 'Claude Desktop Cowork'; }
 	if (normalized.includes('/.claude/projects/')) { return detectClaudeCodeEditorVariant(filePath); }
 	if (normalized.includes('/.vibe/logs/session/')) { return 'Mistral Vibe'; }

--- a/src/adapters/adapterRegistry.ts
+++ b/src/adapters/adapterRegistry.ts
@@ -20,7 +20,7 @@ import { ContinueDataAccess } from '../continue';
 import { EclipseDataAccess } from '../eclipse';
 import { VisualStudioDataAccess } from '../visualstudio';
 import { ClaudeCodeDataAccess } from '../claudecode';
-import { ClaudeDesktopCoworkDataAccess } from '../claudedesktop';
+import { ClaudeDesktopDataAccess } from '../claudedesktop';
 import { MistralVibeDataAccess } from '../mistralvibe';
 import { GeminiCliDataAccess } from '../geminicli';
 import { AntigravityDataAccess } from '../antigravity';
@@ -63,7 +63,7 @@ continue_: ContinueDataAccess;
 eclipse: EclipseDataAccess;
 visualStudio: VisualStudioDataAccess;
 claudeCode: ClaudeCodeDataAccess;
-claudeDesktopCowork: ClaudeDesktopCoworkDataAccess;
+claudeDesktop: ClaudeDesktopDataAccess;
 mistralVibe: MistralVibeDataAccess;
 geminiCli: GeminiCliDataAccess;
 antigravity: AntigravityDataAccess;
@@ -107,7 +107,7 @@ continue_: new ContinueDataAccess(),
 eclipse: new EclipseDataAccess(),
 visualStudio: new VisualStudioDataAccess(),
 claudeCode: new ClaudeCodeDataAccess(),
-claudeDesktopCowork: new ClaudeDesktopCoworkDataAccess(),
+claudeDesktop: new ClaudeDesktopDataAccess(),
 mistralVibe: new MistralVibeDataAccess(),
 geminiCli: new GeminiCliDataAccess(),
 antigravity: new AntigravityDataAccess(),
@@ -136,7 +136,7 @@ new VisualStudioAdapter(deps.visualStudio, deps.estimateTokens),
 new ContinueAdapter(deps.continue_),
 new EclipseAdapter(deps.eclipse),
 new ClaudeDesktopAdapter(
-deps.claudeDesktopCowork,
+deps.claudeDesktop,
 deps.isMcpTool,
 deps.extractMcpServerName,
 deps.estimateTokens

--- a/src/adapters/claudeDesktopAdapter.ts
+++ b/src/adapters/claudeDesktopAdapter.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import type { ModelUsage, ChatTurn, ActualUsage } from '../types';
 import type { IEcosystemAdapter, IDiscoverableEcosystem, IAnalyzableEcosystem, DiscoveryResult, CandidatePath, UsageAnalysisAdapterContext } from '../ecosystemAdapter';
-import { ClaudeDesktopCoworkDataAccess } from '../claudedesktop';
+import { ClaudeDesktopDataAccess } from '../claudedesktop';
 import { createEmptyContextRefs } from '../tokenEstimation';
 import { readClaudeCodeEventsForAnalysis, createEmptySessionUsageAnalysis, applyModelTierClassification } from '../usageAnalysis';
 import { normalizeClaudeModelId } from '../claudecode';
@@ -12,14 +12,14 @@ export class ClaudeDesktopAdapter implements IEcosystemAdapter, IDiscoverableEco
 	readonly displayName = 'Claude Desktop Cowork';
 
 	constructor(
-		private readonly claudeDesktopCowork: ClaudeDesktopCoworkDataAccess,
+		private readonly claudeDesktop: ClaudeDesktopDataAccess,
 		private readonly isMcpToolFn: (toolName: string) => boolean,
 		private readonly extractMcpServerNameFn: (toolName: string) => string,
 		private readonly estimateTokensFn: (text: string, model?: string) => number
 	) {}
 
 	handles(sessionFile: string): boolean {
-		return this.claudeDesktopCowork.isCoworkSessionFile(sessionFile);
+		return this.claudeDesktop.isDesktopSessionFile(sessionFile);
 	}
 
 	getBackingPath(sessionFile: string): string {
@@ -31,20 +31,20 @@ export class ClaudeDesktopAdapter implements IEcosystemAdapter, IDiscoverableEco
 	}
 
 	async getTokens(sessionFile: string): Promise<{ tokens: number; thinkingTokens: number; actualTokens: number }> {
-		const result = await this.claudeDesktopCowork.getTokensFromCoworkSession(sessionFile);
+		const result = await this.claudeDesktop.getTokensFromDesktopSession(sessionFile);
 		return { ...result, actualTokens: result.tokens };
 	}
 
 	async countInteractions(sessionFile: string): Promise<number> {
-		return await this.claudeDesktopCowork.countCoworkInteractions(sessionFile);
+		return await this.claudeDesktop.countDesktopSessionInteractions(sessionFile);
 	}
 
 	async getModelUsage(sessionFile: string): Promise<ModelUsage> {
-		return await this.claudeDesktopCowork.getCoworkModelUsage(sessionFile);
+		return await this.claudeDesktop.getDesktopSessionModelUsage(sessionFile);
 	}
 
 	async getMeta(sessionFile: string): Promise<{ title: string | undefined; firstInteraction: string | null; lastInteraction: string | null; workspacePath?: string }> {
-		const meta = await this.claudeDesktopCowork.getCoworkSessionMeta(sessionFile);
+		const meta = await this.claudeDesktop.getDesktopSessionMeta(sessionFile);
 		return {
 			title: meta?.title,
 			firstInteraction: meta?.firstInteraction || null,
@@ -53,15 +53,15 @@ export class ClaudeDesktopAdapter implements IEcosystemAdapter, IDiscoverableEco
 		};
 	}
 
-	getEditorRoot(_sessionFile: string): string {
-		return this.claudeDesktopCowork.getCoworkBaseDir();
+	getEditorRoot(sessionFile: string): string {
+		return this.claudeDesktop.getSessionDirForFile(sessionFile);
 	}
 
 	async discover(log: (msg: string) => void): Promise<DiscoveryResult> {
 		const candidatePaths = this.getCandidatePaths();
 		const sessionFiles: string[] = [];
 		try {
-			const files = await this.claudeDesktopCowork.getCoworkSessionFiles();
+			const files = await this.claudeDesktop.getDesktopSessionFiles();
 			if (files.length > 0) {
 				log(`📄 Found ${files.length} session file(s) in Claude Desktop Cowork`);
 				sessionFiles.push(...files);
@@ -73,13 +73,13 @@ export class ClaudeDesktopAdapter implements IEcosystemAdapter, IDiscoverableEco
 	}
 
 	getCandidatePaths(): CandidatePath[] {
-		const baseDir = this.claudeDesktopCowork.getCoworkBaseDir();
-		return baseDir ? [{ path: baseDir, source: 'Claude Desktop (Cowork)' }] : [];
+		return this.claudeDesktop.getDesktopSessionDirs()
+			.map(dir => ({ path: dir, source: 'Claude Desktop (Cowork)' }));
 	}
 
 	async buildTurns(sessionFile: string): Promise<{ turns: ChatTurn[]; actualTokens?: number }> {
 		const turns: ChatTurn[] = [];
-		const events = await this.claudeDesktopCowork.readCoworkEvents(sessionFile);
+		const events = await this.claudeDesktop.readDesktopSessionEvents(sessionFile);
 		let currentUserEvent: any = null;
 		const pendingAssistantEvents: any[] = [];
 

--- a/src/claudedesktop.ts
+++ b/src/claudedesktop.ts
@@ -2,16 +2,23 @@
  * Claude Desktop Cowork data access layer.
  * Handles reading session data from Claude Desktop's Cowork (local agent mode) feature.
  *
- * Cowork sessions are stored at:
- *   Windows: %LOCALAPPDATA%\Packages\Claude_pzs8sxrjxfjjc\LocalCache\Roaming\Claude\local-agent-mode-sessions\
- *   macOS:   ~/Library/Application Support/Claude/local-agent-mode-sessions/
+ * Cowork sessions are stored under the Claude Desktop config dir:
+ *   Windows: %LOCALAPPDATA%\Packages\Claude_pzs8sxrjxfjjc\LocalCache\Roaming\Claude\
+ *   macOS:   ~/Library/Application Support/Claude/
+ * in a session subdirectory that was RENAMED by the desktop app:
+ *   current: claude-code-sessions\         (since ~Aug 2026)
+ *   legacy:  local-agent-mode-sessions\    (still read for older installs)
  *
- * Directory structure:
+ * Directory structure (both names):
  *   <base>/<app-uuid>/<machine-uuid>/local_<session-id>.json        — session metadata (title, timestamps, model)
  *   <base>/<app-uuid>/<machine-uuid>/local_<session-id>/
  *     .claude/projects/<hash>/<uuid>.jsonl                          — JSONL conversation + token data
  *     audit.jsonl                                                   — SKIP: HMAC audit trail, no usage data
  *     agent/                                                        — SKIP: background ditto sub-sessions
+ *
+ * Note: newer desktop versions may store only the metadata .json files here and write
+ * the actual transcripts to the shared ~/.claude/projects/ directory (linked via the
+ * metadata's cliSessionId) — those are picked up by the Claude Code adapter instead.
  *
  * ── JSONL FORMAT ────────────────────────────────────────────────────────────────────────────────
  *
@@ -65,13 +72,20 @@ import { normalizePathForComparison, normalizePath } from './workspaceHelpers';
 /** Package name for the Claude Desktop Windows Store app. */
 const CLAUDE_DESKTOP_PACKAGE = 'Claude_pzs8sxrjxfjjc';
 
-export class ClaudeDesktopCoworkDataAccess {
+/**
+ * Session directory names used by the Claude Desktop app, newest first.
+ * The app renamed 'local-agent-mode-sessions' to 'claude-code-sessions';
+ * both are read so older installs keep working.
+ */
+const CLAUDE_DESKTOP_SESSION_DIR_NAMES = ['claude-code-sessions', 'local-agent-mode-sessions'] as const;
+
+export class ClaudeDesktopDataAccess {
 
 	/**
-	 * Get the Claude Desktop Cowork sessions base directory.
+	 * Get the Claude Desktop config directory that holds the session subdirectories.
 	 * Returns an empty string on unsupported platforms (Linux).
 	 */
-	getCoworkBaseDir(): string {
+	private getDesktopConfigDir(): string {
 		const platform = os.platform();
 		if (platform === 'win32') {
 			const localAppData = process.env.LOCALAPPDATA || path.join(os.homedir(), 'AppData', 'Local');
@@ -81,8 +95,7 @@ export class ClaudeDesktopCoworkDataAccess {
 				CLAUDE_DESKTOP_PACKAGE,
 				'LocalCache',
 				'Roaming',
-				'Claude',
-				'local-agent-mode-sessions'
+				'Claude'
 			);
 		}
 		if (platform === 'darwin') {
@@ -90,39 +103,62 @@ export class ClaudeDesktopCoworkDataAccess {
 				os.homedir(),
 				'Library',
 				'Application Support',
-				'Claude',
-				'local-agent-mode-sessions'
+				'Claude'
 			);
 		}
 		return '';
 	}
 
 	/**
-	 * Check if a file path is a Claude Desktop Cowork session file.
-	 * Cowork session files live inside local-agent-mode-sessions/ and end with .jsonl.
+	 * Get all candidate Claude Desktop session base directories (newest naming first,
+	 * legacy 'local-agent-mode-sessions' last). Empty on unsupported platforms.
 	 */
-	isCoworkSessionFile(filePath: string): boolean {
-		const normalized = normalizePathForComparison(filePath);
-		return normalized.includes('/local-agent-mode-sessions/') && normalized.endsWith('.jsonl');
+	getDesktopSessionDirs(): string[] {
+		const configDir = this.getDesktopConfigDir();
+		if (!configDir) { return []; }
+		return CLAUDE_DESKTOP_SESSION_DIR_NAMES.map(name => path.join(configDir, name));
 	}
 
 	/**
-	 * Get all Cowork session JSONL file paths.
+	 * Resolve which session base directory a session file belongs to. Falls back to
+	 * the first (current-naming) candidate when the file matches none.
+	 */
+	getSessionDirForFile(filePath: string): string {
+		const normalized = normalizePathForComparison(filePath);
+		for (const dir of this.getDesktopSessionDirs()) {
+			if (normalized.startsWith(normalizePathForComparison(dir))) { return dir; }
+		}
+		return this.getDesktopSessionDirs()[0] ?? '';
+	}
+
+	/**
+	 * Check if a file path is a Claude Desktop Cowork session file.
+	 * Cowork session files live inside claude-code-sessions/ (current) or
+	 * local-agent-mode-sessions/ (legacy) and end with .jsonl.
+	 */
+	isDesktopSessionFile(filePath: string): boolean {
+		const normalized = normalizePathForComparison(filePath);
+		return CLAUDE_DESKTOP_SESSION_DIR_NAMES.some(name => normalized.includes(`/${name}/`))
+			&& normalized.endsWith('.jsonl');
+	}
+
+	/**
+	 * Get all Cowork session JSONL file paths across every candidate session directory.
 	 * Walks the nested directory structure: <base>/<app>/<machine>/<session>/.claude/projects/<hash>/<uuid>.jsonl
 	 */
-	async getCoworkSessionFiles(): Promise<string[]> {
-		const baseDir = this.getCoworkBaseDir();
-		if (!baseDir) { return []; }
-		try {
-			await fs.promises.access(baseDir);
-		} catch {
-			return [];
-		}
+	async getDesktopSessionFiles(): Promise<string[]> {
 		const results: string[] = [];
-		try {
-			await this.walkForJsonlFiles(baseDir, results, 0, 8);
-		} catch {
-			// Ignore top-level errors
+		for (const baseDir of this.getDesktopSessionDirs()) {
+			try {
+				await fs.promises.access(baseDir);
+			} catch {
+				continue;
+			}
+			try {
+				await this.walkForJsonlFiles(baseDir, results, 0, 8);
+			} catch {
+				// Ignore top-level errors
+			}
 		}
 		return results;
 	}
@@ -159,7 +195,7 @@ export class ClaudeDesktopCoworkDataAccess {
 	 * Parse all JSONL events from a Cowork session file.
 	 * Public so extension.ts can use it for log viewer turn building.
 	 */
-	async readCoworkEvents(sessionFilePath: string): Promise<any[]> {
+	async readDesktopSessionEvents(sessionFilePath: string): Promise<any[]> {
 		try {
 			const content = await fs.promises.readFile(sessionFilePath, 'utf8');
 			const lines = content.trim().split('\n');
@@ -182,13 +218,13 @@ export class ClaudeDesktopCoworkDataAccess {
 	 * Get token counts from a Cowork session.
 	 * Uses actual Anthropic API counts; de-duplicates by requestId using only final events.
 	 */
-	async getTokensFromCoworkSession(sessionFilePath: string): Promise<{ tokens: number; thinkingTokens: number }> {
-		const events = await this.readCoworkEvents(sessionFilePath);
+	async getTokensFromDesktopSession(sessionFilePath: string): Promise<{ tokens: number; thinkingTokens: number }> {
+		const events = await this.readDesktopSessionEvents(sessionFilePath);
 		let totalInputTokens = 0;
 		let totalOutputTokens = 0;
 		const seenRequestIds = new Set<string>();
 		for (const event of events) {
-			const counts = this.extractCoworkEventTokens(event, seenRequestIds);
+			const counts = this.extractDesktopEventTokens(event, seenRequestIds);
 			if (!counts) { continue; }
 			totalInputTokens += counts.inputTokens;
 			totalOutputTokens += counts.outputTokens;
@@ -196,7 +232,7 @@ export class ClaudeDesktopCoworkDataAccess {
 		return { tokens: totalInputTokens + totalOutputTokens, thinkingTokens: 0 };
 	}
 
-	private computeCoworkTokenCounts(usage: any): { inputTokens: number; outputTokens: number; cacheCreation: number; cachedRead: number; cacheCreation1h: number } {
+	private computeDesktopTokenCounts(usage: any): { inputTokens: number; outputTokens: number; cacheCreation: number; cachedRead: number; cacheCreation1h: number } {
 		const cacheCreation = typeof usage.cache_creation_input_tokens === 'number' ? usage.cache_creation_input_tokens : 0;
 		// Split out the 1-hour TTL portion of cache-creation tokens (billed at a higher
 		// rate than the default 5-minute TTL) — see calculateEstimatedCost() in tokenEstimation.ts.
@@ -209,7 +245,7 @@ export class ClaudeDesktopCoworkDataAccess {
 		return { inputTokens, outputTokens, cacheCreation, cachedRead, cacheCreation1h };
 	}
 
-	private extractCoworkEventTokens(event: any, seenRequestIds: Set<string>): { inputTokens: number; outputTokens: number } | null {
+	private extractDesktopEventTokens(event: any, seenRequestIds: Set<string>): { inputTokens: number; outputTokens: number } | null {
 		if (event.type !== 'assistant') { return null; }
 		const usage = event.message?.usage;
 		if (!usage) { return null; }
@@ -219,15 +255,15 @@ export class ClaudeDesktopCoworkDataAccess {
 			if (seenRequestIds.has(requestId)) { return null; }
 			seenRequestIds.add(requestId);
 		}
-		const { inputTokens, outputTokens } = this.computeCoworkTokenCounts(usage);
+		const { inputTokens, outputTokens } = this.computeDesktopTokenCounts(usage);
 		return { inputTokens, outputTokens };
 	}
 
 	/**
 	 * Count user interactions in a Cowork session.
 	 */
-	async countCoworkInteractions(sessionFilePath: string): Promise<number> {
-		const events = await this.readCoworkEvents(sessionFilePath);
+	async countDesktopSessionInteractions(sessionFilePath: string): Promise<number> {
+		const events = await this.readDesktopSessionEvents(sessionFilePath);
 		let count = 0;
 		for (const event of events) {
 			if (event.type === 'user' && !event.isSidechain && event.message?.role === 'user') {
@@ -248,29 +284,29 @@ export class ClaudeDesktopCoworkDataAccess {
 	/**
 	 * Get per-model token usage from a Cowork session.
 	 */
-	async getCoworkModelUsage(sessionFilePath: string): Promise<ModelUsage> {
-		const events = await this.readCoworkEvents(sessionFilePath);
+	async getDesktopSessionModelUsage(sessionFilePath: string): Promise<ModelUsage> {
+		const events = await this.readDesktopSessionEvents(sessionFilePath);
 		const modelUsage: ModelUsage = {};
 		const seenRequestIds = new Set<string>();
 		for (const event of events) {
-			this.processCoworkEventModelUsage(event, seenRequestIds, modelUsage);
+			this.processDesktopEventModelUsage(event, seenRequestIds, modelUsage);
 		}
 		return modelUsage;
 	}
 
-	private processCoworkEventModelUsage(event: any, seenRequestIds: Set<string>, modelUsage: ModelUsage): void {
+	private processDesktopEventModelUsage(event: any, seenRequestIds: Set<string>, modelUsage: ModelUsage): void {
 		if (event.type !== 'assistant') { return; }
 		const usage = event.message?.usage;
 		if (!usage) { return; }
-		if (!this.shouldCountCoworkRequest(event, seenRequestIds)) { return; }
+		if (!this.shouldCountDesktopRequest(event, seenRequestIds)) { return; }
 		const model = normalizeClaudeModelId(event.message?.model || 'unknown');
 		// Untrusted `model` string from parsed session JSON — see protoGuard.ts.
 		if (isUnsafeObjectKey(model)) { return; }
 		if (!modelUsage[model]) { modelUsage[model] = { inputTokens: 0, outputTokens: 0, sessions: 0 }; }
-		this.applyCoworkTokenCounts(modelUsage[model], usage);
+		this.applyDesktopTokenCounts(modelUsage[model], usage);
 	}
 
-	private shouldCountCoworkRequest(event: any, seenRequestIds: Set<string>): boolean {
+	private shouldCountDesktopRequest(event: any, seenRequestIds: Set<string>): boolean {
 		const requestId = event.requestId;
 		if (!requestId) { return true; }
 		if (!event.message?.stop_reason) { return false; }
@@ -279,8 +315,8 @@ export class ClaudeDesktopCoworkDataAccess {
 		return true;
 	}
 
-	private applyCoworkTokenCounts(entry: ModelUsage[ModelId], usage: any): void {
-		const { inputTokens, outputTokens, cacheCreation, cachedRead, cacheCreation1h } = this.computeCoworkTokenCounts(usage);
+	private applyDesktopTokenCounts(entry: ModelUsage[ModelId], usage: any): void {
+		const { inputTokens, outputTokens, cacheCreation, cachedRead, cacheCreation1h } = this.computeDesktopTokenCounts(usage);
 		entry.inputTokens += inputTokens;
 		entry.outputTokens += outputTokens;
 		if (cacheCreation > 0) { entry.cacheCreationTokens = (entry.cacheCreationTokens ?? 0) + cacheCreation; }
@@ -291,8 +327,9 @@ export class ClaudeDesktopCoworkDataAccess {
 	/**
 	 * Derive the metadata JSON file path from a Cowork session JSONL path.
 	 *
-	 * Structure: .../local-agent-mode-sessions/<app>/<machine>/local_<id>/.claude/.../<uuid>.jsonl
-	 * Metadata:  .../local-agent-mode-sessions/<app>/<machine>/local_<id>.json
+	 * Structure: .../<session-base>/<app>/<machine>/local_<id>/.claude/.../<uuid>.jsonl
+	 * Metadata:  .../<session-base>/<app>/<machine>/local_<id>.json
+	 * where <session-base> is claude-code-sessions (current) or local-agent-mode-sessions (legacy).
 	 */
 	private getMetadataPathFromJsonl(jsonlPath: string): string | null {
 		const normalized = normalizePath(jsonlPath);
@@ -312,7 +349,7 @@ export class ClaudeDesktopCoworkDataAccess {
 	 * Read session metadata (title, timestamps, cwd) for a Cowork session.
 	 * The metadata comes from the sibling .json file alongside the session directory.
 	 */
-	async getCoworkSessionMeta(sessionFilePath: string): Promise<{
+	async getDesktopSessionMeta(sessionFilePath: string): Promise<{
 		title?: string;
 		firstInteraction?: string;
 		lastInteraction?: string;

--- a/src/workspaceHelpers.ts
+++ b/src/workspaceHelpers.ts
@@ -1115,6 +1115,7 @@ function detectToolEditorFromPath(
 	const globalStorageEditor = detectGlobalStorageEditorFromPath(lowerPath);
 	if (globalStorageEditor) { return globalStorageEditor; }
 	if (lowerPath.includes('/.continue/sessions/')) { return 'Continue'; }
+	if (lowerPath.includes('/claude-code-sessions/')) { return 'Claude Desktop Cowork'; }
 	if (lowerPath.includes('/local-agent-mode-sessions/')) { return 'Claude Desktop Cowork'; }
 	if (lowerPath.includes('/.claude/projects/')) { return detectClaudeCodeEditorVariant(filePath); }
 	if (lowerPath.includes('/.vibe/logs/session/')) { return 'Mistral Vibe'; }
@@ -1152,7 +1153,8 @@ function detectVSCodeVariantFromPath(lowerPath: string): string | undefined {
  * Note: 'Claude Code' and 'Claude Desktop' share the same ~/.claude/projects/ directory
  * and are distinguished by the `entrypoint` field inside the session file, not the path
  * (see detectClaudeCodeEditorVariant). 'Claude Desktop Cowork' is a separate, unrelated
- * feature (local-agent-mode-sessions) and is still detected purely by path.
+ * feature (claude-code-sessions, formerly local-agent-mode-sessions) and is still
+ * detected purely by path.
  */
 export function getEditorTypeFromPath(filePath: string, isOpenCodeSessionFile?: (p: string) => boolean): string {
 	const lowerPath = normalizePathForComparison(filePath);

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-engineering-fluency",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-engineering-fluency",
-      "version": "0.17.2",
+      "version": "0.17.3",
       "dependencies": {
         "@azure/arm-resources": "^8.0.0",
         "@azure/arm-resources-subscriptions": "^3.0.0",
@@ -45,7 +45,7 @@
         "typescript": "^5.9.3"
       },
       "engines": {
-        "vscode": "^1.125.0"
+        "vscode": "^1.134.0"
       }
     },
     "node_modules/@asamuzakjp/css-color": {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -106,7 +106,7 @@ import type { CrushDataAccess } from '../../src/crush';
 import type { VisualStudioDataAccess } from '../../src/visualstudio';
 import type { ContinueDataAccess } from '../../src/continue';
 import type { ClaudeCodeDataAccess } from '../../src/claudecode';
-import type { ClaudeDesktopCoworkDataAccess } from '../../src/claudedesktop';
+import type { ClaudeDesktopDataAccess } from '../../src/claudedesktop';
 import type { MistralVibeDataAccess } from '../../src/mistralvibe';
 import type { GeminiCliDataAccess } from '../../src/geminicli';
 import type { IEcosystemAdapter } from '../../src/ecosystemAdapter';
@@ -457,7 +457,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 	public visualStudio!: VisualStudioDataAccess;
 	private continue_!: ContinueDataAccess;
 	private claudeCode!: ClaudeCodeDataAccess;
-	private claudeDesktopCowork!: ClaudeDesktopCoworkDataAccess;
+	private claudeDesktop!: ClaudeDesktopDataAccess;
 	private mistralVibe!: MistralVibeDataAccess;
 	private geminiCli!: GeminiCliDataAccess;
 	public windsurf!: WindsurfDataAccess;
@@ -1306,7 +1306,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 		this.continue_ = dataAccess.continue_;
 		this.visualStudio = dataAccess.visualStudio;
 		this.claudeCode = dataAccess.claudeCode;
-		this.claudeDesktopCowork = dataAccess.claudeDesktopCowork;
+		this.claudeDesktop = dataAccess.claudeDesktop;
 		this.mistralVibe = dataAccess.mistralVibe;
 		this.geminiCli = dataAccess.geminiCli;
 		this.windsurf = new WindsurfDataAccess(extensionUri, (m) => this.log(m));

--- a/vscode-extension/test/unit/ecosystemAdapters.test.ts
+++ b/vscode-extension/test/unit/ecosystemAdapters.test.ts
@@ -37,7 +37,7 @@ import { CrushDataAccess } from '../../../src/crush';
 import { ContinueDataAccess } from '../../../src/continue';
 import { EclipseDataAccess } from '../../../src/eclipse';
 import { ClaudeCodeDataAccess } from '../../../src/claudecode';
-import { ClaudeDesktopCoworkDataAccess } from '../../../src/claudedesktop';
+import { ClaudeDesktopDataAccess } from '../../../src/claudedesktop';
 import { VisualStudioDataAccess } from '../../../src/visualstudio';
 import { MistralVibeDataAccess } from '../../../src/mistralvibe';
 import { GeminiCliDataAccess } from '../../../src/geminicli';
@@ -60,7 +60,7 @@ const crushDA = new CrushDataAccess(null as any);
 const continueDA = new ContinueDataAccess();
 const eclipseDA = new EclipseDataAccess();
 const claudeCodeDA = new ClaudeCodeDataAccess();
-const claudeDesktopDA = new ClaudeDesktopCoworkDataAccess();
+const claudeDesktopDA = new ClaudeDesktopDataAccess();
 const visualStudioDA = new VisualStudioDataAccess();
 const mistralVibeDA = new MistralVibeDataAccess();
 const geminiCliDA = new GeminiCliDataAccess();
@@ -429,7 +429,7 @@ test('VisualStudioAdapter.getCandidatePaths: returns VS log dir and SSMS session
 test('getEditorRoot: all adapters return non-empty string', () => {
     const dummyFile = '/dummy/path/session.json';
     for (const adapter of allAdapters) {
-        // claudedesktop is Windows/macOS only; getCoworkBaseDir() returns '' on Linux
+        // claudedesktop is Windows/macOS only; getDesktopSessionDirs() returns [] on Linux
         if (adapter.id === 'claudedesktop' && os.platform() === 'linux') { continue; }
         const root = adapter.getEditorRoot(dummyFile);
         assert.ok(typeof root === 'string' && root.length > 0, `${adapter.id}: getEditorRoot should return non-empty string`);

--- a/vscode-extension/test/unit/parserRobustness.test.ts
+++ b/vscode-extension/test/unit/parserRobustness.test.ts
@@ -32,7 +32,7 @@ import { ContinueDataAccess } from '../../../src/continue';
 import { KiroDataAccess } from '../../../src/kiro';
 import { ClineDataAccess } from '../../../src/cline';
 import { PiDataAccess } from '../../../src/pi';
-import { ClaudeDesktopCoworkDataAccess } from '../../../src/claudedesktop';
+import { ClaudeDesktopDataAccess } from '../../../src/claudedesktop';
 import { EclipseDataAccess } from '../../../src/eclipse';
 import { MistralVibeDataAccess } from '../../../src/mistralvibe';
 import { TokenAccumulator } from '../../../src/sessionParser';
@@ -535,8 +535,8 @@ test('ClaudeDesktop Cowork: __proto__ model is skipped and does not pollute Obje
 			{ type: 'assistant', message: { role: 'assistant', model: 'claude-sonnet-4-6', stop_reason: 'end_turn', usage: { input_tokens: 7, output_tokens: 3 } } },
 		];
 		fs.writeFileSync(file, events.map(e => JSON.stringify(e)).join('\n'), 'utf8');
-		const cowork = new ClaudeDesktopCoworkDataAccess();
-		const modelUsage = await cowork.getCoworkModelUsage(file);
+		const cowork = new ClaudeDesktopDataAccess();
+		const modelUsage = await cowork.getDesktopSessionModelUsage(file);
 		assertNoPrototypePollution();
 		assert.equal(Object.prototype.hasOwnProperty.call(modelUsage, '__proto__'), false);
 		assert.ok(modelUsage['claude-sonnet-4.6'], 'legitimate model must still be counted');

--- a/vscode-extension/test/unit/workspaceHelpers.test.ts
+++ b/vscode-extension/test/unit/workspaceHelpers.test.ts
@@ -490,6 +490,10 @@ test('getEditorTypeFromPath: detects Claude Desktop Cowork', () => {
         assert.equal(getEditorTypeFromPath('/home/user/AppData/Local/Packages/Claude_pzs/LocalCache/Roaming/claude/local-agent-mode-sessions/session.jsonl'), 'Claude Desktop Cowork');
 });
 
+test('getEditorTypeFromPath: detects Claude Desktop Cowork from renamed claude-code-sessions dir', () => {
+        assert.equal(getEditorTypeFromPath('/home/user/AppData/Local/Packages/Claude_pzs/LocalCache/Roaming/claude/claude-code-sessions/app/machine/local_abc/.claude/projects/hash/session.jsonl'), 'Claude Desktop Cowork');
+});
+
 test('getEditorTypeFromPath: returns Unknown for unrecognized paths', () => {
         assert.equal(getEditorTypeFromPath('/tmp/random/file.json'), 'Unknown');
 });
@@ -547,6 +551,7 @@ test('detectEditorSource: detects Visual Studio', () => {
 
 test('detectEditorSource: detects Claude Desktop Cowork', () => {
         assert.equal(detectEditorSource('/home/user/.config/local-agent-mode-sessions/session.json'), 'Claude Desktop Cowork');
+        assert.equal(detectEditorSource('/home/user/.config/claude-code-sessions/session.json'), 'Claude Desktop Cowork');
 });
 
 test('detectEditorSource: detects Crush', () => {


### PR DESCRIPTION
## Why

The Claude Desktop app renamed its Cowork (local agent mode) session store from `local-agent-mode-sessions` to `claude-code-sessions`. On updated installs, session discovery found nothing for Claude Desktop Cowork, and path-based editor detection no longer recognized the new location.

## What changed

- `src/claudedesktop.ts` now reads **both** session directories: `claude-code-sessions` (current) first, `local-agent-mode-sessions` (legacy) kept for older installs. Candidate paths and `getEditorRoot` handle both.
- Path-based editor detection in `src/workspaceHelpers.ts` and `cli/src/analysis.ts` matches both directory names (still reported as "Claude Desktop Cowork").
- Naming kept in sync with the rename: `ClaudeDesktopCoworkDataAccess` -> `ClaudeDesktopDataAccess`, `getCoworkBaseDir()` -> `getDesktopSessionDirs()` / `getSessionDirForFile()`, and the `*Cowork*` parse methods -> `*DesktopSession*` / `*Desktop*`. Rippled through the adapter, registry, `extension.ts`, and tests.

## Notes for reviewers

- The user-facing display name "Claude Desktop Cowork" is unchanged on purpose; it is the feature name, not the directory name.
- Verified on a live install: the desktop app's new store contains only metadata `.json` files whose `cliSessionId` links to transcripts in the shared `~/.claude/projects/` dir, which the Claude Code adapter already covers. The legacy nested-transcript layout is still walked for older installs.
- Also verified that Claude Code **cloud** sessions (`cse_...` / `session_01...`) write no local transcripts at all; discovering those would require the Anthropic sessions API and is out of scope here.
- Includes a `package-lock.json` sync (version/engines fields that had drifted from `package.json`).

## Validation

- `npm run compile` clean (vscode-extension), CLI builds clean
- 367 extension unit tests pass (ecosystemAdapters, workspaceHelpers, parserRobustness), 26 CLI unit tests pass
- Added test coverage for the new `claude-code-sessions` path detection