### PR TITLE
Add 90-day time window to shared selectors

### DIFF
--- a/src/timeWindows.ts
+++ b/src/timeWindows.ts
@@ -1,0 +1,43 @@
+import type { ChartTimeWindow } from './types';
+
+const ROLLING_WINDOW_DAYS: Partial<Record<ChartTimeWindow, number>> = {
+	today: 1,
+	last7: 7,
+	last30: 30,
+	last90: 90,
+};
+
+/** Returns the local-calendar start date for a chart time window, or null for all time. */
+export function getTimeWindowStartDate(timeWindow: ChartTimeWindow, now: Date): Date | null {
+	if (timeWindow === 'allTime') {
+		return null;
+	}
+	if (timeWindow === 'currentMonth') {
+		return new Date(now.getFullYear(), now.getMonth(), 1);
+	}
+	const days = ROLLING_WINDOW_DAYS[timeWindow];
+	if (days === undefined) {
+		return null;
+	}
+	return new Date(now.getFullYear(), now.getMonth(), now.getDate() - days + 1);
+}
+
+/** Formats a chart window's local start date as YYYY-MM-DD. */
+export function getTimeWindowStartDayKey(timeWindow: ChartTimeWindow, now: Date): string {
+	const start = getTimeWindowStartDate(timeWindow, now);
+	if (!start) {
+		return '0000-00-00';
+	}
+	return [
+		start.getFullYear(),
+		String(start.getMonth() + 1).padStart(2, '0'),
+		String(start.getDate()).padStart(2, '0'),
+	].join('-');
+}
+
+/** Formats the month containing a chart window's local start date as YYYY-MM. */
+export function getTimeWindowStartMonthKey(timeWindow: ChartTimeWindow, now: Date): string {
+	return timeWindow === 'allTime'
+		? '0000-00'
+		: getTimeWindowStartDayKey(timeWindow, now).slice(0, 7);
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -221,7 +221,7 @@ export interface DailyModelEfficiency {
 }
 
 /** Time-window selector options available in the Chart view. */
-export type ChartTimeWindow = 'today' | 'last7' | 'last30' | 'currentMonth' | 'allTime';
+export type ChartTimeWindow = 'today' | 'last7' | 'last30' | 'last90' | 'currentMonth' | 'allTime';
 
 /** Aggregated data for one time window (day/week/month) in the chart. */
 export interface ChartPeriodData {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -76,6 +76,7 @@ import type {
   CorrectionSessionEntry,
   RepeatedTaskReport,
 } from '../../src/types';
+import { getTimeWindowStartDate, getTimeWindowStartDayKey } from '../../src/timeWindows';
 
 // --- Correction-moment detection (per-repo report over recent sessions) ---
 import {
@@ -4322,8 +4323,18 @@ class CopilotTokenTracker implements vscode.Disposable {
 		// every path (including errors) so the webview never hangs on "Loading...".
 		let sessions: TodaySessionSummary[] = [];
 		try {
-			const stats = this.lastUsageAnalysisStats ?? await this.calculateUsageAnalysisStats(true);
-			sessions = stats.recentSessions?.[period as 'last7' | 'last30' | 'currentMonth'] ?? [];
+			if (period === 'last90') {
+				const now = new Date();
+				const start = getTimeWindowStartDate(period, now);
+				if (!start) {
+					throw new Error(`Cannot load recent sessions for time window "${period}"`);
+				}
+				const { results } = await this.loadUsageSessionFiles(undefined, start.getTime());
+				sessions = this.buildRecentSessionBucket(results, getTimeWindowStartDayKey(period, now));
+			} else {
+				const stats = this.lastUsageAnalysisStats ?? await this.calculateUsageAnalysisStats(true);
+				sessions = stats.recentSessions?.[period] ?? [];
+			}
 		} catch (error) {
 			this.error('Error loading recent sessions:', error);
 		}
@@ -4339,9 +4350,29 @@ class CopilotTokenTracker implements vscode.Disposable {
 		results: ({ sessionFile: string; sessionData: SessionFileCache; mtime: number } | null | undefined)[],
 		now: Date
 	): { last7: TodaySessionSummary[]; last30: TodaySessionSummary[]; currentMonth: TodaySessionSummary[] } {
-		const last7Key = toLocalDayKey(new Date(now.getFullYear(), now.getMonth(), now.getDate() - 7));
-		const last30Key = toLocalDayKey(new Date(now.getFullYear(), now.getMonth(), now.getDate() - 30));
-		const monthKey = toLocalDayKey(new Date(now.getFullYear(), now.getMonth(), 1));
+		const last7Key = getTimeWindowStartDayKey('last7', now);
+		const last30Key = getTimeWindowStartDayKey('last30', now);
+		const monthKey = getTimeWindowStartDayKey('currentMonth', now);
+		const items = this.buildRecentSessionItems(results);
+		return {
+			last7: items.filter(it => it.activityKey >= last7Key).map(it => it.value),
+			last30: items.filter(it => it.activityKey >= last30Key).map(it => it.value),
+			currentMonth: items.filter(it => it.activityKey >= monthKey).map(it => it.value),
+		};
+	}
+
+	private buildRecentSessionBucket(
+		results: ({ sessionFile: string; sessionData: SessionFileCache; mtime: number } | null | undefined)[],
+		startKey: string
+	): TodaySessionSummary[] {
+		return this.buildRecentSessionItems(results)
+			.filter(it => it.activityKey >= startKey)
+			.map(it => it.value);
+	}
+
+	private buildRecentSessionItems(
+		results: ({ sessionFile: string; sessionData: SessionFileCache; mtime: number } | null | undefined)[]
+	): { activityKey: string; interactions: number; value: TodaySessionSummary }[] {
 		const items: { activityKey: string; interactions: number; value: TodaySessionSummary }[] = [];
 		for (const r of results) {
 			if (!r || r.sessionData.interactions === 0) { continue; }
@@ -4350,13 +4381,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			items.push({ activityKey: this.computeLastActivityKey(r.sessionData, r.mtime), interactions: r.sessionData.interactions, value });
 		}
 		items.sort((a, b) => b.interactions - a.interactions);
-		const buckets = { last7: [] as TodaySessionSummary[], last30: [] as TodaySessionSummary[], currentMonth: [] as TodaySessionSummary[] };
-		for (const it of items) {
-			if (it.activityKey >= last7Key) { buckets.last7.push(it.value); }
-			if (it.activityKey >= last30Key) { buckets.last30.push(it.value); }
-			if (it.activityKey >= monthKey) { buckets.currentMonth.push(it.value); }
-		}
-		return buckets;
+		return items;
 	}
 
 	private computeLastActivityKey(sessionData: SessionFileCache, mtime: number): string {
@@ -6935,7 +6960,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 	}
 
 	private setChartTimeWindowPreference(timeWindow: string): void {
-		const valid: ChartTimeWindow[] = ['today', 'last7', 'last30', 'currentMonth', 'allTime'];
+		const valid: ChartTimeWindow[] = ['today', 'last7', 'last30', 'last90', 'currentMonth', 'allTime'];
 		if (valid.includes(timeWindow as ChartTimeWindow)) { this.lastChartTimeWindow = timeWindow as ChartTimeWindow; }
 	}
 

--- a/vscode-extension/src/webview/chart/main.ts
+++ b/vscode-extension/src/webview/chart/main.ts
@@ -3,10 +3,12 @@ import { el, createButton, iconHeading } from '../shared/domUtils';
 import { getNavButtons } from '../shared/buttonConfig';
 import { formatCompact, setCompactNumbers } from '../shared/formatUtils';
 import { wireExtensionPointButtons } from '../shared/extensionPoints';
-import { createPeriodSelector, PERIOD_LABELS, type Period } from '../shared/periodSelector';
+import { createPeriodSelector, PERIOD_LABELS } from '../shared/periodSelector';
 import { getCurrentPeriodFraction, computeProjectionExtra } from './projectionUtils';
 import { createViewStateManager } from '../shared/viewState';
 import { initializeWebviewLocalization, setCurrentLanguage } from '../shared/localization';
+import type { ChartTimeWindow } from '../../../../src/types';
+import { getTimeWindowStartDayKey, getTimeWindowStartMonthKey } from '../../../../src/timeWindows';
 // CSS imported as text via esbuild
 import themeStyles from '../shared/theme.css';
 import styles from './styles.css';
@@ -56,7 +58,6 @@ type ChartPeriodData = {
 };
 
 type ChartPeriod = import('./projectionUtils').ChartPeriod;
-type ChartTimeWindow = Period;
 
 type InitialChartData = {
 	labels: string[];
@@ -158,42 +159,6 @@ function saveWebviewState(): void {
 	chartState.save({ period: currentPeriod, timeWindow: currentTimeWindow, metric: currentMetric, split: currentSplit, displayMode: currentDisplayMode, editorListCollapsed });
 }
 
-function getWindowStartDate(timeWindow: ChartTimeWindow, now: Date): string {
-	const y = now.getFullYear();
-	const m = now.getMonth();
-	const d = now.getDate();
-	switch (timeWindow) {
-		case 'today':
-			return `${y}-${String(m + 1).padStart(2, '0')}-${String(d).padStart(2, '0')}`;
-		case 'last7': {
-			const start = new Date(y, m, d - 6);
-			return `${start.getFullYear()}-${String(start.getMonth() + 1).padStart(2, '0')}-${String(start.getDate()).padStart(2, '0')}`;
-		}
-		case 'last30': {
-			const start = new Date(y, m, d - 29);
-			return `${start.getFullYear()}-${String(start.getMonth() + 1).padStart(2, '0')}-${String(start.getDate()).padStart(2, '0')}`;
-		}
-		case 'currentMonth':
-			return `${y}-${String(m + 1).padStart(2, '0')}-01`;
-		case 'allTime':
-			return '0000-00-00';
-	}
-}
-
-function getWindowStartMonth(timeWindow: ChartTimeWindow, now: Date): string {
-	if (timeWindow === 'allTime') {
-		return '0000-00';
-	}
-	const y = now.getFullYear();
-	const m = now.getMonth();
-	if (timeWindow === 'currentMonth') {
-		return `${y}-${String(m + 1).padStart(2, '0')}`;
-	}
-	// For today/last7/last30, include the current month and previous month if needed.
-	const start = new Date(y, m, timeWindow === 'today' ? 1 : timeWindow === 'last7' ? -5 : -29);
-	return `${start.getFullYear()}-${String(start.getMonth() + 1).padStart(2, '0')}`;
-}
-
 function sliceByIndices<T>(arr: T[] | undefined, indices: number[]): T[] | undefined {
 	if (!arr) { return undefined; }
 	return indices.map(i => arr[i]);
@@ -208,7 +173,9 @@ function sliceDatasetsByIndices(datasets: object[] | undefined, indices: number[
 }
 
 function getFilterStartKey(timeWindow: ChartTimeWindow, periodType: ChartPeriod, now: Date): string {
-	return periodType === 'month' ? getWindowStartMonth(timeWindow, now) : getWindowStartDate(timeWindow, now);
+	return periodType === 'month'
+		? getTimeWindowStartMonthKey(timeWindow, now)
+		: getTimeWindowStartDayKey(timeWindow, now);
 }
 
 function buildCoreFilteredPeriod(period: ChartPeriodData, indices: number[]): ChartPeriodData {
@@ -463,7 +430,7 @@ function buildTimeWindowControl(data: InitialChartData): HTMLElement {
 	const { wrapper } = createPeriodSelector({
 		id: 'time-window-select',
 		selected: currentTimeWindow,
-		disabled: periodsReady ? [] : ['allTime'],
+		disabled: periodsReady ? [] : ['last90', 'allTime'],
 		disabledTitle: 'Full history is still loading',
 		label: 'Time window:',
 		onChange: (value) => { void switchTimeWindow(value as ChartTimeWindow, data); },
@@ -472,7 +439,7 @@ function buildTimeWindowControl(data: InitialChartData): HTMLElement {
 	group.append(wrapper);
 	if (!periodsReady) {
 		const loadingNote = el('span', 'loading-note', 'Loading history…');
-		loadingNote.title = 'Full history is still loading. "All time" and weekly/monthly aggregation are not available yet.';
+		loadingNote.title = 'Full history is still loading. "Last 90 days", "All time", and weekly/monthly aggregation are not available yet.';
 		group.append(loadingNote);
 	}
 	return group;
@@ -976,7 +943,7 @@ function getChartColors(): ChartColors {
 }
 
 function buildBaseOptions(c: ChartColors, periodsReady: boolean) {
-	const title = !periodsReady && currentTimeWindow === 'allTime'
+	const title = !periodsReady && (currentTimeWindow === 'last90' || currentTimeWindow === 'allTime')
 		? `${PERIOD_LABELS[currentTimeWindow]} (loading history…)`
 		: PERIOD_LABELS[currentTimeWindow];
 	return {
@@ -1455,4 +1422,3 @@ registerMessageHandler((message) => {
 		renderLayout(message.data as InitialChartData);
 	}
 });
-

--- a/vscode-extension/src/webview/shared/periodSelector.ts
+++ b/vscode-extension/src/webview/shared/periodSelector.ts
@@ -17,10 +17,10 @@ export const PERIOD_LABELS: Record<Period, string> = {
 };
 
 /** Ordered list of the canonical periods used by default. */
-export const CANONICAL_PERIODS: Period[] = ['today', 'last7', 'last30', 'currentMonth', 'allTime'];
+export const CANONICAL_PERIODS: Period[] = ['today', 'last7', 'last30', 'last90', 'currentMonth', 'allTime'];
 
 /** Ordered list of every known period, including extras such as Previous month / This week. */
-export const ALL_PERIODS: Period[] = ['today', 'last7', 'last30', 'currentMonth', 'lastMonth', 'thisWeek', 'allTime'];
+export const ALL_PERIODS: Period[] = ['today', 'last7', 'last30', 'last90', 'currentMonth', 'lastMonth', 'thisWeek', 'allTime'];
 
 export type PeriodSelectorExtraOption = {
 	value: string;
@@ -34,7 +34,7 @@ export type PeriodSelectorExtraOption = {
 export type PeriodSelectorOptions = {
 	/** Value currently selected. */
 	selected: string;
-	/** Which known periods to show and in which order. Defaults to the canonical 5. */
+	/** Which known periods to show and in which order. Defaults to the canonical periods. */
 	periods?: Period[];
 	/** Extra ad-hoc options appended after the known periods (e.g. "Yesterday"). */
 	extraOptions?: PeriodSelectorExtraOption[];

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -4635,7 +4635,7 @@ function renderModelEfficiencyPeriodSelector(): void {
 	wrapper.replaceChildren();
 	const { wrapper: selectorWrapper } = createPeriodSelector({
 		selected: efficiencySelectedPeriod,
-		disabled: ['last7', 'allTime'],
+		disabled: ['last7', 'last90', 'allTime'],
 		disabledTitle: 'Not available for model efficiency',
 		label: '',
 		onChange: (value) => {

--- a/vscode-extension/test/unit/timeWindows.test.ts
+++ b/vscode-extension/test/unit/timeWindows.test.ts
@@ -1,0 +1,36 @@
+import test from 'node:test';
+import * as assert from 'node:assert/strict';
+
+import {
+	getTimeWindowStartDate,
+	getTimeWindowStartDayKey,
+	getTimeWindowStartMonthKey,
+} from '../../../src/timeWindows';
+import { ALL_PERIODS, CANONICAL_PERIODS, PERIOD_LABELS } from '../../src/webview/shared/periodSelector';
+
+const NOW = new Date(2025, 4, 15, 12);
+
+test('canonical period selectors include the 90-day window', () => {
+	assert.deepEqual(CANONICAL_PERIODS, ['today', 'last7', 'last30', 'last90', 'currentMonth', 'allTime']);
+	assert.ok(ALL_PERIODS.includes('last90'));
+	assert.equal(PERIOD_LABELS.last90, 'Last 90 days');
+});
+
+test('last90 starts 89 local calendar days before today', () => {
+	assert.equal(getTimeWindowStartDayKey('last90', NOW), '2025-02-15');
+	assert.equal(getTimeWindowStartMonthKey('last90', NOW), '2025-02');
+});
+
+test('rolling windows include today in their day count', () => {
+	assert.equal(getTimeWindowStartDayKey('today', NOW), '2025-05-15');
+	assert.equal(getTimeWindowStartDayKey('last7', NOW), '2025-05-09');
+	assert.equal(getTimeWindowStartDayKey('last30', NOW), '2025-04-16');
+});
+
+test('calendar and all-time windows retain their existing boundaries', () => {
+	assert.equal(getTimeWindowStartDayKey('currentMonth', NOW), '2025-05-01');
+	assert.equal(getTimeWindowStartMonthKey('currentMonth', NOW), '2025-05');
+	assert.equal(getTimeWindowStartDate('allTime', NOW), null);
+	assert.equal(getTimeWindowStartDayKey('allTime', NOW), '0000-00-00');
+	assert.equal(getTimeWindowStartMonthKey('allTime', NOW), '0000-00');
+});


### PR DESCRIPTION
## Summary

Users need a three-month view between the existing 30-day and all-time ranges. This adds the existing `last90` period to the shared default selector and wires it through chart filtering, saved preferences, and recent-session loading.

The date-boundary logic is centralized around inclusive local-calendar windows so day and month aggregation stay consistent. Recent sessions load the larger range lazily to avoid expanding the normal refresh workload, while views without 90-day data keep the option disabled.

## Testing

- `npm run test:node`
- `npm run compile`
- Focused time-window boundary tests