### PR TITLE
Prevent worktree discovery from stalling on blocked roots

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -118,6 +118,7 @@ import {
   sumWorktreeBytes as _sumWorktreeBytes,
   type WorktreeBackgroundScanResult,
 } from './worktreeBackgroundScan';
+import { scanWorktreeRootsWithTimeout as _scanWorktreeRootsWithTimeout } from './worktreeScan';
 
 // --- Ecosystem adapter types & helpers ---
 import type { OpenCodeDataAccess } from '../../src/opencode';
@@ -9796,37 +9797,42 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString())}
 
     // Phase 1 — fast discovery: locate worktrees and report each with cheap git metadata only
     // (size and push status are left pending and filled in during phase 2).
-    const discovered: WorktreeScanResult[] = [];
-    for (const root of rootPaths) {
-      if (!isActive()) { return; }
-      let isDirectory = false;
-      try { isDirectory = (await fs.promises.stat(root)).isDirectory(); } catch { isDirectory = false; }
-      if (!isDirectory) {
-        send({ command: "worktreeScanRootSkipped", root, reason: "Path does not exist or is not a directory" });
-        continue;
-      }
-
-      send({ command: "worktreeScanRootStarted", root });
-      const gitMarkers: string[] = [];
-      // Report folder-walk progress (throttled) so the user sees activity on large roots
-      // long before the first worktree is found.
-      let dirsScanned = 0;
-      let lastWalkPost = 0;
-      const onDir = (): void => {
-        dirsScanned++;
-        const now = Date.now();
-        if (now - lastWalkPost >= 200) {
-          lastWalkPost = now;
-          send({ command: "worktreeScanWalkProgress", root, dirsScanned, markersFound: gitMarkers.length, elapsedMs: now - startTime });
+    const discovered = await _scanWorktreeRootsWithTimeout<WorktreeScanResult>({
+      roots: rootPaths,
+      isActive,
+      scanRoot: async (root, isRootActive) => {
+        let isDirectory = false;
+        try { isDirectory = (await fs.promises.stat(root)).isDirectory(); } catch { isDirectory = false; }
+        if (!isDirectory) {
+          send({ command: "worktreeScanRootSkipped", root, reason: "Path does not exist or is not a directory" });
+          return [];
         }
-      };
-      await this.findGitMarkerFiles(root, excludeDirs, gitMarkers, isActive, onDir);
-      if (!isActive()) { return; }
-      send({ command: "worktreeScanRootMarkersFound", root, count: gitMarkers.length });
 
-      discovered.push(...await this.discoverWorktreesFromMarkers(gitMarkers, root, isActive, send, startTime));
-      if (!isActive()) { return; }
-    }
+        send({ command: "worktreeScanRootStarted", root });
+        const gitMarkers: string[] = [];
+        // Report folder-walk progress (throttled) so the user sees activity on large roots
+        // long before the first worktree is found.
+        let dirsScanned = 0;
+        let lastWalkPost = 0;
+        const onDir = (): void => {
+          dirsScanned++;
+          const now = Date.now();
+          if (now - lastWalkPost >= 200) {
+            lastWalkPost = now;
+            send({ command: "worktreeScanWalkProgress", root, dirsScanned, markersFound: gitMarkers.length, elapsedMs: now - startTime });
+          }
+        };
+        await this.findGitMarkerFiles(root, excludeDirs, gitMarkers, isRootActive, onDir);
+        if (!isRootActive()) { return []; }
+        send({ command: "worktreeScanRootMarkersFound", root, count: gitMarkers.length });
+
+        return this.discoverWorktreesFromMarkers(gitMarkers, root, isRootActive, send, startTime);
+      },
+      onRootError: (root, error) => {
+        send({ command: "worktreeScanRootSkipped", root, reason: error.message });
+      },
+    });
+    if (!isActive()) { return; }
 
     // Phase 2 — background enrichment: compute disk size and push status concurrently and
     // patch each row as results arrive, so discovery is not blocked by these slow operations.

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -9803,6 +9803,7 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString())}
       scanRoot: async (root, isRootActive) => {
         let isDirectory = false;
         try { isDirectory = (await fs.promises.stat(root)).isDirectory(); } catch { isDirectory = false; }
+        if (!isRootActive()) { return []; }
         if (!isDirectory) {
           send({ command: "worktreeScanRootSkipped", root, reason: "Path does not exist or is not a directory" });
           return [];
@@ -9815,6 +9816,7 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString())}
         let dirsScanned = 0;
         let lastWalkPost = 0;
         const onDir = (): void => {
+          if (!isRootActive()) { return; }
           dirsScanned++;
           const now = Date.now();
           if (now - lastWalkPost >= 200) {

--- a/vscode-extension/src/worktreeScan.ts
+++ b/vscode-extension/src/worktreeScan.ts
@@ -1,0 +1,44 @@
+import { withTimeout } from './utils/promises';
+
+/** Maximum time one root may block discovery before the scan moves on. */
+export const WORKTREE_ROOT_SCAN_TIMEOUT_MS = 30_000;
+
+export interface WorktreeRootScanOptions<T> {
+	roots: string[];
+	isActive: () => boolean;
+	scanRoot: (root: string, isRootActive: () => boolean) => Promise<T[]>;
+	onRootError: (root: string, error: Error) => void;
+	timeoutMs?: number;
+}
+
+/**
+ * Scans roots sequentially while bounding each root independently. A timed-out operation cannot
+ * be cancelled by Node's filesystem API, so `isRootActive` lets the traversal stop safely if the
+ * pending I/O eventually settles.
+ */
+export async function scanWorktreeRootsWithTimeout<T>(
+	options: WorktreeRootScanOptions<T>,
+): Promise<T[]> {
+	const results: T[] = [];
+	const timeoutMs = options.timeoutMs ?? WORKTREE_ROOT_SCAN_TIMEOUT_MS;
+
+	for (const root of options.roots) {
+		if (!options.isActive()) { break; }
+		let rootActive = true;
+		try {
+			const rootResults = await withTimeout(
+				options.scanRoot(root, () => rootActive && options.isActive()),
+				timeoutMs,
+				`Worktree scan for "${root}"`,
+			);
+			if (!options.isActive()) { break; }
+			results.push(...rootResults);
+		} catch (error) {
+			rootActive = false;
+			if (!options.isActive()) { break; }
+			options.onRootError(root, error instanceof Error ? error : new Error(String(error)));
+		}
+	}
+
+	return results;
+}

--- a/vscode-extension/test/unit/worktreeBackgroundScan.test.ts
+++ b/vscode-extension/test/unit/worktreeBackgroundScan.test.ts
@@ -8,6 +8,7 @@ import {
 	WORKTREE_BACKGROUND_SCAN_INTERVAL_MS,
 	WORKTREE_SCAN_NOTIFY_MIN_BYTES,
 } from '../../src/worktreeBackgroundScan';
+import { scanWorktreeRootsWithTimeout } from '../../src/worktreeScan';
 
 // ---------------------------------------------------------------------------
 // shouldRunDailyWorktreeScan
@@ -111,4 +112,46 @@ test('sumWorktreeBytes: sums only known (non-negative) byte counts', () => {
 
 test('sumWorktreeBytes: empty list -> 0', () => {
 	assert.equal(sumWorktreeBytes([]), 0);
+});
+
+test('scanWorktreeRootsWithTimeout: skips a blocked root and continues scanning', async () => {
+	const errors: Array<{ root: string; message: string }> = [];
+	const visited: string[] = [];
+
+	const results = await scanWorktreeRootsWithTimeout({
+		roots: ['blocked', 'healthy'],
+		isActive: () => true,
+		timeoutMs: 10,
+		scanRoot: async (root) => {
+			visited.push(root);
+			if (root === 'blocked') {
+				return new Promise<string[]>(() => { /* never settles */ });
+			}
+			return ['found'];
+		},
+		onRootError: (root, error) => errors.push({ root, message: error.message }),
+	});
+
+	assert.deepEqual(visited, ['blocked', 'healthy']);
+	assert.deepEqual(results, ['found']);
+	assert.equal(errors.length, 1);
+	assert.equal(errors[0].root, 'blocked');
+	assert.match(errors[0].message, /timed out after 10ms/);
+});
+
+test('scanWorktreeRootsWithTimeout: invalidates a timed-out root callback', async () => {
+	let isBlockedRootActive: (() => boolean) | undefined;
+
+	await scanWorktreeRootsWithTimeout({
+		roots: ['blocked'],
+		isActive: () => true,
+		timeoutMs: 10,
+		scanRoot: async (_root, isRootActive) => {
+			isBlockedRootActive = isRootActive;
+			return new Promise<string[]>(() => { /* never settles */ });
+		},
+		onRootError: () => undefined,
+	});
+
+	assert.equal(isBlockedRootActive?.(), false);
 });


### PR DESCRIPTION
## Why

Worktree discovery processes persisted roots sequentially, but filesystem operations had no deadline. One unavailable or pathological root could therefore leave the Worktrees tab stuck indefinitely and prevent all remaining roots from being scanned.

## What changed

- Bound each root scan to 30 seconds and report timed-out roots through the existing skipped-root UI.
- Invalidate the timed-out root callback so late filesystem completion cannot add stale results.
- Continue scanning healthy roots after a blocked root.
- Add regression coverage for timeout continuation and late-operation cancellation.

## Validation

- `npm run test:node`
- `npm run compile` (completed with three pre-existing lint warnings outside this change)