### PR TITLE
Speed up iterative VS Code extension compilation

### DIFF
--- a/.claude/agents/new-editor-support.md
+++ b/.claude/agents/new-editor-support.md
@@ -164,7 +164,7 @@ For broader session-level caveats (multiple bullet points), use the `editorNote:
 | Sessions discovered but tokens show 0 | Check the adapter's `getTokens()` — it may be missing or not returning early; confirm the underlying data-access method actually extracts text from the right fields |
 | Virtual paths fail `fs.promises.stat()` | Implement `stat()` on the adapter to resolve virtual paths to the real backing DB/file path (see `getBackingPath()` in `CrushAdapter`) |
 | Discovery loop finds 0 sessions even though the file/DB exists | Verify the project/workspace registry reader returns the correct data directory (not just the project's working-directory path) and that the joined path matches the actual file on disk |
-| ESLint/complexity warnings appear after `npm run validate` even though there are 0 errors | `npm run validate` runs type-checking, ESLint, and esbuild — ESLint enforces a max complexity of 15 (`sonarjs/cognitive-complexity`, `complexity`). Extract small helper methods proactively instead of chaining ternaries or nesting loops; don't treat 0 *errors* as "done" — re-run validation and check for warnings too |
+| ESLint/complexity warnings appear after `npm --prefix vscode-extension run validate` even though there are 0 errors | `npm --prefix vscode-extension run validate` runs type-checking, ESLint, and esbuild — ESLint enforces a max complexity of 15 (`sonarjs/cognitive-complexity`, `complexity`). Extract small helper methods proactively instead of chaining ternaries or nesting loops; don't treat 0 *errors* as "done" — re-run validation and check for warnings too |
 | `test/unit/ecosystemAdapters.test.ts` fails after adding an adapter | The adapter count assertion (`assert.equal(allAdapters.length, N)`) is hardcoded — bump it and add the new adapter's `id` assertion (Step 7) |
 
 ---
@@ -180,7 +180,7 @@ For broader session-level caveats (multiple bullet points), use the `editorNote:
 - [ ] `test/unit/ecosystemAdapters.test.ts` — adapter added to `allAdapters`, count bumped, `id` assertion added
 - [ ] (Optional) `webview/diagnostics/main.ts` + `styles.css` — dedicated badge class/colour, only if the generic fallback isn't distinctive enough
 - [ ] (Optional) `webview/logviewer/main.ts` — `ESTIMATED_TOKENS_NOTES` entry if the editor doesn't persist actual token counts
-- [ ] `npm run validate` passes with **0 errors and 0 warnings** (not just 0 errors — check for complexity/lint warnings on new code)
+- [ ] `npm --prefix vscode-extension run validate` passes with **0 errors and 0 warnings** (not just 0 errors — check for complexity/lint warnings on new code)
 - [ ] CLI build (`cd cli && npm run build`) succeeds, since it shares the same adapter registry
 - [ ] `node cli/dist/cli.js diagnostics` shows the new editor's candidate path as `yes` (exists) with non-zero file/session/token counts — this is the fastest end-to-end confidence check
 - [ ] Sessions appear in the session list with the correct editor name and icon

