### PR TITLE
Defer stalled session preloads

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -141,7 +141,7 @@ import { getVSCodeUserPaths } from '../../src/adapters/copilotChatAdapter';
 import { isJetBrainsSessionPath } from '../../src/adapters/adapterPredicates';
 import { detectJetBrainsModelHintFromContent } from '../../src/jetbrains';
 import { extractCopilotCliSessionId, getCopilotCliExactUsage, getCopilotCliOtelStatus, getCopilotCliOtelUsage, loadCopilotCliOtelIndex } from '../../src/copilotCliOtel';
-import { createWakeupGate, withTimeout as _withTimeout } from './utils/promises';
+import { createWakeupGate, TimeoutError as _TimeoutError, withTimeout as _withTimeout } from './utils/promises';
 
 // --- Session parsing & token estimation ---
 import {
@@ -597,6 +597,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 	private _updateTokenStatsInFlight: Promise<DetailedStats | undefined> | undefined;
 	// Timed-out preloads continue in the background; skip duplicate work until their cache entries settle.
 	private readonly _deferredSessionPreloadFiles = new Set<string>();
+	private _deferredSessionPreloadCount = 0;
 	private _deferredSessionRefreshTimer: NodeJS.Timeout | undefined;
 	private _updateTokenStatsStartedAt: number | undefined;
 
@@ -2487,6 +2488,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 		const preloaded: SessionFilePreload[] = [];
 		let processed = 0;
 		const CONCURRENCY = 20;
+		this._deferredSessionPreloadCount = 0;
 
 		// Event-driven wakeups: workers that find the queue empty park on the gate
 		// instead of polling on a timer, avoiding pointless wake-ups while discovery runs.
@@ -2543,13 +2545,20 @@ class CopilotTokenTracker implements vscode.Disposable {
 			return { sessionFiles, preloaded: [] };
 		}
 
-		this.log(`📊 Analyzed ${sessionFiles.length} session file(s)`);
-		this.log(`📦 Preloaded ${preloaded.length}/${sessionFiles.length} session file(s) within date range in ${((Date.now() - analyzeStartMs) / 1000).toFixed(1)}s`);
+		this.logPreloadSessionFileSummary(sessionFiles, preloaded, analyzeStartMs);
 
 		// Defer expired-cache cleanup to avoid blocking discovery/workers startup
 		void Promise.resolve().then(() => this.cacheManager.clearExpiredCache());
 
 		return { sessionFiles, preloaded };
+	}
+
+	private logPreloadSessionFileSummary(sessionFiles: string[], preloaded: SessionFilePreload[], analyzeStartMs: number): void {
+		this.log(`📊 Analyzed ${sessionFiles.length} session file(s)`);
+		this.log(`📦 Preloaded ${preloaded.length}/${sessionFiles.length} session file(s) within date range in ${((Date.now() - analyzeStartMs) / 1000).toFixed(1)}s`);
+		if (this._deferredSessionPreloadCount > 0) {
+			this.warn(`⏳ Deferred ${this._deferredSessionPreloadCount} slow session parse(s) to the background`);
+		}
 	}
 
 	/**
@@ -2570,9 +2579,9 @@ class CopilotTokenTracker implements vscode.Disposable {
 			await _withTimeout(processing, CopilotTokenTracker.SESSION_PRELOAD_TIMEOUT_MS, operation);
 			this.debugCrashLog(`done  ${sessionFile}`);
 		} catch (e) {
-			if (e instanceof Error && e.message === `${operation} timed out after ${CopilotTokenTracker.SESSION_PRELOAD_TIMEOUT_MS}ms`) {
+			if (e instanceof _TimeoutError) {
 				this.debugCrashLog(`deferred ${sessionFile}`);
-				this.warn(`⏳ Deferring slow session parse to the background: ${path.basename(sessionFile)}`);
+				this._deferredSessionPreloadCount++;
 				this.deferSessionPreloadRefresh(sessionFile, processing);
 				return;
 			}

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -141,7 +141,7 @@ import { getVSCodeUserPaths } from '../../src/adapters/copilotChatAdapter';
 import { isJetBrainsSessionPath } from '../../src/adapters/adapterPredicates';
 import { detectJetBrainsModelHintFromContent } from '../../src/jetbrains';
 import { extractCopilotCliSessionId, getCopilotCliExactUsage, getCopilotCliOtelStatus, getCopilotCliOtelUsage, loadCopilotCliOtelIndex } from '../../src/copilotCliOtel';
-import { createWakeupGate } from './utils/promises';
+import { createWakeupGate, withTimeout as _withTimeout } from './utils/promises';
 
 // --- Session parsing & token estimation ---
 import {
@@ -451,6 +451,8 @@ type UsageAnalysisTab = 'activity' | 'tools' | 'health' | 'worktrees' | 'insight
 class CopilotTokenTracker implements vscode.Disposable {
 	// Cache version - increment this when making changes that require cache invalidation
 	private static readonly CACHE_VERSION = 69; // uncapped correction counts and generated-message filtering
+	/** Initial stats should not wait indefinitely for one inaccessible or stalled session. */
+	private static readonly SESSION_PRELOAD_TIMEOUT_MS = 15_000;
 	// Maximum length for displaying workspace IDs in diagnostics/customization matrix
 	private static readonly WORKSPACE_ID_DISPLAY_LENGTH = 8;
 	private static readonly SEEN_EDITORS_STATE_KEY = 'discovery.seenEditors';
