### PR TITLE
Fix correction insight accuracy

### DIFF
--- a/src/correctionDetection.ts
+++ b/src/correctionDetection.ts
@@ -59,7 +59,7 @@ interface CorrectionPattern {
 
 /** User-message phrasings that indicate the user is correcting the agent. */
 export const USER_CORRECTION_PATTERNS: CorrectionPattern[] = [
-	{ re: /^\s*(no[,.! ]|nope\b)/i, label: "starts with 'no'" },
+	{ re: /^\s*(no[,.!](?:\s|$)|nope\b)/i, label: "starts with 'no'" },
 	{ re: /\bthat'?s (not|wrong|incorrect)/i, label: "'that's not/wrong/incorrect'" },
 	{ re: /\bnot what i (asked|meant|wanted)/i, label: "'not what I asked/meant/wanted'" },
 	{ re: /\byou('?re| are) wrong/i, label: "'you're wrong'" },
@@ -115,11 +115,35 @@ function matchPattern(text: string | undefined, patterns: CorrectionPattern[]): 
  * Detect edit retries and edit self-corrections in one turn's ordered tool
  * calls, mirroring the definitions in modelEfficiency.analyzeTurnToolCalls.
  */
+export interface CorrectionDetectionResult {
+	moments: CorrectionMoment[];
+	counts: CorrectionCounts;
+}
+
+interface CorrectionDetectionState extends CorrectionDetectionResult {
+	openToolErrors: Map<string, CorrectionMoment>;
+}
+
+function retainMoment(state: CorrectionDetectionState, moment: CorrectionMoment): void {
+	addMomentToCounts(state.counts, moment);
+	if (state.moments.length < MAX_MOMENTS_PER_SESSION) {
+		state.moments.push(moment);
+		return;
+	}
+	if (moment.type !== 'user-correction') { return; }
+	for (let i = state.moments.length - 1; i >= 0; i--) {
+		if (state.moments[i].type !== 'user-correction') {
+			state.moments[i] = moment;
+			return;
+		}
+	}
+}
+
 function detectEditMoments(
 	toolCalls: NonNullable<CorrectionTurn['toolCalls']>,
 	turnNumber: number,
 	timestamp: string | null,
-	moments: CorrectionMoment[]
+	state: CorrectionDetectionState
 ): void {
 	const editedFiles = new Set<string>();
 	let lastEditFile: string | null = null;
@@ -135,7 +159,7 @@ function detectEditMoments(
 		// produce false retry/self-correction positives (same as modelEfficiency).
 		const key = file ?? `-${unknownPathCounter++}`;
 		if (editedFiles.has(key)) {
-			moments.push({
+			retainMoment(state, {
 				type: lastEditFile === key ? 'edit-retry' : 'edit-self-correction',
 				turnNumber,
 				timestamp,
@@ -152,20 +176,21 @@ function detectEditMoments(
  * Detect all correction moments in a session's turns.
  * Turn numbers are 1-based array positions, matching ChatTurn.turnNumber.
  */
-export function detectCorrectionMoments(turns: CorrectionTurn[]): CorrectionMoment[] {
-	const moments: CorrectionMoment[] = [];
-	// toolName -> index into moments of the most recent un-retried tool-error.
-	const openToolErrors = new Map<string, number>();
+export function detectCorrectionAnalysis(turns: CorrectionTurn[]): CorrectionDetectionResult {
+	const state: CorrectionDetectionState = {
+		moments: [],
+		counts: createEmptyCorrectionCounts(),
+		openToolErrors: new Map(),
+	};
 
 	for (let i = 0; i < turns.length; i++) {
-		if (moments.length >= MAX_MOMENTS_PER_SESSION) { break; }
 		const turn = turns[i];
 		const turnNumber = i + 1;
 		const timestamp = turn.timestamp ?? null;
 
 		const userMatch = matchPattern(turn.userMessage, USER_CORRECTION_PATTERNS);
 		if (userMatch) {
-			moments.push({
+			retainMoment(state, {
 				type: 'user-correction', turnNumber, timestamp,
 				snippet: makeSnippet(turn.userMessage!, userMatch.index),
 				matchedPattern: userMatch.label,
@@ -174,7 +199,7 @@ export function detectCorrectionMoments(turns: CorrectionTurn[]): CorrectionMome
 
 		const agentMatch = matchPattern(turn.assistantResponse, AGENT_SELF_CORRECTION_PATTERNS);
 		if (agentMatch) {
-			moments.push({
+			retainMoment(state, {
 				type: 'agent-self-correction', turnNumber, timestamp,
 				snippet: makeSnippet(turn.assistantResponse!, agentMatch.index),
 				matchedPattern: agentMatch.label,
@@ -184,28 +209,33 @@ export function detectCorrectionMoments(turns: CorrectionTurn[]): CorrectionMome
 		const toolCalls = turn.toolCalls ?? [];
 		for (const call of toolCalls) {
 			// A later call of the same tool marks an earlier failure as recovered.
-			const openIdx = openToolErrors.get(call.toolName);
-			if (openIdx !== undefined) {
-				moments[openIdx].retried = true;
-				openToolErrors.delete(call.toolName);
+			const openError = state.openToolErrors.get(call.toolName);
+			if (openError) {
+				openError.retried = true;
+				state.counts.toolErrorsRetried++;
+				state.openToolErrors.delete(call.toolName);
 			}
 			if (call.isError === true) {
-				moments.push({
+				const moment: CorrectionMoment = {
 					type: 'tool-error', turnNumber, timestamp,
 					snippet: `Tool failed: ${call.toolName}`,
 					tool: call.toolName,
 					retried: false,
-				});
-				openToolErrors.set(call.toolName, moments.length - 1);
+				};
+				retainMoment(state, moment);
+				state.openToolErrors.set(call.toolName, moment);
 			}
 		}
 
-		detectEditMoments(toolCalls, turnNumber, timestamp, moments);
+		detectEditMoments(toolCalls, turnNumber, timestamp, state);
 	}
 
-	// A single turn can push past the cap (the loop-level check is only a
-	// performance guard), so trim to the first MAX_MOMENTS_PER_SESSION here.
-	return moments.slice(0, MAX_MOMENTS_PER_SESSION);
+	state.moments.sort((a, b) => a.turnNumber - b.turnNumber);
+	return { moments: state.moments, counts: state.counts };
+}
+
+export function detectCorrectionMoments(turns: CorrectionTurn[]): CorrectionMoment[] {
+	return detectCorrectionAnalysis(turns).moments;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/types.ts
+++ b/src/types.ts
@@ -446,6 +446,8 @@ export interface SessionUsageAnalysis {
    * per-turn detail or no moments were found.
    */
   correctionMoments?: CorrectionMoment[];
+  /** Complete correction counts; unlike correctionMoments, these are not detail-capped. */
+  correctionCounts?: CorrectionCounts;
   /**
    * The session's first user prompt (truncated), captured for repeated-task
    * detection (see src/repeatedTasks.ts). Absent when the session format
@@ -607,6 +609,8 @@ export interface CorrectionCounts {
 /** Period-level correction counters plus the number of sessions that had any moment. */
 export interface CorrectionPeriodCounts extends CorrectionCounts {
   sessionsWithMoments: number;
+  /** Sessions containing at least one user-correction moment. */
+  sessionsWithUserCorrections?: number;
 }
 
 /** One session's entry in the correction report. */
@@ -615,6 +619,8 @@ export interface CorrectionSessionEntry {
   title?: string | null;
   lastInteraction?: string | null;
   moments: CorrectionMoment[];
+  /** Complete count before correctionMoments is detail-capped. */
+  totalMoments?: number;
 }
 
 /** Correction moments for one repository, over its most recent sessions. */

--- a/src/usageAnalysis.ts
+++ b/src/usageAnalysis.ts
@@ -29,7 +29,7 @@ import {
 	applyModelUsageToEfficiency,
 	type EfficiencyTurn,
 } from './modelEfficiency';
-import { detectCorrectionMoments, mergeCorrectionCounts, summarizeCorrectionMoments } from './correctionDetection';
+import { detectCorrectionAnalysis, mergeCorrectionCounts, summarizeCorrectionMoments } from './correctionDetection';
 import { MAX_PROMPT_LENGTH } from './repeatedTasks';
 
 /** Store the session's first user prompt (truncated) for repeated-task detection. */
@@ -754,8 +754,14 @@ function _applyJsonRequestsEfficiency(
 	if (turns.length === 0) { return; }
 	analysis.modelEfficiency = computeEfficiencyFromTurns(turns);
 	_setFirstUserPrompt(analysis, turns.find(t => t.userMessage)?.userMessage);
-	const moments = detectCorrectionMoments(turns);
-	if (moments.length > 0) { analysis.correctionMoments = moments; }
+	_setCorrectionDetection(analysis, turns);
+}
+
+function _setCorrectionDetection(analysis: SessionUsageAnalysis, turns: EfficiencyTurn[]): void {
+	const detection = detectCorrectionAnalysis(turns);
+	if (detection.moments.length === 0) { return; }
+	analysis.correctionMoments = detection.moments;
+	analysis.correctionCounts = detection.counts;
 }
 
 /** Concatenate the non-thinking text of a JSON request's response items (correction detection only). */
@@ -1211,10 +1217,12 @@ export function mergeUsageAnalysis(period: UsageAnalysisPeriod, analysis: Sessio
 function _muaMergeCorrections(period: UsageAnalysisPeriod, analysis: SessionUsageAnalysis): void {
 	if (!analysis.correctionMoments || analysis.correctionMoments.length === 0) { return; }
 	if (!period.corrections) {
-		period.corrections = { userCorrections: 0, editRetries: 0, editSelfCorrections: 0, toolErrors: 0, toolErrorsRetried: 0, agentSelfCorrections: 0, sessionsWithMoments: 0 };
+		period.corrections = { userCorrections: 0, editRetries: 0, editSelfCorrections: 0, toolErrors: 0, toolErrorsRetried: 0, agentSelfCorrections: 0, sessionsWithMoments: 0, sessionsWithUserCorrections: 0 };
 	}
-	mergeCorrectionCounts(period.corrections, summarizeCorrectionMoments(analysis.correctionMoments));
+	const counts = analysis.correctionCounts ?? summarizeCorrectionMoments(analysis.correctionMoments);
+	mergeCorrectionCounts(period.corrections, counts);
 	period.corrections.sessionsWithMoments++;
+	if (counts.userCorrections > 0) { period.corrections.sessionsWithUserCorrections!++; }
 }
 
 /** @internal lookup table for analyzeContextReferences */
@@ -2142,12 +2150,21 @@ export function extractInvokedSkillNameFromPlainText(content: unknown): string |
 	return m ? m[1] : null;
 }
 
-/** Create the efficiency turn for a user.message event (with text for correction detection). */
+function _asuCorrectionUserMessage(event: any): string | undefined {
+	const content = event.data?.content;
+	if (typeof content !== 'string') { return undefined; }
+	const source = event.data?.source;
+	const generated = (typeof source === 'string' && (source.startsWith('skill-') || source.startsWith('agent-')))
+		|| /^\s*<(?:skill-context|cross_session_message|system_(?:notification|reminder))\b/i.test(content);
+	return generated ? undefined : content;
+}
+
+/** Create the efficiency turn for a user.message event (with human text for correction detection). */
 function _asuCreateEfficiencyTurn(event: any, cliState: AsuCliState): EfficiencyTurn {
 	return {
 		model: event.model || cliState.defaultModel,
 		toolCalls: [],
-		userMessage: typeof event.data?.content === 'string' ? event.data.content : undefined,
+		userMessage: _asuCorrectionUserMessage(event),
 		timestamp: typeof event.timestamp === 'string' ? event.timestamp : null,
 	};
 }
@@ -2357,8 +2374,7 @@ async function _asuProcessNonDeltaJsonl(
 	if (cliState.efficiencyTurns.length > 0) {
 		analysis.modelEfficiency = computeEfficiencyFromTurns(cliState.efficiencyTurns);
 		_setFirstUserPrompt(analysis, cliState.efficiencyTurns.find(t => t.userMessage)?.userMessage);
-		const moments = detectCorrectionMoments(cliState.efficiencyTurns);
-		if (moments.length > 0) { analysis.correctionMoments = moments; }
+		_setCorrectionDetection(analysis, cliState.efficiencyTurns);
 	}
 	await calculateModelSwitching(deps, sessionFile, analysis, fileContent);
 	// Track LOC/edit metrics for CLI sessions (delta path already handles this above)
@@ -2372,7 +2388,7 @@ async function _asuProcessNonDeltaJsonl(
  * already provided them. Efficiency is optional — never fail analysis over it.
  */
 async function _addTurnEfficiencyFromAdapter(eco: IEcosystemAdapter, sessionFile: string, analysis: SessionUsageAnalysis): Promise<void> {
-	if (analysis.modelEfficiency && analysis.correctionMoments && analysis.firstUserPrompt) { return; }
+	if (analysis.modelEfficiency && analysis.correctionMoments && analysis.correctionCounts && analysis.firstUserPrompt) { return; }
 	if (!eco.buildTurns) { return; }
 	try {
 		const { turns } = await eco.buildTurns(sessionFile);
@@ -2381,8 +2397,7 @@ async function _addTurnEfficiencyFromAdapter(eco: IEcosystemAdapter, sessionFile
 			if (Object.keys(eff).length > 0) { analysis.modelEfficiency = eff; }
 		}
 		if (!analysis.correctionMoments) {
-			const moments = detectCorrectionMoments(turns);
-			if (moments.length > 0) { analysis.correctionMoments = moments; }
+			_setCorrectionDetection(analysis, turns);
 		}
 		_setFirstUserPrompt(analysis, turns.find(t => t.userMessage)?.userMessage);
 	} catch { /* efficiency and correction moments are optional */ }
@@ -2815,6 +2830,4 @@ export async function getModelUsageFromSession(deps: Pick<UsageAnalysisDeps, 'wa
 	}
 	return modelUsage;
 }
-
-
 

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -70,6 +70,7 @@ import type {
   EvaluatedInsight,
   InsightStateBag,
   ToolCurationAnalysis,
+  CorrectionCounts,
   CorrectionReport,
   CorrectionRepoGroup,
   CorrectionSessionEntry,
@@ -445,7 +446,7 @@ type UsageAnalysisTab = 'activity' | 'tools' | 'health' | 'worktrees' | 'insight
 
 class CopilotTokenTracker implements vscode.Disposable {
 	// Cache version - increment this when making changes that require cache invalidation
-	private static readonly CACHE_VERSION = 68; // per-model tool-call counters for the local model leaderboard
+	private static readonly CACHE_VERSION = 69; // uncapped correction counts and generated-message filtering
 	// Maximum length for displaying workspace IDs in diagnostics/customization matrix
 	private static readonly WORKSPACE_ID_DISPLAY_LENGTH = 8;
 	private static readonly SEEN_EDITORS_STATE_KEY = 'discovery.seenEditors';
@@ -4400,21 +4401,33 @@ class CopilotTokenTracker implements vscode.Disposable {
 		let sessionsWithMoments = 0;
 		for (const [repository, entries] of [...byRepo.entries()].sort((a, b) => a[0].localeCompare(b[0]))) {
 			entries.sort((a, b) => b.mtime - a.mtime);
-			const sessions: CorrectionSessionEntry[] = entries
-				.slice(0, CopilotTokenTracker.CORRECTION_SCAN_SESSIONS_PER_REPO)
+			const selectedEntries = entries.slice(0, CopilotTokenTracker.CORRECTION_SCAN_SESSIONS_PER_REPO);
+			const sessions: CorrectionSessionEntry[] = selectedEntries
 				.map(e => ({
 					file: e.sessionFile,
 					title: e.sessionData.title ?? null,
 					lastInteraction: e.sessionData.lastInteraction ?? null,
 					moments: e.sessionData.usageAnalysis!.correctionMoments!,
+					totalMoments: this.correctionMomentCount(
+						e.sessionData.usageAnalysis!.correctionCounts
+							?? _summarizeCorrectionMoments(e.sessionData.usageAnalysis!.correctionMoments!)
+					),
 				}));
 			const counts = _createEmptyCorrectionCounts();
-			for (const s of sessions) { _mergeCorrectionCounts(counts, _summarizeCorrectionMoments(s.moments)); }
+			for (const entry of selectedEntries) {
+				const analysis = entry.sessionData.usageAnalysis!;
+				_mergeCorrectionCounts(counts, analysis.correctionCounts ?? _summarizeCorrectionMoments(analysis.correctionMoments!));
+			}
 			_mergeCorrectionCounts(totals, counts);
 			sessionsWithMoments += sessions.length;
 			repos.push({ repository, sessions, counts, sessionsWithMoments: sessions.length });
 		}
 		return { sessionsPerRepo: CopilotTokenTracker.CORRECTION_SCAN_SESSIONS_PER_REPO, repos, counts: totals, sessionsWithMoments };
+	}
+
+	private correctionMomentCount(counts: CorrectionCounts): number {
+		return counts.userCorrections + counts.editRetries + counts.editSelfCorrections
+			+ counts.toolErrors + counts.agentSelfCorrections;
 	}
 
 	/**

--- a/vscode-extension/src/insightsEngine.ts
+++ b/vscode-extension/src/insightsEngine.ts
@@ -1350,7 +1350,7 @@ export const INSIGHT_CATALOG: InsightDefinition[] = [
 		buildBody: (ctx) => {
 			const c = ctx.last30Days.corrections;
 			const count = c?.userCorrections ?? 0;
-			const sessions = c?.sessionsWithMoments ?? 0;
+			const sessions = c?.sessionsWithUserCorrections ?? Math.min(count, c?.sessionsWithMoments ?? 0);
 			return `In the last 30 days you corrected the agent ${count} time${count !== 1 ? 's' : ''} across ${sessions} session${sessions !== 1 ? 's' : ''} ` +
 				`(messages like "no, that's wrong" or "not what I asked"). Recurring corrections often mean the agent is missing project conventions — ` +
 				`capturing them in \`copilot-instructions.md\` or an \`AGENTS.md\` file can prevent the same mistakes. ` +

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -129,6 +129,7 @@ type CorrectionSessionEntry = {
 	title?: string | null;
 	lastInteraction?: string | null;
 	moments: CorrectionMoment[];
+	totalMoments?: number;
 };
 
 type CorrectionRepoGroup = {
@@ -1527,6 +1528,9 @@ function sanitizeCorrectionSession(raw: any): CorrectionSessionEntry | null {
 		title: typeof raw.title === 'string' ? raw.title : null,
 		lastInteraction: typeof raw.lastInteraction === 'string' ? raw.lastInteraction : null,
 		moments,
+		totalMoments: typeof raw.totalMoments === 'number' && isFinite(raw.totalMoments)
+			? Math.max(moments.length, raw.totalMoments)
+			: moments.length,
 	};
 }
 
@@ -3285,10 +3289,14 @@ function buildCorrectionSessionHtml(session: CorrectionSessionEntry): string {
 	const title = session.title || session.file.split(/[\\/]/).pop() || session.file;
 	const date = session.lastInteraction ? new Date(session.lastInteraction) : null;
 	const dateLabel = date && !isNaN(date.getTime()) ? date.toLocaleDateString() : '';
+	const totalMoments = session.totalMoments ?? session.moments.length;
+	const truncatedLabel = totalMoments > session.moments.length
+		? ` · showing ${session.moments.length} of ${totalMoments} moments`
+		: '';
 	return `
 		<div style="margin:10px 0 4px; padding:10px 12px; background:var(--bg-tertiary); border-radius:6px;">
 			<div style="font-size:12px; font-weight:600; color:var(--text-primary); overflow-wrap:anywhere;">
-				${escapeHtml(title)}${dateLabel ? ` <span style="font-weight:400; color:var(--text-secondary);">· ${escapeHtml(dateLabel)}</span>` : ''}
+				${escapeHtml(title)}${dateLabel || truncatedLabel ? ` <span style="font-weight:400; color:var(--text-secondary);">${dateLabel ? `· ${escapeHtml(dateLabel)}` : ''}${escapeHtml(truncatedLabel)}</span>` : ''}
 			</div>
 			${session.moments.map(buildCorrectionMomentHtml).join('')}
 		</div>`;
@@ -3336,7 +3344,8 @@ function buildCorrectionsTabPanelHtml(report: CorrectionReport | null): string {
 				<div class="section-subtitle">
 					Moments where the agent corrected itself after an error, or you had to correct the agent —
 					heuristic detection over each repository's ${report.sessionsPerRepo} most recent sessions with detected moments —
-					sessions without corrections are not listed. Pattern-based matches are candidates, not verdicts; open the session in the log viewer for full context.
+					sessions without corrections are not listed. Summary counts include all detected moments; long sessions show a capped detail sample.
+					Pattern-based matches are candidates, not verdicts; open the session in the log viewer for full context.
 				</div>
 				<div style="display:flex; flex-wrap:wrap; gap:6px; margin-top:12px;">${summaryChips}</div>
 				${repoSections}

--- a/vscode-extension/test/unit/correctionDetection.test.ts
+++ b/vscode-extension/test/unit/correctionDetection.test.ts
@@ -2,6 +2,7 @@ import test from 'node:test';
 import * as assert from 'node:assert/strict';
 import {
     detectCorrectionMoments,
+    detectCorrectionAnalysis,
     summarizeCorrectionMoments,
     mergeCorrectionCounts,
     createEmptyCorrectionCounts,
@@ -62,6 +63,8 @@ test('user-correction: leaves ordinary requests alone', () => {
         'can you stop the server when done?',  // "stop" only counts as an imperative correction
         'run the tests',
         'note: actually is fine inside prose-only requests',  // no comma after "actually"
+        'No rulesets matched your search',
+        'No blocker remaining — the work is done',
     ];
     for (const message of cases) {
         const moments = detectCorrectionMoments([{ userMessage: message }]);
@@ -212,6 +215,32 @@ test('a single turn cannot exceed MAX_MOMENTS_PER_SESSION', () => {
     const moments = detectCorrectionMoments([{ userMessage: 'do all the things', toolCalls }]);
     assert.equal(moments.length, MAX_MOMENTS_PER_SESSION);
     assert.ok(moments.every(m => m.turnNumber === 1));
+});
+
+test('uncapped counts retain a late user correction in the capped detail sample', () => {
+    const noisyTurn = {
+        toolCalls: Array.from({ length: MAX_MOMENTS_PER_SESSION + 10 }, (_, i) => ({
+            toolName: `tool${i}`,
+            isError: true,
+        })),
+    };
+    const result = detectCorrectionAnalysis([noisyTurn, { userMessage: 'please revert that' }]);
+    assert.equal(result.counts.toolErrors, MAX_MOMENTS_PER_SESSION + 10);
+    assert.equal(result.counts.userCorrections, 1);
+    assert.equal(result.moments.length, MAX_MOMENTS_PER_SESSION);
+    assert.ok(result.moments.some(m => m.type === 'user-correction' && m.turnNumber === 2));
+});
+
+test('uncapped counts track retries after tool-error details reach the cap', () => {
+    const failedCalls = Array.from({ length: MAX_MOMENTS_PER_SESSION + 10 }, (_, i) => ({
+        toolName: `tool${i}`,
+        isError: true,
+    }));
+    const retryCalls = failedCalls.map(({ toolName }) => ({ toolName }));
+    const result = detectCorrectionAnalysis([{ toolCalls: failedCalls }, { toolCalls: retryCalls }]);
+    assert.equal(result.counts.toolErrors, MAX_MOMENTS_PER_SESSION + 10);
+    assert.equal(result.counts.toolErrorsRetried, MAX_MOMENTS_PER_SESSION + 10);
+    assert.equal(result.moments.length, MAX_MOMENTS_PER_SESSION);
 });
 
 test('snippets are whitespace-normalized and length-capped', () => {

--- a/vscode-extension/test/unit/insightsEngine.test.ts
+++ b/vscode-extension/test/unit/insightsEngine.test.ts
@@ -711,11 +711,13 @@ function emptyCorrections() {
 
 test('corrections-user-pushback: fires at >= 3 user corrections', () => {
 	const ctx = makeCtx();
-	ctx.last30Days.corrections = { ...emptyCorrections(), userCorrections: 3, sessionsWithMoments: 2 };
+	ctx.last30Days.corrections = { ...emptyCorrections(), userCorrections: 3, sessionsWithMoments: 9, sessionsWithUserCorrections: 2 };
 	const results = evaluateInsights(ctx, {}, 7, null);
 	const insight = results.find(i => i.id === 'corrections-user-pushback');
 	assert.ok(insight, 'should fire at the threshold');
 	assert.match(insight.body, /3 times/);
+	assert.match(insight.body, /across 2 sessions/);
+	assert.equal(insight.actionCommand, 'aiEngineeringFluency.openCorrectionsTab');
 });
 
 test('corrections-user-pushback: does NOT fire below the threshold or without data', () => {

--- a/vscode-extension/test/unit/usageAnalysis.test.ts
+++ b/vscode-extension/test/unit/usageAnalysis.test.ts
@@ -172,6 +172,23 @@ test('mergeUsageAnalysis: leaves period.modelEfficiency absent when analysis has
     assert.equal(period.modelEfficiency, undefined);
 });
 
+test('mergeUsageAnalysis: uses uncapped correction counts and tracks user-correction sessions separately', () => {
+    const period = emptyPeriod();
+    const analysis = emptyAnalysis();
+    analysis.correctionMoments = [{
+        type: 'tool-error', turnNumber: 1, timestamp: null, snippet: 'Tool failed: edit', tool: 'edit',
+    }];
+    analysis.correctionCounts = {
+        userCorrections: 2, editRetries: 60, editSelfCorrections: 4,
+        toolErrors: 70, toolErrorsRetried: 50, agentSelfCorrections: 1,
+    };
+    mergeUsageAnalysis(period, analysis);
+    assert.equal(period.corrections?.editRetries, 60);
+    assert.equal(period.corrections?.toolErrors, 70);
+    assert.equal(period.corrections?.sessionsWithMoments, 1);
+    assert.equal(period.corrections?.sessionsWithUserCorrections, 1);
+});
+
 test('mergeModelEfficiencyTokens: folds per-session model usage tokens and cost into the period', () => {
     const period = emptyPeriod();
     mergeModelEfficiencyTokens(period, {
@@ -1288,6 +1305,25 @@ test('analyzeSessionUsage: Copilot CLI regular user message (no slash) does not 
     const deps = makeMockDeps();
     const result = await analyzeSessionUsage(deps, '/home/user/.copilot/session-state/abc/events.jsonl', content);
     assert.equal(result.skillCalls?.total ?? 0, 0);
+});
+
+test('analyzeSessionUsage: generated CLI messages do not become user corrections', async () => {
+    const events = [
+        { type: 'session.start', data: { selectedModel: 'claude-sonnet-5' } },
+        { type: 'user.message', data: { content: 'Stop doing that', source: 'agent-parent-session', parentAgentTaskId: 'subagent-task' } },
+        { type: 'user.message', data: { content: '<skill-context>you deleted files</skill-context>', source: 'skill-test' } },
+        { type: 'user.message', data: { content: '<cross_session_message>No blocker remains</cross_session_message>' } },
+        { type: 'user.message', data: { content: 'please revert that', parentAgentTaskId: 'main-agent-task' } },
+    ];
+    const content = events.map(e => JSON.stringify(e)).join('\n');
+    const result = await analyzeSessionUsage(
+        makeMockDeps(),
+        '/home/user/.copilot/session-state/abc/events.jsonl',
+        content,
+    );
+    assert.equal(result.correctionCounts?.userCorrections, 1);
+    assert.equal(result.correctionMoments?.filter(m => m.type === 'user-correction').length, 1);
+    assert.match(result.correctionMoments?.find(m => m.type === 'user-correction')?.snippet ?? '', /revert/);
 });
 
 test('analyzeSessionUsage: CLI JSONL session produces model efficiency counters with retry detection', async () => {


### PR DESCRIPTION
The Corrections view and Insights cards could disagree because generated session messages were treated as human feedback, aggregate counts were capped with the detail list, and the session wording counted any correction type rather than sessions with user corrections.

This change filters generated skill, subagent, cross-session, and system-wrapped messages from user-correction heuristics while retaining their normal usage accounting. It also keeps complete aggregate correction counts independently of the capped detail list, prioritizes genuine user corrections in retained details, reports detail truncation in the Corrections view, and uses the actual number of sessions containing user corrections in Insights.

The correction-analysis cache version is bumped so previously cached false positives are recalculated. Correction insight actions now use the existing deferred navigation path to open the Corrections tab reliably.