--- a/.claude/agents/new-editor-support.md
+++ b/.claude/agents/new-editor-support.md
@@ -164,7 +164,7 @@ For broader session-level caveats (multiple bullet points), use the `editorNote:
 | Sessions discovered but tokens show 0 | Check the adapter's `getTokens()` — it may be missing or not returning early; confirm the underlying data-access method actually extracts text from the right fields |
 | Virtual paths fail `fs.promises.stat()` | Implement `stat()` on the adapter to resolve virtual paths to the real backing DB/file path (see `getBackingPath()` in `CrushAdapter`) |
 | Discovery loop finds 0 sessions even though the file/DB exists | Verify the project/workspace registry reader returns the correct data directory (not just the project's working-directory path) and that the joined path matches the actual file on disk |
-| ESLint/complexity warnings appear after `npm run compile` even though there are 0 errors | `npm run compile` runs `tsc && eslint && esbuild` — ESLint enforces a max complexity of 15 (`sonarjs/cognitive-complexity`, `complexity`). Extract small helper methods proactively instead of chaining ternaries or nesting loops; don't treat 0 *errors* as "done" — re-run compile and check for warnings too |
+| ESLint/complexity warnings appear after `npm run validate` even though there are 0 errors | `npm run validate` runs type-checking, ESLint, and esbuild — ESLint enforces a max complexity of 15 (`sonarjs/cognitive-complexity`, `complexity`). Extract small helper methods proactively instead of chaining ternaries or nesting loops; don't treat 0 *errors* as "done" — re-run validation and check for warnings too |
 | `test/unit/ecosystemAdapters.test.ts` fails after adding an adapter | The adapter count assertion (`assert.equal(allAdapters.length, N)`) is hardcoded — bump it and add the new adapter's `id` assertion (Step 7) |
 
 ---
@@ -180,7 +180,7 @@ For broader session-level caveats (multiple bullet points), use the `editorNote:
 - [ ] `test/unit/ecosystemAdapters.test.ts` — adapter added to `allAdapters`, count bumped, `id` assertion added
 - [ ] (Optional) `webview/diagnostics/main.ts` + `styles.css` — dedicated badge class/colour, only if the generic fallback isn't distinctive enough
 - [ ] (Optional) `webview/logviewer/main.ts` — `ESTIMATED_TOKENS_NOTES` entry if the editor doesn't persist actual token counts
-- [ ] `npm run compile` passes with **0 errors and 0 warnings** (not just 0 errors — check for complexity/lint warnings on new code)
+- [ ] `npm run validate` passes with **0 errors and 0 warnings** (not just 0 errors — check for complexity/lint warnings on new code)
 - [ ] CLI build (`cd cli && npm run build`) succeeds, since it shares the same adapter registry
 - [ ] `node cli/dist/cli.js diagnostics` shows the new editor's candidate path as `yes` (exists) with non-zero file/session/token counts — this is the fastest end-to-end confidence check
 - [ ] Sessions appear in the session list with the correct editor name and icon

--- a/.claude/agents/tool-names.md
+++ b/.claude/agents/tool-names.md
@@ -146,7 +146,7 @@ When adding a new tool to `toolNames.json`, also determine if it belongs in `aut
 
 After editing `src/toolNames.json`:
 
-1. Run `npm run compile` to verify ESLint + build passes
+1. Run `npm run validate` to verify type-checking, ESLint, and the build pass
 2. Ensure the JSON is valid (no trailing commas, proper quoting)
 3. Run tests with `npm run test:node` to confirm nothing is broken
 
@@ -194,5 +194,5 @@ This is already handled by `workspaceHelpers.ts` (`detectToolEditorFromPath`, `d
 - [ ] Generate friendly names following the conventions above
 - [ ] Add entries to `src/toolNames.json` in the correct location
 - [ ] For each new tool, decide if it is **automatic** or **intentional** — add automatic tools to `src/automaticTools.json`
-- [ ] Run `npm run compile` to validate
+- [ ] Run `npm run validate`
 - [ ] Run `npm run test:node` to confirm tests pass

--- a/.claude/agents/tool-names.md
+++ b/.claude/agents/tool-names.md
@@ -146,9 +146,9 @@ When adding a new tool to `toolNames.json`, also determine if it belongs in `aut
 
 After editing `src/toolNames.json`:
 
-1. Run `npm run validate` to verify type-checking, ESLint, and the build pass
+1. Run `npm --prefix vscode-extension run validate` to verify type-checking, ESLint, and the build pass
 2. Ensure the JSON is valid (no trailing commas, proper quoting)
-3. Run tests with `npm run test:node` to confirm nothing is broken
+3. Run tests with `npm --prefix vscode-extension run test:node` to confirm nothing is broken
 
 ## Upstream Sync Reference
 
@@ -194,5 +194,5 @@ This is already handled by `workspaceHelpers.ts` (`detectToolEditorFromPath`, `d
 - [ ] Generate friendly names following the conventions above
 - [ ] Add entries to `src/toolNames.json` in the correct location
 - [ ] For each new tool, decide if it is **automatic** or **intentional** — add automatic tools to `src/automaticTools.json`