@@ -593,6 +595,9 @@ class CopilotTokenTracker implements vscode.Disposable {
 
 	// In-flight updateTokenStats promise — coalesces concurrent callers onto the same run
 	private _updateTokenStatsInFlight: Promise<DetailedStats | undefined> | undefined;
+	// Timed-out preloads continue in the background; skip duplicate work until their cache entries settle.
+	private readonly _deferredSessionPreloadFiles = new Set<string>();
+	private _deferredSessionRefreshTimer: NodeJS.Timeout | undefined;
 
 	// --- Multi-window refresh coordination ---
 	// When several VS Code/Codium windows are open, only the window that holds the
@@ -2548,12 +2553,57 @@ class CopilotTokenTracker implements vscode.Disposable {
 	 * for the same file means the process died while processing it.
 	 */
 	private async processPreloadQueueFileWithCrashLog(sessionFile: string, cutoffMs: number, preloaded: SessionFilePreload[], missBudget?: { remaining: number }): Promise<void> {
+		if (this._deferredSessionPreloadFiles.has(sessionFile)) {
+			this.debugCrashLog(`deferred ${sessionFile}`);
+			return;
+		}
 		this.debugCrashLog(`start ${sessionFile}`);
+		const processing = this.processPreloadQueueFile(sessionFile, cutoffMs, preloaded, missBudget);
+		const operation = `Parsing session "${sessionFile}"`;
 		try {
-			await this.processPreloadQueueFile(sessionFile, cutoffMs, preloaded, missBudget);
+			await _withTimeout(processing, CopilotTokenTracker.SESSION_PRELOAD_TIMEOUT_MS, operation);
 			this.debugCrashLog(`done  ${sessionFile}`);
 		} catch (e) {
+			if (e instanceof Error && e.message === `${operation} timed out after ${CopilotTokenTracker.SESSION_PRELOAD_TIMEOUT_MS}ms`) {
+				this.debugCrashLog(`deferred ${sessionFile}`);
+				this.warn(`⏳ Deferring slow session parse to the background: ${path.basename(sessionFile)}`);
+				this.deferSessionPreloadRefresh(sessionFile, processing);
+				return;
+			}
 			this.debugCrashLog(`error ${sessionFile}: ${e}`);
+		}
+	}
+
+	/**
+	 * Keeps a timed-out preload alive without holding the initial statistics pass. Once every
+	 * deferred parse has filled its cache entry, a single refresh incorporates those results.
+	 */
+	private deferSessionPreloadRefresh(sessionFile: string, processing: Promise<void>): void {
+		this._deferredSessionPreloadFiles.add(sessionFile);
+		void processing
+			.then(() => this.debugCrashLog(`done(background)  ${sessionFile}`))
+			.catch(error => this.debugCrashLog(`error(background) ${sessionFile}: ${error}`))
+			.finally(() => {
+				this._deferredSessionPreloadFiles.delete(sessionFile);
+				if (this._deferredSessionPreloadFiles.size === 0) {
+					this.scheduleDeferredSessionRefresh();
+				}
+			});
+	}
+
+	private scheduleDeferredSessionRefresh(): void {
+		if (this._deferredSessionRefreshTimer || this._disposed) { return; }
+		this._deferredSessionRefreshTimer = setTimeout(() => {
+			this._deferredSessionRefreshTimer = undefined;
+			if (this._disposed) { return; }
+			if (this._updateTokenStatsInFlight) {
+				void this._updateTokenStatsInFlight.finally(() => this.scheduleDeferredSessionRefresh());
+				return;
+			}
+			void this.updateTokenStats(true, true);
+		}, 0);
+		if (typeof this._deferredSessionRefreshTimer.unref === 'function') {
+			this._deferredSessionRefreshTimer.unref();
 		}
 	}
 
@@ -11385,6 +11435,10 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString())}
     if (this._followerResyncTimer) {
       clearTimeout(this._followerResyncTimer);
       this._followerResyncTimer = undefined;
+    }
+    if (this._deferredSessionRefreshTimer) {
+      clearTimeout(this._deferredSessionRefreshTimer);
+      this._deferredSessionRefreshTimer = undefined;
     }
     // Release the refresh leader lock if this window held it, so another window can
     // take over promptly instead of waiting for the stale-lock timeout.

