### PR TITLE
feat(usage): add local model leaderboard

### DIFF
--- a/.github/skills/visual-view-diff/fixtures/usage.json
+++ b/.github/skills/visual-view-diff/fixtures/usage.json
@@ -372,6 +372,86 @@
       "sessionCount": 231,
       "switchCount": 55
     },
+    "modelEfficiency": {
+      "claude-opus-4.6": {
+        "calls": 148,
+        "toolCalls": 1124,
+        "editTurns": 91,
+        "oneShotEditTurns": 76,
+        "retries": 8,
+        "selfCorrections": 7,
+        "editToolCalls": 194,
+        "inputTokens": 8740000,
+        "outputTokens": 1290000,
+        "cachedReadTokens": 5960000,
+        "cost": 42.18
+      },
+      "gpt-5.4": {
+        "calls": 121,
+        "toolCalls": 728,
+        "editTurns": 78,
+        "oneShotEditTurns": 58,
+        "retries": 13,
+        "selfCorrections": 7,
+        "editToolCalls": 166,
+        "inputTokens": 5110000,
+        "outputTokens": 842000,
+        "cachedReadTokens": 2790000,
+        "cost": 18.72
+      },
+      "gemini-3.1-pro-preview": {
+        "calls": 87,
+        "toolCalls": 626,
+        "editTurns": 54,
+        "oneShotEditTurns": 43,
+        "retries": 7,
+        "selfCorrections": 4,
+        "editToolCalls": 119,
+        "inputTokens": 3960000,
+        "outputTokens": 711000,
+        "cachedReadTokens": 1860000,
+        "cost": 9.46
+      },
+      "claude-sonnet-4.6": {
+        "calls": 64,
+        "toolCalls": 358,
+        "editTurns": 42,
+        "oneShotEditTurns": 29,
+        "retries": 8,
+        "selfCorrections": 5,
+        "editToolCalls": 94,
+        "inputTokens": 2880000,
+        "outputTokens": 492000,
+        "cachedReadTokens": 1910000,
+        "cost": 12.84
+      },
+      "gpt-5.4-mini": {
+        "calls": 38,
+        "toolCalls": 184,
+        "editTurns": 21,
+        "oneShotEditTurns": 17,
+        "retries": 3,
+        "selfCorrections": 1,
+        "editToolCalls": 47,
+        "inputTokens": 1340000,
+        "outputTokens": 219000,
+        "cachedReadTokens": 724000,
+        "cost": 2.18
+      },
+      "unknown": {
+        "calls": 19,
+        "toolCalls": 61,
+        "editTurns": 7,
+        "oneShotEditTurns": 3,
+        "retries": 3,
+        "selfCorrections": 1,
+        "editToolCalls": 17,
+        "inputTokens": 462000,
+        "outputTokens": 78000,
+        "cachedReadTokens": 0,
+        "cost": 0.74
+      }
+    },
     "multiAgentParentSessions": 33,
     "delegationSessions": 55
   },