-- [ ] Run `npm run validate`
-- [ ] Run `npm run test:node` to confirm tests pass
+- [ ] Run `npm --prefix vscode-extension run validate`
+- [ ] Run `npm --prefix vscode-extension run test:node` to confirm tests pass

--- a/.claude/skills/check-urls/SKILL.md
+++ b/.claude/skills/check-urls/SKILL.md
@@ -43,7 +43,7 @@ The script will:
 2. **404 on code.visualstudio.com**: The VS Code docs may have been reorganised. Search [VS Code docs](https://code.visualstudio.com/docs) for the relevant topic and update the link.
 3. **Timeout**: May be a transient network issue. Re-run the script to confirm before changing anything.
 4. After fixing, re-run `node .github/skills/check-urls/check-urls.js` to confirm all URLs resolve.
-5. Run `npm run validate` to confirm type-checking, linting, and the build still pass.
+5. Run `npm --prefix vscode-extension run validate` to confirm type-checking, linting, and the build still pass.
 
 ## Files in This Directory
 

--- a/.claude/skills/check-urls/SKILL.md
+++ b/.claude/skills/check-urls/SKILL.md
@@ -43,7 +43,7 @@ The script will:
 2. **404 on code.visualstudio.com**: The VS Code docs may have been reorganised. Search [VS Code docs](https://code.visualstudio.com/docs) for the relevant topic and update the link.
 3. **Timeout**: May be a transient network issue. Re-run the script to confirm before changing anything.
 4. After fixing, re-run `node .github/skills/check-urls/check-urls.js` to confirm all URLs resolve.
-5. Run `npm run compile` to confirm the TypeScript build still passes.
+5. Run `npm run validate` to confirm type-checking, linting, and the build still pass.
 
 ## Files in This Directory
 

--- a/.claude/skills/improve-tool-families/SKILL.md
+++ b/.claude/skills/improve-tool-families/SKILL.md
@@ -81,7 +81,7 @@ node .github/skills/improve-tool-families/analyze-tool-families.js --json
      tools, orchestration tools like `task`/`write_agent`) → leave it out;
      not every tool needs a family.
 3. Edit `vscode-extension/src/toolFamilies.ts` (`DEFAULT_TOOL_FAMILIES`).
-4. Verify with `cd vscode-extension && npm run compile` (tsc + eslint +
+4. Verify with `cd vscode-extension && npm run validate` (tsc + eslint +
    esbuild).
 5. Re-run this script to confirm the previously-uncovered names are now
    covered.

--- a/.github/agents/new-editor-support.agent.md
+++ b/.github/agents/new-editor-support.agent.md
@@ -164,7 +164,7 @@ For broader session-level caveats (multiple bullet points), use the `editorNote:
 | Sessions discovered but tokens show 0 | Check the adapter's `getTokens()` — it may be missing or not returning early; confirm the underlying data-access method actually extracts text from the right fields |
 | Virtual paths fail `fs.promises.stat()` | Implement `stat()` on the adapter to resolve virtual paths to the real backing DB/file path (see `getBackingPath()` in `CrushAdapter`) |
 | Discovery loop finds 0 sessions even though the file/DB exists | Verify the project/workspace registry reader returns the correct data directory (not just the project's working-directory path) and that the joined path matches the actual file on disk |
-| ESLint/complexity warnings appear after `npm run validate` even though there are 0 errors | `npm run validate` runs type-checking, ESLint, and esbuild — ESLint enforces a max complexity of 15 (`sonarjs/cognitive-complexity`, `complexity`). Extract small helper methods proactively instead of chaining ternaries or nesting loops; don't treat 0 *errors* as "done" — re-run validation and check for warnings too |
+| ESLint/complexity warnings appear after `npm --prefix vscode-extension run validate` even though there are 0 errors | `npm --prefix vscode-extension run validate` runs type-checking, ESLint, and esbuild — ESLint enforces a max complexity of 15 (`sonarjs/cognitive-complexity`, `complexity`). Extract small helper methods proactively instead of chaining ternaries or nesting loops; don't treat 0 *errors* as "done" — re-run validation and check for warnings too |
 | `test/unit/ecosystemAdapters.test.ts` fails after adding an adapter | The adapter count assertion (`assert.equal(allAdapters.length, N)`) is hardcoded — bump it and add the new adapter's `id` assertion (Step 7) |
 
 ---
@@ -180,7 +180,7 @@ For broader session-level caveats (multiple bullet points), use the `editorNote:
 - [ ] `test/unit/ecosystemAdapters.test.ts` — adapter added to `allAdapters`, count bumped, `id` assertion added
 - [ ] (Optional) `webview/diagnostics/main.ts` + `styles.css` — dedicated badge class/colour, only if the generic fallback isn't distinctive enough
 - [ ] (Optional) `webview/logviewer/main.ts` — `ESTIMATED_TOKENS_NOTES` entry if the editor doesn't persist actual token counts
-- [ ] `npm run validate` passes with **0 errors and 0 warnings** (not just 0 errors — check for complexity/lint warnings on new code)
+- [ ] `npm --prefix vscode-extension run validate` passes with **0 errors and 0 warnings** (not just 0 errors — check for complexity/lint warnings on new code)
 - [ ] CLI build (`cd cli && npm run build`) succeeds, since it shares the same adapter registry
 - [ ] `node cli/dist/cli.js diagnostics` shows the new editor's candidate path as `yes` (exists) with non-zero file/session/token counts — this is the fastest end-to-end confidence check
 - [ ] Sessions appear in the session list with the correct editor name and icon

--- a/.github/agents/new-editor-support.agent.md
+++ b/.github/agents/new-editor-support.agent.md
@@ -164,7 +164,7 @@ For broader session-level caveats (multiple bullet points), use the `editorNote:
 | Sessions discovered but tokens show 0 | Check the adapter's `getTokens()` — it may be missing or not returning early; confirm the underlying data-access method actually extracts text from the right fields |
 | Virtual paths fail `fs.promises.stat()` | Implement `stat()` on the adapter to resolve virtual paths to the real backing DB/file path (see `getBackingPath()` in `CrushAdapter`) |
 | Discovery loop finds 0 sessions even though the file/DB exists | Verify the project/workspace registry reader returns the correct data directory (not just the project's working-directory path) and that the joined path matches the actual file on disk |
-| ESLint/complexity warnings appear after `npm run compile` even though there are 0 errors | `npm run compile` runs `tsc && eslint && esbuild` — ESLint enforces a max complexity of 15 (`sonarjs/cognitive-complexity`, `complexity`). Extract small helper methods proactively instead of chaining ternaries or nesting loops; don't treat 0 *errors* as "done" — re-run compile and check for warnings too |
+| ESLint/complexity warnings appear after `npm run validate` even though there are 0 errors | `npm run validate` runs type-checking, ESLint, and esbuild — ESLint enforces a max complexity of 15 (`sonarjs/cognitive-complexity`, `complexity`). Extract small helper methods proactively instead of chaining ternaries or nesting loops; don't treat 0 *errors* as "done" — re-run validation and check for warnings too |
 | `test/unit/ecosystemAdapters.test.ts` fails after adding an adapter | The adapter count assertion (`assert.equal(allAdapters.length, N)`) is hardcoded — bump it and add the new adapter's `id` assertion (Step 7) |
 
 ---
@@ -180,7 +180,7 @@ For broader session-level caveats (multiple bullet points), use the `editorNote:
 - [ ] `test/unit/ecosystemAdapters.test.ts` — adapter added to `allAdapters`, count bumped, `id` assertion added
 - [ ] (Optional) `webview/diagnostics/main.ts` + `styles.css` — dedicated badge class/colour, only if the generic fallback isn't distinctive enough
 - [ ] (Optional) `webview/logviewer/main.ts` — `ESTIMATED_TOKENS_NOTES` entry if the editor doesn't persist actual token counts
-- [ ] `npm run compile` passes with **0 errors and 0 warnings** (not just 0 errors — check for complexity/lint warnings on new code)
+- [ ] `npm run validate` passes with **0 errors and 0 warnings** (not just 0 errors — check for complexity/lint warnings on new code)
 - [ ] CLI build (`cd cli && npm run build`) succeeds, since it shares the same adapter registry
 - [ ] `node cli/dist/cli.js diagnostics` shows the new editor's candidate path as `yes` (exists) with non-zero file/session/token counts — this is the fastest end-to-end confidence check
 - [ ] Sessions appear in the session list with the correct editor name and icon

--- a/.github/agents/tool-names.agent.md
+++ b/.github/agents/tool-names.agent.md
@@ -169,7 +169,7 @@ When adding a new tool to `toolNames.json`, also determine if it belongs in `aut
 
 After editing `src/toolNames.json`:
 
-1. Run `npm run compile` to verify ESLint + build passes
+1. Run `npm run validate` to verify type-checking, ESLint, and the build pass
 2. Ensure the JSON is valid (no trailing commas, proper quoting)
 3. Run tests with `npm run test:node` to confirm nothing is broken
 
@@ -217,5 +217,5 @@ This is already handled by `workspaceHelpers.ts` (`detectToolEditorFromPath`, `d
 - [ ] Generate friendly names following the conventions above
 - [ ] Add entries to `src/toolNames.json` in the correct location
 - [ ] For each new tool, decide if it is **automatic** or **intentional** — add automatic tools to `src/automaticTools.json`
-- [ ] Run `npm run compile` to validate
+- [ ] Run `npm run validate`
 - [ ] Run `npm run test:node` to confirm tests pass

--- a/.github/agents/tool-names.agent.md
+++ b/.github/agents/tool-names.agent.md
@@ -169,9 +169,9 @@ When adding a new tool to `toolNames.json`, also determine if it belongs in `aut
 
 After editing `src/toolNames.json`:
 
-1. Run `npm run validate` to verify type-checking, ESLint, and the build pass
+1. Run `npm --prefix vscode-extension run validate` to verify type-checking, ESLint, and the build pass
 2. Ensure the JSON is valid (no trailing commas, proper quoting)
-3. Run tests with `npm run test:node` to confirm nothing is broken
+3. Run tests with `npm --prefix vscode-extension run test:node` to confirm nothing is broken
 
 ## Upstream Sync Reference
 
@@ -217,5 +217,5 @@ This is already handled by `workspaceHelpers.ts` (`detectToolEditorFromPath`, `d
 - [ ] Generate friendly names following the conventions above
 - [ ] Add entries to `src/toolNames.json` in the correct location
 - [ ] For each new tool, decide if it is **automatic** or **intentional** — add automatic tools to `src/automaticTools.json`
-- [ ] Run `npm run validate`
-- [ ] Run `npm run test:node` to confirm tests pass
+- [ ] Run `npm --prefix vscode-extension run validate`
+- [ ] Run `npm --prefix vscode-extension run test:node` to confirm tests pass

--- a/.github/instructions/vscode-extension.instructions.md
+++ b/.github/instructions/vscode-extension.instructions.md
@@ -49,13 +49,14 @@ The entire extension's logic is contained within the `CopilotTokenTracker` class
 ## Developer Workflow
 
 - **Setup**: Run `npm install` inside `vscode-extension/` to install dependencies.
-- **Build**: Run `npm run compile` from `vscode-extension/` to lint and build the extension using `esbuild`. The output is a single file: `vscode-extension/dist/extension.js`.
+- **Build**: Run `npm run compile` from `vscode-extension/` to build the extension using `esbuild`. The output is a single file: `vscode-extension/dist/extension.js`.
+- **Validation**: Run `npm run validate` to type-check, lint, and build the extension.
 - **Watch Mode**: For active development, use `npm run watch` from `vscode-extension/`. This will automatically recompile the extension on file changes.
-- **Testing/Debugging (human developers only)**: Press `F5` in VS Code to open the Extension Development Host. This will launch a new VS Code window with the extension running. `console.log` statements from `vscode-extension/src/extension.ts` will appear in the Developer Tools console of this new window (Help > Toggle Developer Tools). **AI agents must never do this** — see "Never launch a real editor/IDE instance" in the root `.github/copilot-instructions.md`. Use `npm run compile` and `npm run test:node` / `npm run test:coverage` to validate changes instead.
+- **Testing/Debugging (human developers only)**: Press `F5` in VS Code to open the Extension Development Host. This will launch a new VS Code window with the extension running. `console.log` statements from `vscode-extension/src/extension.ts` will appear in the Developer Tools console of this new window (Help > Toggle Developer Tools). **AI agents must never do this** — see "Never launch a real editor/IDE instance" in the root `.github/copilot-instructions.md`. Use `npm run validate` and `npm run test:node` / `npm run test:coverage` to validate changes instead.
 
-**Important build guidance:** After making changes to source code or related files (TypeScript, JavaScript, JSON, or other code files used by the extension), always run both `npm ci` and then `npm run compile` from `vscode-extension/` to validate that the project still builds and lints cleanly before opening a pull request or releasing. Also run the unit tests with `npm run test:node` to catch any regressions. You do not need to run the full compile step for documentation-only changes (Markdown files), but you should run it after any edits that touch source, configuration, or JSON data files.
+**Important build guidance:** After making changes to source code or related files (TypeScript, JavaScript, JSON, or other code files used by the extension), always run both `npm ci` and then `npm run validate` from `vscode-extension/` to validate that the project still builds and lints cleanly before opening a pull request or releasing. Also run the unit tests with `npm run test:node` to catch any regressions. You do not need to run the full validation step for documentation-only changes (Markdown files), but you should run it after any edits that touch source, configuration, or JSON data files.
 
-**Zero warnings policy:** `npm run compile` must report `0 problems (0 errors, 0 warnings)`. ESLint warnings count as failures — do not leave new warnings in the codebase. If `compile` outputs `✖ N problems`, fix all of them before committing.
+**Zero warnings policy:** `npm run validate` must report `0 problems (0 errors, 0 warnings)`. ESLint warnings count as failures — do not leave new warnings in the codebase. If validation outputs `✖ N problems`, fix all of them before committing.
 
 **Always use `npm ci` (not `npm install`) when validating a build** — `npm ci` installs from the lockfile exactly, mirroring what CI does, and will catch any dependency drift. Use `npm install` only when intentionally adding or updating packages.
 
@@ -304,7 +305,7 @@ To maintain a consistent, VS Code-native look across all webview panels (Details
 - **Checklist for PRs touching webviews**:
   - Ensure the toolkit is registered before creating `vscode-button` elements.
   - Keep navigation command names unchanged so `extension.ts` handlers continue to work.
-  - Run `npm run compile` and verify TypeScript and ESLint pass.
+  - Run `npm run validate` and verify TypeScript and ESLint pass.
   - Visually compare the header with the Details and other panels to confirm parity.
 
 ## Webview State Persistence
@@ -405,4 +406,3 @@ Current adapter set (9):
 - [ ] Also update the CLI side — see `.github/instructions/cli.instructions.md`
 
 **`handles()` for CopilotChat/Cli currently returns `false`**: discovery is owned by the adapters, but per-session parsing is still routed through the existing fallback path in `extension.ts` (`countInteractionsInSession`, `estimateTokensFromSession`, `getSessionFileDataCached`). A future PR can flip `handles()` to use the exported `isCopilotChatSessionPath` / `isCopilotCliSessionPath` predicates once the JSON parser helpers are extracted from `extension.ts`. When you flip `handles()`, also fix `_detectEditorSource(filePath, (p) => !!this.findEcosystem(p))` at extension.ts:~3224 — the predicate must check `?.id === 'opencode'` (or use `getEditorTypeFromPath` convention) so that VS Code paths are still labeled "VS Code", not "OpenCode".
-

--- a/.github/skills/check-urls/SKILL.md
+++ b/.github/skills/check-urls/SKILL.md
@@ -43,7 +43,7 @@ The script will:
 2. **404 on code.visualstudio.com**: The VS Code docs may have been reorganised. Search [VS Code docs](https://code.visualstudio.com/docs) for the relevant topic and update the link.
 3. **Timeout**: May be a transient network issue. Re-run the script to confirm before changing anything.
 4. After fixing, re-run `node .github/skills/check-urls/check-urls.js` to confirm all URLs resolve.
-5. Run `npm run validate` to confirm type-checking, linting, and the build still pass.
+5. Run `npm --prefix vscode-extension run validate` to confirm type-checking, linting, and the build still pass.
 
 ## Files in This Directory
 

--- a/.github/skills/check-urls/SKILL.md
+++ b/.github/skills/check-urls/SKILL.md
@@ -43,7 +43,7 @@ The script will:
 2. **404 on code.visualstudio.com**: The VS Code docs may have been reorganised. Search [VS Code docs](https://code.visualstudio.com/docs) for the relevant topic and update the link.
 3. **Timeout**: May be a transient network issue. Re-run the script to confirm before changing anything.
 4. After fixing, re-run `node .github/skills/check-urls/check-urls.js` to confirm all URLs resolve.
-5. Run `npm run compile` to confirm the TypeScript build still passes.
+5. Run `npm run validate` to confirm type-checking, linting, and the build still pass.
 
 ## Files in This Directory
 

--- a/.github/skills/improve-tool-families/SKILL.md
+++ b/.github/skills/improve-tool-families/SKILL.md
@@ -81,7 +81,7 @@ node .github/skills/improve-tool-families/analyze-tool-families.js --json
      tools, orchestration tools like `task`/`write_agent`) → leave it out;
      not every tool needs a family.
 3. Edit `vscode-extension/src/toolFamilies.ts` (`DEFAULT_TOOL_FAMILIES`).
-4. Verify with `cd vscode-extension && npm run compile` (tsc + eslint +
+4. Verify with `cd vscode-extension && npm run validate` (tsc + eslint +
    esbuild).
 5. Re-run this script to confirm the previously-uncovered names are now
    covered.

--- a/.github/skills/visual-view-diff/visual-diff.js
+++ b/.github/skills/visual-view-diff/visual-diff.js
@@ -80,9 +80,8 @@ function buildWebviews(checkoutRoot, label) {
 	}
 
 	console.log(`\n▶ Building webview bundles (${label})…`);
-	// esbuild only — `npm run compile` would also run tsc and eslint, which are
-	// irrelevant to how a view looks and would fail the baseline build for
-	// reasons that have nothing to do with this comparison.
+	// Invoke esbuild directly because baseline revisions may still define
+	// `npm run compile` as a combined type-check, lint, and bundle command.
 	run(process.execPath, ['esbuild.js'], extensionDir);
 }
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,7 +146,8 @@ Do not enter retry loops trying to capture terminal output. These patterns waste
 ### What to do instead
 
 1. **Use `npm` scripts for standard operations** (from inside `vscode-extension/`):
-   - `npm run compile` — lint + build
+   - `npm run compile` — build the extension bundles
+   - `npm run validate` — type-check + lint + build
    - `npm run compile-tests` — compile test files to `out/`
    - `npm run test:node` — compile + run unit tests
    - `npm run test:coverage` — compile + run tests with coverage thresholds

--- a/build.ps1
+++ b/build.ps1
@@ -80,7 +80,7 @@ function Build-VsCode {
     Push-Location "$PSScriptRoot/vscode-extension"
     try {
         switch ($Target) {
-            'build'   { Ensure-NpmDeps .; npm run compile }
+            'build'   { Ensure-NpmDeps .; npm run validate }
             'package' { Ensure-NpmDeps .; npm run package; npx vsce package }
             'test'    { Ensure-NpmDeps .; npm run test:node }
             'clean'   { Remove-Item -Recurse -Force dist, out -ErrorAction SilentlyContinue }

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -503,7 +503,8 @@
   },
   "scripts": {
     "vscode:prepublish": "npm run package",
-    "compile": "tsc --noEmit && eslint src ../src && node esbuild.js",
+    "compile": "node esbuild.js",
+    "validate": "npm run check-types && npm run lint && npm run compile",
     "watch": "npm-run-all -p watch:*",
     "watch:esbuild": "node esbuild.js --watch",
     "watch:tsc": "tsc --noEmit --watch --project tsconfig.json",


### PR DESCRIPTION
`npm run compile` had grown into a full type-check, lint, and bundle pipeline, making every iterative rebuild take 20-30 seconds or longer on a cold filesystem.

This change restores `compile` as an esbuild-only command and adds `npm run validate` for the former full pipeline. CI and packaging retain their existing type-checking and linting safeguards, while local warmed compilation drops to approximately 2.6 seconds. Contributor instructions, skills, and mirrored Claude agent guidance now point to `validate` when full verification is required.