### PR TITLE
Fix dropped extension-to-webview messages

### DIFF
--- a/vscode-extension/src/webview/shared/messageHandler.ts
+++ b/vscode-extension/src/webview/shared/messageHandler.ts
@@ -6,17 +6,22 @@
  *     switch (message.type) { ... }
  *   });
  *
- * VS Code webviews load content from a `vscode-webview://` origin and only the
- * extension host (via `webview.postMessage`) can post to `window` from that
- * context, but we still verify `event.source === window` so a handler never
- * acts on a message that was somehow posted by embedded/child content (e.g. an
- * iframe) rather than the top-level webview window itself.
+ * VS Code delivers extension-host messages with a null `event.source`. Browser
+ * messages sent by the webview itself use `window`; messages from child frames
+ * have a different, non-null source and are rejected.
  */
 type MessageHandler<T> = (message: T) => void;
 
+export function isTrustedWebviewMessageSource(
+    source: MessageEventSource | null,
+    currentWindow: Window,
+): boolean {
+    return source === null || source === currentWindow;
+}
+
 export function registerMessageHandler<T>(handler: MessageHandler<T>): void {
     window.addEventListener("message", (event: MessageEvent<T>) => {
-        if (event.source !== window) {
+        if (!isTrustedWebviewMessageSource(event.source, window)) {
             return;
         }
         handler(event.data);

--- a/vscode-extension/test/unit/webview-messageHandler.test.ts
+++ b/vscode-extension/test/unit/webview-messageHandler.test.ts
@@ -1,0 +1,40 @@
+/// <reference path="../../src/types/jsdom.d.ts" />
+import { test } from 'node:test';
+import * as assert from 'node:assert/strict';
+import { JSDOM } from 'jsdom';
+import { isTrustedWebviewMessageSource } from '../../src/webview/shared/messageHandler';
+
+test('accepts extension-host messages with a null source', () => {
+	const dom = new JSDOM();
+	try {
+		assert.equal(isTrustedWebviewMessageSource(null, dom.window as unknown as Window), true);
+	} finally {
+		dom.window.close();
+	}
+});
+
+test('accepts messages from the top-level webview window', () => {
+	const dom = new JSDOM();
+	try {
+		assert.equal(
+			isTrustedWebviewMessageSource(dom.window, dom.window as unknown as Window),
+			true,
+		);
+	} finally {
+		dom.window.close();
+	}
+});
+
+test('rejects messages from a child frame', () => {
+	const dom = new JSDOM('<iframe></iframe>');
+	try {
+		const childWindow = dom.window.document.querySelector('iframe')?.contentWindow;
+		assert.ok(childWindow);
+		assert.equal(
+			isTrustedWebviewMessageSource(childWindow, dom.window as unknown as Window),
+			false,
+		);
+	} finally {
+		dom.window.close();
+	}
+});


### PR DESCRIPTION
VS Code delivers extension-host messages to webviews with a null `MessageEvent.source`. The shared message handler required `event.source === window`, so it silently dropped Repository PR progress, Cloud Agent results, and other extension-to-webview updates.

This change accepts the null source used by VS Code and the top-level webview window while continuing to reject messages from child frames. Regression tests cover all three cases.