--- a/src/modelEfficiency.ts
+++ b/src/modelEfficiency.ts
@@ -118,7 +118,7 @@ export interface EfficiencyTurn {
 
 export function createEmptyModelEfficiencyCounters(): ModelEfficiencyCounters {
 	return {
-		calls: 0, editTurns: 0, oneShotEditTurns: 0, retries: 0, selfCorrections: 0,
+		calls: 0, toolCalls: 0, editTurns: 0, oneShotEditTurns: 0, retries: 0, selfCorrections: 0,
 		editToolCalls: 0, inputTokens: 0, outputTokens: 0, cachedReadTokens: 0, cost: 0,
 	};
 }
@@ -133,6 +133,7 @@ function analyzeTurnToolCalls(toolCalls: { toolName: string; arguments?: string 
 	let editCalls = 0;
 	let retries = 0;
 	let selfCorrections = 0;
+	counters.toolCalls = (counters.toolCalls ?? 0) + toolCalls.length;
 	const editedFiles = new Set<string>();
 	// File edited by the immediately preceding tool call, or null when the
 	// preceding call was not an edit (or there is no preceding call).
@@ -225,6 +226,7 @@ export function mergeModelEfficiency(target: ModelEfficiencyUsage, source: Model
 	for (const [model, counters] of Object.entries(source)) {
 		const t = ensureCounters(target, model);
 		t.calls += counters.calls;
+		t.toolCalls = (t.toolCalls ?? 0) + (counters.toolCalls ?? 0);
 		t.editTurns += counters.editTurns;
 		t.oneShotEditTurns += counters.oneShotEditTurns;
 		t.retries += counters.retries;
@@ -366,6 +368,7 @@ export function accumulateDailyModelCounters(target: DailyModelEfficiency, input
 	for (const [model, counters] of Object.entries(input.modelEfficiency ?? {})) {
 		const entry = ensureDailyEntry(target, model);
 		entry.calls += counters.calls;
+		entry.toolCalls = (entry.toolCalls ?? 0) + (counters.toolCalls ?? 0);
 		entry.editTurns += counters.editTurns;
 		entry.oneShotEditTurns += counters.oneShotEditTurns;
 		entry.retries += counters.retries;
@@ -410,6 +413,7 @@ export function buildSessionEfficiencyAttribution(sessionData: SessionFileCache)
 	for (const [model, s] of Object.entries(src)) {
 		const t = ensureDailyEntry(target, model);
 		t.calls += s.calls;
+		t.toolCalls = (t.toolCalls ?? 0) + (s.toolCalls ?? 0);
 		t.editTurns += s.editTurns;
 		t.oneShotEditTurns += s.oneShotEditTurns;
 		t.retries += s.retries;
@@ -448,6 +452,8 @@ export interface ModelEfficiencyRates {
 	costPerEdit: number | null;
 	/** Average output tokens per user-request turn. */
 	outputTokensPerCall: number | null;
+	/** Average tool invocations per user-request turn. */
+	toolCallsPerCall: number | null;
 	/** Cache-read share of input tokens (0..1). */
 	cacheHitRate: number | null;
 }
@@ -460,6 +466,7 @@ export function deriveModelEfficiencyRates(c: ModelEfficiencyCounters): ModelEff
 		costPerCall: c.calls > 0 ? c.cost / c.calls : null,
 		costPerEdit: c.editTurns > 0 ? c.cost / c.editTurns : null,
 		outputTokensPerCall: c.calls > 0 ? c.outputTokens / c.calls : null,
+		toolCallsPerCall: c.calls > 0 ? (c.toolCalls ?? 0) / c.calls : null,
 		// Cap at 1.0: some providers report cachedReadTokens > inputTokens (e.g. DeepSeek).
 		cacheHitRate: c.inputTokens > 0 ? Math.min(1, c.cachedReadTokens / c.inputTokens) : null,
 	};

--- a/src/types.ts
+++ b/src/types.ts
@@ -527,6 +527,8 @@ export interface SkillCallUsage {
 export interface ModelEfficiencyCounters {
   /** User-request turns attributed to this model. */
   calls: number;
+  /** Tool invocations across those turns. Used as the local equivalent of agent steps. */
+  toolCalls?: number;
   /** Turns containing at least one file-edit tool call. */
   editTurns: number;
   /** Edit turns with no retries and no self-corrections. */

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -443,7 +443,7 @@ interface WorktreeScanResult {
 
 class CopilotTokenTracker implements vscode.Disposable {
 	// Cache version - increment this when making changes that require cache invalidation
-	private static readonly CACHE_VERSION = 67; // firstUserPrompt capture for repeated-task detection + Copilot desktop app CLI sessions split into modeUsage.cliApp
+	private static readonly CACHE_VERSION = 68; // per-model tool-call counters for the local model leaderboard
 	// Maximum length for displaying workspace IDs in diagnostics/customization matrix
 	private static readonly WORKSPACE_ID_DISPLAY_LENGTH = 8;
 	private static readonly SEEN_EDITORS_STATE_KEY = 'discovery.seenEditors';

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -4329,11 +4329,12 @@ function buildUnknownMcpToolsBannerHtml(stats: UsageAnalysisStats): string {
 	`;
 }
 
-// --- Model Efficiency section (issue #1649) ---
+// --- Local model leaderboard ---
 
 type EfficiencyPeriodKey = 'today' | 'last30Days' | 'month';
+type EfficiencyMetricKey = 'cost' | 'outputTokens' | 'toolSteps';
 type EfficiencyRow = { model: string; counters: ModelEfficiencyCounters; rates: ReturnType<typeof deriveModelEfficiencyRates> };
-type EfficiencySortColumn = 'model' | 'calls' | 'editTurns' | 'oneShotRate' | 'retryRate' | 'selfCorrectionRate' | 'costPerCall' | 'costPerEdit' | 'outputTokensPerCall' | 'cacheHitRate';
+type EfficiencySortColumn = 'model' | 'calls' | 'oneShotRate' | 'retryRate' | 'selfCorrectionRate' | 'costPerCall' | 'outputTokensPerCall' | 'toolCallsPerCall' | 'cacheHitRate';
 
 const EFFICIENCY_PERIOD_TO_DATA_KEY: Partial<Record<Period, EfficiencyPeriodKey>> = {
 	today: 'today',
@@ -4343,6 +4344,7 @@ const EFFICIENCY_PERIOD_TO_DATA_KEY: Partial<Record<Period, EfficiencyPeriodKey>
 
 let efficiencySelectedPeriod: Period = 'last30';
 let efficiencyPeriod: EfficiencyPeriodKey = 'last30Days';
+let efficiencyMetric: EfficiencyMetricKey = 'cost';
 let efficiencySortColumn: EfficiencySortColumn = 'calls';
 let efficiencySortDirection: 'asc' | 'desc' = 'desc';
 let cachedModelEfficiency: Partial<Record<EfficiencyPeriodKey, ModelEfficiencyUsage | undefined>> = {};
@@ -4352,36 +4354,57 @@ type EfficiencyColumnDef = {
 	sortKey: EfficiencySortColumn;
 	label: string;
 	title: string;
-	align: 'left' | 'right';
-	sortValue: (r: EfficiencyRow) => number | string | null;
-	render: (r: EfficiencyRow) => string;
+	sortValue: (row: EfficiencyRow) => number | string | null;
+	render: (row: EfficiencyRow, totalCalls: number) => string;
 };
 
-/** Format a per-unit USD cost with 2 decimal places. */
+type EfficiencyMetricDef = {
+	key: EfficiencyMetricKey;
+	label: string;
+	axisLabel: string;
+	value: (row: EfficiencyRow) => number | null;
+	format: (value: number | null) => string;
+};
+
+/** Format a per-unit USD cost with enough precision for inexpensive local turns. */
 function formatUnitCost(value: number | null): string {
 	if (value === null) { return '—'; }
-	return value >= 0.01 ? formatCost(value) : `$${value.toFixed(2)}`;
+	return value >= 0.01 ? formatCost(value) : `$${value.toFixed(3)}`;
 }
 
 function formatRatePercent(value: number | null): string {
 	return value === null ? '—' : formatPercent(value * 100);
 }
 
-function formatPerEdit(value: number | null): string {
-	return value === null ? '—' : formatFixed(value, 2);
+function formatPerTurn(value: number | null): string {
+	return value === null ? '—' : formatFixed(value, 1);
+}
+
+const EFFICIENCY_METRICS: EfficiencyMetricDef[] = [
+	{ key: 'cost', label: 'Cost', axisLabel: 'Average cost per turn', value: row => row.rates.costPerCall, format: formatUnitCost },
+	{ key: 'outputTokens', label: 'Output tokens', axisLabel: 'Average output tokens per turn', value: row => row.rates.outputTokensPerCall, format: value => value === null ? '—' : formatCompact(Math.round(value)) },
+	{ key: 'toolSteps', label: 'Tool steps', axisLabel: 'Average tool steps per turn', value: row => row.rates.toolCallsPerCall, format: formatPerTurn },
+];
+
+function buildLocalUsageCell(row: EfficiencyRow, totalCalls: number): string {
+	const share = totalCalls > 0 ? row.counters.calls / totalCalls : 0;
+	return `<div class="model-use-cell">
+		<div class="model-use-track" aria-hidden="true"><span style="width:${Math.max(2, share * 100).toFixed(1)}%"></span></div>
+		<strong>${formatRatePercent(share)}</strong>
+		<span>${formatNumber(row.counters.calls)} turns</span>
+	</div>`;
 }
 
 const EFFICIENCY_COLUMN_DEFS: EfficiencyColumnDef[] = [
-	{ sortKey: 'model', label: 'Model', title: 'Model identifier', align: 'left', sortValue: r => r.model, render: r => escapeHtml(getModelDisplayName(r.model)) },
-	{ sortKey: 'calls', label: 'Turns', title: 'User-request turns attributed to this model', align: 'right', sortValue: r => r.counters.calls, render: r => r.counters.calls > 0 ? formatNumber(r.counters.calls) : '—' },
-	{ sortKey: 'editTurns', label: 'Edit turns', title: 'Turns containing at least one file-edit tool call', align: 'right', sortValue: r => r.counters.editTurns, render: r => r.counters.calls > 0 ? formatNumber(r.counters.editTurns) : '—' },
-	{ sortKey: 'oneShotRate', label: 'One-shot edit rate', title: 'Share of edit turns completed without retries or self-corrections', align: 'right', sortValue: r => r.rates.oneShotRate, render: r => formatRatePercent(r.rates.oneShotRate) },
-	{ sortKey: 'retryRate', label: 'Retries/edit', title: 'Average immediate same-file retries per edit turn', align: 'right', sortValue: r => r.rates.retryRate, render: r => formatPerEdit(r.rates.retryRate) },
-	{ sortKey: 'selfCorrectionRate', label: 'Self-corr/edit', title: 'Average self-corrections (re-edits after other tool calls) per edit turn', align: 'right', sortValue: r => r.rates.selfCorrectionRate, render: r => formatPerEdit(r.rates.selfCorrectionRate) },
-	{ sortKey: 'costPerCall', label: 'Cost/turn', title: 'Average estimated cost per turn (provider rates)', align: 'right', sortValue: r => r.rates.costPerCall, render: r => formatUnitCost(r.rates.costPerCall) },
-	{ sortKey: 'costPerEdit', label: 'Cost/edit', title: 'Average estimated cost per edit turn (provider rates)', align: 'right', sortValue: r => r.rates.costPerEdit, render: r => formatUnitCost(r.rates.costPerEdit) },
-	{ sortKey: 'outputTokensPerCall', label: 'Out tok/turn', title: 'Average output tokens per turn', align: 'right', sortValue: r => r.rates.outputTokensPerCall, render: r => r.rates.outputTokensPerCall === null ? '—' : formatCompact(Math.round(r.rates.outputTokensPerCall)) },
-	{ sortKey: 'cacheHitRate', label: 'Cache hit', title: 'Cache-read share of input tokens', align: 'right', sortValue: r => r.rates.cacheHitRate, render: r => formatRatePercent(r.rates.cacheHitRate) },
+	{ sortKey: 'model', label: 'Model', title: 'Model identifier', sortValue: row => row.model, render: row => escapeHtml(getModelDisplayName(row.model)) },
+	{ sortKey: 'calls', label: 'Local use', title: 'Share of user-request turns attributed to this model', sortValue: row => row.counters.calls, render: buildLocalUsageCell },
+	{ sortKey: 'oneShotRate', label: 'One-shot', title: 'Share of edit turns completed without retries or self-corrections', sortValue: row => row.rates.oneShotRate, render: row => formatRatePercent(row.rates.oneShotRate) },
+	{ sortKey: 'retryRate', label: 'Retries/edit', title: 'Average immediate same-file retries per edit turn', sortValue: row => row.rates.retryRate, render: row => formatPerTurn(row.rates.retryRate) },
+	{ sortKey: 'selfCorrectionRate', label: 'Self-corr/edit', title: 'Average re-edits after intervening tool calls per edit turn', sortValue: row => row.rates.selfCorrectionRate, render: row => formatPerTurn(row.rates.selfCorrectionRate) },
+	{ sortKey: 'costPerCall', label: 'Avg cost', title: 'Average estimated provider cost per user-request turn', sortValue: row => row.rates.costPerCall, render: row => formatUnitCost(row.rates.costPerCall) },
+	{ sortKey: 'outputTokensPerCall', label: 'Out tok', title: 'Average output tokens per user-request turn', sortValue: row => row.rates.outputTokensPerCall, render: row => row.rates.outputTokensPerCall === null ? '—' : formatCompact(Math.round(row.rates.outputTokensPerCall)) },
+	{ sortKey: 'toolCallsPerCall', label: 'Steps', title: 'Average tool invocations per user-request turn', sortValue: row => row.rates.toolCallsPerCall, render: row => formatPerTurn(row.rates.toolCallsPerCall) },
+	{ sortKey: 'cacheHitRate', label: 'Cache hit', title: 'Cache-read share of input tokens', sortValue: row => row.rates.cacheHitRate, render: row => formatRatePercent(row.rates.cacheHitRate) },
 ];
 
 function getEfficiencySortIndicator(column: EfficiencySortColumn): string {
@@ -4389,84 +4412,145 @@ function getEfficiencySortIndicator(column: EfficiencySortColumn): string {
 	return efficiencySortDirection === 'desc' ? ' ▼' : ' ▲';
 }
 
-function buildEfficiencyRows(usage: ModelEfficiencyUsage): EfficiencyRow[] {
-	const rows: EfficiencyRow[] = Object.entries(usage).map(([model, counters]) => ({ model, counters, rates: deriveModelEfficiencyRates(counters) }));
-	const col = EFFICIENCY_COLUMN_DEFS.find(c => c.sortKey === efficiencySortColumn) ?? EFFICIENCY_COLUMN_DEFS[1];
-	rows.sort((a, b) => {
-		const av = col.sortValue(a);
-		const bv = col.sortValue(b);
-		// Nulls (no data) always sort to the bottom regardless of direction.
-		if (av === null && bv === null) { return 0; }
-		if (av === null) { return 1; }
-		if (bv === null) { return -1; }
-		const cmp = typeof av === 'string' || typeof bv === 'string'
-			? String(av).localeCompare(String(bv))
-			: av - bv;
-		return efficiencySortDirection === 'desc' ? -cmp : cmp;
-	});
-	return rows;
+function compareEfficiencyRows(a: EfficiencyRow, b: EfficiencyRow, column: EfficiencyColumnDef): number {
+	const av = column.sortValue(a);
+	const bv = column.sortValue(b);
+	if (av === null && bv === null) { return 0; }
+	if (av === null) { return 1; }
+	if (bv === null) { return -1; }
+	const cmp = typeof av === 'string' || typeof bv === 'string'
+		? String(av).localeCompare(String(bv))
+		: av - bv;
+	return efficiencySortDirection === 'desc' ? -cmp : cmp;
 }
 
-function buildModelEfficiencyTableHtml(): string {
+function buildEfficiencyRows(usage: ModelEfficiencyUsage): EfficiencyRow[] {
+	const rows = Object.entries(usage).map(([model, counters]) => ({ model, counters, rates: deriveModelEfficiencyRates(counters) }));
+	const column = EFFICIENCY_COLUMN_DEFS.find(item => item.sortKey === efficiencySortColumn) ?? EFFICIENCY_COLUMN_DEFS[1];
+	return rows.sort((a, b) => compareEfficiencyRows(a, b, column));
+}
+
+function filterLowUsageRows(rows: EfficiencyRow[], usage: ModelEfficiencyUsage): { rows: EfficiencyRow[]; hiddenNote: string } {
+	if (!efficiencyFilterLowUsage) { return { rows, hiddenNote: '' }; }
+	const threshold = computeEfficiencyLowUsageThreshold(usage);
+	if (threshold === null) { return { rows, hiddenNote: '' }; }
+	const filtered = rows.filter(row => row.counters.calls > threshold);
+	const hiddenCount = rows.length - filtered.length;
+	const noun = hiddenCount === 1 ? 'model' : 'models';
+	const turnNoun = threshold === 1 ? 'turn' : 'turns';
+	const hiddenNote = hiddenCount > 0 ? `${hiddenCount} low-usage ${noun} hidden (≤${threshold} ${turnNoun})` : '';
+	return { rows: filtered, hiddenNote };
+}
+
+const MODEL_COLOR_VARS = ['--stage-1-color', '--stage-2-color', '--stage-3-color', '--stage-4-color', '--success-fg', '--warning-fg'];
+
+function getModelColor(model: string): string {
+	let hash = 0;
+	for (let i = 0; i < model.length; i++) { hash = ((hash << 5) - hash + model.charCodeAt(i)) | 0; }
+	return `var(${MODEL_COLOR_VARS[Math.abs(hash) % MODEL_COLOR_VARS.length]})`;
+}
+
+function formatMetricTick(metric: EfficiencyMetricDef, value: number): string {
+	if (metric.key === 'cost') { return formatUnitCost(value); }
+	if (metric.key === 'outputTokens') { return formatCompact(Math.round(value)); }
+	return formatFixed(value, 1);
+}
+
+function buildEfficiencyGrid(metric: EfficiencyMetricDef, maxX: number): string {
+	const vertical = [0, 0.25, 0.5, 0.75, 1].map(fraction => {
+		const x = 76 + fraction * 760;
+		return `<line x1="${x}" y1="24" x2="${x}" y2="286"></line><text x="${x}" y="310" text-anchor="middle">${escapeHtml(formatMetricTick(metric, maxX * fraction))}</text>`;
+	}).join('');
+	const horizontal = [0, 0.25, 0.5, 0.75, 1].map(fraction => {
+		const y = 286 - fraction * 262;
+		return `<line x1="76" y1="${y}" x2="836" y2="${y}"></line><text x="64" y="${y + 4}" text-anchor="end">${Math.round(fraction * 100)}%</text>`;
+	}).join('');
+	return `<g class="efficiency-grid">${vertical}${horizontal}</g>`;
+}
+
+function buildEfficiencyPoint(row: EfficiencyRow, metric: EfficiencyMetricDef, maxX: number, index: number): string {
+	const value = metric.value(row) ?? 0;
+	const rate = row.rates.oneShotRate ?? 0;
+	const x = 76 + (value / maxX) * 760;
+	const y = 286 - rate * 262;
+	const color = getModelColor(row.model);
+	const labelY = y < 46 ? y + 18 : y - 10;
+	const rawLabel = getModelDisplayName(row.model);
+	const label = escapeHtml(rawLabel);
+	const aria = `${rawLabel}: ${formatRatePercent(rate)} one-shot edit rate, ${metric.format(value)} ${metric.axisLabel.toLowerCase()}`;
+	return `<g class="efficiency-point" style="--model-color:${color}" tabindex="0" role="img" aria-label="${escapeHtml(aria)}">
+		<circle cx="${x.toFixed(1)}" cy="${y.toFixed(1)}" r="${index < 3 ? 6 : 5}"><title>${escapeHtml(aria)}</title></circle>
+		<text x="${(x + 9).toFixed(1)}" y="${labelY.toFixed(1)}">${label}</text>
+	</g>`;
+}
+
+function buildEfficiencyChartHtml(rows: EfficiencyRow[]): string {
+	const metric = EFFICIENCY_METRICS.find(item => item.key === efficiencyMetric) ?? EFFICIENCY_METRICS[0];
+	const chartRows = rows.filter(row => row.rates.oneShotRate !== null && metric.value(row) !== null)
+		.sort((a, b) => b.counters.calls - a.counters.calls).slice(0, 12);
+	if (chartRows.length === 0) {
+		return '<div class="model-leaderboard-empty"><strong>No comparable edit data yet.</strong><span>The chart appears after local sessions record both a model and structured edit turns.</span></div>';
+	}
+	const maxX = Math.max(...chartRows.map(row => metric.value(row) ?? 0), 0.0001) * 1.08;
+	const points = chartRows.map((row, index) => buildEfficiencyPoint(row, metric, maxX, index)).join('');
+	return `<div class="efficiency-chart-wrap">
+		<svg class="efficiency-chart" viewBox="0 0 900 350" role="img" aria-label="One-shot edit rate compared with ${escapeHtml(metric.axisLabel.toLowerCase())}">
+			${buildEfficiencyGrid(metric, maxX)}
+			<text class="efficiency-axis-title" x="456" y="344" text-anchor="middle">${escapeHtml(metric.axisLabel)}</text>
+			<text class="efficiency-axis-title" x="17" y="155" text-anchor="middle" transform="rotate(-90 17 155)">One-shot edit rate</text>
+			<text class="efficiency-chart-hint" x="836" y="17" text-anchor="end">higher is better ↑</text>
+			${points}
+		</svg>
+	</div>`;
+}
+
+function buildMetricControlsHtml(): string {
+	const buttons = EFFICIENCY_METRICS.map(metric =>
+		`<button class="efficiency-metric-button${metric.key === efficiencyMetric ? ' active' : ''}" type="button" data-eff-metric="${metric.key}" aria-pressed="${metric.key === efficiencyMetric}">${metric.label}</button>`
+	).join('');
+	return `<div class="efficiency-metric-selector" role="group" aria-label="Efficiency comparison metric">${buttons}</div>`;
+}
+
+function buildEfficiencyTableHtml(rows: EfficiencyRow[], totalCalls: number): string {
+	const tableRows = rows.map(row => {
+		const cells = EFFICIENCY_COLUMN_DEFS.map(column => `<td>${column.render(row, totalCalls)}</td>`).join('');
+		return `<tr style="--model-color:${getModelColor(row.model)}">${cells}</tr>`;
+	}).join('');
+	const headers = EFFICIENCY_COLUMN_DEFS.map(column =>
+		`<th class="sortable" data-eff-sort="${column.sortKey}" title="${column.title}">${column.label}${getEfficiencySortIndicator(column.sortKey)}</th>`
+	).join('');
+	return `<div class="model-leaderboard-table-wrap"><table class="model-leaderboard-table"><thead><tr>${headers}</tr></thead><tbody>${tableRows}</tbody></table></div>`;
+}
+
+function buildModelEfficiencyContentHtml(): string {
 	const usage = cachedModelEfficiency[efficiencyPeriod];
 	if (!usage || Object.keys(usage).length === 0) {
-		return '<div style="color: var(--text-secondary); font-size: 13px; padding: 16px;">No per-model efficiency data recorded for this period yet.</div>';
+		return '<div class="model-leaderboard-empty"><strong>No per-model efficiency data for this period.</strong><span>Run local agent sessions with model and tool-call metadata, then refresh the dashboard.</span></div>';
 	}
-	let rows = buildEfficiencyRows(usage);
-	let hiddenNote = '';
-	if (efficiencyFilterLowUsage) {
-		const threshold = computeEfficiencyLowUsageThreshold(usage);
-		if (threshold !== null) {
-			const before = rows.length;
-			rows = rows.filter(r => r.counters.calls > threshold);
-			const hiddenCount = before - rows.length;
-			if (hiddenCount > 0) {
-				hiddenNote = `<div style="color:var(--text-secondary); font-size:11px; padding:4px 8px 2px;">${hiddenCount} model${hiddenCount === 1 ? '' : 's'} hidden (≤${threshold} turn${threshold === 1 ? '' : 's'})</div>`;
-			}
-		}
-	}
-	const tableRows = rows.map(r => {
-		const cells = EFFICIENCY_COLUMN_DEFS.map(col => {
-			const alignStyle = col.align === 'right' ? 'text-align:right;' : '';
-			return `<td style="padding:6px 8px; border-bottom:1px solid var(--border-subtle); font-size:12px; ${alignStyle}">${col.render(r)}</td>`;
-		}).join('');
-		return `<tr>${cells}</tr>`;
-	}).join('');
-	const headerCells = EFFICIENCY_COLUMN_DEFS.map(col => {
-		const alignStyle = col.align === 'right' ? ' text-align:right;' : '';
-		return `<th class="sortable" data-eff-sort="${col.sortKey}" title="${col.title}" style="padding:6px 8px; cursor:pointer;${alignStyle}">${col.label}${getEfficiencySortIndicator(col.sortKey)}</th>`;
-	}).join('');
-	return `
-		<div style="overflow-x:auto;">
-		<table style="width:100%; border-collapse:collapse; min-width:900px;">
-			<thead>
-				<tr style="color:var(--text-secondary); font-size:11px; text-align:left;">${headerCells}</tr>
-			</thead>
-			<tbody>${tableRows}</tbody>
-		</table>
-		</div>
-		${hiddenNote}`;
+	const allRows = buildEfficiencyRows(usage);
+	const totalCalls = allRows.reduce((sum, row) => sum + row.counters.calls, 0);
+	const filtered = filterLowUsageRows(allRows, usage);
+	const note = filtered.hiddenNote ? `<span class="model-leaderboard-filter-note">${filtered.hiddenNote}</span>` : '';
+	return `<div class="efficiency-chart-header"><div><strong>Efficiency frontier</strong><span>One-shot edit rate is a local quality proxy, not a benchmark pass rate.</span></div>${buildMetricControlsHtml()}</div>
+		${buildEfficiencyChartHtml(filtered.rows)}
+		<div class="model-leaderboard-heading"><div><strong>Most used models locally</strong><span>Ranked by your local turns; all averages use the same selected period.</span></div>${note}</div>
+		${buildEfficiencyTableHtml(filtered.rows, totalCalls)}`;
 }
 
 function buildModelEfficiencySectionHtml(stats: UsageAnalysisStats): string {
-	cachedModelEfficiency = {
-		today: stats.today.modelEfficiency,
-		last30Days: stats.last30Days.modelEfficiency,
-		month: stats.month.modelEfficiency,
-	};
-	return `
-		<div class="section" id="section-model-efficiency">
-			<div class="section-title"><span>🎯</span><span>Model Efficiency</span></div>
-			<div class="section-subtitle">Compare models on quality and efficiency, not just cost — one-shot edit rate, retries, self-corrections, per-turn cost, and cache hit rate. Retry/self-correction detection needs structured tool-call data, so some editors show token metrics only.</div>
-			<div id="model-efficiency-controls" style="display:flex; gap:6px; flex-wrap:wrap; margin:8px 0;"><span id="model-efficiency-period-selector"></span></div>
-			<div style="margin:2px 0 8px 0;">
-				<label style="display:inline-flex; align-items:center; gap:6px; font-size:12px; color:var(--text-secondary); cursor:pointer;" title="Shows only models above the 25th-percentile turn count (Q1). Uncheck to see all models.">
-					<input type="checkbox" id="eff-filter-low-usage"${efficiencyFilterLowUsage ? ' checked' : ''} style="cursor:pointer;">
-					Hide low-usage models
-				</label>
-			</div>
-			<div id="model-efficiency-table">${buildModelEfficiencyTableHtml()}</div>
-		</div>`;
+	cachedModelEfficiency = { today: stats.today.modelEfficiency, last30Days: stats.last30Days.modelEfficiency, month: stats.month.modelEfficiency };
+	return `<div class="section" id="section-model-efficiency">
+		<div class="section-title"><span>🎯</span><span>Local Model Leaderboard</span></div>
+		<div class="section-subtitle">Compare the models in your own sessions by local usage, one-shot edits, cost, output tokens, and tool steps. Exactness depends on what each editor records; missing structured data is shown as unavailable rather than estimated.</div>
+		<div class="model-leaderboard-controls">
+			<span id="model-efficiency-period-selector"></span>
+			<label class="model-leaderboard-filter" title="Show only models above the 25th-percentile local turn count.">
+				<input type="checkbox" id="eff-filter-low-usage"${efficiencyFilterLowUsage ? ' checked' : ''}>
+				Hide low-usage models
+			</label>
+		</div>
+		<div id="model-efficiency-content">${buildModelEfficiencyContentHtml()}</div>
+	</div>`;
 }
 
 function renderModelEfficiencyPeriodSelector(): void {
@@ -4483,43 +4567,48 @@ function renderModelEfficiencyPeriodSelector(): void {
 			if (!dataKey) { return; }
 			efficiencySelectedPeriod = value as Period;
 			efficiencyPeriod = dataKey;
-			rerenderModelEfficiencyTable();
+			rerenderModelEfficiencyContent();
 		},
 	});
 	wrapper.append(selectorWrapper);
 }
 
-function rerenderModelEfficiencyTable(): void {
-	const table = document.getElementById('model-efficiency-table');
-	if (table) { setHtml(table, buildModelEfficiencyTableHtml()); }
+function rerenderModelEfficiencyContent(): void {
+	const content = document.getElementById('model-efficiency-content');
+	if (content) { setHtml(content, buildModelEfficiencyContentHtml()); }
 }
 
 function handleEfficiencySortClick(th: HTMLElement): void {
-	const col = th.getAttribute('data-eff-sort') as EfficiencySortColumn | null;
-	if (!col) { return; }
-	if (efficiencySortColumn === col) {
+	const column = th.getAttribute('data-eff-sort') as EfficiencySortColumn | null;
+	if (!column) { return; }
+	if (efficiencySortColumn === column) {
 		efficiencySortDirection = efficiencySortDirection === 'desc' ? 'asc' : 'desc';
 	} else {
-		efficiencySortColumn = col;
-		efficiencySortDirection = col === 'model' ? 'asc' : 'desc';
+		efficiencySortColumn = column;
+		efficiencySortDirection = column === 'model' ? 'asc' : 'desc';
 	}
-	rerenderModelEfficiencyTable();
+	rerenderModelEfficiencyContent();
 }
 
-/** Wires sortable headers and the low-usage filter for the Model Efficiency section (delegated, survives table re-renders). */
+/** Wires sortable headers, metric selection, and the low-usage filter. */
 function setupModelEfficiencySection(): void {
 	const section = document.getElementById('section-model-efficiency');
 	if (!section) { return; }
-	section.addEventListener('click', (e) => {
-		const target = e.target as HTMLElement;
-		const th = target.closest<HTMLElement>('th[data-eff-sort]');
-		if (th) { handleEfficiencySortClick(th); }
+	section.addEventListener('click', (event) => {
+		const target = event.target as HTMLElement;
+		const header = target.closest<HTMLElement>('th[data-eff-sort]');
+		if (header) { handleEfficiencySortClick(header); return; }
+		const metric = target.closest<HTMLButtonElement>('button[data-eff-metric]')?.dataset.effMetric as EfficiencyMetricKey | undefined;
+		if (metric && EFFICIENCY_METRICS.some(item => item.key === metric)) {
+			efficiencyMetric = metric;
+			rerenderModelEfficiencyContent();
+		}
 	});
-	section.addEventListener('change', (e) => {
-		const target = e.target as HTMLInputElement;
+	section.addEventListener('change', (event) => {
+		const target = event.target as HTMLInputElement;
 		if (target.id === 'eff-filter-low-usage') {
 			efficiencyFilterLowUsage = target.checked;
-			rerenderModelEfficiencyTable();
+			rerenderModelEfficiencyContent();
 		}
 	});
 }

--- a/vscode-extension/src/webview/usage/styles.css
+++ b/vscode-extension/src/webview/usage/styles.css
@@ -218,6 +218,291 @@ body {
 	transition: width 0.3s ease;
 }
 
+/* Local model leaderboard */
+.model-leaderboard-controls,
+.efficiency-chart-header,
+.model-leaderboard-heading {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px;
+	flex-wrap: wrap;
+}
+
+.model-leaderboard-controls {
+	margin: 8px 0 14px;
+}
+
+.model-leaderboard-filter {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	color: var(--text-secondary);
+	font-size: 12px;
+	cursor: pointer;
+}
+
+.model-leaderboard-filter input {
+	accent-color: var(--link-color);
+}
+
+.efficiency-chart-header,
+.model-leaderboard-heading {
+	margin: 14px 2px 8px;
+}
+
+.efficiency-chart-header > div:first-child,
+.model-leaderboard-heading > div:first-child,
+.model-leaderboard-empty {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+}
+
+.efficiency-chart-header strong,
+.model-leaderboard-heading strong,
+.model-leaderboard-empty strong {
+	font-size: 13px;
+	color: var(--text-primary);
+}
+
+.efficiency-chart-header span,
+.model-leaderboard-heading span,
+.model-leaderboard-empty span {
+	font-size: 11px;
+	color: var(--text-secondary);
+}
+
+.efficiency-metric-selector {
+	display: inline-flex;
+	border: 1px solid var(--border-color);
+	border-radius: 5px;
+	overflow: hidden;
+}
+
+.efficiency-metric-button {
+	border: 0;
+	border-right: 1px solid var(--border-color);
+	background: var(--button-secondary-bg);
+	color: var(--button-secondary-fg);
+	padding: 5px 10px;
+	font: inherit;
+	font-size: 11px;
+	cursor: pointer;
+	transition: background-color 0.15s ease, color 0.15s ease;
+}
+
+.efficiency-metric-button:last-child {
+	border-right: 0;
+}
+
+.efficiency-metric-button:hover {
+	background: var(--button-secondary-hover-bg);
+}
+
+.efficiency-metric-button.active {
+	background: var(--button-bg);
+	color: var(--button-fg);
+}
+
+.efficiency-metric-button:focus-visible,
+.efficiency-point:focus {
+	outline: 2px solid var(--focus-border);
+	outline-offset: -2px;
+}
+
+.efficiency-chart-wrap {
+	overflow-x: auto;
+	border: 1px solid var(--border-color);
+	background: var(--list-hover-bg);
+	border-radius: 6px;
+}
+
+.efficiency-chart {
+	display: block;
+	width: 100%;
+	min-width: 700px;
+	min-height: 300px;
+}
+
+.efficiency-grid line {
+	stroke: var(--border-subtle);
+	stroke-width: 1;
+}
+
+.efficiency-grid text,
+.efficiency-axis-title,
+.efficiency-chart-hint,
+.efficiency-point text {
+	fill: var(--text-secondary);
+	font-family: inherit;
+	font-size: 10px;
+}
+
+.efficiency-axis-title {
+	font-size: 11px;
+	font-weight: 600;
+}
+
+.efficiency-chart-hint {
+	fill: var(--success-fg);
+	font-style: italic;
+}
+
+.efficiency-point {
+	cursor: default;
+}
+
+.efficiency-point circle {
+	fill: var(--model-color);
+	stroke: var(--bg-tertiary);
+	stroke-width: 2;
+	transition: r 0.15s ease;
+}
+
+.efficiency-point:hover circle,
+.efficiency-point:focus circle {
+	r: 8px;
+}
+
+.efficiency-point text {
+	fill: var(--model-color);
+	font-size: 10px;
+	font-weight: 600;
+	paint-order: stroke;
+	stroke: var(--bg-tertiary);
+	stroke-width: 3px;
+	stroke-linejoin: round;
+}
+
+.model-leaderboard-filter-note {
+	color: var(--text-muted);
+	font-size: 11px;
+}
+
+.model-leaderboard-table-wrap {
+	overflow-x: auto;
+	border: 1px solid var(--border-color);
+	border-radius: 6px;
+}
+
+.model-leaderboard-table {
+	width: 100%;
+	min-width: 940px;
+	border-collapse: collapse;
+	font-size: 12px;
+	font-variant-numeric: tabular-nums;
+}
+
+.model-leaderboard-table th,
+.model-leaderboard-table td {
+	padding: 8px 10px;
+	text-align: right;
+	border-bottom: 1px solid var(--border-subtle);
+	white-space: nowrap;
+}
+
+.model-leaderboard-table th:first-child,
+.model-leaderboard-table td:first-child,
+.model-leaderboard-table th:nth-child(2),
+.model-leaderboard-table td:nth-child(2) {
+	text-align: left;
+}
+
+.model-leaderboard-table th {
+	color: var(--text-secondary);
+	background: var(--bg-tertiary);
+	font-size: 11px;
+	font-weight: 600;
+}
+
+.model-leaderboard-table th.sortable {
+	cursor: pointer;
+	user-select: none;
+}
+
+.model-leaderboard-table th.sortable:hover {
+	color: var(--link-color);
+	background: var(--list-hover-bg);
+}
+
+.model-leaderboard-table tbody tr:last-child td {
+	border-bottom: 0;
+}
+
+.model-leaderboard-table tbody tr:hover td {
+	background: var(--list-hover-bg);
+}
+
+.model-leaderboard-table td:first-child {
+	color: var(--text-primary);
+	font-weight: 600;
+}
+
+.model-leaderboard-table td:first-child::before {
+	content: "";
+	display: inline-block;
+	width: 7px;
+	height: 7px;
+	margin-right: 7px;
+	border-radius: 50%;
+	background: var(--model-color);
+}
+
+.model-use-cell {
+	display: grid;
+	grid-template-columns: 82px 42px auto;
+	align-items: center;
+	gap: 7px;
+}
+
+.model-use-track {
+	height: 6px;
+	overflow: hidden;
+	background: var(--row-alternate-bg);
+	border-radius: 3px;
+}
+
+.model-use-track span {
+	display: block;
+	height: 100%;
+	background: var(--model-color);
+	border-radius: inherit;
+}
+
+.model-use-cell strong {
+	color: var(--text-primary);
+	text-align: right;
+}
+
+.model-use-cell > span {
+	color: var(--text-secondary);
+	font-size: 11px;
+}
+
+.model-leaderboard-empty {
+	align-items: flex-start;
+	padding: 18px;
+	border: 1px dashed var(--border-color);
+	border-radius: 6px;
+	background: var(--list-hover-bg);
+}
+
+@media (width <= 768px) {
+	.efficiency-chart-header,
+	.model-leaderboard-heading {
+		align-items: flex-start;
+	}
+
+	.efficiency-metric-selector {
+		width: 100%;
+	}
+
+	.efficiency-metric-button {
+		flex: 1;
+	}
+}
+
 .list {
 	background: var(--list-hover-bg);
 	border: 1px solid var(--border-color);

--- a/vscode-extension/test/unit/modelEfficiency.test.ts
+++ b/vscode-extension/test/unit/modelEfficiency.test.ts
@@ -82,6 +82,7 @@ test('computeEfficiencyFromTurns: one-shot edit turn counts as one-shot', () => 
     assert.equal(c.retries, 0);
     assert.equal(c.selfCorrections, 0);
     assert.equal(c.editToolCalls, 2);
+    assert.equal(c.toolCalls, 3);
 });
 
 test('computeEfficiencyFromTurns: consecutive same-file edits count as retries', () => {
@@ -187,13 +188,14 @@ test('jsonRequestToToolCalls: handles missing response gracefully', () => {
 
 test('mergeModelEfficiency: sums counters per model and creates missing entries', () => {
     const target: ModelEfficiencyUsage = {
-        'gpt-4o': { ...createEmptyModelEfficiencyCounters(), calls: 2, editTurns: 1, oneShotEditTurns: 1 },
+        'gpt-4o': { ...createEmptyModelEfficiencyCounters(), calls: 2, toolCalls: 5, editTurns: 1, oneShotEditTurns: 1 },
     };
     mergeModelEfficiency(target, {
-        'gpt-4o': { ...createEmptyModelEfficiencyCounters(), calls: 3, editTurns: 2, retries: 1 },
-        'claude-sonnet-4.5': { ...createEmptyModelEfficiencyCounters(), calls: 1 },
+        'gpt-4o': { ...createEmptyModelEfficiencyCounters(), calls: 3, toolCalls: 7, editTurns: 2, retries: 1 },
+        'claude-sonnet-4.5': { ...createEmptyModelEfficiencyCounters(), calls: 1, toolCalls: 2 },
     });
     assert.equal(target['gpt-4o'].calls, 5);
+    assert.equal(target['gpt-4o'].toolCalls, 12);
     assert.equal(target['gpt-4o'].editTurns, 3);
     assert.equal(target['gpt-4o'].oneShotEditTurns, 1);
     assert.equal(target['gpt-4o'].retries, 1);
@@ -232,7 +234,7 @@ test('applyModelUsageToEfficiency: folds tokens and estimated cost into counters
 test('deriveModelEfficiencyRates: computes all rates from counters', () => {
     const rates = deriveModelEfficiencyRates({
         calls: 10, editTurns: 4, oneShotEditTurns: 3, retries: 2, selfCorrections: 1,
-        editToolCalls: 7, inputTokens: 1000, outputTokens: 500, cachedReadTokens: 800, cost: 2,
+        toolCalls: 25, editToolCalls: 7, inputTokens: 1000, outputTokens: 500, cachedReadTokens: 800, cost: 2,
     });
     assert.equal(rates.oneShotRate, 0.75);
     assert.equal(rates.retryRate, 0.5);
@@ -240,6 +242,7 @@ test('deriveModelEfficiencyRates: computes all rates from counters', () => {
     assert.equal(rates.costPerCall, 0.2);
     assert.equal(rates.costPerEdit, 0.5);
     assert.equal(rates.outputTokensPerCall, 50);
+    assert.equal(rates.toolCallsPerCall, 2.5);
     assert.equal(rates.cacheHitRate, 0.8);
 });
 
@@ -251,6 +254,7 @@ test('deriveModelEfficiencyRates: zero denominators produce nulls', () => {
     assert.equal(rates.costPerCall, null);
     assert.equal(rates.costPerEdit, null);
     assert.equal(rates.outputTokensPerCall, null);
+    assert.equal(rates.toolCallsPerCall, null);
     assert.equal(rates.cacheHitRate, null);
 });
 
@@ -258,7 +262,7 @@ test('deriveModelEfficiencyRates: cacheHitRate is capped at 1.0 when cachedReadT
     // Some providers (e.g. DeepSeek) report cachedReadTokens > inputTokens; cap at 100%.
     const rates = deriveModelEfficiencyRates({
         calls: 5, editTurns: 0, oneShotEditTurns: 0, retries: 0, selfCorrections: 0,
-        editToolCalls: 0, inputTokens: 100, outputTokens: 200, cachedReadTokens: 3000, cost: 0,
+        toolCalls: 0, editToolCalls: 0, inputTokens: 100, outputTokens: 200, cachedReadTokens: 3000, cost: 0,
     });
     assert.equal(rates.cacheHitRate, 1);
 });
@@ -347,8 +351,8 @@ test('accumulateDailyModelCounters: splits duration and LOC by token share, summ
             'gpt-5.5': { inputTokens: 150, outputTokens: 50, sessions: 1 },
         },
         modelEfficiency: {
-            'kimi-k3': counters({ calls: 8, editTurns: 5, retries: 2, oneShotEditTurns: 3 }),
-            'gpt-5.5': counters({ calls: 2, editTurns: 1, oneShotEditTurns: 1 }),
+            'kimi-k3': counters({ calls: 8, toolCalls: 42, editTurns: 5, retries: 2, oneShotEditTurns: 3 }),
+            'gpt-5.5': counters({ calls: 2, toolCalls: 6, editTurns: 1, oneShotEditTurns: 1 }),
         },
         activeDurationMs: 600_000,
         linesAdded: 100,
@@ -359,6 +363,7 @@ test('accumulateDailyModelCounters: splits duration and LOC by token share, summ
 
     // Turn counters are exact per model — never split.
     assert.equal(daily['kimi-k3'].editTurns, 5);
+    assert.equal(daily['kimi-k3'].toolCalls, 42);
     assert.equal(daily['kimi-k3'].retries, 2);
     assert.equal(daily['gpt-5.5'].editTurns, 1);
 
@@ -423,13 +428,14 @@ test('mergeDailyModelEfficiency: sums every field when rolling days into a windo
     const b: DailyModelEfficiency = {};
     const input = {
         modelUsage: { m: { inputTokens: 100, outputTokens: 0, sessions: 1 } },
-        modelEfficiency: { m: counters({ calls: 2, editTurns: 1, retries: 1 }) },
+        modelEfficiency: { m: counters({ calls: 2, toolCalls: 7, editTurns: 1, retries: 1 }) },
         activeDurationMs: 1000, linesAdded: 10, applies: 2, codeBlocks: 4,
     };
     accumulateDailyModelCounters(a, input);
     accumulateDailyModelCounters(b, input);
     mergeDailyModelEfficiency(a, b);
     assert.equal(a['m'].calls, 4);
+    assert.equal(a['m'].toolCalls, 14);
     assert.equal(a['m'].retries, 2);
     assert.equal(a['m'].sessionShare, 2);
     assert.equal(a['m'].activeDurationMs, 2000);


### PR DESCRIPTION
## Summary

- add a DeepSWE-inspired local efficiency frontier to Usage Analysis
- compare one-shot edit rate against average cost, output tokens, or tool steps per turn
- rank the most-used local models with usage share, retry, self-correction, cost, token, step, and cache metrics
- aggregate tool invocations per model and preserve compatibility with older cached counters
- add fixture coverage for headless light/dark rendering

## Notes

One-shot edit rate is explicitly presented as a local quality proxy, not a benchmark pass rate. Models without the structured data required for a metric are shown as unavailable.

## Validation

- `npm run test:node`
- `npm run compile`
- model-efficiency focused unit tests
- headless usage-view visual diff in dark and light themes