--- a/vscode-extension/src/utils/promises.ts
+++ b/vscode-extension/src/utils/promises.ts
@@ -2,6 +2,13 @@
  * Promise utility helpers.
  */
 
+export class TimeoutError extends Error {
+  constructor(operation: string, timeoutMs: number) {
+    super(`${operation} timed out after ${timeoutMs}ms`);
+    this.name = 'TimeoutError';
+  }
+}
+
 /**
  * Wraps a promise with a timeout to prevent indefinite hangs.
  * The timeout handle is cleared via `.finally()` to prevent memory leaks when
@@ -26,7 +33,7 @@ export function withTimeout<T>(
     }),
     new Promise<never>((_, reject) => {
       timeoutHandle = setTimeout(
-        () => reject(new Error(`${operation} timed out after ${timeoutMs}ms`)),
+        () => reject(new TimeoutError(operation, timeoutMs)),
         timeoutMs,
       );
     }),

--- a/vscode-extension/test/unit/utils-promises.test.ts
+++ b/vscode-extension/test/unit/utils-promises.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import * as assert from 'node:assert/strict';
 
-import { createWakeupGate, withTimeout } from '../../src/utils/promises';
+import { createWakeupGate, TimeoutError, withTimeout } from '../../src/utils/promises';
 
 test('createWakeupGate: signal resolves all currently parked waiters', async () => {
 	const gate = createWakeupGate();
@@ -81,7 +81,7 @@ test('withTimeout: resolves when the promise settles in time', async () => {
 test('withTimeout: rejects with a descriptive error when it times out', async () => {
 	await assert.rejects(
 		withTimeout(new Promise(() => { /* never settles */ }), 10, 'slow op'),
-		/slow op timed out after 10ms/,
+		(error: Error) => error instanceof TimeoutError && error.message === 'slow op timed out after 10ms',
 	);
 });
 

--- a/vscode-extension/test/unit/utils-promises.test.ts
+++ b/vscode-extension/test/unit/utils-promises.test.ts
@@ -84,3 +84,16 @@ test('withTimeout: rejects with a descriptive error when it times out', async ()
 		/slow op timed out after 10ms/,
 	);
 });
+
+test('withTimeout: does not cancel work that can be deferred after a timeout', async () => {
+	let resolveWork: ((value: string) => void) | undefined;
+	const work = new Promise<string>((resolve) => { resolveWork = resolve; });
+
+	await assert.rejects(
+		withTimeout(work, 10, 'deferred session'),
+		/deferred session timed out after 10ms/,
+	);
+
+	resolveWork?.('cached');
+	assert.equal(await work, 'cached');
+});


### PR DESCRIPTION
Initial activity scans currently wait for every discovered session, so one inaccessible or slow session can leave the details view loading long after the rest of the data is ready.

Apply a 15-second deadline to each preload task. Timed-out work continues in the background, avoids duplicate parsing, and triggers one silent refresh once all deferred cache entries have settled. The follow-up refresh waits for an active foreground refresh to finish, preventing a race that could otherwise lose the updated result.