### PR TITLE
Fix discovery progress timer start

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -593,6 +593,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 
 	// In-flight updateTokenStats promise — coalesces concurrent callers onto the same run
 	private _updateTokenStatsInFlight: Promise<DetailedStats | undefined> | undefined;
+	private _updateTokenStatsStartedAt: number | undefined;
 
 	// --- Multi-window refresh coordination ---
 	// When several VS Code/Codium windows are open, only the window that holds the
@@ -2447,11 +2448,16 @@ class CopilotTokenTracker implements vscode.Disposable {
 			return this._updateTokenStatsInFlight;
 		}
 
+		const startedAt = Date.now();
+		this._updateTokenStatsStartedAt = startedAt;
 		this._updateTokenStatsInFlight = this._runUpdateTokenStats(silent);
 		try {
 			return await this._updateTokenStatsInFlight;
 		} finally {
 			this._updateTokenStatsInFlight = undefined;
+			if (this._updateTokenStatsStartedAt === startedAt) {
+				this._updateTokenStatsStartedAt = undefined;
+			}
 		}
 	}
 
@@ -6762,7 +6768,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			this.log('No cached stats — showing loading screen while calculating...');
 			this._detailsPanelIsLoading = true;
 			this.statusBarItem.tooltip = l10n.t('statusBar.loadingInPanel');
-			this.detailsPanel.webview.html = this.getLoadingHtml(this.detailsPanel.webview);
+			this.detailsPanel.webview.html = this.getLoadingHtml(this.detailsPanel.webview, this._updateTokenStatsStartedAt ?? Date.now());
 
 			stats = await this.updateTokenStats();
 
@@ -9170,7 +9176,7 @@ private async shareTextToSocialPlatform(shareText: string, platform: 'linkedin' 
     return '';
   }
 
-  private getLoadingHtml(webview: vscode.Webview): string {
+  private getLoadingHtml(webview: vscode.Webview, startedAtMs: number = Date.now()): string {
     const nonce = getNonce();
     const iconUri = webview.asWebviewUri(vscode.Uri.joinPath(this.extensionUri, 'media', 'robot-icon.png'));
     return `<!DOCTYPE html>
@@ -9185,7 +9191,7 @@ ${this.getLoadingHtmlCssBase()}
 ${this.getLoadingHtmlCssSteps()}
 </style>
 </head>
-${this.getLoadingHtmlBody(nonce, iconUri.toString())}
+${this.getLoadingHtmlBody(nonce, iconUri.toString(), startedAtMs)}
 </html>`;
   }
 
@@ -9197,8 +9203,8 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString())}
     return loadingHtml.getLoadingHtmlCssSteps();
   }
 
-  private getLoadingHtmlBody(nonce: string, iconUri?: string): string {
-    return loadingHtml.getLoadingHtmlBody(nonce, iconUri);
+  private getLoadingHtmlBody(nonce: string, iconUri?: string, startedAtMs: number = Date.now()): string {
+    return loadingHtml.getLoadingHtmlBody(nonce, iconUri, startedAtMs);
   }
 
   private getDetailsHtml(

--- a/vscode-extension/src/loadingHtml.ts
+++ b/vscode-extension/src/loadingHtml.ts
@@ -67,7 +67,7 @@ export function getLoadingHtmlCssSteps(): string {
 .pop { animation: pop-in 0.35s ease both; }`;
 }
 
-export function getLoadingHtmlBody(nonce: string, iconUri?: string): string {
+export function getLoadingHtmlBody(nonce: string, iconUri?: string, startedAtMs: number = Date.now()): string {
 	const badgeIcon = iconUri
 		? `<img src="${iconUri}" alt="" width="20" height="20" style="vertical-align:middle;margin-right:6px;border-radius:3px;" />`
 		: '🤖 ';
@@ -102,22 +102,24 @@ export function getLoadingHtmlBody(nonce: string, iconUri?: string): string {
     </div>
 </div>
 <script nonce="${nonce}">
-${getLoadingHtmlScript()}
+${getLoadingHtmlScript(startedAtMs)}
 </script>
 </body>`;
 }
 
-export function getLoadingHtmlScript(): string {
+export function getLoadingHtmlScript(startedAtMs: number = Date.now()): string {
 	return `(function () {
-    var t0 = Date.now();
+    var t0 = ${Math.floor(startedAtMs)};
     var EDITORS = [];
     var editorsSeen = 0;
-    setInterval(function () {
+    function updateElapsed() {
         var s = Math.floor((Date.now() - t0) / 1000);
         var el = document.getElementById('badge-elapsed');
         if (!el) return;
         if (s < 60) { el.textContent = s + 's'; } else { el.textContent = Math.floor(s / 60) + 'm ' + (s % 60) + 's'; }
-    }, 1000);
+    }
+    updateElapsed();
+    setInterval(updateElapsed, 1000);
     function esc(s) { return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
     function setDone(id) {
         var el = document.getElementById(id); if (!el) return;

--- a/vscode-extension/test/unit/loadingHtml.test.ts
+++ b/vscode-extension/test/unit/loadingHtml.test.ts
@@ -1,0 +1,12 @@
+import test from 'node:test';
+import * as assert from 'node:assert/strict';
+
+import { getLoadingHtmlBody, getLoadingHtmlScript } from '../../src/loadingHtml';
+
+test('loading timer starts from the supplied analysis start time', () => {
+	const startedAtMs = 1_725_000_123_456;
+
+	assert.match(getLoadingHtmlScript(startedAtMs), /var t0 = 1725000123456;/);
+	assert.match(getLoadingHtmlScript(startedAtMs), /updateElapsed\(\);\s+setInterval\(updateElapsed, 1000\);/);
+	assert.match(getLoadingHtmlBody('nonce', undefined, startedAtMs), /var t0 = 1725000123456;/);
+});


### PR DESCRIPTION
The progress window currently starts its elapsed timer when the webview opens, even if the startup analysis has already been running. This makes the displayed duration shorter than the actual discovery run.

Track the active analysis start timestamp in the extension and pass it into the shared loading view. The elapsed value now renders immediately from that timestamp and continues updating once per second. A focused unit test covers timestamp propagation and immediate timer initialization.

**Validation**
- `npm run compile`
- `npm run test:node`