### PR TITLE
fix(usage): make worktree notification "Show Me" reliably open the Worktrees tab

### DIFF
--- a/visualstudio-extension/src/AIEngineeringFluency/webview/usage.js
+++ b/visualstudio-extension/src/AIEngineeringFluency/webview/usage.js
@@ -2629,6 +2629,22 @@ body[data-vscode-theme-kind="vscode-high-contrast-light"] .title {
     };
   }
 
+  // src/webview/usage/switchableTabs.ts
+  var SWITCHABLE_TABS = /* @__PURE__ */ new Set([
+    "activity",
+    "sessions",
+    "tools",
+    "health",
+    "repos",
+    "agent",
+    "worktrees",
+    "insights",
+    "corrections"
+  ]);
+  function isSwitchableTab(value) {
+    return SWITCHABLE_TABS.has(String(value));
+  }
+
   // ../src/utils/toolUtils.ts
   var GUID_MCP_PATTERN = /^mcp__[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}__(.+)$/i;
   function toTitleCase(s4) {
@@ -3139,7 +3155,8 @@ Please add friendly names for these tools to improve the user experience.`
     { label: "\u{1F916} Agent Mode", key: "agent", gradient: "linear-gradient(90deg, #7c3aed, #a855f7)" },
     { label: "\u{1F4CB} Plan Mode", key: "plan", gradient: "linear-gradient(90deg, #f59e0b, #fbbf24)" },
     { label: "\u26A1 Custom Agent", key: "customAgent", gradient: "linear-gradient(90deg, #ec4899, #f472b6)" },
-    { label: "\u{1F5A5}\uFE0F CLI", key: "cli", gradient: "linear-gradient(90deg, #06b6d4, #22d3ee)" }
+    { label: "\u{1F5A5}\uFE0F CLI", key: "cli", gradient: "linear-gradient(90deg, #06b6d4, #22d3ee)" },
+    { label: "\u2728 Copilot App", key: "cliApp", gradient: "linear-gradient(90deg, #6366f1, #818cf8)" }
   ];
   function renderModeBarItem(label, count, total, gradient) {
     const pct = total > 0 ? count / total * 100 : 0;
@@ -3150,8 +3167,8 @@ Please add friendly names for these tools to improve the user experience.`
 </div>`;
   }
   function renderModeBarChart(modeUsage, title) {
-    const total = modeUsage.ask + modeUsage.edit + modeUsage.agent + modeUsage.plan + modeUsage.customAgent + modeUsage.cli;
-    const bars = MODE_BAR_CONFIGS.map(({ label, key, gradient }) => renderModeBarItem(label, modeUsage[key], total, gradient)).join("");
+    const total = modeUsage.ask + modeUsage.edit + modeUsage.agent + modeUsage.plan + modeUsage.customAgent + modeUsage.cli + (modeUsage.cliApp ?? 0);
+    const bars = MODE_BAR_CONFIGS.map(({ label, key, gradient }) => renderModeBarItem(label, modeUsage[key] ?? 0, total, gradient)).join("");
     return `
 <div>
 <h4 style="color: var(--text-primary); font-size: 13px; margin-bottom: 8px;">${title}</h4>
@@ -3667,7 +3684,8 @@ ${_renderMultiModelMixedCostSessions(switching)}
       agent: coerceNumber2(m2.agent),
       plan: coerceNumber2(m2.plan),
       customAgent: coerceNumber2(m2.customAgent),
-      cli: coerceNumber2(m2.cli)
+      cli: coerceNumber2(m2.cli),
+      cliApp: coerceNumber2(m2.cliApp)
     };
   }
   function sanitizeContextRefs(refs) {
@@ -4397,6 +4415,7 @@ ${_renderMultiModelMixedCostSessions(switching)}
     return {
       authenticated: Boolean(src.authenticated),
       since: typeof src.since === "string" || typeof src.since === "number" ? src.since : Date.now(),
+      error: typeof src.error === "string" ? escapeHtml(src.error) : void 0,
       repos: repos.map((repo) => {
         const r6 = repo && typeof repo === "object" ? repo : {};
         const aiDetails = Array.isArray(r6.aiDetails) ? r6.aiDetails : [];
@@ -4464,6 +4483,14 @@ ${_renderMultiModelMixedCostSessions(switching)}
   }
   function renderReposPrContent(data) {
     const sinceDate = escapeHtml(new Date(data.since).toLocaleDateString());
+    if (data.error) {
+      return `
+			<div style="margin-top:12px; padding:12px; background:var(--bg-tertiary); border:1px solid var(--border-color); border-radius:6px; font-size:12px; color:var(--text-secondary);">
+				<strong>\u26A0\uFE0F Failed to load repository PR activity</strong><br/>
+				${data.error}<br/>
+				Switch to another tab and back to retry \u2014 details are in the extension Output channel.
+			</div>`;
+    }
     if (!data.authenticated) {
       return `
 			<div style="margin-top:12px; padding:12px; background:var(--bg-tertiary); border:1px solid var(--border-color); border-radius:6px; font-size:12px; color:var(--text-secondary);">
@@ -6043,9 +6070,9 @@ ${_renderMultiModelMixedCostSessions(switching)}
     const modelCostHtml = safeSectionHtml("Model Cost", () => buildModelCostSectionHtml(stats));
     const billingComparisonHtml = safeSectionHtml("AI Billing Coverage", () => buildBillingComparisonSectionHtml(stats));
     const modeUsageHtml = safeSectionHtml("Interaction Modes", () => `
-			<div class="section">
+			<div class="section" id="section-interaction-modes">
 				<div class="section-title"><span>\u{1F3AF}</span><span>Interaction Modes</span></div>
-				<div class="section-subtitle">How you're using Copilot: Ask (chat), Edit (code edits), or Agent (autonomous tasks)</div>
+				<div class="section-subtitle">How you're using Copilot: Ask (chat), Edit (code edits), Agent (autonomous tasks), Plan, Custom Agent, CLI (terminal), or Copilot App (desktop-app CLI sessions)</div>
 				<div class="two-column">
 					${renderModeBarChart(stats.today.modeUsage, "\u{1F4C5} Today")}
 					${renderModeBarChart(stats.last30Days.modeUsage, "\u{1F4CA} Last 30 Days")}
@@ -6965,7 +6992,12 @@ ${_renderMultiModelMixedCostSessions(switching)}
     }
   }
   function handleSwitchTab(message) {
-    const btn = document.querySelector(`.tab-button[data-tab="${String(message.tab)}"]`);
+    const tab = String(message.tab);
+    if (!isSwitchableTab(tab)) {
+      return;
+    }
+    activeTab = tab;
+    const btn = document.querySelector(`.tab-button[data-tab="${tab}"]`);
     btn?.click();
     if (message.anchor) {
       const anchor = document.getElementById(String(message.anchor));

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -6972,6 +6972,9 @@ class CopilotTokenTracker implements vscode.Disposable {
 	/** Opens the Usage Analysis panel, pushes the latest background worktree scan findings, and activates the Worktrees tab. */
 	public async showUsageAnalysisOnWorktreesTab(): Promise<void> {
 		await this.showUsageAnalysis();
+		// showUsageAnalysis() creates a fresh panel with preserveFocus: true; for this explicit
+		// notification action, force focus so the panel visibly comes forward.
+		this.analysisPanel?.reveal(vscode.ViewColumn.One, false);
 		this.postWorktreeBackgroundResults();
 		void this.analysisPanel?.webview.postMessage({ command: 'switchTab', tab: 'worktrees' });
 	}

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -4973,8 +4973,20 @@ function handleExtensionMessage(message: any): void {
 	}
 }
 
+// Tabs the extension host may activate via the 'switchTab' message. Guarded so a bogus tab
+// name can never blank the dashboard by leaving every panel hidden.
+const SWITCHABLE_TABS = new Set(['activity', 'sessions', 'tools', 'health', 'repos', 'agent', 'worktrees', 'insights', 'corrections']);
+
 function handleSwitchTab(message: any): void {
-	const btn = document.querySelector<HTMLButtonElement>(`.tab-button[data-tab="${String(message.tab)}"]`);
+	const tab = String(message.tab);
+	if (SWITCHABLE_TABS.has(tab)) {
+		// Persist the requested tab in module state, not just the DOM: while the webview is in
+		// its loading state the tab bar doesn't exist, so btn.click() below silently no-ops and
+		// the later renderLayout would land on the default tab — swallowing e.g. the worktree
+		// notification's "Show Me" action. With activeTab set, the eventual render honors it.
+		activeTab = tab;
+	}
+	const btn = document.querySelector<HTMLButtonElement>(`.tab-button[data-tab="${tab}"]`);
 	btn?.click();
 	if (message.anchor) {
 		const anchor = document.getElementById(String(message.anchor));

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -20,6 +20,7 @@ import { sanitizeCustomizationMatrix } from './customizationSanitizer';
 import { applyBillingFields, type CopilotApiBalance } from './billingStatsSanitizer';
 import { billingExtGroupCostsHtml } from './billingCoverage';
 import { sanitizeAgentSessionsData, toSafeNumber, toSafeHttpUrl, type AgentRepoSummary, type AgentSessionsResult } from './agentSessionsSanitizer';
+import { nextActiveTab } from './switchableTabs';
 
 type ModelSwitchingAnalysis = BaseModelSwitchingAnalysis & {
 	minModelsPerSession: number;
@@ -4973,19 +4974,13 @@ function handleExtensionMessage(message: any): void {
 	}
 }
 
-// Tabs the extension host may activate via the 'switchTab' message. Guarded so a bogus tab
-// name can never blank the dashboard by leaving every panel hidden.
-const SWITCHABLE_TABS = new Set(['activity', 'sessions', 'tools', 'health', 'repos', 'agent', 'worktrees', 'insights', 'corrections']);
-
 function handleSwitchTab(message: any): void {
 	const tab = String(message.tab);
-	if (SWITCHABLE_TABS.has(tab)) {
-		// Persist the requested tab in module state, not just the DOM: while the webview is in
-		// its loading state the tab bar doesn't exist, so btn.click() below silently no-ops and
-		// the later renderLayout would land on the default tab — swallowing e.g. the worktree
-		// notification's "Show Me" action. With activeTab set, the eventual render honors it.
-		activeTab = tab;
-	}
+	// Persist the requested tab in module state, not just the DOM: while the webview is in
+	// its loading state the tab bar doesn't exist, so btn.click() below silently no-ops and
+	// the later renderLayout would land on the default tab — swallowing e.g. the worktree
+	// notification's "Show Me" action. With activeTab set, the eventual render honors it.
+	activeTab = nextActiveTab(tab, activeTab);
 	const btn = document.querySelector<HTMLButtonElement>(`.tab-button[data-tab="${tab}"]`);
 	btn?.click();
 	if (message.anchor) {

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -20,7 +20,7 @@ import { sanitizeCustomizationMatrix } from './customizationSanitizer';
 import { applyBillingFields, type CopilotApiBalance } from './billingStatsSanitizer';
 import { billingExtGroupCostsHtml } from './billingCoverage';
 import { sanitizeAgentSessionsData, toSafeNumber, toSafeHttpUrl, type AgentRepoSummary, type AgentSessionsResult } from './agentSessionsSanitizer';
-import { nextActiveTab } from './switchableTabs';
+import { isSwitchableTab } from './switchableTabs';
 
 type ModelSwitchingAnalysis = BaseModelSwitchingAnalysis & {
 	minModelsPerSession: number;
@@ -4976,11 +4976,14 @@ function handleExtensionMessage(message: any): void {
 
 function handleSwitchTab(message: any): void {
 	const tab = String(message.tab);
+	// Ignore unknown tabs entirely: a bogus name must not blank the dashboard, and only
+	// allowlisted names may be interpolated into the selector below.
+	if (!isSwitchableTab(tab)) { return; }
 	// Persist the requested tab in module state, not just the DOM: while the webview is in
 	// its loading state the tab bar doesn't exist, so btn.click() below silently no-ops and
 	// the later renderLayout would land on the default tab — swallowing e.g. the worktree
 	// notification's "Show Me" action. With activeTab set, the eventual render honors it.
-	activeTab = nextActiveTab(tab, activeTab);
+	activeTab = tab;
 	const btn = document.querySelector<HTMLButtonElement>(`.tab-button[data-tab="${tab}"]`);
 	btn?.click();
 	if (message.anchor) {

--- a/vscode-extension/src/webview/usage/switchableTabs.ts
+++ b/vscode-extension/src/webview/usage/switchableTabs.ts
@@ -1,15 +1,12 @@
 // Tabs the extension host may activate via the 'switchTab' message. Guarded so a bogus tab
-// name can never blank the dashboard by leaving every panel hidden.
+// name can never blank the dashboard by leaving every panel hidden, and so untrusted input
+// is never interpolated into a CSS selector.
 export const SWITCHABLE_TABS: ReadonlySet<string> = new Set([
 	'activity', 'sessions', 'tools', 'health', 'repos', 'agent', 'worktrees', 'insights', 'corrections'
 ]);
 
-// Tab the webview should persist as active after a switchTab message: the requested tab when
-// it is switchable, otherwise the current one. Persisting in module state (not just the DOM)
-// matters because while the webview is in its loading state the tab bar doesn't exist, so
-// clicking the tab button silently no-ops and the eventual renderLayout must still land on
-// the requested tab — e.g. the worktree notification's "Show Me" action.
-export function nextActiveTab(requested: unknown, current: string): string {
-	const tab = String(requested);
-	return SWITCHABLE_TABS.has(tab) ? tab : current;
+// True when a switchTab message names a tab the webview actually renders. Non-string input is
+// coerced first so it can never throw or slip past the guard.
+export function isSwitchableTab(value: unknown): boolean {
+	return SWITCHABLE_TABS.has(String(value));
 }

--- a/vscode-extension/src/webview/usage/switchableTabs.ts
+++ b/vscode-extension/src/webview/usage/switchableTabs.ts
@@ -1,0 +1,15 @@
+// Tabs the extension host may activate via the 'switchTab' message. Guarded so a bogus tab
+// name can never blank the dashboard by leaving every panel hidden.
+export const SWITCHABLE_TABS: ReadonlySet<string> = new Set([
+	'activity', 'sessions', 'tools', 'health', 'repos', 'agent', 'worktrees', 'insights', 'corrections'
+]);
+
+// Tab the webview should persist as active after a switchTab message: the requested tab when
+// it is switchable, otherwise the current one. Persisting in module state (not just the DOM)
+// matters because while the webview is in its loading state the tab bar doesn't exist, so
+// clicking the tab button silently no-ops and the eventual renderLayout must still land on
+// the requested tab — e.g. the worktree notification's "Show Me" action.
+export function nextActiveTab(requested: unknown, current: string): string {
+	const tab = String(requested);
+	return SWITCHABLE_TABS.has(tab) ? tab : current;
+}

--- a/vscode-extension/test/unit/webview-switchableTabs.test.ts
+++ b/vscode-extension/test/unit/webview-switchableTabs.test.ts
@@ -1,29 +1,27 @@
 import test from 'node:test';
 import * as assert from 'node:assert/strict';
-import { SWITCHABLE_TABS, nextActiveTab } from '../../src/webview/usage/switchableTabs';
+import { SWITCHABLE_TABS, isSwitchableTab } from '../../src/webview/usage/switchableTabs';
 
 // handleSwitchTab persists the requested tab in module state (not just the DOM) so a switchTab
 // message arriving while the webview is still in its loading state — e.g. the worktree
-// notification's "Show Me" action — survives until the eventual renderLayout. The guard keeps
-// a bogus tab name from blanking the dashboard by leaving every panel hidden.
+// notification's "Show Me" action — survives until the eventual renderLayout. Unknown tabs are
+// rejected up front so a bogus name can neither blank the dashboard nor be interpolated into
+// a CSS selector.
 
-test('nextActiveTab: switches to a known tab', () => {
-	assert.equal(nextActiveTab('worktrees', 'activity'), 'worktrees');
-	assert.equal(nextActiveTab('sessions', 'activity'), 'sessions');
-});
-
-test('SWITCHABLE_TABS: covers every tab rendered in the tab bar', () => {
+test('isSwitchableTab: accepts every tab rendered in the tab bar', () => {
 	for (const tab of ['activity', 'sessions', 'tools', 'health', 'repos', 'agent', 'worktrees', 'insights', 'corrections']) {
 		assert.ok(SWITCHABLE_TABS.has(tab), `missing ${tab}`);
+		assert.ok(isSwitchableTab(tab));
 	}
 });
 
-test('nextActiveTab: keeps the current tab for an unknown tab name', () => {
-	assert.equal(nextActiveTab('nonsense', 'sessions'), 'sessions');
+test('isSwitchableTab: rejects unknown tab names', () => {
+	assert.equal(isSwitchableTab('nonsense'), false);
+	assert.equal(isSwitchableTab('worktrees")], [*'), false);
 });
 
-test('nextActiveTab: coerces non-string input before guarding', () => {
-	assert.equal(nextActiveTab(undefined, 'activity'), 'activity');
-	assert.equal(nextActiveTab(null, 'activity'), 'activity');
-	assert.equal(nextActiveTab(42, 'tools'), 'tools');
+test('isSwitchableTab: coerces non-string input before guarding', () => {
+	assert.equal(isSwitchableTab(undefined), false);
+	assert.equal(isSwitchableTab(null), false);
+	assert.equal(isSwitchableTab(42), false);
 });

--- a/vscode-extension/test/unit/webview-switchableTabs.test.ts
+++ b/vscode-extension/test/unit/webview-switchableTabs.test.ts
@@ -1,0 +1,29 @@
+import test from 'node:test';
+import * as assert from 'node:assert/strict';
+import { SWITCHABLE_TABS, nextActiveTab } from '../../src/webview/usage/switchableTabs';
+
+// handleSwitchTab persists the requested tab in module state (not just the DOM) so a switchTab
+// message arriving while the webview is still in its loading state — e.g. the worktree
+// notification's "Show Me" action — survives until the eventual renderLayout. The guard keeps
+// a bogus tab name from blanking the dashboard by leaving every panel hidden.
+
+test('nextActiveTab: switches to a known tab', () => {
+	assert.equal(nextActiveTab('worktrees', 'activity'), 'worktrees');
+	assert.equal(nextActiveTab('sessions', 'activity'), 'sessions');
+});
+
+test('SWITCHABLE_TABS: covers every tab rendered in the tab bar', () => {
+	for (const tab of ['activity', 'sessions', 'tools', 'health', 'repos', 'agent', 'worktrees', 'insights', 'corrections']) {
+		assert.ok(SWITCHABLE_TABS.has(tab), `missing ${tab}`);
+	}
+});
+
+test('nextActiveTab: keeps the current tab for an unknown tab name', () => {
+	assert.equal(nextActiveTab('nonsense', 'sessions'), 'sessions');
+});
+
+test('nextActiveTab: coerces non-string input before guarding', () => {
+	assert.equal(nextActiveTab(undefined, 'activity'), 'activity');
+	assert.equal(nextActiveTab(null, 'activity'), 'activity');
+	assert.equal(nextActiveTab(42, 'tools'), 'tools');
+});


### PR DESCRIPTION
## Why

Clicking **"Show Me"** on the daily background worktree-scan notification ("We found X GB of data hidden in N git worktrees...") could appear to do nothing: the Usage Analysis panel stayed on whatever tab it was showing (or opened on the default tab) instead of the Worktrees tab.

## Root cause

The extension posts a `switchTab` message to the webview, and `handleSwitchTab` only did `document.querySelector('.tab-button[data-tab=...]')?.click()`. When the webview has no tab bar rendered yet -- a freshly created panel still in its loading state (cold stats cache), or a mid-refresh loading screen -- the click silently no-ops, and the later `renderLayout` lands on the default `activity` tab. Verified with a headless jsdom repro against the real built bundle: `switchTab` posted during the loading state was lost.

A second, smaller issue: `showUsageAnalysis()` creates fresh panels with `preserveFocus: true`, so a Show Me click on a window without an open panel opened it unfocused in the background.

## Fix

- `handleSwitchTab` (webview) now persists the requested tab in module-level `activeTab` (guarded against unknown tab names), so the eventual render honors it even when the button click no-ops during the loading state. This also covers the Insights/Tools/Activity tab-switch flows, which share the same handler.
- `showUsageAnalysisOnWorktreesTab` (extension host) now forces a focused reveal after `showUsageAnalysis()`, so the panel visibly comes forward when invoked from the notification.

## Verification

- Headless jsdom repro of both scenarios: (a) panel already open on the Repository PRs tab, (b) fresh panel still in loading state -- after the fix both land on the Worktrees tab with the background scan results populated.
- `npm run compile` (tsc + eslint + esbuild) clean; `worktreeBackgroundScan` and `extension` unit tests pass.