### PR TITLE
Fix recent sessions loading in thin IDE hosts

### DIFF
--- a/cli/src/helpers.ts
+++ b/cli/src/helpers.ts
@@ -22,6 +22,7 @@ import type { DetailedStats, ModelUsage, UsageAnalysisStats, WorkspaceCustomizat
 import { analyzeSessionUsage, mergeUsageAnalysis, getModelUsageFromSession } from '../../src/usageAnalysis';
 import { reconcileModelUsageToActualTokens } from '../../src/statsHelpers';
 import { withErrorRecovery } from '../../src/utils/errors';
+import { buildRecentSessionBuckets, type RecentSessionBucketItem } from '../../src/recentSessions';
 import * as vscodeStub from './vscode-stub';
 import { loadCache, saveCache, disableCache, getCached, setCached, getCacheStats } from './cliCache';
 import { ENVIRONMENTAL } from './constants';
@@ -540,6 +541,7 @@ export async function calculateUsageAnalysisStats(sessionFiles: string[]): Promi
 	const monthPeriod = createEmptyUsageAnalysisPeriod();
 	const lastMonthPeriod = createEmptyUsageAnalysisPeriod();
 	const todaySessions: TodaySessionSummary[] = [];
+	const recentSessionItems: RecentSessionBucketItem<TodaySessionSummary>[] = [];
 
 	for (const file of sessionFiles) {
 		try {
@@ -551,6 +553,38 @@ export async function calculateUsageAnalysisStats(sessionFiles: string[]): Promi
 			}
 
 			const analysis = await analyzeSessionUsage(deps, file);
+			let sessionSummary: TodaySessionSummary | undefined;
+			const data = modified >= last30DaysStart ? await processSessionFile(file) : undefined;
+			if (data && data.interactions > 0) {
+				let inputTokens = 0, outputTokens = 0, cachedTokens = 0;
+				for (const usage of Object.values(data.modelUsage)) {
+					inputTokens += usage.inputTokens;
+					outputTokens += usage.outputTokens;
+					cachedTokens += usage.cachedReadTokens ?? 0;
+				}
+				sessionSummary = {
+					title: null,
+					filePath: file,
+					interactions: data.interactions,
+					toolCalls: analysis.toolCalls.total,
+					inputTokens,
+					outputTokens,
+					thinkingTokens: data.thinkingTokens ?? 0,
+					cachedTokens,
+					totalTokens: data.tokens,
+					estimatedCost: calculateEstimatedCost(data.modelUsage, modelPricing),
+					editor: data.editorSource,
+					models: Object.keys(data.modelUsage),
+					lastActivity: data.lastModified.toISOString(),
+					...(analysis.sessionDuration?.totalDurationMs !== undefined ? { durationMs: analysis.sessionDuration.totalDurationMs } : {}),
+					...(analysis.sessionDuration?.activeDurationMs !== undefined ? { activeDurationMs: analysis.sessionDuration.activeDurationMs } : {}),
+				};
+				recentSessionItems.push({
+					activityKey: toLocalDayKey(data.lastModified),
+					interactions: data.interactions,
+					value: sessionSummary,
+				});
+			}
 
 			if (modified >= last30DaysStart) {
 				mergeUsageAnalysis(last30DaysPeriod, analysis);
@@ -563,34 +597,7 @@ export async function calculateUsageAnalysisStats(sessionFiles: string[]): Promi
 			if (modified >= todayStart) {
 				mergeUsageAnalysis(todayPeriod, analysis);
 				todayPeriod.sessions++;
-				// Build per-session summary for the Today's Sessions tab.
-				// processSessionFile uses the shared LRU cache so the file isn't re-read on disk.
-				const data = await processSessionFile(file);
-				if (data && data.interactions > 0) {
-					let inputTokens = 0, outputTokens = 0, cachedTokens = 0;
-					for (const usage of Object.values(data.modelUsage)) {
-						inputTokens += usage.inputTokens;
-						outputTokens += usage.outputTokens;
-						cachedTokens += usage.cachedReadTokens ?? 0;
-					}
-					todaySessions.push({
-						title: null,
-						filePath: file,
-						interactions: data.interactions,
-						toolCalls: analysis.toolCalls.total,
-						inputTokens,
-						outputTokens,
-						thinkingTokens: data.thinkingTokens ?? 0,
-						cachedTokens,
-						totalTokens: data.tokens,
-						estimatedCost: calculateEstimatedCost(data.modelUsage, modelPricing),
-						editor: data.editorSource,
-						models: Object.keys(data.modelUsage),
-						lastActivity: data.lastModified.toISOString(),
-						...(analysis.sessionDuration?.totalDurationMs !== undefined ? { durationMs: analysis.sessionDuration.totalDurationMs } : {}),
-						...(analysis.sessionDuration?.activeDurationMs !== undefined ? { activeDurationMs: analysis.sessionDuration.activeDurationMs } : {}),
-					});
-				}
+				if (sessionSummary) { todaySessions.push(sessionSummary); }
 			}
 			if (modified >= lastMonthStart && modified < monthStart) {
 				mergeUsageAnalysis(lastMonthPeriod, analysis);
@@ -608,6 +615,7 @@ export async function calculateUsageAnalysisStats(sessionFiles: string[]): Promi
 		lastMonth: lastMonthPeriod,
 		lastUpdated: now,
 		todaySessions: todaySessions.sort((a, b) => b.interactions - a.interactions),
+		recentSessions: buildRecentSessionBuckets(recentSessionItems, now),
 	};
 }
 

--- a/cli/src/test/sharedLogicContract.test.ts
+++ b/cli/src/test/sharedLogicContract.test.ts
@@ -26,7 +26,7 @@ import { getModelUsageFromSession } from '../../../src/usageAnalysis';
 import tokenEstimatorsData from '../../../src/tokenEstimators.json';
 import modelPricingData from '../../../src/modelPricing.json';
 
-import { processSessionFile } from '../helpers';
+import { calculateUsageAnalysisStats, processSessionFile } from '../helpers';
 import { disableCache } from '../cliCache';
 
 const tokenEstimators: { [key: string]: number } = tokenEstimatorsData.estimators;
@@ -98,4 +98,15 @@ test('CLI processSessionFile reports model attribution for delta-format sessions
 	assert.equal(data!.modelUsage['claude-sonnet-4.5']?.inputTokens, 80);
 	assert.equal(data!.modelUsage['claude-sonnet-4.5']?.outputTokens, 25);
 	assert.ok(data!.tokens > 0, 'token counts should come from estimateTokensFromJsonlSession');
+});
+
+test('CLI usage analysis includes recent-session buckets for thin IDE hosts', async () => {
+	disableCache();
+
+	const stats = await calculateUsageAnalysisStats([FIXTURE_PATH]);
+
+	assert.equal(stats.recentSessions?.last7.length, 1);
+	assert.equal(stats.recentSessions?.last30.length, 1);
+	assert.equal(stats.recentSessions?.currentMonth.length, 1);
+	assert.equal(stats.recentSessions?.last7[0].filePath, FIXTURE_PATH);
 });

--- a/src/recentSessions.ts
+++ b/src/recentSessions.ts
@@ -1,0 +1,31 @@
+import { toLocalDayKey } from './utils/dayKeys';
+
+export type RecentSessionBuckets<T> = {
+	last7: T[];
+	last30: T[];
+	currentMonth: T[];
+};
+
+export type RecentSessionBucketItem<T> = {
+	activityKey: string;
+	interactions: number;
+	value: T;
+};
+
+export function buildRecentSessionBuckets<T>(
+	items: RecentSessionBucketItem<T>[],
+	now: Date,
+): RecentSessionBuckets<T> {
+	const last7Key = toLocalDayKey(new Date(now.getFullYear(), now.getMonth(), now.getDate() - 7));
+	const last30Key = toLocalDayKey(new Date(now.getFullYear(), now.getMonth(), now.getDate() - 30));
+	const monthKey = toLocalDayKey(new Date(now.getFullYear(), now.getMonth(), 1));
+	const buckets: RecentSessionBuckets<T> = { last7: [], last30: [], currentMonth: [] };
+
+	for (const item of [...items].sort((a, b) => b.interactions - a.interactions)) {
+		if (item.activityKey >= last7Key) { buckets.last7.push(item.value); }
+		if (item.activityKey >= last30Key) { buckets.last30.push(item.value); }
+		if (item.activityKey >= monthKey) { buckets.currentMonth.push(item.value); }
+	}
+
+	return buckets;
+}

--- a/src/recentSessions.ts
+++ b/src/recentSessions.ts
@@ -1,4 +1,4 @@
-import { toLocalDayKey } from './utils/dayKeys';
+import { getTimeWindowStartDayKey } from './timeWindows';
 
 export type RecentSessionBuckets<T> = {
 	last7: T[];
@@ -16,9 +16,9 @@ export function buildRecentSessionBuckets<T>(
 	items: RecentSessionBucketItem<T>[],
 	now: Date,
 ): RecentSessionBuckets<T> {
-	const last7Key = toLocalDayKey(new Date(now.getFullYear(), now.getMonth(), now.getDate() - 7));
-	const last30Key = toLocalDayKey(new Date(now.getFullYear(), now.getMonth(), now.getDate() - 30));
-	const monthKey = toLocalDayKey(new Date(now.getFullYear(), now.getMonth(), 1));
+	const last7Key = getTimeWindowStartDayKey('last7', now);
+	const last30Key = getTimeWindowStartDayKey('last30', now);
+	const monthKey = getTimeWindowStartDayKey('currentMonth', now);
 	const buckets: RecentSessionBuckets<T> = { last7: [], last30: [], currentMonth: [] };
 
 	for (const item of [...items].sort((a, b) => b.interactions - a.interactions)) {

--- a/visualstudio-extension/src/AIEngineeringFluency/webview/usage.js
+++ b/visualstudio-extension/src/AIEngineeringFluency/webview/usage.js
@@ -1,908 +1,9 @@
-"use strict";
-(() => {
-  var __defProp = Object.defineProperty;
-  var __getOwnPropNames = Object.getOwnPropertyNames;
-  var __esm = (fn, res, err) => function __init() {
-    if (err) throw err[0];
-    try {
-      return fn && (res = (0, fn[__getOwnPropNames(fn)[0]])(fn = 0)), res;
-    } catch (e7) {
-      throw err = [e7], e7;
-    }
-  };
-  var __export = (target, all) => {
-    for (var name in all)
-      __defProp(target, name, { get: all[name], enumerable: true });
-  };
-
-  // node_modules/@lit/reactive-element/css-tag.js
-  var t, e, s, o, n, r, i, S, c;
-  var init_css_tag = __esm({
-    "node_modules/@lit/reactive-element/css-tag.js"() {
-      t = globalThis;
-      e = t.ShadowRoot && (void 0 === t.ShadyCSS || t.ShadyCSS.nativeShadow) && "adoptedStyleSheets" in Document.prototype && "replace" in CSSStyleSheet.prototype;
-      s = /* @__PURE__ */ Symbol();
-      o = /* @__PURE__ */ new WeakMap();
-      n = class {
-        constructor(t4, e7, o7) {
-          if (this._$cssResult$ = true, o7 !== s) throw Error("CSSResult is not constructable. Use `unsafeCSS` or `css` instead.");
-          this.cssText = t4, this.t = e7;
-        }
-        get styleSheet() {
-          let t4 = this.o;
-          const s4 = this.t;
-          if (e && void 0 === t4) {
-            const e7 = void 0 !== s4 && 1 === s4.length;
-            e7 && (t4 = o.get(s4)), void 0 === t4 && ((this.o = t4 = new CSSStyleSheet()).replaceSync(this.cssText), e7 && o.set(s4, t4));
-          }
-          return t4;
-        }
-        toString() {
-          return this.cssText;
-        }
-      };
-      r = (t4) => new n("string" == typeof t4 ? t4 : t4 + "", void 0, s);
-      i = (t4, ...e7) => {
-        const o7 = 1 === t4.length ? t4[0] : e7.reduce((e8, s4, o8) => e8 + ((t5) => {
-          if (true === t5._$cssResult$) return t5.cssText;
-          if ("number" == typeof t5) return t5;
-          throw Error("Value passed to 'css' function must be a 'css' function result: " + t5 + ". Use 'unsafeCSS' to pass non-literal values, but take care to ensure page security.");
-        })(s4) + t4[o8 + 1], t4[0]);
-        return new n(o7, t4, s);
-      };
-      S = (s4, o7) => {
-        if (e) s4.adoptedStyleSheets = o7.map((t4) => t4 instanceof CSSStyleSheet ? t4 : t4.styleSheet);
-        else for (const e7 of o7) {
-          const o8 = document.createElement("style"), n5 = t.litNonce;
-          void 0 !== n5 && o8.setAttribute("nonce", n5), o8.textContent = e7.cssText, s4.appendChild(o8);
-        }
-      };
-      c = e ? (t4) => t4 : (t4) => t4 instanceof CSSStyleSheet ? ((t5) => {
-        let e7 = "";
-        for (const s4 of t5.cssRules) e7 += s4.cssText;
-        return r(e7);
-      })(t4) : t4;
-    }
-  });
-
-  // node_modules/@lit/reactive-element/reactive-element.js
-  var i2, e2, h, r2, o2, n2, a, c2, l, p, d, u, f, b, y;
-  var init_reactive_element = __esm({
-    "node_modules/@lit/reactive-element/reactive-element.js"() {
-      init_css_tag();
-      init_css_tag();
-      ({ is: i2, defineProperty: e2, getOwnPropertyDescriptor: h, getOwnPropertyNames: r2, getOwnPropertySymbols: o2, getPrototypeOf: n2 } = Object);
-      a = globalThis;
-      c2 = a.trustedTypes;
-      l = c2 ? c2.emptyScript : "";
-      p = a.reactiveElementPolyfillSupport;
-      d = (t4, s4) => t4;
-      u = { toAttribute(t4, s4) {
-        switch (s4) {
-          case Boolean:
-            t4 = t4 ? l : null;
-            break;
-          case Object:
-          case Array:
-            t4 = null == t4 ? t4 : JSON.stringify(t4);
-        }
-        return t4;
-      }, fromAttribute(t4, s4) {
-        let i6 = t4;
-        switch (s4) {
-          case Boolean:
-            i6 = null !== t4;
-            break;
-          case Number:
-            i6 = null === t4 ? null : Number(t4);
-            break;
-          case Object:
-          case Array:
-            try {
-              i6 = JSON.parse(t4);
-            } catch (t5) {
-              i6 = null;
-            }
-        }
-        return i6;
-      } };
-      f = (t4, s4) => !i2(t4, s4);
-      b = { attribute: true, type: String, converter: u, reflect: false, useDefault: false, hasChanged: f };
-      Symbol.metadata ?? (Symbol.metadata = /* @__PURE__ */ Symbol("metadata")), a.litPropertyMetadata ?? (a.litPropertyMetadata = /* @__PURE__ */ new WeakMap());
-      y = class extends HTMLElement {
-        static addInitializer(t4) {
-          this._$Ei(), (this.l ?? (this.l = [])).push(t4);
-        }
-        static get observedAttributes() {
-          return this.finalize(), this._$Eh && [...this._$Eh.keys()];
-        }
-        static createProperty(t4, s4 = b) {
-          if (s4.state && (s4.attribute = false), this._$Ei(), this.prototype.hasOwnProperty(t4) && ((s4 = Object.create(s4)).wrapped = true), this.elementProperties.set(t4, s4), !s4.noAccessor) {
-            const i6 = /* @__PURE__ */ Symbol(), h3 = this.getPropertyDescriptor(t4, i6, s4);
-            void 0 !== h3 && e2(this.prototype, t4, h3);
-          }
-        }
-        static getPropertyDescriptor(t4, s4, i6) {
-          const { get: e7, set: r6 } = h(this.prototype, t4) ?? { get() {
-            return this[s4];
-          }, set(t5) {
-            this[s4] = t5;
-          } };
-          return { get: e7, set(s5) {
-            const h3 = e7?.call(this);
-            r6?.call(this, s5), this.requestUpdate(t4, h3, i6);
-          }, configurable: true, enumerable: true };
-        }
-        static getPropertyOptions(t4) {
-          return this.elementProperties.get(t4) ?? b;
-        }
-        static _$Ei() {
-          if (this.hasOwnProperty(d("elementProperties"))) return;
-          const t4 = n2(this);
-          t4.finalize(), void 0 !== t4.l && (this.l = [...t4.l]), this.elementProperties = new Map(t4.elementProperties);
-        }
-        static finalize() {
-          if (this.hasOwnProperty(d("finalized"))) return;
-          if (this.finalized = true, this._$Ei(), this.hasOwnProperty(d("properties"))) {
-            const t5 = this.properties, s4 = [...r2(t5), ...o2(t5)];
-            for (const i6 of s4) this.createProperty(i6, t5[i6]);
-          }
-          const t4 = this[Symbol.metadata];
-          if (null !== t4) {
-            const s4 = litPropertyMetadata.get(t4);
-            if (void 0 !== s4) for (const [t5, i6] of s4) this.elementProperties.set(t5, i6);
-          }
-          this._$Eh = /* @__PURE__ */ new Map();
-          for (const [t5, s4] of this.elementProperties) {
-            const i6 = this._$Eu(t5, s4);
-            void 0 !== i6 && this._$Eh.set(i6, t5);
-          }
-          this.elementStyles = this.finalizeStyles(this.styles);
-        }
-        static finalizeStyles(s4) {
-          const i6 = [];
-          if (Array.isArray(s4)) {
-            const e7 = new Set(s4.flat(1 / 0).reverse());
-            for (const s5 of e7) i6.unshift(c(s5));
-          } else void 0 !== s4 && i6.push(c(s4));
-          return i6;
-        }
-        static _$Eu(t4, s4) {
-          const i6 = s4.attribute;
-          return false === i6 ? void 0 : "string" == typeof i6 ? i6 : "string" == typeof t4 ? t4.toLowerCase() : void 0;
-        }
-        constructor() {
-          super(), this._$Ep = void 0, this.isUpdatePending = false, this.hasUpdated = false, this._$Em = null, this._$Ev();
-        }
-        _$Ev() {
-          this._$ES = new Promise((t4) => this.enableUpdating = t4), this._$AL = /* @__PURE__ */ new Map(), this._$E_(), this.requestUpdate(), this.constructor.l?.forEach((t4) => t4(this));
-        }
-        addController(t4) {
-          (this._$EO ?? (this._$EO = /* @__PURE__ */ new Set())).add(t4), void 0 !== this.renderRoot && this.isConnected && t4.hostConnected?.();
-        }
-        removeController(t4) {
-          this._$EO?.delete(t4);
-        }
-        _$E_() {
-          const t4 = /* @__PURE__ */ new Map(), s4 = this.constructor.elementProperties;
-          for (const i6 of s4.keys()) this.hasOwnProperty(i6) && (t4.set(i6, this[i6]), delete this[i6]);
-          t4.size > 0 && (this._$Ep = t4);
-        }
-        createRenderRoot() {
-          const t4 = this.shadowRoot ?? this.attachShadow(this.constructor.shadowRootOptions);
-          return S(t4, this.constructor.elementStyles), t4;
-        }
-        connectedCallback() {
-          this.renderRoot ?? (this.renderRoot = this.createRenderRoot()), this.enableUpdating(true), this._$EO?.forEach((t4) => t4.hostConnected?.());
-        }
-        enableUpdating(t4) {
-        }
-        disconnectedCallback() {
-          this._$EO?.forEach((t4) => t4.hostDisconnected?.());
-        }
-        attributeChangedCallback(t4, s4, i6) {
-          this._$AK(t4, i6);
-        }
-        _$ET(t4, s4) {
-          const i6 = this.constructor.elementProperties.get(t4), e7 = this.constructor._$Eu(t4, i6);
-          if (void 0 !== e7 && true === i6.reflect) {
-            const h3 = (void 0 !== i6.converter?.toAttribute ? i6.converter : u).toAttribute(s4, i6.type);
-            this._$Em = t4, null == h3 ? this.removeAttribute(e7) : this.setAttribute(e7, h3), this._$Em = null;
-          }
-        }
-        _$AK(t4, s4) {
-          const i6 = this.constructor, e7 = i6._$Eh.get(t4);
-          if (void 0 !== e7 && this._$Em !== e7) {
-            const t5 = i6.getPropertyOptions(e7), h3 = "function" == typeof t5.converter ? { fromAttribute: t5.converter } : void 0 !== t5.converter?.fromAttribute ? t5.converter : u;
-            this._$Em = e7;
-            const r6 = h3.fromAttribute(s4, t5.type);
-            this[e7] = r6 ?? this._$Ej?.get(e7) ?? r6, this._$Em = null;
-          }
-        }
-        requestUpdate(t4, s4, i6, e7 = false, h3) {
-          if (void 0 !== t4) {
-            const r6 = this.constructor;
-            if (false === e7 && (h3 = this[t4]), i6 ?? (i6 = r6.getPropertyOptions(t4)), !((i6.hasChanged ?? f)(h3, s4) || i6.useDefault && i6.reflect && h3 === this._$Ej?.get(t4) && !this.hasAttribute(r6._$Eu(t4, i6)))) return;
-            this.C(t4, s4, i6);
-          }
-          false === this.isUpdatePending && (this._$ES = this._$EP());
-        }
-        C(t4, s4, { useDefault: i6, reflect: e7, wrapped: h3 }, r6) {
-          i6 && !(this._$Ej ?? (this._$Ej = /* @__PURE__ */ new Map())).has(t4) && (this._$Ej.set(t4, r6 ?? s4 ?? this[t4]), true !== h3 || void 0 !== r6) || (this._$AL.has(t4) || (this.hasUpdated || i6 || (s4 = void 0), this._$AL.set(t4, s4)), true === e7 && this._$Em !== t4 && (this._$Eq ?? (this._$Eq = /* @__PURE__ */ new Set())).add(t4));
-        }
-        async _$EP() {
-          this.isUpdatePending = true;
-          try {
-            await this._$ES;
-          } catch (t5) {
-            Promise.reject(t5);
-          }
-          const t4 = this.scheduleUpdate();
-          return null != t4 && await t4, !this.isUpdatePending;
-        }
-        scheduleUpdate() {
-          return this.performUpdate();
-        }
-        performUpdate() {
-          if (!this.isUpdatePending) return;
-          if (!this.hasUpdated) {
-            if (this.renderRoot ?? (this.renderRoot = this.createRenderRoot()), this._$Ep) {
-              for (const [t6, s5] of this._$Ep) this[t6] = s5;
-              this._$Ep = void 0;
-            }
-            const t5 = this.constructor.elementProperties;
-            if (t5.size > 0) for (const [s5, i6] of t5) {
-              const { wrapped: t6 } = i6, e7 = this[s5];
-              true !== t6 || this._$AL.has(s5) || void 0 === e7 || this.C(s5, void 0, i6, e7);
-            }
-          }
-          let t4 = false;
-          const s4 = this._$AL;
-          try {
-            t4 = this.shouldUpdate(s4), t4 ? (this.willUpdate(s4), this._$EO?.forEach((t5) => t5.hostUpdate?.()), this.update(s4)) : this._$EM();
-          } catch (s5) {
-            throw t4 = false, this._$EM(), s5;
-          }
-          t4 && this._$AE(s4);
-        }
-        willUpdate(t4) {
-        }
-        _$AE(t4) {
-          this._$EO?.forEach((t5) => t5.hostUpdated?.()), this.hasUpdated || (this.hasUpdated = true, this.firstUpdated(t4)), this.updated(t4);
-        }
-        _$EM() {
-          this._$AL = /* @__PURE__ */ new Map(), this.isUpdatePending = false;
-        }
-        get updateComplete() {
-          return this.getUpdateComplete();
-        }
-        getUpdateComplete() {
-          return this._$ES;
-        }
-        shouldUpdate(t4) {
-          return true;
-        }
-        update(t4) {
-          this._$Eq && (this._$Eq = this._$Eq.forEach((t5) => this._$ET(t5, this[t5]))), this._$EM();
-        }
-        updated(t4) {
-        }
-        firstUpdated(t4) {
-        }
-      };
-      y.elementStyles = [], y.shadowRootOptions = { mode: "open" }, y[d("elementProperties")] = /* @__PURE__ */ new Map(), y[d("finalized")] = /* @__PURE__ */ new Map(), p?.({ ReactiveElement: y }), (a.reactiveElementVersions ?? (a.reactiveElementVersions = [])).push("2.1.2");
-    }
-  });
-
-  // node_modules/lit-html/lit-html.js
-  function V(t4, i6) {
-    if (!u2(t4) || !t4.hasOwnProperty("raw")) throw Error("invalid template strings array");
-    return void 0 !== e3 ? e3.createHTML(i6) : i6;
-  }
-  function M(t4, i6, s4 = t4, e7) {
-    if (i6 === E) return i6;
-    let h3 = void 0 !== e7 ? s4._$Co?.[e7] : s4._$Cl;
-    const o7 = a2(i6) ? void 0 : i6._$litDirective$;
-    return h3?.constructor !== o7 && (h3?._$AO?.(false), void 0 === o7 ? h3 = void 0 : (h3 = new o7(t4), h3._$AT(t4, s4, e7)), void 0 !== e7 ? (s4._$Co ?? (s4._$Co = []))[e7] = h3 : s4._$Cl = h3), void 0 !== h3 && (i6 = M(t4, h3._$AS(t4, i6.values), h3, e7)), i6;
-  }
-  var t2, i3, s2, e3, h2, o3, n3, r3, l2, c3, a2, u2, d2, f2, v, _, m, p2, g, $, y2, x, b2, w, T, E, A, C, P, N, S2, R, k, H, I, L, z, Z, B, D;
-  var init_lit_html = __esm({
-    "node_modules/lit-html/lit-html.js"() {
-      t2 = globalThis;
-      i3 = (t4) => t4;
-      s2 = t2.trustedTypes;
-      e3 = s2 ? s2.createPolicy("lit-html", { createHTML: (t4) => t4 }) : void 0;
-      h2 = "$lit$";
-      o3 = `lit$${Math.random().toFixed(9).slice(2)}$`;
-      n3 = "?" + o3;
-      r3 = `<${n3}>`;
-      l2 = document;
-      c3 = () => l2.createComment("");
-      a2 = (t4) => null === t4 || "object" != typeof t4 && "function" != typeof t4;
-      u2 = Array.isArray;
-      d2 = (t4) => u2(t4) || "function" == typeof t4?.[Symbol.iterator];
-      f2 = "[ 	\n\f\r]";
-      v = /<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g;
-      _ = /-->/g;
-      m = />/g;
-      p2 = RegExp(`>|${f2}(?:([^\\s"'>=/]+)(${f2}*=${f2}*(?:[^ 	
-\f\r"'\`<>=]|("|')|))|$)`, "g");
-      g = /'/g;
-      $ = /"/g;
-      y2 = /^(?:script|style|textarea|title)$/i;
-      x = (t4) => (i6, ...s4) => ({ _$litType$: t4, strings: i6, values: s4 });
-      b2 = x(1);
-      w = x(2);
-      T = x(3);
-      E = /* @__PURE__ */ Symbol.for("lit-noChange");
-      A = /* @__PURE__ */ Symbol.for("lit-nothing");
-      C = /* @__PURE__ */ new WeakMap();
-      P = l2.createTreeWalker(l2, 129);
-      N = (t4, i6) => {
-        const s4 = t4.length - 1, e7 = [];
-        let n5, l3 = 2 === i6 ? "<svg>" : 3 === i6 ? "<math>" : "", c4 = v;
-        for (let i7 = 0; i7 < s4; i7++) {
-          const s5 = t4[i7];
-          let a3, u3, d3 = -1, f3 = 0;
-          for (; f3 < s5.length && (c4.lastIndex = f3, u3 = c4.exec(s5), null !== u3); ) f3 = c4.lastIndex, c4 === v ? "!--" === u3[1] ? c4 = _ : void 0 !== u3[1] ? c4 = m : void 0 !== u3[2] ? (y2.test(u3[2]) && (n5 = RegExp("</" + u3[2], "g")), c4 = p2) : void 0 !== u3[3] && (c4 = p2) : c4 === p2 ? ">" === u3[0] ? (c4 = n5 ?? v, d3 = -1) : void 0 === u3[1] ? d3 = -2 : (d3 = c4.lastIndex - u3[2].length, a3 = u3[1], c4 = void 0 === u3[3] ? p2 : '"' === u3[3] ? $ : g) : c4 === $ || c4 === g ? c4 = p2 : c4 === _ || c4 === m ? c4 = v : (c4 = p2, n5 = void 0);
-          const x2 = c4 === p2 && t4[i7 + 1].startsWith("/>") ? " " : "";
-          l3 += c4 === v ? s5 + r3 : d3 >= 0 ? (e7.push(a3), s5.slice(0, d3) + h2 + s5.slice(d3) + o3 + x2) : s5 + o3 + (-2 === d3 ? i7 : x2);
-        }
-        return [V(t4, l3 + (t4[s4] || "<?>") + (2 === i6 ? "</svg>" : 3 === i6 ? "</math>" : "")), e7];
-      };
-      S2 = class _S {
-        constructor({ strings: t4, _$litType$: i6 }, e7) {
-          let r6;
-          this.parts = [];
-          let l3 = 0, a3 = 0;
-          const u3 = t4.length - 1, d3 = this.parts, [f3, v2] = N(t4, i6);
-          if (this.el = _S.createElement(f3, e7), P.currentNode = this.el.content, 2 === i6 || 3 === i6) {
-            const t5 = this.el.content.firstChild;
-            t5.replaceWith(...t5.childNodes);
-          }
-          for (; null !== (r6 = P.nextNode()) && d3.length < u3; ) {
-            if (1 === r6.nodeType) {
-              if (r6.hasAttributes()) for (const t5 of r6.getAttributeNames()) if (t5.endsWith(h2)) {
-                const i7 = v2[a3++], s4 = r6.getAttribute(t5).split(o3), e8 = /([.?@])?(.*)/.exec(i7);
-                d3.push({ type: 1, index: l3, name: e8[2], strings: s4, ctor: "." === e8[1] ? I : "?" === e8[1] ? L : "@" === e8[1] ? z : H }), r6.removeAttribute(t5);
-              } else t5.startsWith(o3) && (d3.push({ type: 6, index: l3 }), r6.removeAttribute(t5));
-              if (y2.test(r6.tagName)) {
-                const t5 = r6.textContent.split(o3), i7 = t5.length - 1;
-                if (i7 > 0) {
-                  r6.textContent = s2 ? s2.emptyScript : "";
-                  for (let s4 = 0; s4 < i7; s4++) r6.append(t5[s4], c3()), P.nextNode(), d3.push({ type: 2, index: ++l3 });
-                  r6.append(t5[i7], c3());
-                }
-              }
-            } else if (8 === r6.nodeType) if (r6.data === n3) d3.push({ type: 2, index: l3 });
-            else {
-              let t5 = -1;
-              for (; -1 !== (t5 = r6.data.indexOf(o3, t5 + 1)); ) d3.push({ type: 7, index: l3 }), t5 += o3.length - 1;
-            }
-            l3++;
-          }
-        }
-        static createElement(t4, i6) {
-          const s4 = l2.createElement("template");
-          return s4.innerHTML = t4, s4;
-        }
-      };
-      R = class {
-        constructor(t4, i6) {
-          this._$AV = [], this._$AN = void 0, this._$AD = t4, this._$AM = i6;
-        }
-        get parentNode() {
-          return this._$AM.parentNode;
-        }
-        get _$AU() {
-          return this._$AM._$AU;
-        }
-        u(t4) {
-          const { el: { content: i6 }, parts: s4 } = this._$AD, e7 = (t4?.creationScope ?? l2).importNode(i6, true);
-          P.currentNode = e7;
-          let h3 = P.nextNode(), o7 = 0, n5 = 0, r6 = s4[0];
-          for (; void 0 !== r6; ) {
-            if (o7 === r6.index) {
-              let i7;
-              2 === r6.type ? i7 = new k(h3, h3.nextSibling, this, t4) : 1 === r6.type ? i7 = new r6.ctor(h3, r6.name, r6.strings, this, t4) : 6 === r6.type && (i7 = new Z(h3, this, t4)), this._$AV.push(i7), r6 = s4[++n5];
-            }
-            o7 !== r6?.index && (h3 = P.nextNode(), o7++);
-          }
-          return P.currentNode = l2, e7;
-        }
-        p(t4) {
-          let i6 = 0;
-          for (const s4 of this._$AV) void 0 !== s4 && (void 0 !== s4.strings ? (s4._$AI(t4, s4, i6), i6 += s4.strings.length - 2) : s4._$AI(t4[i6])), i6++;
-        }
-      };
-      k = class _k {
-        get _$AU() {
-          return this._$AM?._$AU ?? this._$Cv;
-        }
-        constructor(t4, i6, s4, e7) {
-          this.type = 2, this._$AH = A, this._$AN = void 0, this._$AA = t4, this._$AB = i6, this._$AM = s4, this.options = e7, this._$Cv = e7?.isConnected ?? true;
-        }
-        get parentNode() {
-          let t4 = this._$AA.parentNode;
-          const i6 = this._$AM;
-          return void 0 !== i6 && 11 === t4?.nodeType && (t4 = i6.parentNode), t4;
-        }
-        get startNode() {
-          return this._$AA;
-        }
-        get endNode() {
-          return this._$AB;
-        }
-        _$AI(t4, i6 = this) {
-          t4 = M(this, t4, i6), a2(t4) ? t4 === A || null == t4 || "" === t4 ? (this._$AH !== A && this._$AR(), this._$AH = A) : t4 !== this._$AH && t4 !== E && this._(t4) : void 0 !== t4._$litType$ ? this.$(t4) : void 0 !== t4.nodeType ? this.T(t4) : d2(t4) ? this.k(t4) : this._(t4);
-        }
-        O(t4) {
-          return this._$AA.parentNode.insertBefore(t4, this._$AB);
-        }
-        T(t4) {
-          this._$AH !== t4 && (this._$AR(), this._$AH = this.O(t4));
-        }
-        _(t4) {
-          this._$AH !== A && a2(this._$AH) ? this._$AA.nextSibling.data = t4 : this.T(l2.createTextNode(t4)), this._$AH = t4;
-        }
-        $(t4) {
-          const { values: i6, _$litType$: s4 } = t4, e7 = "number" == typeof s4 ? this._$AC(t4) : (void 0 === s4.el && (s4.el = S2.createElement(V(s4.h, s4.h[0]), this.options)), s4);
-          if (this._$AH?._$AD === e7) this._$AH.p(i6);
-          else {
-            const t5 = new R(e7, this), s5 = t5.u(this.options);
-            t5.p(i6), this.T(s5), this._$AH = t5;
-          }
-        }
-        _$AC(t4) {
-          let i6 = C.get(t4.strings);
-          return void 0 === i6 && C.set(t4.strings, i6 = new S2(t4)), i6;
-        }
-        k(t4) {
-          u2(this._$AH) || (this._$AH = [], this._$AR());
-          const i6 = this._$AH;
-          let s4, e7 = 0;
-          for (const h3 of t4) e7 === i6.length ? i6.push(s4 = new _k(this.O(c3()), this.O(c3()), this, this.options)) : s4 = i6[e7], s4._$AI(h3), e7++;
-          e7 < i6.length && (this._$AR(s4 && s4._$AB.nextSibling, e7), i6.length = e7);
-        }
-        _$AR(t4 = this._$AA.nextSibling, s4) {
-          for (this._$AP?.(false, true, s4); t4 !== this._$AB; ) {
-            const s5 = i3(t4).nextSibling;
-            i3(t4).remove(), t4 = s5;
-          }
-        }
-        setConnected(t4) {
-          void 0 === this._$AM && (this._$Cv = t4, this._$AP?.(t4));
-        }
-      };
-      H = class {
-        get tagName() {
-          return this.element.tagName;
-        }
-        get _$AU() {
-          return this._$AM._$AU;
-        }
-        constructor(t4, i6, s4, e7, h3) {
-          this.type = 1, this._$AH = A, this._$AN = void 0, this.element = t4, this.name = i6, this._$AM = e7, this.options = h3, s4.length > 2 || "" !== s4[0] || "" !== s4[1] ? (this._$AH = Array(s4.length - 1).fill(new String()), this.strings = s4) : this._$AH = A;
-        }
-        _$AI(t4, i6 = this, s4, e7) {
-          const h3 = this.strings;
-          let o7 = false;
-          if (void 0 === h3) t4 = M(this, t4, i6, 0), o7 = !a2(t4) || t4 !== this._$AH && t4 !== E, o7 && (this._$AH = t4);
-          else {
-            const e8 = t4;
-            let n5, r6;
-            for (t4 = h3[0], n5 = 0; n5 < h3.length - 1; n5++) r6 = M(this, e8[s4 + n5], i6, n5), r6 === E && (r6 = this._$AH[n5]), o7 || (o7 = !a2(r6) || r6 !== this._$AH[n5]), r6 === A ? t4 = A : t4 !== A && (t4 += (r6 ?? "") + h3[n5 + 1]), this._$AH[n5] = r6;
-          }
-          o7 && !e7 && this.j(t4);
-        }
-        j(t4) {
-          t4 === A ? this.element.removeAttribute(this.name) : this.element.setAttribute(this.name, t4 ?? "");
-        }
-      };
-      I = class extends H {
-        constructor() {
-          super(...arguments), this.type = 3;
-        }
-        j(t4) {
-          this.element[this.name] = t4 === A ? void 0 : t4;
-        }
-      };
-      L = class extends H {
-        constructor() {
-          super(...arguments), this.type = 4;
-        }
-        j(t4) {
-          this.element.toggleAttribute(this.name, !!t4 && t4 !== A);
-        }
-      };
-      z = class extends H {
-        constructor(t4, i6, s4, e7, h3) {
-          super(t4, i6, s4, e7, h3), this.type = 5;
-        }
-        _$AI(t4, i6 = this) {
-          if ((t4 = M(this, t4, i6, 0) ?? A) === E) return;
-          const s4 = this._$AH, e7 = t4 === A && s4 !== A || t4.capture !== s4.capture || t4.once !== s4.once || t4.passive !== s4.passive, h3 = t4 !== A && (s4 === A || e7);
-          e7 && this.element.removeEventListener(this.name, this, s4), h3 && this.element.addEventListener(this.name, this, t4), this._$AH = t4;
-        }
-        handleEvent(t4) {
-          "function" == typeof this._$AH ? this._$AH.call(this.options?.host ?? this.element, t4) : this._$AH.handleEvent(t4);
-        }
-      };
-      Z = class {
-        constructor(t4, i6, s4) {
-          this.element = t4, this.type = 6, this._$AN = void 0, this._$AM = i6, this.options = s4;
-        }
-        get _$AU() {
-          return this._$AM._$AU;
-        }
-        _$AI(t4) {
-          M(this, t4);
-        }
-      };
-      B = t2.litHtmlPolyfillSupport;
-      B?.(S2, k), (t2.litHtmlVersions ?? (t2.litHtmlVersions = [])).push("3.3.3");
-      D = (t4, i6, s4) => {
-        const e7 = s4?.renderBefore ?? i6;
-        let h3 = e7._$litPart$;
-        if (void 0 === h3) {
-          const t5 = s4?.renderBefore ?? null;
-          e7._$litPart$ = h3 = new k(i6.insertBefore(c3(), t5), t5, void 0, s4 ?? {});
-        }
-        return h3._$AI(t4), h3;
-      };
-    }
-  });
-
-  // node_modules/lit-element/lit-element.js
-  var s3, i4, o4;
-  var init_lit_element = __esm({
-    "node_modules/lit-element/lit-element.js"() {
-      init_reactive_element();
-      init_reactive_element();
-      init_lit_html();
-      init_lit_html();
-      s3 = globalThis;
-      i4 = class extends y {
-        constructor() {
-          super(...arguments), this.renderOptions = { host: this }, this._$Do = void 0;
-        }
-        createRenderRoot() {
-          var _a;
-          const t4 = super.createRenderRoot();
-          return (_a = this.renderOptions).renderBefore ?? (_a.renderBefore = t4.firstChild), t4;
-        }
-        update(t4) {
-          const r6 = this.render();
-          this.hasUpdated || (this.renderOptions.isConnected = this.isConnected), super.update(t4), this._$Do = D(r6, this.renderRoot, this.renderOptions);
-        }
-        connectedCallback() {
-          super.connectedCallback(), this._$Do?.setConnected(true);
-        }
-        disconnectedCallback() {
-          super.disconnectedCallback(), this._$Do?.setConnected(false);
-        }
-        render() {
-          return E;
-        }
-      };
-      i4._$litElement$ = true, i4["finalized"] = true, s3.litElementHydrateSupport?.({ LitElement: i4 });
-      o4 = s3.litElementPolyfillSupport;
-      o4?.({ LitElement: i4 });
-      (s3.litElementVersions ?? (s3.litElementVersions = [])).push("4.2.2");
-    }
-  });
-
-  // node_modules/lit-html/is-server.js
-  var init_is_server = __esm({
-    "node_modules/lit-html/is-server.js"() {
-    }
-  });
-
-  // node_modules/lit/index.js
-  var init_lit = __esm({
-    "node_modules/lit/index.js"() {
-      init_reactive_element();
-      init_lit_html();
-      init_lit_element();
-      init_is_server();
-    }
-  });
-
-  // node_modules/@lit/reactive-element/decorators/custom-element.js
-  var init_custom_element = __esm({
-    "node_modules/@lit/reactive-element/decorators/custom-element.js"() {
-    }
-  });
-
-  // node_modules/@lit/reactive-element/decorators/property.js
-  function n4(t4) {
-    return (e7, o7) => "object" == typeof o7 ? r4(t4, e7, o7) : ((t5, e8, o8) => {
-      const r6 = e8.hasOwnProperty(o8);
-      return e8.constructor.createProperty(o8, t5), r6 ? Object.getOwnPropertyDescriptor(e8, o8) : void 0;
-    })(t4, e7, o7);
-  }
-  var o5, r4;
-  var init_property = __esm({
-    "node_modules/@lit/reactive-element/decorators/property.js"() {
-      init_reactive_element();
-      o5 = { attribute: true, type: String, converter: u, reflect: false, hasChanged: f };
-      r4 = (t4 = o5, e7, r6) => {
-        const { kind: n5, metadata: i6 } = r6;
-        let s4 = globalThis.litPropertyMetadata.get(i6);
-        if (void 0 === s4 && globalThis.litPropertyMetadata.set(i6, s4 = /* @__PURE__ */ new Map()), "setter" === n5 && ((t4 = Object.create(t4)).wrapped = true), s4.set(r6.name, t4), "accessor" === n5) {
-          const { name: o7 } = r6;
-          return { set(r7) {
-            const n6 = e7.get.call(this);
-            e7.set.call(this, r7), this.requestUpdate(o7, n6, t4, true, r7);
-          }, init(e8) {
-            return void 0 !== e8 && this.C(o7, void 0, t4, e8), e8;
-          } };
-        }
-        if ("setter" === n5) {
-          const { name: o7 } = r6;
-          return function(r7) {
-            const n6 = this[o7];
-            e7.call(this, r7), this.requestUpdate(o7, n6, t4, true, r7);
-          };
-        }
-        throw Error("Unsupported decorator location: " + n5);
-      };
-    }
-  });
-
-  // node_modules/@lit/reactive-element/decorators/state.js
-  function r5(r6) {
-    return n4({ ...r6, state: true, attribute: false });
-  }
-  var init_state = __esm({
-    "node_modules/@lit/reactive-element/decorators/state.js"() {
-      init_property();
-    }
-  });
-
-  // node_modules/@lit/reactive-element/decorators/event-options.js
-  var init_event_options = __esm({
-    "node_modules/@lit/reactive-element/decorators/event-options.js"() {
-    }
-  });
-
-  // node_modules/@lit/reactive-element/decorators/base.js
-  var init_base = __esm({
-    "node_modules/@lit/reactive-element/decorators/base.js"() {
-    }
-  });
-
-  // node_modules/@lit/reactive-element/decorators/query.js
-  var init_query = __esm({
-    "node_modules/@lit/reactive-element/decorators/query.js"() {
-      init_base();
-    }
-  });
-
-  // node_modules/@lit/reactive-element/decorators/query-all.js
-  var init_query_all = __esm({
-    "node_modules/@lit/reactive-element/decorators/query-all.js"() {
-      init_base();
-    }
-  });
-
-  // node_modules/@lit/reactive-element/decorators/query-async.js
-  var init_query_async = __esm({
-    "node_modules/@lit/reactive-element/decorators/query-async.js"() {
-      init_base();
-    }
-  });
-
-  // node_modules/@lit/reactive-element/decorators/query-assigned-elements.js
-  var init_query_assigned_elements = __esm({
-    "node_modules/@lit/reactive-element/decorators/query-assigned-elements.js"() {
-      init_base();
-    }
-  });
-
-  // node_modules/@lit/reactive-element/decorators/query-assigned-nodes.js
-  var init_query_assigned_nodes = __esm({
-    "node_modules/@lit/reactive-element/decorators/query-assigned-nodes.js"() {
-      init_base();
-    }
-  });
-
-  // node_modules/lit/decorators.js
-  var init_decorators = __esm({
-    "node_modules/lit/decorators.js"() {
-      init_custom_element();
-      init_property();
-      init_state();
-      init_event_options();
-      init_query();
-      init_query_all();
-      init_query_async();
-      init_query_assigned_elements();
-      init_query_assigned_nodes();
-    }
-  });
-
-  // node_modules/lit-html/directive.js
-  var t3, e5, i5;
-  var init_directive = __esm({
-    "node_modules/lit-html/directive.js"() {
-      t3 = { ATTRIBUTE: 1, CHILD: 2, PROPERTY: 3, BOOLEAN_ATTRIBUTE: 4, EVENT: 5, ELEMENT: 6 };
-      e5 = (t4) => (...e7) => ({ _$litDirective$: t4, values: e7 });
-      i5 = class {
-        constructor(t4) {
-        }
-        get _$AU() {
-          return this._$AM._$AU;
-        }
-        _$AT(t4, e7, i6) {
-          this._$Ct = t4, this._$AM = e7, this._$Ci = i6;
-        }
-        _$AS(t4, e7) {
-          return this.update(t4, e7);
-        }
-        update(t4, e7) {
-          return this.render(...e7);
-        }
-      };
-    }
-  });
-
-  // node_modules/lit-html/directives/class-map.js
-  var e6;
-  var init_class_map = __esm({
-    "node_modules/lit-html/directives/class-map.js"() {
-      init_lit_html();
-      init_directive();
-      e6 = e5(class extends i5 {
-        constructor(t4) {
-          if (super(t4), t4.type !== t3.ATTRIBUTE || "class" !== t4.name || t4.strings?.length > 2) throw Error("`classMap()` can only be used in the `class` attribute and must be the only part in the attribute.");
-        }
-        render(t4) {
-          return " " + Object.keys(t4).filter((s4) => t4[s4]).join(" ") + " ";
-        }
-        update(s4, [i6]) {
-          if (void 0 === this.st) {
-            this.st = /* @__PURE__ */ new Set(), void 0 !== s4.strings && (this.nt = new Set(s4.strings.join(" ").split(/\s/).filter((t4) => "" !== t4)));
-            for (const t4 in i6) i6[t4] && !this.nt?.has(t4) && this.st.add(t4);
-            return this.render(i6);
-          }
-          const r6 = s4.element.classList;
-          for (const t4 of this.st) t4 in i6 || (r6.remove(t4), this.st.delete(t4));
-          for (const t4 in i6) {
-            const s5 = !!i6[t4];
-            s5 === this.st.has(t4) || this.nt?.has(t4) || (s5 ? (r6.add(t4), this.st.add(t4)) : (r6.remove(t4), this.st.delete(t4)));
-          }
-          return E;
-        }
-      });
-    }
-  });
-
-  // node_modules/lit/directives/class-map.js
-  var init_class_map2 = __esm({
-    "node_modules/lit/directives/class-map.js"() {
-      init_class_map();
-    }
-  });
-
-  // node_modules/@vscode-elements/elements/dist/includes/VscElement.js
-  var VERSION, CONFIG_KEY, warn, VscElement, customElement;
-  var init_VscElement = __esm({
-    "node_modules/@vscode-elements/elements/dist/includes/VscElement.js"() {
-      init_lit();
-      VERSION = "2.5.1";
-      CONFIG_KEY = "__vscodeElements_disableRegistryWarning__";
-      warn = (message, componentInstance) => {
-        const prefix = "[VSCode Elements] ";
-        if (componentInstance) {
-          console.warn(`${prefix}${message}
-%o`, componentInstance);
-        } else {
-          console.warn(`${message}
-%o`, componentInstance);
-        }
-      };
-      VscElement = class extends i4 {
-        /** VSCode Elements version */
-        get version() {
-          return VERSION;
-        }
-        warn(message) {
-          warn(message, this);
-        }
-      };
-      customElement = (tagName) => {
-        return (classOrTarget) => {
-          const customElementClass = customElements.get(tagName);
-          if (!customElementClass) {
-            customElements.define(tagName, classOrTarget);
-            return;
-          }
-          if (CONFIG_KEY in window) {
-            return;
-          }
-          const el2 = document.createElement(tagName);
-          const anotherVersion = el2?.version;
-          let message = "";
-          if (!anotherVersion) {
-            message += "is already registered by an unknown custom element handler class.";
-          } else if (anotherVersion !== VERSION) {
-            message += "is already registered by a different version of VSCode Elements. ";
-            message += `This version is "${VERSION}", while the other one is "${anotherVersion}".`;
-          } else {
-            message += `is already registered by the same version of VSCode Elements (${VERSION}).`;
-          }
-          warn(`The custom element "${tagName}" ${message}
-To suppress this warning, set window.${CONFIG_KEY} to true`);
-        };
-      };
-    }
-  });
-
-  // node_modules/lit-html/directives/if-defined.js
-  var o6;
-  var init_if_defined = __esm({
-    "node_modules/lit-html/directives/if-defined.js"() {
-      init_lit_html();
-      o6 = (o7) => o7 ?? A;
-    }
-  });
-
-  // node_modules/lit/directives/if-defined.js
-  var init_if_defined2 = __esm({
-    "node_modules/lit/directives/if-defined.js"() {
-      init_if_defined();
-    }
-  });
-
-  // node_modules/lit/directive.js
-  var init_directive2 = __esm({
-    "node_modules/lit/directive.js"() {
-      init_directive();
-    }
-  });
-
-  // node_modules/@vscode-elements/elements/dist/includes/style-property-map.js
-  var StylePropertyMap, stylePropertyMap;
-  var init_style_property_map = __esm({
-    "node_modules/@vscode-elements/elements/dist/includes/style-property-map.js"() {
-      init_lit();
-      init_directive2();
-      StylePropertyMap = class extends i5 {
-        constructor(partInfo) {
-          super(partInfo);
-          this._prevProperties = {};
-          if (partInfo.type !== t3.PROPERTY || partInfo.name !== "style") {
-            throw new Error("The `stylePropertyMap` directive must be used in the `style` property");
-          }
-        }
-        update(part, [styleProps]) {
-          Object.entries(styleProps).forEach(([key, val]) => {
-            if (this._prevProperties[key] !== val) {
-              if (key.startsWith("--")) {
-                part.element.style.setProperty(key, val);
-              } else {
-                part.element.style[key] = val;
-              }
-              this._prevProperties[key] = val;
-            }
-          });
-          return E;
-        }
-        render(_styleProps) {
-          return E;
-        }
-      };
-      stylePropertyMap = e5(StylePropertyMap);
-    }
-  });
-
-  // node_modules/@vscode-elements/elements/dist/includes/default.styles.js
-  var default_styles_default;
-  var init_default_styles = __esm({
-    "node_modules/@vscode-elements/elements/dist/includes/default.styles.js"() {
-      init_lit();
-      default_styles_default = i`
+"use strict";(()=>{var sr=Object.defineProperty;var y=(e,t,o)=>()=>{if(o)throw o[0];try{return e&&(t=e(e=0)),t}catch(n){throw o=[n],n}};var rr=(e,t)=>{for(var o in t)sr(e,o,{get:t[o],enumerable:!0})};var xt,kt,ro,$n,Ue,wt,ae,An,io,ao=y(()=>{xt=globalThis,kt=xt.ShadowRoot&&(xt.ShadyCSS===void 0||xt.ShadyCSS.nativeShadow)&&"adoptedStyleSheets"in Document.prototype&&"replace"in CSSStyleSheet.prototype,ro=Symbol(),$n=new WeakMap,Ue=class{constructor(t,o,n){if(this._$cssResult$=!0,n!==ro)throw Error("CSSResult is not constructable. Use `unsafeCSS` or `css` instead.");this.cssText=t,this.t=o}get styleSheet(){let t=this.o,o=this.t;if(kt&&t===void 0){let n=o!==void 0&&o.length===1;n&&(t=$n.get(o)),t===void 0&&((this.o=t=new CSSStyleSheet).replaceSync(this.cssText),n&&$n.set(o,t))}return t}toString(){return this.cssText}},wt=e=>new Ue(typeof e=="string"?e:e+"",void 0,ro),ae=(e,...t)=>{let o=e.length===1?e[0]:t.reduce((n,s,r)=>n+(i=>{if(i._$cssResult$===!0)return i.cssText;if(typeof i=="number")return i;throw Error("Value passed to 'css' function must be a 'css' function result: "+i+". Use 'unsafeCSS' to pass non-literal values, but take care to ensure page security.")})(s)+e[r+1],e[0]);return new Ue(o,e,ro)},An=(e,t)=>{if(kt)e.adoptedStyleSheets=t.map(o=>o instanceof CSSStyleSheet?o:o.styleSheet);else for(let o of t){let n=document.createElement("style"),s=xt.litNonce;s!==void 0&&n.setAttribute("nonce",s),n.textContent=o.cssText,e.appendChild(n)}},io=kt?e=>e:e=>e instanceof CSSStyleSheet?(t=>{let o="";for(let n of t.cssRules)o+=n.cssText;return wt(o)})(e):e});var Ir,zr,Br,Or,Nr,Hr,te,Mn,jr,Fr,Ie,ze,Ct,En,K,Be=y(()=>{ao();ao();({is:Ir,defineProperty:zr,getOwnPropertyDescriptor:Br,getOwnPropertyNames:Or,getOwnPropertySymbols:Nr,getPrototypeOf:Hr}=Object),te=globalThis,Mn=te.trustedTypes,jr=Mn?Mn.emptyScript:"",Fr=te.reactiveElementPolyfillSupport,Ie=(e,t)=>e,ze={toAttribute(e,t){switch(t){case Boolean:e=e?jr:null;break;case Object:case Array:e=e==null?e:JSON.stringify(e)}return e},fromAttribute(e,t){let o=e;switch(t){case Boolean:o=e!==null;break;case Number:o=e===null?null:Number(e);break;case Object:case Array:try{o=JSON.parse(e)}catch{o=null}}return o}},Ct=(e,t)=>!Ir(e,t),En={attribute:!0,type:String,converter:ze,reflect:!1,useDefault:!1,hasChanged:Ct};Symbol.metadata??(Symbol.metadata=Symbol("metadata")),te.litPropertyMetadata??(te.litPropertyMetadata=new WeakMap);K=class extends HTMLElement{static addInitializer(t){this._$Ei(),(this.l??(this.l=[])).push(t)}static get observedAttributes(){return this.finalize(),this._$Eh&&[...this._$Eh.keys()]}static createProperty(t,o=En){if(o.state&&(o.attribute=!1),this._$Ei(),this.prototype.hasOwnProperty(t)&&((o=Object.create(o)).wrapped=!0),this.elementProperties.set(t,o),!o.noAccessor){let n=Symbol(),s=this.getPropertyDescriptor(t,n,o);s!==void 0&&zr(this.prototype,t,s)}}static getPropertyDescriptor(t,o,n){let{get:s,set:r}=Br(this.prototype,t)??{get(){return this[o]},set(i){this[o]=i}};return{get:s,set(i){let a=s?.call(this);r?.call(this,i),this.requestUpdate(t,a,n)},configurable:!0,enumerable:!0}}static getPropertyOptions(t){return this.elementProperties.get(t)??En}static _$Ei(){if(this.hasOwnProperty(Ie("elementProperties")))return;let t=Hr(this);t.finalize(),t.l!==void 0&&(this.l=[...t.l]),this.elementProperties=new Map(t.elementProperties)}static finalize(){if(this.hasOwnProperty(Ie("finalized")))return;if(this.finalized=!0,this._$Ei(),this.hasOwnProperty(Ie("properties"))){let o=this.properties,n=[...Or(o),...Nr(o)];for(let s of n)this.createProperty(s,o[s])}let t=this[Symbol.metadata];if(t!==null){let o=litPropertyMetadata.get(t);if(o!==void 0)for(let[n,s]of o)this.elementProperties.set(n,s)}this._$Eh=new Map;for(let[o,n]of this.elementProperties){let s=this._$Eu(o,n);s!==void 0&&this._$Eh.set(s,o)}this.elementStyles=this.finalizeStyles(this.styles)}static finalizeStyles(t){let o=[];if(Array.isArray(t)){let n=new Set(t.flat(1/0).reverse());for(let s of n)o.unshift(io(s))}else t!==void 0&&o.push(io(t));return o}static _$Eu(t,o){let n=o.attribute;return n===!1?void 0:typeof n=="string"?n:typeof t=="string"?t.toLowerCase():void 0}constructor(){super(),this._$Ep=void 0,this.isUpdatePending=!1,this.hasUpdated=!1,this._$Em=null,this._$Ev()}_$Ev(){this._$ES=new Promise(t=>this.enableUpdating=t),this._$AL=new Map,this._$E_(),this.requestUpdate(),this.constructor.l?.forEach(t=>t(this))}addController(t){(this._$EO??(this._$EO=new Set)).add(t),this.renderRoot!==void 0&&this.isConnected&&t.hostConnected?.()}removeController(t){this._$EO?.delete(t)}_$E_(){let t=new Map,o=this.constructor.elementProperties;for(let n of o.keys())this.hasOwnProperty(n)&&(t.set(n,this[n]),delete this[n]);t.size>0&&(this._$Ep=t)}createRenderRoot(){let t=this.shadowRoot??this.attachShadow(this.constructor.shadowRootOptions);return An(t,this.constructor.elementStyles),t}connectedCallback(){this.renderRoot??(this.renderRoot=this.createRenderRoot()),this.enableUpdating(!0),this._$EO?.forEach(t=>t.hostConnected?.())}enableUpdating(t){}disconnectedCallback(){this._$EO?.forEach(t=>t.hostDisconnected?.())}attributeChangedCallback(t,o,n){this._$AK(t,n)}_$ET(t,o){let n=this.constructor.elementProperties.get(t),s=this.constructor._$Eu(t,n);if(s!==void 0&&n.reflect===!0){let r=(n.converter?.toAttribute!==void 0?n.converter:ze).toAttribute(o,n.type);this._$Em=t,r==null?this.removeAttribute(s):this.setAttribute(s,r),this._$Em=null}}_$AK(t,o){let n=this.constructor,s=n._$Eh.get(t);if(s!==void 0&&this._$Em!==s){let r=n.getPropertyOptions(s),i=typeof r.converter=="function"?{fromAttribute:r.converter}:r.converter?.fromAttribute!==void 0?r.converter:ze;this._$Em=s;let a=i.fromAttribute(o,r.type);this[s]=a??this._$Ej?.get(s)??a,this._$Em=null}}requestUpdate(t,o,n,s=!1,r){if(t!==void 0){let i=this.constructor;if(s===!1&&(r=this[t]),n??(n=i.getPropertyOptions(t)),!((n.hasChanged??Ct)(r,o)||n.useDefault&&n.reflect&&r===this._$Ej?.get(t)&&!this.hasAttribute(i._$Eu(t,n))))return;this.C(t,o,n)}this.isUpdatePending===!1&&(this._$ES=this._$EP())}C(t,o,{useDefault:n,reflect:s,wrapped:r},i){n&&!(this._$Ej??(this._$Ej=new Map)).has(t)&&(this._$Ej.set(t,i??o??this[t]),r!==!0||i!==void 0)||(this._$AL.has(t)||(this.hasUpdated||n||(o=void 0),this._$AL.set(t,o)),s===!0&&this._$Em!==t&&(this._$Eq??(this._$Eq=new Set)).add(t))}async _$EP(){this.isUpdatePending=!0;try{await this._$ES}catch(o){Promise.reject(o)}let t=this.scheduleUpdate();return t!=null&&await t,!this.isUpdatePending}scheduleUpdate(){return this.performUpdate()}performUpdate(){if(!this.isUpdatePending)return;if(!this.hasUpdated){if(this.renderRoot??(this.renderRoot=this.createRenderRoot()),this._$Ep){for(let[s,r]of this._$Ep)this[s]=r;this._$Ep=void 0}let n=this.constructor.elementProperties;if(n.size>0)for(let[s,r]of n){let{wrapped:i}=r,a=this[s];i!==!0||this._$AL.has(s)||a===void 0||this.C(s,void 0,r,a)}}let t=!1,o=this._$AL;try{t=this.shouldUpdate(o),t?(this.willUpdate(o),this._$EO?.forEach(n=>n.hostUpdate?.()),this.update(o)):this._$EM()}catch(n){throw t=!1,this._$EM(),n}t&&this._$AE(o)}willUpdate(t){}_$AE(t){this._$EO?.forEach(o=>o.hostUpdated?.()),this.hasUpdated||(this.hasUpdated=!0,this.firstUpdated(t)),this.updated(t)}_$EM(){this._$AL=new Map,this.isUpdatePending=!1}get updateComplete(){return this.getUpdateComplete()}getUpdateComplete(){return this._$ES}shouldUpdate(t){return!0}update(t){this._$Eq&&(this._$Eq=this._$Eq.forEach(o=>this._$ET(o,this[o]))),this._$EM()}updated(t){}firstUpdated(t){}};K.elementStyles=[],K.shadowRootOptions={mode:"open"},K[Ie("elementProperties")]=new Map,K[Ie("finalized")]=new Map,Fr?.({ReactiveElement:K}),(te.reactiveElementVersions??(te.reactiveElementVersions=[])).push("2.1.2")});function Nn(e,t){if(!fo(e)||!e.hasOwnProperty("raw"))throw Error("invalid template strings array");return _n!==void 0?_n.createHTML(t):t}function ye(e,t,o=e,n){if(t===O)return t;let s=n!==void 0?o._$Co?.[n]:o._$Cl,r=je(t)?void 0:t._$litDirective$;return s?.constructor!==r&&(s?._$AO?.(!1),r===void 0?s=void 0:(s=new r(e),s._$AT(e,o,n)),n!==void 0?(o._$Co??(o._$Co=[]))[n]=s:o._$Cl=s),s!==void 0&&(t=ye(e,s._$AS(e,t.values),s,n)),t}var Ne,Rn,St,_n,zn,oe,Bn,Wr,ce,He,je,fo,qr,lo,Oe,Pn,Dn,le,Ln,Un,On,bo,G,Bc,Oc,O,T,In,de,Kr,Fe,co,We,he,uo,po,go,mo,Gr,Hn,ve=y(()=>{Ne=globalThis,Rn=e=>e,St=Ne.trustedTypes,_n=St?St.createPolicy("lit-html",{createHTML:e=>e}):void 0,zn="$lit$",oe=`lit$${Math.random().toFixed(9).slice(2)}$`,Bn="?"+oe,Wr=`<${Bn}>`,ce=document,He=()=>ce.createComment(""),je=e=>e===null||typeof e!="object"&&typeof e!="function",fo=Array.isArray,qr=e=>fo(e)||typeof e?.[Symbol.iterator]=="function",lo=`[ 	
+\f\r]`,Oe=/<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g,Pn=/-->/g,Dn=/>/g,le=RegExp(`>|${lo}(?:([^\\s"'>=/]+)(${lo}*=${lo}*(?:[^ 	
+\f\r"'\`<>=]|("|')|))|$)`,"g"),Ln=/'/g,Un=/"/g,On=/^(?:script|style|textarea|title)$/i,bo=e=>(t,...o)=>({_$litType$:e,strings:t,values:o}),G=bo(1),Bc=bo(2),Oc=bo(3),O=Symbol.for("lit-noChange"),T=Symbol.for("lit-nothing"),In=new WeakMap,de=ce.createTreeWalker(ce,129);Kr=(e,t)=>{let o=e.length-1,n=[],s,r=t===2?"<svg>":t===3?"<math>":"",i=Oe;for(let a=0;a<o;a++){let l=e[a],u,c,p=-1,b=0;for(;b<l.length&&(i.lastIndex=b,c=i.exec(l),c!==null);)b=i.lastIndex,i===Oe?c[1]==="!--"?i=Pn:c[1]!==void 0?i=Dn:c[2]!==void 0?(On.test(c[2])&&(s=RegExp("</"+c[2],"g")),i=le):c[3]!==void 0&&(i=le):i===le?c[0]===">"?(i=s??Oe,p=-1):c[1]===void 0?p=-2:(p=i.lastIndex-c[2].length,u=c[1],i=c[3]===void 0?le:c[3]==='"'?Un:Ln):i===Un||i===Ln?i=le:i===Pn||i===Dn?i=Oe:(i=le,s=void 0);let h=i===le&&e[a+1].startsWith("/>")?" ":"";r+=i===Oe?l+Wr:p>=0?(n.push(u),l.slice(0,p)+zn+l.slice(p)+oe+h):l+oe+(p===-2?a:h)}return[Nn(e,r+(e[o]||"<?>")+(t===2?"</svg>":t===3?"</math>":"")),n]},Fe=class e{constructor({strings:t,_$litType$:o},n){let s;this.parts=[];let r=0,i=0,a=t.length-1,l=this.parts,[u,c]=Kr(t,o);if(this.el=e.createElement(u,n),de.currentNode=this.el.content,o===2||o===3){let p=this.el.content.firstChild;p.replaceWith(...p.childNodes)}for(;(s=de.nextNode())!==null&&l.length<a;){if(s.nodeType===1){if(s.hasAttributes())for(let p of s.getAttributeNames())if(p.endsWith(zn)){let b=c[i++],h=s.getAttribute(p).split(oe),S=/([.?@])?(.*)/.exec(b);l.push({type:1,index:r,name:S[2],strings:h,ctor:S[1]==="."?uo:S[1]==="?"?po:S[1]==="@"?go:he}),s.removeAttribute(p)}else p.startsWith(oe)&&(l.push({type:6,index:r}),s.removeAttribute(p));if(On.test(s.tagName)){let p=s.textContent.split(oe),b=p.length-1;if(b>0){s.textContent=St?St.emptyScript:"";for(let h=0;h<b;h++)s.append(p[h],He()),de.nextNode(),l.push({type:2,index:++r});s.append(p[b],He())}}}else if(s.nodeType===8)if(s.data===Bn)l.push({type:2,index:r});else{let p=-1;for(;(p=s.data.indexOf(oe,p+1))!==-1;)l.push({type:7,index:r}),p+=oe.length-1}r++}}static createElement(t,o){let n=ce.createElement("template");return n.innerHTML=t,n}};co=class{constructor(t,o){this._$AV=[],this._$AN=void 0,this._$AD=t,this._$AM=o}get parentNode(){return this._$AM.parentNode}get _$AU(){return this._$AM._$AU}u(t){let{el:{content:o},parts:n}=this._$AD,s=(t?.creationScope??ce).importNode(o,!0);de.currentNode=s;let r=de.nextNode(),i=0,a=0,l=n[0];for(;l!==void 0;){if(i===l.index){let u;l.type===2?u=new We(r,r.nextSibling,this,t):l.type===1?u=new l.ctor(r,l.name,l.strings,this,t):l.type===6&&(u=new mo(r,this,t)),this._$AV.push(u),l=n[++a]}i!==l?.index&&(r=de.nextNode(),i++)}return de.currentNode=ce,s}p(t){let o=0;for(let n of this._$AV)n!==void 0&&(n.strings!==void 0?(n._$AI(t,n,o),o+=n.strings.length-2):n._$AI(t[o])),o++}},We=class e{get _$AU(){return this._$AM?._$AU??this._$Cv}constructor(t,o,n,s){this.type=2,this._$AH=T,this._$AN=void 0,this._$AA=t,this._$AB=o,this._$AM=n,this.options=s,this._$Cv=s?.isConnected??!0}get parentNode(){let t=this._$AA.parentNode,o=this._$AM;return o!==void 0&&t?.nodeType===11&&(t=o.parentNode),t}get startNode(){return this._$AA}get endNode(){return this._$AB}_$AI(t,o=this){t=ye(this,t,o),je(t)?t===T||t==null||t===""?(this._$AH!==T&&this._$AR(),this._$AH=T):t!==this._$AH&&t!==O&&this._(t):t._$litType$!==void 0?this.$(t):t.nodeType!==void 0?this.T(t):qr(t)?this.k(t):this._(t)}O(t){return this._$AA.parentNode.insertBefore(t,this._$AB)}T(t){this._$AH!==t&&(this._$AR(),this._$AH=this.O(t))}_(t){this._$AH!==T&&je(this._$AH)?this._$AA.nextSibling.data=t:this.T(ce.createTextNode(t)),this._$AH=t}$(t){let{values:o,_$litType$:n}=t,s=typeof n=="number"?this._$AC(t):(n.el===void 0&&(n.el=Fe.createElement(Nn(n.h,n.h[0]),this.options)),n);if(this._$AH?._$AD===s)this._$AH.p(o);else{let r=new co(s,this),i=r.u(this.options);r.p(o),this.T(i),this._$AH=r}}_$AC(t){let o=In.get(t.strings);return o===void 0&&In.set(t.strings,o=new Fe(t)),o}k(t){fo(this._$AH)||(this._$AH=[],this._$AR());let o=this._$AH,n,s=0;for(let r of t)s===o.length?o.push(n=new e(this.O(He()),this.O(He()),this,this.options)):n=o[s],n._$AI(r),s++;s<o.length&&(this._$AR(n&&n._$AB.nextSibling,s),o.length=s)}_$AR(t=this._$AA.nextSibling,o){for(this._$AP?.(!1,!0,o);t!==this._$AB;){let n=Rn(t).nextSibling;Rn(t).remove(),t=n}}setConnected(t){this._$AM===void 0&&(this._$Cv=t,this._$AP?.(t))}},he=class{get tagName(){return this.element.tagName}get _$AU(){return this._$AM._$AU}constructor(t,o,n,s,r){this.type=1,this._$AH=T,this._$AN=void 0,this.element=t,this.name=o,this._$AM=s,this.options=r,n.length>2||n[0]!==""||n[1]!==""?(this._$AH=Array(n.length-1).fill(new String),this.strings=n):this._$AH=T}_$AI(t,o=this,n,s){let r=this.strings,i=!1;if(r===void 0)t=ye(this,t,o,0),i=!je(t)||t!==this._$AH&&t!==O,i&&(this._$AH=t);else{let a=t,l,u;for(t=r[0],l=0;l<r.length-1;l++)u=ye(this,a[n+l],o,l),u===O&&(u=this._$AH[l]),i||(i=!je(u)||u!==this._$AH[l]),u===T?t=T:t!==T&&(t+=(u??"")+r[l+1]),this._$AH[l]=u}i&&!s&&this.j(t)}j(t){t===T?this.element.removeAttribute(this.name):this.element.setAttribute(this.name,t??"")}},uo=class extends he{constructor(){super(...arguments),this.type=3}j(t){this.element[this.name]=t===T?void 0:t}},po=class extends he{constructor(){super(...arguments),this.type=4}j(t){this.element.toggleAttribute(this.name,!!t&&t!==T)}},go=class extends he{constructor(t,o,n,s,r){super(t,o,n,s,r),this.type=5}_$AI(t,o=this){if((t=ye(this,t,o,0)??T)===O)return;let n=this._$AH,s=t===T&&n!==T||t.capture!==n.capture||t.once!==n.once||t.passive!==n.passive,r=t!==T&&(n===T||s);s&&this.element.removeEventListener(this.name,this,n),r&&this.element.addEventListener(this.name,this,t),this._$AH=t}handleEvent(t){typeof this._$AH=="function"?this._$AH.call(this.options?.host??this.element,t):this._$AH.handleEvent(t)}},mo=class{constructor(t,o,n){this.element=t,this.type=6,this._$AN=void 0,this._$AM=o,this.options=n}get _$AU(){return this._$AM._$AU}_$AI(t){ye(this,t)}},Gr=Ne.litHtmlPolyfillSupport;Gr?.(Fe,We),(Ne.litHtmlVersions??(Ne.litHtmlVersions=[])).push("3.3.3");Hn=(e,t,o)=>{let n=o?.renderBefore??t,s=n._$litPart$;if(s===void 0){let r=o?.renderBefore??null;n._$litPart$=s=new We(t.insertBefore(He(),r),r,void 0,o??{})}return s._$AI(e),s}});var qe,ne,Vr,jn=y(()=>{Be();Be();ve();ve();qe=globalThis,ne=class extends K{constructor(){super(...arguments),this.renderOptions={host:this},this._$Do=void 0}createRenderRoot(){var o;let t=super.createRenderRoot();return(o=this.renderOptions).renderBefore??(o.renderBefore=t.firstChild),t}update(t){let o=this.render();this.hasUpdated||(this.renderOptions.isConnected=this.isConnected),super.update(t),this._$Do=Hn(o,this.renderRoot,this.renderOptions)}connectedCallback(){super.connectedCallback(),this._$Do?.setConnected(!0)}disconnectedCallback(){super.disconnectedCallback(),this._$Do?.setConnected(!1)}render(){return O}};ne._$litElement$=!0,ne.finalized=!0,qe.litElementHydrateSupport?.({LitElement:ne});Vr=qe.litElementPolyfillSupport;Vr?.({LitElement:ne});(qe.litElementVersions??(qe.litElementVersions=[])).push("4.2.2")});var Fn=y(()=>{});var se=y(()=>{Be();ve();jn();Fn()});var Wn=y(()=>{});function v(e){return(t,o)=>typeof o=="object"?Jr(e,t,o):((n,s,r)=>{let i=s.hasOwnProperty(r);return s.constructor.createProperty(r,n),i?Object.getOwnPropertyDescriptor(s,r):void 0})(e,t,o)}var Yr,Jr,yo=y(()=>{Be();Yr={attribute:!0,type:String,converter:ze,reflect:!1,hasChanged:Ct},Jr=(e=Yr,t,o)=>{let{kind:n,metadata:s}=o,r=globalThis.litPropertyMetadata.get(s);if(r===void 0&&globalThis.litPropertyMetadata.set(s,r=new Map),n==="setter"&&((e=Object.create(e)).wrapped=!0),r.set(o.name,e),n==="accessor"){let{name:i}=o;return{set(a){let l=t.get.call(this);t.set.call(this,a),this.requestUpdate(i,l,e,!0,a)},init(a){return a!==void 0&&this.C(i,void 0,e,a),a}}}if(n==="setter"){let{name:i}=o;return function(a){let l=this[i];t.call(this,a),this.requestUpdate(i,l,e,!0,a)}}throw Error("Unsupported decorator location: "+n)}});function ho(e){return v({...e,state:!0,attribute:!1})}var qn=y(()=>{yo();});var Kn=y(()=>{});var xe=y(()=>{});var Gn=y(()=>{xe();});var Vn=y(()=>{xe();});var Yn=y(()=>{xe();});var Jn=y(()=>{xe();});var Xn=y(()=>{xe();});var vo=y(()=>{Wn();yo();qn();Kn();Gn();Vn();Yn();Jn();Xn()});var $t,At,ke,xo=y(()=>{$t={ATTRIBUTE:1,CHILD:2,PROPERTY:3,BOOLEAN_ATTRIBUTE:4,EVENT:5,ELEMENT:6},At=e=>(...t)=>({_$litDirective$:e,values:t}),ke=class{constructor(t){}get _$AU(){return this._$AM._$AU}_$AT(t,o,n){this._$Ct=t,this._$AM=o,this._$Ci=n}_$AS(t,o){return this.update(t,o)}update(t,o){return this.render(...o)}}});var Mt,Zn=y(()=>{ve();xo();Mt=At(class extends ke{constructor(e){if(super(e),e.type!==$t.ATTRIBUTE||e.name!=="class"||e.strings?.length>2)throw Error("`classMap()` can only be used in the `class` attribute and must be the only part in the attribute.")}render(e){return" "+Object.keys(e).filter(t=>e[t]).join(" ")+" "}update(e,[t]){if(this.st===void 0){this.st=new Set,e.strings!==void 0&&(this.nt=new Set(e.strings.join(" ").split(/\s/).filter(n=>n!=="")));for(let n in t)t[n]&&!this.nt?.has(n)&&this.st.add(n);return this.render(t)}let o=e.element.classList;for(let n of this.st)n in t||(o.remove(n),this.st.delete(n));for(let n in t){let s=!!t[n];s===this.st.has(n)||this.nt?.has(n)||(s?(o.add(n),this.st.add(n)):(o.remove(n),this.st.delete(n)))}return O}})});var ko=y(()=>{Zn()});var Et,Qn,es,we,Rt,wo=y(()=>{se();Et="2.5.1",Qn="__vscodeElements_disableRegistryWarning__",es=(e,t)=>{console.warn(t?`[VSCode Elements] ${e}
+%o`:`${e}
+%o`,t)},we=class extends ne{get version(){return Et}warn(t){es(t,this)}},Rt=e=>t=>{if(!customElements.get(e)){customElements.define(e,t);return}if(Qn in window)return;let s=document.createElement(e)?.version,r="";s?s!==Et?(r+="is already registered by a different version of VSCode Elements. ",r+=`This version is "${Et}", while the other one is "${s}".`):r+=`is already registered by the same version of VSCode Elements (${Et}).`:r+="is already registered by an unknown custom element handler class.",es(`The custom element "${e}" ${r}
+To suppress this warning, set window.${Qn} to true`)}});var Ce,ts=y(()=>{ve();Ce=e=>e??T});var Co=y(()=>{ts()});var os=y(()=>{xo()});var So,ns,ss=y(()=>{se();os();So=class extends ke{constructor(t){if(super(t),this._prevProperties={},t.type!==$t.PROPERTY||t.name!=="style")throw new Error("The `stylePropertyMap` directive must be used in the `style` property")}update(t,[o]){return Object.entries(o).forEach(([n,s])=>{this._prevProperties[n]!==s&&(n.startsWith("--")?t.element.style.setProperty(n,s):t.element.style[n]=s,this._prevProperties[n]=s)}),O}render(t){return O}},ns=At(So)});var _t,To=y(()=>{se();_t=ae`
   :host([hidden]) {
     display: none;
   }
@@ -913,19 +14,7 @@ To suppress this warning, set window.${CONFIG_KEY} to true`);
     opacity: 0.4;
     pointer-events: none;
   }
-`;
-    }
-  });
-
-  // node_modules/@vscode-elements/elements/dist/vscode-icon/vscode-icon.styles.js
-  var styles, vscode_icon_styles_default;
-  var init_vscode_icon_styles = __esm({
-    "node_modules/@vscode-elements/elements/dist/vscode-icon/vscode-icon.styles.js"() {
-      init_lit();
-      init_default_styles();
-      styles = [
-        default_styles_default,
-        i`
+`});var Xr,rs,is=y(()=>{se();To();Xr=[_t,ae`
     :host {
       color: var(--vscode-icon-foreground, #cccccc);
       display: inline-block;
@@ -985,168 +74,25 @@ To suppress this warning, set window.${CONFIG_KEY} to true`);
       animation-timing-function: linear;
       animation-iteration-count: infinite;
     }
-  `
-      ];
-      vscode_icon_styles_default = styles;
-    }
-  });
-
-  // node_modules/@vscode-elements/elements/dist/vscode-icon/vscode-icon.js
-  var __decorate, VscodeIcon_1, VscodeIcon;
-  var init_vscode_icon = __esm({
-    "node_modules/@vscode-elements/elements/dist/vscode-icon/vscode-icon.js"() {
-      init_lit();
-      init_decorators();
-      init_class_map2();
-      init_if_defined2();
-      init_VscElement();
-      init_style_property_map();
-      init_vscode_icon_styles();
-      __decorate = function(decorators, target, key, desc) {
-        var c4 = arguments.length, r6 = c4 < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d3;
-        if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r6 = Reflect.decorate(decorators, target, key, desc);
-        else for (var i6 = decorators.length - 1; i6 >= 0; i6--) if (d3 = decorators[i6]) r6 = (c4 < 3 ? d3(r6) : c4 > 3 ? d3(target, key, r6) : d3(target, key)) || r6;
-        return c4 > 3 && r6 && Object.defineProperty(target, key, r6), r6;
-      };
-      VscodeIcon = VscodeIcon_1 = class VscodeIcon2 extends VscElement {
-        constructor() {
-          super(...arguments);
-          this.label = "";
-          this.name = "";
-          this.size = 16;
-          this.spin = false;
-          this.spinDuration = 1.5;
-          this.actionIcon = false;
-          this._onButtonClick = (ev) => {
-            this.dispatchEvent(new CustomEvent("vsc-click", { detail: { originalEvent: ev } }));
-          };
-        }
-        connectedCallback() {
-          super.connectedCallback();
-          const { href, nonce } = this._getStylesheetConfig();
-          VscodeIcon_1.stylesheetHref = href;
-          VscodeIcon_1.nonce = nonce;
-        }
-        /**
-         * For using web fonts in web components, the font stylesheet must be included
-         * twice: on the page and in the web component. This function looks for the
-         * font stylesheet on the page and returns the stylesheet URL and the nonce
-         * id.
-         */
-        _getStylesheetConfig() {
-          if (typeof document === "undefined") {
-            return { nonce: void 0, href: void 0 };
-          }
-          const linkElement = document.getElementById("vscode-codicon-stylesheet");
-          const href = linkElement?.getAttribute("href") || void 0;
-          const nonce = linkElement?.nonce || void 0;
-          if (!linkElement) {
-            let msg = 'To use the Icon component, the codicons.css file must be included in the page with the id "vscode-codicon-stylesheet"! ';
-            msg += "See https://vscode-elements.github.io/components/icon/ for more details.";
-            this.warn(msg);
-          }
-          return { nonce, href };
-        }
-        render() {
-          const { stylesheetHref, nonce } = VscodeIcon_1;
-          const content = b2`<span
-      class=${e6({
-            codicon: true,
-            ["codicon-" + this.name]: true,
-            spin: this.spin
-          })}
-      .style=${stylePropertyMap({
-            animationDuration: String(this.spinDuration) + "s",
-            fontSize: this.size + "px",
-            height: this.size + "px",
-            width: this.size + "px"
-          })}
-    ></span>`;
-          const wrapped = this.actionIcon ? b2` <button
+  `],rs=Xr});var ue,Ke,N,as=y(()=>{se();vo();ko();Co();wo();ss();is();ue=function(e,t,o,n){var s=arguments.length,r=s<3?t:n===null?n=Object.getOwnPropertyDescriptor(t,o):n,i;if(typeof Reflect=="object"&&typeof Reflect.decorate=="function")r=Reflect.decorate(e,t,o,n);else for(var a=e.length-1;a>=0;a--)(i=e[a])&&(r=(s<3?i(r):s>3?i(t,o,r):i(t,o))||r);return s>3&&r&&Object.defineProperty(t,o,r),r},N=Ke=class extends we{constructor(){super(...arguments),this.label="",this.name="",this.size=16,this.spin=!1,this.spinDuration=1.5,this.actionIcon=!1,this._onButtonClick=t=>{this.dispatchEvent(new CustomEvent("vsc-click",{detail:{originalEvent:t}}))}}connectedCallback(){super.connectedCallback();let{href:t,nonce:o}=this._getStylesheetConfig();Ke.stylesheetHref=t,Ke.nonce=o}_getStylesheetConfig(){if(typeof document>"u")return{nonce:void 0,href:void 0};let t=document.getElementById("vscode-codicon-stylesheet"),o=t?.getAttribute("href")||void 0,n=t?.nonce||void 0;if(!t){let s='To use the Icon component, the codicons.css file must be included in the page with the id "vscode-codicon-stylesheet"! ';s+="See https://vscode-elements.github.io/components/icon/ for more details.",this.warn(s)}return{nonce:n,href:o}}render(){let{stylesheetHref:t,nonce:o}=Ke,n=G`<span
+      class=${Mt({codicon:!0,["codicon-"+this.name]:!0,spin:this.spin})}
+      .style=${ns({animationDuration:String(this.spinDuration)+"s",fontSize:this.size+"px",height:this.size+"px",width:this.size+"px"})}
+    ></span>`,s=this.actionIcon?G` <button
           class="button"
           @click=${this._onButtonClick}
           aria-label=${this.label}
         >
-          ${content}
-        </button>` : b2` <span class="icon" aria-hidden="true" role="presentation"
-          >${content}</span
-        >`;
-          return b2`
+          ${n}
+        </button>`:G` <span class="icon" aria-hidden="true" role="presentation"
+          >${n}</span
+        >`;return G`
       <link
         rel="stylesheet"
-        href=${o6(stylesheetHref)}
-        nonce=${o6(nonce)}
+        href=${Ce(t)}
+        nonce=${Ce(o)}
       />
-      ${wrapped}
-    `;
-        }
-      };
-      VscodeIcon.styles = vscode_icon_styles_default;
-      VscodeIcon.stylesheetHref = "";
-      VscodeIcon.nonce = "";
-      __decorate([
-        n4()
-      ], VscodeIcon.prototype, "label", void 0);
-      __decorate([
-        n4({ type: String })
-      ], VscodeIcon.prototype, "name", void 0);
-      __decorate([
-        n4({ type: Number })
-      ], VscodeIcon.prototype, "size", void 0);
-      __decorate([
-        n4({ type: Boolean, reflect: true })
-      ], VscodeIcon.prototype, "spin", void 0);
-      __decorate([
-        n4({ type: Number, attribute: "spin-duration" })
-      ], VscodeIcon.prototype, "spinDuration", void 0);
-      __decorate([
-        n4({ type: Boolean, reflect: true, attribute: "action-icon" })
-      ], VscodeIcon.prototype, "actionIcon", void 0);
-      VscodeIcon = VscodeIcon_1 = __decorate([
-        customElement("vscode-icon")
-      ], VscodeIcon);
-    }
-  });
-
-  // node_modules/@vscode-elements/elements/dist/vscode-icon/index.js
-  var init_vscode_icon2 = __esm({
-    "node_modules/@vscode-elements/elements/dist/vscode-icon/index.js"() {
-      init_vscode_icon();
-    }
-  });
-
-  // node_modules/@vscode-elements/elements/dist/includes/helpers.js
-  function getDefaultFontStack() {
-    if (navigator.userAgent.indexOf("Linux") > -1) {
-      return 'system-ui, "Ubuntu", "Droid Sans", sans-serif';
-    } else if (navigator.userAgent.indexOf("Mac") > -1) {
-      return "-apple-system, BlinkMacSystemFont, sans-serif";
-    } else if (navigator.userAgent.indexOf("Windows") > -1) {
-      return '"Segoe WPC", "Segoe UI", sans-serif';
-    } else {
-      return "sans-serif";
-    }
-  }
-  var DEFAULT_LINE_HEIGHT, DEFAULT_FONT_SIZE, INPUT_LINE_HEIGHT_RATIO;
-  var init_helpers = __esm({
-    "node_modules/@vscode-elements/elements/dist/includes/helpers.js"() {
-      DEFAULT_LINE_HEIGHT = 16;
-      DEFAULT_FONT_SIZE = 13;
-      INPUT_LINE_HEIGHT_RATIO = DEFAULT_LINE_HEIGHT / DEFAULT_FONT_SIZE;
-    }
-  });
-
-  // node_modules/@vscode-elements/elements/dist/vscode-button/vscode-button.styles.js
-  var defaultFontStack, styles2, vscode_button_styles_default;
-  var init_vscode_button_styles = __esm({
-    "node_modules/@vscode-elements/elements/dist/vscode-button/vscode-button.styles.js"() {
-      init_lit();
-      init_default_styles();
-      init_helpers();
-      defaultFontStack = r(getDefaultFontStack());
-      styles2 = [
-        default_styles_default,
-        i`
+      ${s}
+    `}};N.styles=rs;N.stylesheetHref="";N.nonce="";ue([v()],N.prototype,"label",void 0);ue([v({type:String})],N.prototype,"name",void 0);ue([v({type:Number})],N.prototype,"size",void 0);ue([v({type:Boolean,reflect:!0})],N.prototype,"spin",void 0);ue([v({type:Number,attribute:"spin-duration"})],N.prototype,"spinDuration",void 0);ue([v({type:Boolean,reflect:!0,attribute:"action-icon"})],N.prototype,"actionIcon",void 0);N=Ke=ue([Rt("vscode-icon")],N)});var ls=y(()=>{as()});function ds(){return navigator.userAgent.indexOf("Linux")>-1?'system-ui, "Ubuntu", "Droid Sans", sans-serif':navigator.userAgent.indexOf("Mac")>-1?"-apple-system, BlinkMacSystemFont, sans-serif":navigator.userAgent.indexOf("Windows")>-1?'"Segoe WPC", "Segoe UI", sans-serif':"sans-serif"}var cs=y(()=>{});var Zr,Qr,us,ps=y(()=>{se();To();cs();Zr=wt(ds()),Qr=[_t,ae`
     :host {
       cursor: pointer;
       display: inline-block;
@@ -1174,7 +120,7 @@ To suppress this warning, set window.${CONFIG_KEY} to true`);
       box-sizing: border-box;
       color: var(--vscode-button-foreground, #ffffff);
       display: flex;
-      font-family: var(--vscode-font-family, ${defaultFontStack});
+      font-family: var(--vscode-font-family, ${Zr});
       font-size: var(--vscode-font-size, 13px);
       font-weight: var(--vscode-font-weight, normal);
       height: 100%;
@@ -1330,637 +276,35 @@ To suppress this warning, set window.${CONFIG_KEY} to true`);
     :host([icon]) .icon-after {
       margin-left: 3px;
     }
-  `
-      ];
-      vscode_button_styles_default = styles2;
-    }
-  });
-
-  // node_modules/@vscode-elements/elements/dist/vscode-button/vscode-button.js
-  var __decorate2, VscodeButton;
-  var init_vscode_button = __esm({
-    "node_modules/@vscode-elements/elements/dist/vscode-button/vscode-button.js"() {
-      init_lit();
-      init_decorators();
-      init_class_map2();
-      init_VscElement();
-      init_vscode_icon2();
-      init_vscode_button_styles();
-      init_if_defined2();
-      __decorate2 = function(decorators, target, key, desc) {
-        var c4 = arguments.length, r6 = c4 < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d3;
-        if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r6 = Reflect.decorate(decorators, target, key, desc);
-        else for (var i6 = decorators.length - 1; i6 >= 0; i6--) if (d3 = decorators[i6]) r6 = (c4 < 3 ? d3(r6) : c4 > 3 ? d3(target, key, r6) : d3(target, key)) || r6;
-        return c4 > 3 && r6 && Object.defineProperty(target, key, r6), r6;
-      };
-      VscodeButton = class VscodeButton2 extends VscElement {
-        get form() {
-          return this._internals.form;
-        }
-        constructor() {
-          super();
-          this.autofocus = false;
-          this.tabIndex = 0;
-          this.secondary = false;
-          this.block = false;
-          this.role = "button";
-          this.disabled = false;
-          this.icon = "";
-          this.iconSpin = false;
-          this.iconAfter = "";
-          this.iconAfterSpin = false;
-          this.focused = false;
-          this.name = void 0;
-          this.iconOnly = false;
-          this.type = "button";
-          this.value = "";
-          this._prevTabindex = 0;
-          this._hasContentBefore = false;
-          this._hasContentAfter = false;
-          this._handleFocus = () => {
-            this.focused = true;
-          };
-          this._handleBlur = () => {
-            this.focused = false;
-          };
-          this.addEventListener("keydown", this._handleKeyDown.bind(this));
-          this.addEventListener("click", this._handleClick.bind(this));
-          this._internals = this.attachInternals();
-        }
-        connectedCallback() {
-          super.connectedCallback();
-          if (this.autofocus) {
-            if (this.tabIndex < 0) {
-              this.tabIndex = 0;
-            }
-            this.updateComplete.then(() => {
-              this.focus();
-              this.requestUpdate();
-            });
-          }
-          this.addEventListener("focus", this._handleFocus);
-          this.addEventListener("blur", this._handleBlur);
-        }
-        disconnectedCallback() {
-          super.disconnectedCallback();
-          this.removeEventListener("focus", this._handleFocus);
-          this.removeEventListener("blur", this._handleBlur);
-        }
-        update(changedProperties) {
-          super.update(changedProperties);
-          if (changedProperties.has("value")) {
-            this._internals.setFormValue(this.value);
-          }
-          if (changedProperties.has("disabled")) {
-            if (this.disabled) {
-              this._prevTabindex = this.tabIndex;
-              this.tabIndex = -1;
-            } else {
-              this.tabIndex = this._prevTabindex;
-            }
-          }
-        }
-        _executeAction() {
-          if (this.type === "submit" && this._internals.form) {
-            this._internals.form.requestSubmit();
-          }
-          if (this.type === "reset" && this._internals.form) {
-            this._internals.form.reset();
-          }
-        }
-        _handleKeyDown(event) {
-          if ((event.key === "Enter" || event.key === " ") && !this.hasAttribute("disabled")) {
-            const syntheticClick = new MouseEvent("click", {
-              bubbles: true,
-              cancelable: true
-            });
-            syntheticClick.synthetic = true;
-            this.dispatchEvent(syntheticClick);
-            this._executeAction();
-          }
-        }
-        _handleClick(event) {
-          if (event.synthetic) {
-            return;
-          }
-          if (!this.hasAttribute("disabled")) {
-            this._executeAction();
-          }
-        }
-        _handleSlotChange(ev) {
-          const slot = ev.target;
-          if (slot.name === "content-before") {
-            this._hasContentBefore = slot.assignedElements().length > 0;
-          }
-          if (slot.name === "content-after") {
-            this._hasContentAfter = slot.assignedElements().length > 0;
-          }
-        }
-        render() {
-          const hasIcon = this.icon !== "";
-          const hasIconAfter = this.iconAfter !== "";
-          const baseClasses = {
-            base: true,
-            "icon-only": this.iconOnly,
-            "has-content-before": this._hasContentBefore,
-            "has-content-after": this._hasContentAfter
-          };
-          const iconElem = hasIcon ? b2`<vscode-icon
+  `],us=Qr});var M,C,gs=y(()=>{se();vo();ko();wo();ls();ps();Co();M=function(e,t,o,n){var s=arguments.length,r=s<3?t:n===null?n=Object.getOwnPropertyDescriptor(t,o):n,i;if(typeof Reflect=="object"&&typeof Reflect.decorate=="function")r=Reflect.decorate(e,t,o,n);else for(var a=e.length-1;a>=0;a--)(i=e[a])&&(r=(s<3?i(r):s>3?i(t,o,r):i(t,o))||r);return s>3&&r&&Object.defineProperty(t,o,r),r},C=class extends we{get form(){return this._internals.form}constructor(){super(),this.autofocus=!1,this.tabIndex=0,this.secondary=!1,this.block=!1,this.role="button",this.disabled=!1,this.icon="",this.iconSpin=!1,this.iconAfter="",this.iconAfterSpin=!1,this.focused=!1,this.name=void 0,this.iconOnly=!1,this.type="button",this.value="",this._prevTabindex=0,this._hasContentBefore=!1,this._hasContentAfter=!1,this._handleFocus=()=>{this.focused=!0},this._handleBlur=()=>{this.focused=!1},this.addEventListener("keydown",this._handleKeyDown.bind(this)),this.addEventListener("click",this._handleClick.bind(this)),this._internals=this.attachInternals()}connectedCallback(){super.connectedCallback(),this.autofocus&&(this.tabIndex<0&&(this.tabIndex=0),this.updateComplete.then(()=>{this.focus(),this.requestUpdate()})),this.addEventListener("focus",this._handleFocus),this.addEventListener("blur",this._handleBlur)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener("focus",this._handleFocus),this.removeEventListener("blur",this._handleBlur)}update(t){super.update(t),t.has("value")&&this._internals.setFormValue(this.value),t.has("disabled")&&(this.disabled?(this._prevTabindex=this.tabIndex,this.tabIndex=-1):this.tabIndex=this._prevTabindex)}_executeAction(){this.type==="submit"&&this._internals.form&&this._internals.form.requestSubmit(),this.type==="reset"&&this._internals.form&&this._internals.form.reset()}_handleKeyDown(t){if((t.key==="Enter"||t.key===" ")&&!this.hasAttribute("disabled")){let o=new MouseEvent("click",{bubbles:!0,cancelable:!0});o.synthetic=!0,this.dispatchEvent(o),this._executeAction()}}_handleClick(t){t.synthetic||this.hasAttribute("disabled")||this._executeAction()}_handleSlotChange(t){let o=t.target;o.name==="content-before"&&(this._hasContentBefore=o.assignedElements().length>0),o.name==="content-after"&&(this._hasContentAfter=o.assignedElements().length>0)}render(){let t=this.icon!=="",o=this.iconAfter!=="",n={base:!0,"icon-only":this.iconOnly,"has-content-before":this._hasContentBefore,"has-content-after":this._hasContentAfter},s=t?G`<vscode-icon
           name=${this.icon}
           ?spin=${this.iconSpin}
-          spin-duration=${o6(this.iconSpinDuration)}
+          spin-duration=${Ce(this.iconSpinDuration)}
           class="icon"
-        ></vscode-icon>` : A;
-          const iconAfterElem = hasIconAfter ? b2`<vscode-icon
+        ></vscode-icon>`:T,r=o?G`<vscode-icon
           name=${this.iconAfter}
           ?spin=${this.iconAfterSpin}
-          spin-duration=${o6(this.iconAfterSpinDuration)}
+          spin-duration=${Ce(this.iconAfterSpinDuration)}
           class="icon-after"
-        ></vscode-icon>` : A;
-          return b2`
+        ></vscode-icon>`:T;return G`
       <div
-        class=${e6(baseClasses)}
+        class=${Mt(n)}
         part="base"
         @slotchange=${this._handleSlotChange}
       >
         <slot name="content-before"></slot>
-        ${iconElem}
+        ${s}
         <slot></slot>
-        ${iconAfterElem}
+        ${r}
         <slot name="content-after"></slot>
       </div>
-    `;
-        }
-      };
-      VscodeButton.styles = vscode_button_styles_default;
-      VscodeButton.formAssociated = true;
-      __decorate2([
-        n4({ type: Boolean, reflect: true })
-      ], VscodeButton.prototype, "autofocus", void 0);
-      __decorate2([
-        n4({ type: Number, reflect: true })
-      ], VscodeButton.prototype, "tabIndex", void 0);
-      __decorate2([
-        n4({ type: Boolean, reflect: true })
-      ], VscodeButton.prototype, "secondary", void 0);
-      __decorate2([
-        n4({ type: Boolean, reflect: true })
-      ], VscodeButton.prototype, "block", void 0);
-      __decorate2([
-        n4({ reflect: true })
-      ], VscodeButton.prototype, "role", void 0);
-      __decorate2([
-        n4({ type: Boolean, reflect: true })
-      ], VscodeButton.prototype, "disabled", void 0);
-      __decorate2([
-        n4()
-      ], VscodeButton.prototype, "icon", void 0);
-      __decorate2([
-        n4({ type: Boolean, reflect: true, attribute: "icon-spin" })
-      ], VscodeButton.prototype, "iconSpin", void 0);
-      __decorate2([
-        n4({ type: Number, reflect: true, attribute: "icon-spin-duration" })
-      ], VscodeButton.prototype, "iconSpinDuration", void 0);
-      __decorate2([
-        n4({ attribute: "icon-after" })
-      ], VscodeButton.prototype, "iconAfter", void 0);
-      __decorate2([
-        n4({ type: Boolean, reflect: true, attribute: "icon-after-spin" })
-      ], VscodeButton.prototype, "iconAfterSpin", void 0);
-      __decorate2([
-        n4({
-          type: Number,
-          reflect: true,
-          attribute: "icon-after-spin-duration"
-        })
-      ], VscodeButton.prototype, "iconAfterSpinDuration", void 0);
-      __decorate2([
-        n4({ type: Boolean, reflect: true })
-      ], VscodeButton.prototype, "focused", void 0);
-      __decorate2([
-        n4({ type: String, reflect: true })
-      ], VscodeButton.prototype, "name", void 0);
-      __decorate2([
-        n4({ type: Boolean, reflect: true, attribute: "icon-only" })
-      ], VscodeButton.prototype, "iconOnly", void 0);
-      __decorate2([
-        n4({ reflect: true })
-      ], VscodeButton.prototype, "type", void 0);
-      __decorate2([
-        n4()
-      ], VscodeButton.prototype, "value", void 0);
-      __decorate2([
-        r5()
-      ], VscodeButton.prototype, "_hasContentBefore", void 0);
-      __decorate2([
-        r5()
-      ], VscodeButton.prototype, "_hasContentAfter", void 0);
-      VscodeButton = __decorate2([
-        customElement("vscode-button")
-      ], VscodeButton);
-    }
-  });
-
-  // node_modules/@vscode-elements/elements/dist/vscode-button/index.js
-  var vscode_button_exports = {};
-  __export(vscode_button_exports, {
-    VscodeButton: () => VscodeButton
-  });
-  var init_vscode_button2 = __esm({
-    "node_modules/@vscode-elements/elements/dist/vscode-button/index.js"() {
-      init_vscode_button();
-    }
-  });
-
-  // src/webview/shared/domUtils.ts
-  function setHtml(el2, html) {
-    if (!el2) {
-      return;
-    }
-    el2.innerHTML = html;
-  }
-  function el(tag, className, text) {
-    const node = document.createElement(tag);
-    if (className) {
-      node.className = className;
-    }
-    if (text !== void 0) {
-      node.textContent = text;
-    }
-    return node;
-  }
-
-  // src/webview/shared/periodSelector.ts
-  var PERIOD_LABELS = {
-    today: "Today",
-    last7: "Last 7 days",
-    last14: "Last 14 days",
-    last30: "Last 30 days",
-    last90: "Last 90 days",
-    currentMonth: "Current month",
-    lastMonth: "Previous month",
-    thisWeek: "This week",
-    allTime: "All time"
-  };
-  var CANONICAL_PERIODS = ["today", "last7", "last30", "currentMonth", "allTime"];
-  function setOptionSelected(option, value, selected) {
-    if (value === selected) {
-      option.selected = true;
-    }
-  }
-  function createPeriodSelector(options) {
-    const wrapper = el("div", "period-selector");
-    wrapper.style.display = "inline-flex";
-    wrapper.style.alignItems = "center";
-    wrapper.style.gap = "4px";
-    const labelText = options.label ?? "Time window:";
-    if (labelText) {
-      const label = el("span", "period-selector-label", labelText);
-      label.style.fontSize = "11px";
-      label.style.color = "var(--vscode-descriptionForeground, var(--text-secondary, #9ca3af))";
-      wrapper.append(label);
-    }
-    const select = document.createElement("select");
-    select.className = "period-selector-select";
-    if (options.id) {
-      select.id = options.id;
-    }
-    select.style.background = "var(--vscode-dropdown-background, var(--button-secondary-bg, #2d2d2d))";
-    select.style.color = "var(--vscode-dropdown-foreground, var(--text-primary, #cccccc))";
-    select.style.border = "1px solid var(--border-subtle, #555555)";
-    select.style.borderRadius = "4px";
-    select.style.padding = "4px 8px";
-    select.style.fontSize = "13px";
-    select.style.cursor = "pointer";
-    select.style.minHeight = "24px";
-    const disabledSet = new Set(options.disabled ?? []);
-    const periods = options.periods ?? CANONICAL_PERIODS;
-    for (const period of periods) {
-      const option = document.createElement("option");
-      option.value = period;
-      option.textContent = PERIOD_LABELS[period];
-      setOptionSelected(option, period, options.selected);
-      if (disabledSet.has(period)) {
-        option.disabled = true;
-        if (options.disabledTitle) {
-          option.title = options.disabledTitle;
-        }
-      }
-      select.append(option);
-    }
-    for (const extra of options.extraOptions ?? []) {
-      const option = document.createElement("option");
-      option.value = extra.value;
-      option.textContent = extra.label;
-      if (extra.title) {
-        option.title = extra.title;
-      }
-      setOptionSelected(option, extra.value, options.selected);
-      if (extra.disabled) {
-        option.disabled = true;
-      }
-      select.append(option);
-    }
-    select.addEventListener("change", () => {
-      options.onChange(select.value);
-    });
-    wrapper.append(select);
-    return { wrapper, select };
-  }
-
-  // src/webview/shared/localization.ts
-  var DEFAULT_LOCALIZATION = {
-    "nav.btnRefresh": "Refresh",
-    "nav.btnDetails": "Details",
-    "nav.btnChart": "Chart",
-    "nav.btnUsage": "Usage Analysis",
-    "nav.btnDiagnostics": "Diagnostics",
-    "nav.btnMaturity": "Fluency Score",
-    "nav.btnDashboard": "Team Dashboard",
-    "nav.btnLevelViewer": "Level Viewer",
-    "nav.btnEnvironmental": "Environmental Impact",
-    "nav.btnEfficiency": "Efficiency"
-  };
-  var currentLocalization = { ...DEFAULT_LOCALIZATION };
-  function initializeWebviewLocalization(localization) {
-    const resolved = {};
-    for (const [key, value] of Object.entries(localization)) {
-      if (typeof value === "string" && value !== key) {
-        resolved[key] = value;
-      }
-    }
-    currentLocalization = { ...DEFAULT_LOCALIZATION, ...resolved };
-  }
-  function localize(key) {
-    return currentLocalization[key] || DEFAULT_LOCALIZATION[key] || key;
-  }
-  var currentLanguage = "en";
-  function setCurrentLanguage(language) {
-    currentLanguage = language;
-  }
-
-  // src/webview/shared/buttonConfig.ts
-  var BUTTON_DEFS = {
-    "btn-refresh": {
-      id: "btn-refresh",
-      labelKey: "nav.btnRefresh",
-      icon: "refresh",
-      appearance: "primary"
-    },
-    "btn-details": {
-      id: "btn-details",
-      labelKey: "nav.btnDetails",
-      icon: "robot",
-      iconColor: "#c37bff",
-      appearance: "secondary"
-    },
-    "btn-chart": {
-      id: "btn-chart",
-      labelKey: "nav.btnChart",
-      icon: "graph-line",
-      iconColor: "#60a5fa",
-      appearance: "secondary"
-    },
-    "btn-usage": {
-      id: "btn-usage",
-      labelKey: "nav.btnUsage",
-      icon: "graph",
-      iconColor: "#22d3ee",
-      appearance: "secondary"
-    },
-    "btn-diagnostics": {
-      id: "btn-diagnostics",
-      labelKey: "nav.btnDiagnostics",
-      icon: "search",
-      iconColor: "#fb7185",
-      appearance: "secondary"
-    },
-    "btn-maturity": {
-      id: "btn-maturity",
-      labelKey: "nav.btnMaturity",
-      icon: "target",
-      iconColor: "#fbbf24",
-      appearance: "secondary"
-    },
-    "btn-dashboard": {
-      id: "btn-dashboard",
-      labelKey: "nav.btnDashboard",
-      icon: "organization",
-      iconColor: "#818cf8",
-      appearance: "secondary"
-    },
-    "btn-level-viewer": {
-      id: "btn-level-viewer",
-      labelKey: "nav.btnLevelViewer",
-      icon: "list-tree",
-      iconColor: "#94a3b8",
-      appearance: "secondary"
-    },
-    "btn-environmental": {
-      id: "btn-environmental",
-      labelKey: "nav.btnEnvironmental",
-      icon: "globe",
-      iconColor: "#4ade80",
-      appearance: "secondary"
-    },
-    "btn-efficiency": {
-      id: "btn-efficiency",
-      labelKey: "nav.btnEfficiency",
-      icon: "dashboard",
-      iconColor: "#f472b6",
-      appearance: "secondary"
-    }
-  };
-  var BUTTONS = new Proxy({}, {
-    get(_target, prop) {
-      const def = BUTTON_DEFS[prop];
-      if (!def) {
-        return void 0;
-      }
-      const { labelKey, ...rest } = def;
-      return { ...rest, label: localize(labelKey) };
-    }
-  });
-  var NAV_ORDER = [
-    "btn-refresh",
-    "btn-details",
-    "btn-chart",
-    "btn-usage",
-    "btn-maturity",
-    "btn-efficiency",
-    "btn-environmental",
-    "btn-diagnostics",
-    "btn-dashboard"
-  ];
-  function getNavButtons(activeView, backendConfigured) {
-    return NAV_ORDER.filter((id) => id !== "btn-dashboard" || backendConfigured).map((id) => ({ ...BUTTONS[id], active: id === activeView }));
-  }
-  function buttonHtml(idOrConfig) {
-    const config = typeof idOrConfig === "string" ? BUTTONS[idOrConfig] : idOrConfig;
-    if (config.hidden) {
-      return "";
-    }
-    const appearance = config.appearance ? ` appearance="${config.appearance}"` : "";
-    const active = config.active ? ' class="nav-active" disabled aria-current="page"' : "";
-    const iconStyle = config.iconColor ? ` style="--icon-accent:${config.iconColor}"` : "";
-    const icon = config.icon ? `<span class="codicon codicon-${config.icon} nav-icon"${iconStyle}></span>` : "";
-    return `<vscode-button id="${config.id}"${appearance}${active}>${icon}${config.label}</vscode-button>`;
-  }
-  function navButtonsHtml(activeView, backendConfigured) {
-    return getNavButtons(activeView, backendConfigured).map((config) => buttonHtml(config)).join("\n");
-  }
-
-  // src/webview/shared/contextRefUtils.ts
-  function getTotalContextRefs(refs) {
-    return refs.file + refs.selection + refs.implicitSelection + refs.symbol + refs.codebase + refs.workspace + refs.terminal + refs.vscode + refs.copilotInstructions + refs.agentsMd + (refs.terminalLastCommand || 0) + (refs.terminalSelection || 0) + (refs.clipboard || 0) + (refs.changes || 0) + (refs.outputPanel || 0) + (refs.problemsPanel || 0) + (refs.pullRequest || 0);
-  }
-
-  // ../src/webview/shared/dataLoader.ts
-  function getWindowData(key) {
-    const win = globalThis.window;
-    return win ? win[key] : void 0;
-  }
-
-  // src/webview/shared/formatUtils.ts
-  var _estimatorsData = getWindowData("__TOKEN_ESTIMATORS__");
-  var tokenEstimators = _estimatorsData?.estimators ?? {};
-  var currentLocale;
-  var compactNumbersEnabled = true;
-  function setFormatLocale(locale) {
-    currentLocale = locale;
-  }
-  function formatFixed(value, digits) {
-    return new Intl.NumberFormat(currentLocale, {
-      minimumFractionDigits: digits,
-      maximumFractionDigits: digits
-    }).format(value);
-  }
-  function formatPercent(value, digits = 1) {
-    return `${formatFixed(value, digits)}%`;
-  }
-  function formatNumber(value) {
-    return value.toLocaleString(currentLocale);
-  }
-  function formatCompact(value) {
-    if (!compactNumbersEnabled) {
-      return formatNumber(value);
-    }
-    return new Intl.NumberFormat(currentLocale, {
-      notation: "compact",
-      maximumFractionDigits: 1
-    }).format(value);
-  }
-  function formatCost(value) {
-    return new Intl.NumberFormat(currentLocale, {
-      style: "currency",
-      currency: "USD",
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 2
-    }).format(value);
-  }
-  function escapeHtml(text) {
-    return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#039;");
-  }
-  function safeSectionHtml(label, builder, onError = (m2) => console.error(m2)) {
-    try {
-      return builder();
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      onError(`[usage-webview] Section "${label}" failed to render: ${message}`);
-      return `<div class="section" style="border-color: rgba(239, 68, 68, 0.3);">
-			<div class="section-title"><span>\u26A0\uFE0F</span><span>${escapeHtml(label)}</span></div>
+    `}};C.styles=us;C.formAssociated=!0;M([v({type:Boolean,reflect:!0})],C.prototype,"autofocus",void 0);M([v({type:Number,reflect:!0})],C.prototype,"tabIndex",void 0);M([v({type:Boolean,reflect:!0})],C.prototype,"secondary",void 0);M([v({type:Boolean,reflect:!0})],C.prototype,"block",void 0);M([v({reflect:!0})],C.prototype,"role",void 0);M([v({type:Boolean,reflect:!0})],C.prototype,"disabled",void 0);M([v()],C.prototype,"icon",void 0);M([v({type:Boolean,reflect:!0,attribute:"icon-spin"})],C.prototype,"iconSpin",void 0);M([v({type:Number,reflect:!0,attribute:"icon-spin-duration"})],C.prototype,"iconSpinDuration",void 0);M([v({attribute:"icon-after"})],C.prototype,"iconAfter",void 0);M([v({type:Boolean,reflect:!0,attribute:"icon-after-spin"})],C.prototype,"iconAfterSpin",void 0);M([v({type:Number,reflect:!0,attribute:"icon-after-spin-duration"})],C.prototype,"iconAfterSpinDuration",void 0);M([v({type:Boolean,reflect:!0})],C.prototype,"focused",void 0);M([v({type:String,reflect:!0})],C.prototype,"name",void 0);M([v({type:Boolean,reflect:!0,attribute:"icon-only"})],C.prototype,"iconOnly",void 0);M([v({reflect:!0})],C.prototype,"type",void 0);M([v()],C.prototype,"value",void 0);M([ho()],C.prototype,"_hasContentBefore",void 0);M([ho()],C.prototype,"_hasContentAfter",void 0);C=M([Rt("vscode-button")],C)});var ms={};rr(ms,{VscodeButton:()=>C});var fs=y(()=>{gs()});function k(e,t){e&&(e.innerHTML=t)}function m(e,t,o){let n=document.createElement(e);return t&&(n.className=t),o!==void 0&&(n.textContent=o),n}var pt={today:"Today",last7:"Last 7 days",last14:"Last 14 days",last30:"Last 30 days",last90:"Last 90 days",currentMonth:"Current month",lastMonth:"Previous month",thisWeek:"This week",allTime:"All time"},ir=["today","last7","last30","currentMonth","allTime"];function Xo(e,t,o){t===o&&(e.selected=!0)}function Yt(e){let t=m("div","period-selector");t.style.display="inline-flex",t.style.alignItems="center",t.style.gap="4px";let o=e.label??"Time window:";if(o){let i=m("span","period-selector-label",o);i.style.fontSize="11px",i.style.color="var(--vscode-descriptionForeground, var(--text-secondary, #9ca3af))",t.append(i)}let n=document.createElement("select");n.className="period-selector-select",e.id&&(n.id=e.id),n.style.background="var(--vscode-dropdown-background, var(--button-secondary-bg, #2d2d2d))",n.style.color="var(--vscode-dropdown-foreground, var(--text-primary, #cccccc))",n.style.border="1px solid var(--border-subtle, #555555)",n.style.borderRadius="4px",n.style.padding="4px 8px",n.style.fontSize="13px",n.style.cursor="pointer",n.style.minHeight="24px";let s=new Set(e.disabled??[]),r=e.periods??ir;for(let i of r){let a=document.createElement("option");a.value=i,a.textContent=pt[i],Xo(a,i,e.selected),s.has(i)&&(a.disabled=!0,e.disabledTitle&&(a.title=e.disabledTitle)),n.append(a)}for(let i of e.extraOptions??[]){let a=document.createElement("option");a.value=i.value,a.textContent=i.label,i.title&&(a.title=i.title),Xo(a,i.value,e.selected),i.disabled&&(a.disabled=!0),n.append(a)}return n.addEventListener("change",()=>{e.onChange(n.value)}),t.append(n),{wrapper:t,select:n}}var Jt={"nav.btnRefresh":"Refresh","nav.btnDetails":"Details","nav.btnChart":"Chart","nav.btnUsage":"Usage Analysis","nav.btnDiagnostics":"Diagnostics","nav.btnMaturity":"Fluency Score","nav.btnDashboard":"Team Dashboard","nav.btnLevelViewer":"Level Viewer","nav.btnEnvironmental":"Environmental Impact","nav.btnEfficiency":"Efficiency"},Zo={...Jt};function Qo(e){let t={};for(let[o,n]of Object.entries(e))typeof n=="string"&&n!==o&&(t[o]=n);Zo={...Jt,...t}}function en(e){return Zo[e]||Jt[e]||e}var ar="en";function tn(e){ar=e}var lr={"btn-refresh":{id:"btn-refresh",labelKey:"nav.btnRefresh",icon:"refresh",appearance:"primary"},"btn-details":{id:"btn-details",labelKey:"nav.btnDetails",icon:"robot",iconColor:"#c37bff",appearance:"secondary"},"btn-chart":{id:"btn-chart",labelKey:"nav.btnChart",icon:"graph-line",iconColor:"#60a5fa",appearance:"secondary"},"btn-usage":{id:"btn-usage",labelKey:"nav.btnUsage",icon:"graph",iconColor:"#22d3ee",appearance:"secondary"},"btn-diagnostics":{id:"btn-diagnostics",labelKey:"nav.btnDiagnostics",icon:"search",iconColor:"#fb7185",appearance:"secondary"},"btn-maturity":{id:"btn-maturity",labelKey:"nav.btnMaturity",icon:"target",iconColor:"#fbbf24",appearance:"secondary"},"btn-dashboard":{id:"btn-dashboard",labelKey:"nav.btnDashboard",icon:"organization",iconColor:"#818cf8",appearance:"secondary"},"btn-level-viewer":{id:"btn-level-viewer",labelKey:"nav.btnLevelViewer",icon:"list-tree",iconColor:"#94a3b8",appearance:"secondary"},"btn-environmental":{id:"btn-environmental",labelKey:"nav.btnEnvironmental",icon:"globe",iconColor:"#4ade80",appearance:"secondary"},"btn-efficiency":{id:"btn-efficiency",labelKey:"nav.btnEfficiency",icon:"dashboard",iconColor:"#f472b6",appearance:"secondary"}},on=new Proxy({},{get(e,t){let o=lr[t];if(!o)return;let{labelKey:n,...s}=o;return{...s,label:en(n)}}});var dr=["btn-refresh","btn-details","btn-chart","btn-usage","btn-maturity","btn-efficiency","btn-environmental","btn-diagnostics","btn-dashboard"];function cr(e,t){return dr.filter(o=>o!=="btn-dashboard"||t).map(o=>({...on[o],active:o===e}))}function ur(e){let t=typeof e=="string"?on[e]:e;if(t.hidden)return"";let o=t.appearance?` appearance="${t.appearance}"`:"",n=t.active?' class="nav-active" disabled aria-current="page"':"",s=t.iconColor?` style="--icon-accent:${t.iconColor}"`:"",r=t.icon?`<span class="codicon codicon-${t.icon} nav-icon"${s}></span>`:"";return`<vscode-button id="${t.id}"${o}${n}>${r}${t.label}</vscode-button>`}function nn(e,t){return cr(e,t).map(o=>ur(o)).join(`
+`)}function Re(e){return e.file+e.selection+e.implicitSelection+e.symbol+e.codebase+e.workspace+e.terminal+e.vscode+e.copilotInstructions+e.agentsMd+(e.terminalLastCommand||0)+(e.terminalSelection||0)+(e.clipboard||0)+(e.changes||0)+(e.outputPanel||0)+(e.problemsPanel||0)+(e.pullRequest||0)}function q(e){let t=globalThis.window;return t?t[e]:void 0}var pr=q("__TOKEN_ESTIMATORS__"),Yd=pr?.estimators??{},_e,gr=!0;function Xt(e){_e=e}function w(e,t){return new Intl.NumberFormat(_e,{minimumFractionDigits:t,maximumFractionDigits:t}).format(e)}function Q(e,t=1){return`${w(e,t)}%`}function g(e){return e.toLocaleString(_e)}function gt(e){return gr?new Intl.NumberFormat(_e,{notation:"compact",maximumFractionDigits:1}).format(e):g(e)}function sn(e){return new Intl.NumberFormat(_e,{style:"currency",currency:"USD",minimumFractionDigits:2,maximumFractionDigits:2}).format(e)}function d(e){return e.replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;").replace(/"/g,"&quot;").replace(/'/g,"&#039;")}function P(e,t,o=n=>console.error(n)){try{return t()}catch(n){let s=n instanceof Error?n.message:String(n);return o(`[usage-webview] Section "${e}" failed to render: ${s}`),`<div class="section" style="border-color: rgba(239, 68, 68, 0.3);">
+			<div class="section-title"><span>\u26A0\uFE0F</span><span>${d(e)}</span></div>
 			<div style="color: var(--text-secondary); font-size: 12px; padding: 8px 0;">
 				This section couldn't be displayed due to an unexpected error. Other sections are unaffected \u2014 try refreshing the dashboard.
 			</div>
-		</div>`;
-    }
-  }
-  function formatFileSize(bytes) {
-    const numericBytes = Number(bytes);
-    if (!Number.isFinite(numericBytes) || numericBytes < 0) {
-      return "N/A";
-    }
-    if (numericBytes < 1024) {
-      return `${numericBytes} B`;
-    }
-    const units = ["KB", "MB", "GB", "TB", "PB"];
-    let value = numericBytes / 1024;
-    let unitIndex = 0;
-    while (value >= 1024 && unitIndex < units.length - 1) {
-      value /= 1024;
-      unitIndex++;
-    }
-    const decimals = unitIndex === 0 ? 1 : 2;
-    return `${value.toFixed(decimals)} ${units[unitIndex]}`;
-  }
-  function formatDurationShort(durationMs) {
-    if (durationMs === void 0 || !Number.isFinite(durationMs) || durationMs < 0) {
-      return "\u2014";
-    }
-    const totalMinutes = Math.round(durationMs / 6e4);
-    if (totalMinutes < 1) {
-      return "<1m";
-    }
-    if (totalMinutes < 60) {
-      return `${totalMinutes}m`;
-    }
-    const hours = Math.floor(totalMinutes / 60);
-    const minutes = totalMinutes % 60;
-    return `${hours}h ${String(minutes).padStart(2, "0")}m`;
-  }
-  function getTimeSince(isoString) {
-    try {
-      const now = Date.now();
-      const then = new Date(isoString).getTime();
-      if (!Number.isFinite(then)) {
-        return "Unknown";
-      }
-      const diffMs = now - then;
-      if (diffMs < 0) {
-        return "Just now";
-      }
-      const seconds = Math.floor(diffMs / 1e3);
-      const minutes = Math.floor(seconds / 60);
-      const hours = Math.floor(minutes / 60);
-      const days = Math.floor(hours / 24);
-      if (days > 0) {
-        return `${days} day${days !== 1 ? "s" : ""} ago`;
-      }
-      if (hours > 0) {
-        return `${hours} hour${hours !== 1 ? "s" : ""} ago`;
-      }
-      if (minutes > 0) {
-        return `${minutes} minute${minutes !== 1 ? "s" : ""} ago`;
-      }
-      return `${seconds} second${seconds !== 1 ? "s" : ""} ago`;
-    } catch {
-      return "Unknown";
-    }
-  }
-
-  // src/webview/shared/extensionPoints.ts
-  function wireExtensionPointButtons(vscodeApi) {
-    const buttons = window.__EXTENSION_POINT_BUTTONS__ ?? [];
-    if (buttons.length === 0) {
-      return;
-    }
-    const buttonRow = document.querySelector(".button-row");
-    if (!buttonRow) {
-      return;
-    }
-    for (const btn of buttons) {
-      const el2 = document.createElement("vscode-button");
-      el2.id = `ext-point-${btn.id}`;
-      el2.textContent = btn.label;
-      el2.addEventListener("click", () => {
-        vscodeApi.postMessage({ command: "extensionPointAction", buttonId: btn.id });
-      });
-      buttonRow.append(el2);
-    }
-  }
-
-  // src/webview/shared/theme.css
-  var theme_default = `/**
+		</div>`}}function Pe(e){let t=Number(e);if(!Number.isFinite(t)||t<0)return"N/A";if(t<1024)return`${t} B`;let o=["KB","MB","GB","TB","PB"],n=t/1024,s=0;for(;n>=1024&&s<o.length-1;)n/=1024,s++;let r=s===0?1:2;return`${n.toFixed(r)} ${o[s]}`}function Zt(e){if(e===void 0||!Number.isFinite(e)||e<0)return"\u2014";let t=Math.round(e/6e4);if(t<1)return"<1m";if(t<60)return`${t}m`;let o=Math.floor(t/60),n=t%60;return`${o}h ${String(n).padStart(2,"0")}m`}function rn(e){try{let t=Date.now(),o=new Date(e).getTime();if(!Number.isFinite(o))return"Unknown";let n=t-o;if(n<0)return"Just now";let s=Math.floor(n/1e3),r=Math.floor(s/60),i=Math.floor(r/60),a=Math.floor(i/24);return a>0?`${a} day${a!==1?"s":""} ago`:i>0?`${i} hour${i!==1?"s":""} ago`:r>0?`${r} minute${r!==1?"s":""} ago`:`${s} second${s!==1?"s":""} ago`}catch{return"Unknown"}}function an(e){let t=window.__EXTENSION_POINT_BUTTONS__??[];if(t.length===0)return;let o=document.querySelector(".button-row");if(o)for(let n of t){let s=document.createElement("vscode-button");s.id=`ext-point-${n.id}`,s.textContent=n.label,s.addEventListener("click",()=>{e.postMessage({command:"extensionPointAction",buttonId:n.id})}),o.append(s)}}var mt=["last7","last30","currentMonth"];function Qt(e){if(!e||typeof e!="object")return;let t=e,o={};for(let n of mt){let s=t[n];if(!Array.isArray(s))return;o[n]=s.filter(r=>!!r&&typeof r=="object"&&typeof r.interactions=="number")}return o}var ln=`/**
  * Shared theme variables for all webview panels
  * Uses VS Code theme tokens for automatic light/dark theme support.
  *
@@ -2290,10 +634,7 @@ body[data-vscode-theme-kind="vscode-high-contrast-light"] .title {
 	text-shadow: 2px 2px 0 var(--vscode-panel-border);
 	white-space: nowrap;
 }
-`;
-
-  // src/webview/usage/styles.css
-  var styles_default = `* {
+`;var dn=`* {
 	margin: 0;
 	padding: 0;
 	box-sizing: border-box;
@@ -3388,303 +1729,10 @@ background: var(--bg-tertiary);
 	color: var(--text-muted);
 	flex: 1;
 }
-`;
-
-  // src/webview/shared/messageHandler.ts
-  function isTrustedWebviewMessageSource(source, currentWindow) {
-    return source === null || source === currentWindow;
-  }
-  function registerMessageHandler(handler) {
-    window.addEventListener("message", (event) => {
-      if (!isTrustedWebviewMessageSource(event.source, window)) {
-        return;
-      }
-      handler(event.data);
-    });
-  }
-
-  // ../src/webview/shared/modelUtils.ts
-  var _pricingData = getWindowData("__MODEL_PRICING__");
-  var _modelNames = {};
-  for (const [modelId, pricing] of Object.entries(_pricingData?.pricing ?? {})) {
-    if (pricing.displayNames && pricing.displayNames.length > 0) {
-      _modelNames[modelId] = pricing.displayNames[0];
-    }
-  }
-  var CUSTOM_PROVIDER_SUFFIX = " (Custom)";
-  function decodeSegment(segment) {
-    try {
-      return decodeURIComponent(segment);
-    } catch {
-      return segment;
-    }
-  }
-  function parseCustomProviderModel(model) {
-    const parts = model.split("/");
-    if (parts.length !== 3 || parts.some((part) => part.trim() === "")) {
-      return void 0;
-    }
-    return {
-      source: decodeSegment(parts[0]),
-      providerName: decodeSegment(parts[1]),
-      modelId: decodeSegment(parts[2])
-    };
-  }
-  var UUID_PREFIX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\//i;
-  function getModelLookupCandidates(model) {
-    const candidates = [];
-    const add = (id) => {
-      if (id && !candidates.includes(id)) {
-        candidates.push(id);
-      }
-    };
-    const addWithVersionVariant = (id) => {
-      add(id);
-      add(id.replace(/(\d+)-(\d+)(?=-|$)/, "$1.$2"));
-    };
-    const base = model.replace(/^copilot\//, "");
-    addWithVersionVariant(base);
-    const custom = parseCustomProviderModel(base);
-    if (custom) {
-      addWithVersionVariant(custom.modelId);
-    }
-    if (UUID_PREFIX.test(base)) {
-      addWithVersionVariant(base.replace(UUID_PREFIX, ""));
-    }
-    return candidates;
-  }
-  function getCustomProviderGroup(model) {
-    const parsed = parseCustomProviderModel(model);
-    return parsed ? `${parsed.providerName}${CUSTOM_PROVIDER_SUFFIX}` : void 0;
-  }
-  function getModelDisplayName(model) {
-    for (const candidate of getModelLookupCandidates(model)) {
-      if (_modelNames[candidate]) {
-        return _modelNames[candidate];
-      }
-    }
-    const custom = parseCustomProviderModel(model);
-    if (custom) {
-      return custom.modelId;
-    }
-    if (UUID_PREFIX.test(model)) {
-      return model.replace(UUID_PREFIX, "");
-    }
-    return decodeSegment(model);
-  }
-
-  // ../src/tokenEstimation.ts
-  var NANO_AIU_TO_DOLLARS = 1 / 1e11;
-  function parseContextThreshold(threshold) {
-    if (!threshold) {
-      return null;
-    }
-    const m2 = /([\d.]+)\s*([KkMm])?/.exec(threshold);
-    if (!m2) {
-      return null;
-    }
-    const n5 = parseFloat(m2[1]);
-    if (!isFinite(n5) || n5 <= 0) {
-      return null;
-    }
-    const unit = (m2[2] ?? "").toUpperCase();
-    return Math.round(n5 * (unit === "M" ? 1e6 : unit === "K" ? 1e3 : 1));
-  }
-  function getLongContextInfo(modelId, modelPricing = {}) {
-    let pricing = _lookupModelPricing(modelId, modelPricing);
-    if (!pricing) {
-      const id = modelId.toLowerCase();
-      for (const [key, value] of Object.entries(modelPricing)) {
-        if (id.includes(key.toLowerCase()) || key.toLowerCase().includes(id)) {
-          pricing = value;
-          break;
-        }
-      }
-    }
-    const longContext = pricing?.copilotPricing?.longContext;
-    if (!longContext) {
-      return null;
-    }
-    const thresholdTokens = parseContextThreshold(longContext.threshold);
-    if (!thresholdTokens) {
-      return null;
-    }
-    return {
-      thresholdTokens,
-      defaultInputCostPerMillion: pricing.copilotPricing.inputCostPerMillion,
-      longContextInputCostPerMillion: longContext.inputCostPerMillion
-    };
-  }
-  function _lookupModelPricing(model, modelPricing) {
-    for (const candidate of getModelLookupCandidates(model)) {
-      const entry = modelPricing[candidate];
-      if (entry) {
-        return entry;
-      }
-    }
-    return void 0;
-  }
-
-  // ../src/modelEfficiency.ts
-  function deriveModelEfficiencyRates(c4) {
-    return {
-      oneShotRate: c4.editTurns > 0 ? c4.oneShotEditTurns / c4.editTurns : null,
-      retryRate: c4.editTurns > 0 ? c4.retries / c4.editTurns : null,
-      selfCorrectionRate: c4.editTurns > 0 ? c4.selfCorrections / c4.editTurns : null,
-      costPerCall: c4.calls > 0 ? c4.cost / c4.calls : null,
-      costPerEdit: c4.editTurns > 0 ? c4.cost / c4.editTurns : null,
-      outputTokensPerCall: c4.calls > 0 ? c4.outputTokens / c4.calls : null,
-      toolCallsPerCall: c4.calls > 0 ? (c4.toolCalls ?? 0) / c4.calls : null,
-      // Cap at 1.0: some providers report cachedReadTokens > inputTokens (e.g. DeepSeek).
-      cacheHitRate: c4.inputTokens > 0 ? Math.min(1, c4.cachedReadTokens / c4.inputTokens) : null
-    };
-  }
-  function computeEfficiencyLowUsageThreshold(usage) {
-    const calls = Object.values(usage).map((c4) => c4.calls).sort((a3, b3) => a3 - b3);
-    if (calls.length < 4) {
-      return null;
-    }
-    return calls[Math.floor((calls.length - 1) * 0.25)];
-  }
-
-  // ../src/chartDataBuilder.ts
-  var MODEL_PROVIDER_PREFIXES = [
-    ["anthropic", "Anthropic"],
-    ["claude", "Anthropic"],
-    ["codestral", "Mistral AI"],
-    ["devstral", "Mistral AI"],
-    ["gemini", "Google"],
-    ["goldeneye", "xAI"],
-    ["google", "Google"],
-    ["gpt", "OpenAI"],
-    ["grok", "xAI"],
-    ["magistral", "Mistral AI"],
-    ["mai-", "Microsoft"],
-    ["ministral", "Mistral AI"],
-    ["mistral", "Mistral AI"],
-    ["o1", "OpenAI"],
-    ["o3", "OpenAI"],
-    ["o4", "OpenAI"],
-    ["pixtral", "Mistral AI"],
-    ["qwen", "Alibaba"],
-    ["raptor", "xAI"]
-  ];
-  function getModelBillingProvider(modelId) {
-    const customGroup = getCustomProviderGroup(modelId);
-    if (customGroup) {
-      return customGroup;
-    }
-    const match = getModelLookupCandidates(modelId).flatMap((candidate) => MODEL_PROVIDER_PREFIXES.filter(([prefix]) => candidate.toLowerCase().startsWith(prefix))).at(0);
-    return match ? match[1] : "Other";
-  }
-
-  // src/webview/usage/customizationSanitizer.ts
-  var VALID_STATUSES = /* @__PURE__ */ new Set(["\u2705", "\u26A0\uFE0F", "\u274C"]);
-  function coerceNumber(value) {
-    const n5 = Number(value);
-    return Number.isFinite(n5) ? n5 : 0;
-  }
-  function sanitizeCustomizationMatrix(rawMatrix) {
-    if (!rawMatrix || typeof rawMatrix !== "object") {
-      return void 0;
-    }
-    const m2 = rawMatrix;
-    const customizationTypes = Array.isArray(m2.customizationTypes) ? m2.customizationTypes.filter((t4) => !!t4 && typeof t4 === "object").map((t4) => ({
-      id: typeof t4.id === "string" ? t4.id : "",
-      icon: typeof t4.icon === "string" ? t4.icon : "",
-      label: typeof t4.label === "string" ? t4.label : ""
-    })).filter((t4) => t4.id !== "") : [];
-    const workspaces = Array.isArray(m2.workspaces) ? m2.workspaces.filter((w2) => !!w2 && typeof w2 === "object").map((w2) => {
-      const rawStatuses = w2.typeStatuses && typeof w2.typeStatuses === "object" ? w2.typeStatuses : {};
-      const typeStatuses = {};
-      for (const [key, val] of Object.entries(rawStatuses)) {
-        typeStatuses[key] = VALID_STATUSES.has(val) ? val : "\u274C";
-      }
-      return {
-        workspacePath: typeof w2.workspacePath === "string" ? w2.workspacePath : "",
-        workspaceName: typeof w2.workspaceName === "string" ? w2.workspaceName : "",
-        sessionCount: coerceNumber(w2.sessionCount),
-        interactionCount: coerceNumber(w2.interactionCount),
-        typeStatuses
-      };
-    }) : [];
-    return {
-      customizationTypes,
-      workspaces,
-      totalWorkspaces: coerceNumber(m2.totalWorkspaces),
-      workspacesWithIssues: coerceNumber(m2.workspacesWithIssues)
-    };
-  }
-
-  // src/webview/usage/billingStatsSanitizer.ts
-  function finiteNumber(value) {
-    return typeof value === "number" && Number.isFinite(value) ? value : 0;
-  }
-  function sanitizeCopilotApiBalance(raw) {
-    if (!raw || typeof raw !== "object") {
-      return null;
-    }
-    const r6 = raw;
-    return {
-      budgetUsd: finiteNumber(r6.budgetUsd),
-      budgetAiCredits: finiteNumber(r6.budgetAiCredits),
-      remainingAiCredits: finiteNumber(r6.remainingAiCredits),
-      usedAiCredits: finiteNumber(r6.usedAiCredits),
-      pctAvailable: finiteNumber(r6.pctAvailable)
-    };
-  }
-  function sanitizeBillingGroupCosts(raw) {
-    if (!raw || typeof raw !== "object") {
-      return null;
-    }
-    const result = {};
-    for (const [key, value] of Object.entries(raw)) {
-      if (typeof value === "number" && Number.isFinite(value)) {
-        result[key] = value;
-      }
-    }
-    return result;
-  }
-  function applyBillingFields(target, raw) {
-    if (!raw || typeof raw !== "object") {
-      return;
-    }
-    const r6 = raw;
-    const apiBalance = sanitizeCopilotApiBalance(r6.copilotApiBalance);
-    if (apiBalance) {
-      target.copilotApiBalance = apiBalance;
-    }
-    const billingCosts = sanitizeBillingGroupCosts(r6.monthBillingGroupCosts);
-    if (billingCosts) {
-      target.monthBillingGroupCosts = billingCosts;
-    }
-  }
-
-  // src/webview/usage/billingCoverage.ts
-  function billingOtherSessionsCostUsd(groupCosts, api) {
-    if (!api) {
-      return 0;
-    }
-    const copilotCostUsd = groupCosts["GitHub Copilot"] ?? 0;
-    return Math.max(0, api.usedAiCredits * 0.01 - copilotCostUsd);
-  }
-  function billingExtGroupCostsHtml(groupCosts, api) {
-    const otherSessionsCostUsd = billingOtherSessionsCostUsd(groupCosts, api);
-    const hasLocalCopilotRow = "GitHub Copilot" in groupCosts;
-    const totalCostUsd = Object.values(groupCosts).reduce((s4, v2) => s4 + v2, 0) + otherSessionsCostUsd;
-    const otherSessionsRowHtml = otherSessionsCostUsd > 1e-3 ? `<tr>
+`;function br(e,t){return e===null||e===t}function cn(e){window.addEventListener("message",t=>{br(t.source,window)&&e(t.data)})}var yr=q("__MODEL_PRICING__"),eo={};for(let[e,t]of Object.entries(yr?.pricing??{}))t.displayNames&&t.displayNames.length>0&&(eo[e]=t.displayNames[0]);var hr=" (Custom)";function ft(e){try{return decodeURIComponent(e)}catch{return e}}function to(e){let t=e.split("/");if(!(t.length!==3||t.some(o=>o.trim()==="")))return{source:ft(t[0]),providerName:ft(t[1]),modelId:ft(t[2])}}var bt=/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\//i;function De(e){let t=[],o=i=>{i&&!t.includes(i)&&t.push(i)},n=i=>{o(i),o(i.replace(/(\d+)-(\d+)(?=-|$)/,"$1.$2"))},s=e.replace(/^copilot\//,"");n(s);let r=to(s);return r&&n(r.modelId),bt.test(s)&&n(s.replace(bt,"")),t}function oo(e){let t=to(e);return t?`${t.providerName}${hr}`:void 0}function ee(e){for(let o of De(e))if(eo[o])return eo[o];let t=to(e);return t?t.modelId:bt.test(e)?e.replace(bt,""):ft(e)}var gc=1/1e11;function xr(e){if(!e)return null;let t=/([\d.]+)\s*([KkMm])?/.exec(e);if(!t)return null;let o=parseFloat(t[1]);if(!isFinite(o)||o<=0)return null;let n=(t[2]??"").toUpperCase();return Math.round(o*(n==="M"?1e6:n==="K"?1e3:1))}function un(e,t={}){let o=kr(e,t);if(!o){let r=e.toLowerCase();for(let[i,a]of Object.entries(t))if(r.includes(i.toLowerCase())||i.toLowerCase().includes(r)){o=a;break}}let n=o?.copilotPricing?.longContext;if(!n)return null;let s=xr(n.threshold);return s?{thresholdTokens:s,defaultInputCostPerMillion:o.copilotPricing.inputCostPerMillion,longContextInputCostPerMillion:n.inputCostPerMillion}:null}function kr(e,t){for(let o of De(e)){let n=t[o];if(n)return n}}function pn(e){return{oneShotRate:e.editTurns>0?e.oneShotEditTurns/e.editTurns:null,retryRate:e.editTurns>0?e.retries/e.editTurns:null,selfCorrectionRate:e.editTurns>0?e.selfCorrections/e.editTurns:null,costPerCall:e.calls>0?e.cost/e.calls:null,costPerEdit:e.editTurns>0?e.cost/e.editTurns:null,outputTokensPerCall:e.calls>0?e.outputTokens/e.calls:null,toolCallsPerCall:e.calls>0?(e.toolCalls??0)/e.calls:null,cacheHitRate:e.inputTokens>0?Math.min(1,e.cachedReadTokens/e.inputTokens):null}}function gn(e){let t=Object.values(e).map(o=>o.calls).sort((o,n)=>o-n);return t.length<4?null:t[Math.floor((t.length-1)*.25)]}var Cr=[["anthropic","Anthropic"],["claude","Anthropic"],["codestral","Mistral AI"],["devstral","Mistral AI"],["gemini","Google"],["goldeneye","xAI"],["google","Google"],["gpt","OpenAI"],["grok","xAI"],["magistral","Mistral AI"],["mai-","Microsoft"],["ministral","Mistral AI"],["mistral","Mistral AI"],["o1","OpenAI"],["o3","OpenAI"],["o4","OpenAI"],["pixtral","Mistral AI"],["qwen","Alibaba"],["raptor","xAI"]];function yt(e){let t=oo(e);if(t)return t;let o=De(e).flatMap(n=>Cr.filter(([s])=>n.toLowerCase().startsWith(s))).at(0);return o?o[1]:"Other"}var Sr=new Set(["\u2705","\u26A0\uFE0F","\u274C"]);function ht(e){let t=Number(e);return Number.isFinite(t)?t:0}function mn(e){if(!e||typeof e!="object")return;let t=e,o=Array.isArray(t.customizationTypes)?t.customizationTypes.filter(s=>!!s&&typeof s=="object").map(s=>({id:typeof s.id=="string"?s.id:"",icon:typeof s.icon=="string"?s.icon:"",label:typeof s.label=="string"?s.label:""})).filter(s=>s.id!==""):[],n=Array.isArray(t.workspaces)?t.workspaces.filter(s=>!!s&&typeof s=="object").map(s=>{let r=s.typeStatuses&&typeof s.typeStatuses=="object"?s.typeStatuses:{},i={};for(let[a,l]of Object.entries(r))i[a]=Sr.has(l)?l:"\u274C";return{workspacePath:typeof s.workspacePath=="string"?s.workspacePath:"",workspaceName:typeof s.workspaceName=="string"?s.workspaceName:"",sessionCount:ht(s.sessionCount),interactionCount:ht(s.interactionCount),typeStatuses:i}}):[];return{customizationTypes:o,workspaces:n,totalWorkspaces:ht(t.totalWorkspaces),workspacesWithIssues:ht(t.workspacesWithIssues)}}function Le(e){return typeof e=="number"&&Number.isFinite(e)?e:0}function Tr(e){if(!e||typeof e!="object")return null;let t=e;return{budgetUsd:Le(t.budgetUsd),budgetAiCredits:Le(t.budgetAiCredits),remainingAiCredits:Le(t.remainingAiCredits),usedAiCredits:Le(t.usedAiCredits),pctAvailable:Le(t.pctAvailable)}}function $r(e){if(!e||typeof e!="object")return null;let t={};for(let[o,n]of Object.entries(e))typeof n=="number"&&Number.isFinite(n)&&(t[o]=n);return t}function fn(e,t){if(!t||typeof t!="object")return;let o=t,n=Tr(o.copilotApiBalance);n&&(e.copilotApiBalance=n);let s=$r(o.monthBillingGroupCosts);s&&(e.monthBillingGroupCosts=s)}function Ar(e,t){if(!t)return 0;let o=e["GitHub Copilot"]??0;return Math.max(0,t.usedAiCredits*.01-o)}function bn(e,t){let o=Ar(e,t),n="GitHub Copilot"in e,s=Object.values(e).reduce((a,l)=>a+l,0)+o,r=o>.001?`<tr>
 			<td style="padding:4px 8px; font-size:12px; color:var(--text-secondary);">GitHub Copilot - other sessions (remote or different environment)</td>
-			<td style="padding:4px 8px; font-size:12px; color:var(--text-secondary); text-align:right;">$${formatFixed(otherSessionsCostUsd, 2)}</td>
-		</tr>` : "";
-    const rows = Object.entries(groupCosts).sort(([, a3], [, b3]) => b3 - a3).map(([group, cost]) => {
-      const label = group === "GitHub Copilot" ? "GitHub Copilot - local sessions" : group;
-      return `
-				<tr>
-					<td style="padding:4px 8px; font-size:12px; color:var(--text-primary);">${escapeHtml(label)}</td>
-					<td style="padding:4px 8px; font-size:12px; color:var(--text-primary); text-align:right;">$${formatFixed(cost, 2)}</td>
-				</tr>${group === "GitHub Copilot" ? otherSessionsRowHtml : ""}`;
-    }).join("") + (hasLocalCopilotRow ? "" : otherSessionsRowHtml);
-    return `
+			<td style="padding:4px 8px; font-size:12px; color:var(--text-secondary); text-align:right;">$${w(o,2)}</td>
+		</tr>`:"";return`
 		<div style="margin-bottom:12px;">
 			<div style="font-size:12px; font-weight:600; color:var(--text-secondary); margin-bottom:6px;">Extension tracked (this calendar month, IDE sessions only)</div>
 			<table style="width:100%; border-collapse:collapse; border:1px solid var(--border-subtle); border-radius:6px; overflow:hidden;">
@@ -3694,375 +1742,19 @@ background: var(--bg-tertiary);
 						<th style="padding:6px 8px; text-align:right; font-size:11px; color:var(--text-secondary); font-weight:600;">Estimated cost</th>
 					</tr>
 				</thead>
-				<tbody>${rows}</tbody>
+				<tbody>${Object.entries(e).sort(([,a],[,l])=>l-a).map(([a,l])=>`
+				<tr>
+					<td style="padding:4px 8px; font-size:12px; color:var(--text-primary);">${d(a==="GitHub Copilot"?"GitHub Copilot - local sessions":a)}</td>
+					<td style="padding:4px 8px; font-size:12px; color:var(--text-primary); text-align:right;">$${w(l,2)}</td>
+				</tr>${a==="GitHub Copilot"?r:""}`).join("")+(n?"":r)}</tbody>
 				<tfoot>
 					<tr style="border-top:1px solid var(--border-color);">
 						<td style="padding:6px 8px; font-size:12px; font-weight:600; color:var(--text-primary);">Total</td>
-						<td style="padding:6px 8px; font-size:12px; font-weight:600; color:var(--text-primary); text-align:right;">$${formatFixed(totalCostUsd, 2)}</td>
+						<td style="padding:6px 8px; font-size:12px; font-weight:600; color:var(--text-primary); text-align:right;">$${w(s,2)}</td>
 					</tr>
 				</tfoot>
 			</table>
-		</div>`;
-  }
-
-  // src/webview/usage/agentSessionsSanitizer.ts
-  var DEFAULT_SNAPSHOT_REFRESH_INTERVAL_MS = 60 * 60 * 1e3;
-  function toDiscovery(value) {
-    return value === "account" || value === "both" ? value : "workspace";
-  }
-  function toSafeNumber(value) {
-    const n5 = Number(value);
-    return Number.isFinite(n5) && n5 >= 0 ? n5 : 0;
-  }
-  function toSafeHttpUrl(value) {
-    const raw = typeof value === "string" ? value.trim() : "";
-    try {
-      const parsed = new URL(raw);
-      if (parsed.protocol === "http:" || parsed.protocol === "https:") {
-        return parsed.toString();
-      }
-    } catch {
-    }
-    return "#";
-  }
-  function sanitizeAgentSessionsData(input) {
-    const src = input && typeof input === "object" ? input : {};
-    const repos = Array.isArray(src.repos) ? src.repos : [];
-    return {
-      authenticated: Boolean(src.authenticated),
-      since: typeof src.since === "string" ? escapeHtml(src.since) : new Date(Date.now() - 30 * 24 * 60 * 60 * 1e3).toISOString(),
-      fetchedAt: typeof src.fetchedAt === "string" ? src.fetchedAt : "",
-      totalTasks: toSafeNumber(src.totalTasks),
-      totalSessions: toSafeNumber(src.totalSessions),
-      totalCredits: toSafeNumber(src.totalCredits),
-      totalPremiumRequests: toSafeNumber(src.totalPremiumRequests),
-      accountTasksAvailable: Boolean(src.accountTasksAvailable),
-      refreshIntervalMs: toSafeNumber(src.refreshIntervalMs) || DEFAULT_SNAPSHOT_REFRESH_INTERVAL_MS,
-      accountTasksError: typeof src.accountTasksError === "string" ? escapeHtml(src.accountTasksError) : void 0,
-      partial: Boolean(src.partial),
-      repos: repos.map((repo) => {
-        const r6 = repo && typeof repo === "object" ? repo : {};
-        const owner = escapeHtml(typeof r6.owner === "string" ? r6.owner : "");
-        const repoName = escapeHtml(typeof r6.repo === "string" ? r6.repo : "");
-        const unassigned = Boolean(r6.unassigned) || !owner || !repoName;
-        return {
-          owner,
-          repo: repoName,
-          repoUrl: unassigned ? "#" : toSafeHttpUrl(`https://github.com/${owner}/${repoName}`),
-          totalTasks: toSafeNumber(r6.totalTasks),
-          totalSessions: toSafeNumber(r6.totalSessions),
-          totalCredits: toSafeNumber(r6.totalCredits),
-          totalPremiumRequests: toSafeNumber(r6.totalPremiumRequests),
-          tasksScanned: toSafeNumber(r6.tasksScanned),
-          tasksTotal: toSafeNumber(r6.tasksTotal),
-          partial: Boolean(r6.partial),
-          discovery: toDiscovery(r6.discovery),
-          unassigned,
-          error: typeof r6.error === "string" ? escapeHtml(r6.error) : void 0
-        };
-      })
-    };
-  }
-
-  // src/webview/usage/switchableTabs.ts
-  var SWITCHABLE_TABS = /* @__PURE__ */ new Set([
-    "activity",
-    "sessions",
-    "tools",
-    "health",
-    "repos",
-    "agent",
-    "worktrees",
-    "insights",
-    "corrections"
-  ]);
-  function isSwitchableTab(value) {
-    return SWITCHABLE_TABS.has(String(value));
-  }
-
-  // src/webview/usage/modelLeaderboard.ts
-  var MIN_BUBBLE_RADIUS = 5;
-  var MAX_BUBBLE_RADIUS = 16;
-  var LABEL_HEIGHT = 12;
-  var LABEL_CHARACTER_WIDTH = 6;
-  var LABEL_GAP = 4;
-  function scaleBubbleRadius(value, maxValue) {
-    if (!Number.isFinite(value) || value <= 0 || !Number.isFinite(maxValue) || maxValue <= 0) {
-      return MIN_BUBBLE_RADIUS;
-    }
-    const normalized = Math.min(value / maxValue, 1);
-    return MIN_BUBBLE_RADIUS + Math.sqrt(normalized) * (MAX_BUBBLE_RADIUS - MIN_BUBBLE_RADIUS);
-  }
-  function createLabelPlacement(input, x2, y3, textAnchor) {
-    const width = Math.max(18, Array.from(input.label).length * LABEL_CHARACTER_WIDTH);
-    const left = textAnchor === "start" ? x2 : textAnchor === "end" ? x2 - width : x2 - width / 2;
-    return {
-      x: x2,
-      y: y3,
-      textAnchor,
-      bounds: { left, right: left + width, top: y3 - 10, bottom: y3 - 10 + LABEL_HEIGHT }
-    };
-  }
-  function getLabelCandidates(input, bounds) {
-    const right = input.x + input.radius + LABEL_GAP;
-    const left = input.x - input.radius - LABEL_GAP;
-    const above = input.y - input.radius - 6;
-    const below = input.y + input.radius + LABEL_HEIGHT;
-    const sideY = input.y < bounds.top + 22 ? [input.y + 18, input.y - 10] : [input.y - 10, input.y + 18];
-    return [
-      createLabelPlacement(input, right, sideY[0], "start"),
-      createLabelPlacement(input, right, sideY[1], "start"),
-      createLabelPlacement(input, left, sideY[0], "end"),
-      createLabelPlacement(input, left, sideY[1], "end"),
-      createLabelPlacement(input, input.x, above, "middle"),
-      createLabelPlacement(input, input.x, below, "middle")
-    ];
-  }
-  function rectanglesOverlap(a3, b3) {
-    return a3.left < b3.right + 2 && a3.right + 2 > b3.left && a3.top < b3.bottom + 2 && a3.bottom + 2 > b3.top;
-  }
-  function intersectsBubble(rect, bubble) {
-    const nearestX = Math.max(rect.left, Math.min(bubble.x, rect.right));
-    const nearestY = Math.max(rect.top, Math.min(bubble.y, rect.bottom));
-    const dx = bubble.x - nearestX;
-    const dy = bubble.y - nearestY;
-    return dx * dx + dy * dy < (bubble.radius + 2) ** 2;
-  }
-  function getPlacementPenalty(placement, placed, bubbles, bounds) {
-    const rect = placement.bounds;
-    const overflow = Math.max(0, bounds.left - rect.left) + Math.max(0, rect.right - bounds.right) + Math.max(0, bounds.top - rect.top) + Math.max(0, rect.bottom - bounds.bottom);
-    const labelCollisions = placed.filter((other) => rectanglesOverlap(rect, other.bounds)).length;
-    const bubbleCollisions = bubbles.filter((bubble) => intersectsBubble(rect, bubble)).length;
-    return overflow * 1e4 + bubbleCollisions * 1e3 + labelCollisions * 100;
-  }
-  function placeBubbleLabels(inputs, bounds) {
-    const placed = [];
-    for (const input of inputs) {
-      const candidates = getLabelCandidates(input, bounds);
-      const best = candidates.reduce(
-        (current, candidate) => getPlacementPenalty(candidate, placed, inputs, bounds) < getPlacementPenalty(current, placed, inputs, bounds) ? candidate : current
-      );
-      placed.push(best);
-    }
-    return placed;
-  }
-
-  // ../src/utils/toolUtils.ts
-  var GUID_MCP_PATTERN = /^mcp__[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}__(.+)$/i;
-  function toTitleCase(s4) {
-    return s4.replace(/_/g, " ").replace(/\b\w/g, (c4) => c4.toUpperCase());
-  }
-  function resolveGuidMcpToolName(id) {
-    const match = GUID_MCP_PATTERN.exec(id);
-    if (!match) {
-      return void 0;
-    }
-    return `Claude MCP: M365 Connector - ${toTitleCase(match[1])}`;
-  }
-  function isGuidMcpTool(id) {
-    return GUID_MCP_PATTERN.test(id);
-  }
-  var MCP_TOOL_FAMILIES = [
-    {
-      displayName: "GitHub MCP",
-      keywords: ["github"],
-      actions: /* @__PURE__ */ new Set([
-        "actions_list",
-        "add_comment_to_pending_review",
-        "add_issue_comment",
-        "add_reply_to_pull_request_comment",
-        "assign_copilot_to_issue",
-        "create_or_update_file",
-        "create_pull_request",
-        "create_repository",
-        "get_commit",
-        "get_file_contents",
-        "get_job_logs",
-        "get_label",
-        "get_latest_release",
-        "get_me",
-        "get_release_by_tag",
-        "get_repository_tree",
-        "get_tag",
-        "issue_read",
-        "issue_write",
-        "label_write",
-        "list_branches",
-        "list_code_scanning_alerts",
-        "list_commits",
-        "list_issue_fields",
-        "list_issue_types",
-        "list_issues",
-        "list_label",
-        "list_pull_requests",
-        "list_tags",
-        "projects_list",
-        "pull_request_read",
-        "pull_request_review_write",
-        "request_copilot_review",
-        "search_code",
-        "search_issues",
-        "search_pull_requests",
-        "search_repositories",
-        "search_users",
-        "semantic_issue_similarity_search",
-        "semantic_issues_search",
-        "sub_issue_write",
-        "update_pull_request"
-      ])
-    },
-    {
-      displayName: "Playwright MCP",
-      keywords: ["playwright"],
-      actions: /* @__PURE__ */ new Set([
-        "browser_click",
-        "browser_close",
-        "browser_console_messages",
-        "browser_evaluate",
-        "browser_fill_form",
-        "browser_find",
-        "browser_hover",
-        "browser_install",
-        "browser_navigate",
-        "browser_network_request",
-        "browser_network_requests",
-        "browser_press_key",
-        "browser_resize",
-        "browser_run_code",
-        "browser_run_code_unsafe",
-        "browser_snapshot",
-        "browser_tabs",
-        "browser_take_screenshot",
-        "browser_type",
-        "browser_wait_for"
-      ])
-    },
-    {
-      displayName: "Context7 MCP",
-      keywords: ["context7"],
-      actions: /* @__PURE__ */ new Set(["get_library_docs", "query_docs", "resolve_library_id"])
-    },
-    {
-      displayName: "Tavily MCP",
-      keywords: ["tavily"],
-      actions: /* @__PURE__ */ new Set(["tavily_crawl", "tavily_extract", "tavily_research", "tavily_search", "crawl", "extract", "research", "search"])
-    },
-    {
-      displayName: "Microsoft Docs MCP",
-      keywords: ["microsoft_doc", "microsoftdocs", "microsoft_learn"],
-      actions: /* @__PURE__ */ new Set(["docs_fetch", "docs_search", "code_sample_search"])
-    },
-    {
-      displayName: "Claude Browser MCP",
-      keywords: ["claude_browser", "claude_in_chrome"],
-      actions: /* @__PURE__ */ new Set([
-        "computer",
-        "find",
-        "get_page_text",
-        "javascript_tool",
-        "navigate",
-        "preview_list",
-        "preview_logs",
-        "preview_start",
-        "preview_stop",
-        "read_console_messages",
-        "read_network_requests",
-        "read_page",
-        "resize_window",
-        "tabs_close",
-        "tabs_context",
-        "tabs_create",
-        "tabs_select"
-      ])
-    }
-  ];
-  function normalizeMcpId(id) {
-    return id.toLowerCase().replace(/[.-]/g, "_");
-  }
-  function resolveMcpFamilyToolName(id) {
-    const normalized = normalizeMcpId(id);
-    for (const family of MCP_TOOL_FAMILIES) {
-      if (!family.keywords.some((keyword) => normalized.includes(keyword))) {
-        continue;
-      }
-      for (const action of family.actions) {
-        if (normalized === action || normalized.endsWith(`_${action}`)) {
-          return `${family.displayName}: ${toTitleCase(action)}`;
-        }
-      }
-    }
-    return void 0;
-  }
-  function isMcpFamilyResolvedTool(id) {
-    return resolveMcpFamilyToolName(id) !== void 0;
-  }
-
-  // src/webview/usage/main.ts
-  function statusBadgeHtml(status, label) {
-    const titleAttr = label ? ` title="${escapeHtml(label)}"` : "";
-    const base = "display:inline-flex;align-items:center;justify-content:center;width:20px;height:20px;border-radius:4px;font-weight:700;flex-shrink:0;";
-    if (status === "\u2705") {
-      return `<span style="${base}background:rgba(34,197,94,0.2);border:1px solid rgba(34,197,94,0.5);color:#4ade80;font-size:12px;"${titleAttr} aria-label="${escapeHtml(label ?? "Present and fresh")}">\u2713</span>`;
-    } else if (status === "\u26A0\uFE0F") {
-      return `<span style="${base}background:rgba(251,191,36,0.2);border:1px solid rgba(251,191,36,0.5);color:#fbbf24;font-size:12px;"${titleAttr} aria-label="${escapeHtml(label ?? "Present but stale")}">!</span>`;
-    } else {
-      return `<span style="${base}background:rgba(239,68,68,0.2);border:1px solid rgba(239,68,68,0.5);color:#f87171;font-size:12px;"${titleAttr} aria-label="${escapeHtml(label ?? "Missing")}">\u2715</span>`;
-    }
-  }
-  var vscode = acquireVsCodeApi();
-  var curationTraceOnceKeys = /* @__PURE__ */ new Set();
-  var aboutCollapsed = vscode.getState()?.aboutCollapsed ?? false;
-  function traceCuration(stage, details) {
-    try {
-      vscode.postMessage({ command: "traceUsageCuration", stage, details: details ?? {} });
-    } catch {
-    }
-  }
-  function traceCurationOnce(key, stage, details) {
-    if (curationTraceOnceKeys.has(key)) {
-      return;
-    }
-    curationTraceOnceKeys.add(key);
-    traceCuration(stage, details);
-  }
-  var initialData = getWindowData("__INITIAL_USAGE__");
-  if (initialData?.localization) {
-    initializeWebviewLocalization(initialData.localization);
-    const language = initialData.localization["__language__"] || "en";
-    setCurrentLanguage(language);
-  }
-  var hygieneMatrixState = null;
-  var repoAnalysisState = /* @__PURE__ */ new Map();
-  var repoAnalysisInFlight = /* @__PURE__ */ new Set();
-  var selectedRepoPath = null;
-  var isSwitchingRepository = false;
-  var isBatchAnalysisInProgress = false;
-  var isSingleRepoAnalysisInProgress = false;
-  var currentWorkspacePaths = [];
-  var activeTab = "activity";
-  var pendingTabAnchor = null;
-  var loadingTimeoutId = null;
-  var currentInsights = [];
-  var currentCurationAnalysis = null;
-  var worktreeRoots = initialData?.worktreeScanRoots ? [...initialData.worktreeScanRoots] : [];
-  var worktreeResults = initialData?.worktreeBackgroundScan ? initialData.worktreeBackgroundScan.worktrees.map(sanitizeWorktreeResult) : [];
-  var worktreeBackgroundScanMeta = initialData?.worktreeBackgroundScan ? { scannedAt: initialData.worktreeBackgroundScan.scannedAt, totalBytes: initialData.worktreeBackgroundScan.totalBytes } : null;
-  var worktreeScanInProgress = false;
-  var worktreeScanStatus = { root: "", checked: 0, total: 0, foundCount: 0, elapsedMs: 0 };
-  var worktreeScanError = null;
-  var worktreeRenderPending = false;
-  var worktreeExpandedRepos = /* @__PURE__ */ new Set();
-  var worktreeRootsExpanded = false;
-  var worktreeSortColumn = "count";
-  var worktreeSortDir = "desc";
-  var worktreeCleanupInProgress = false;
-  var worktreeCleanupConfirmPending = false;
-  var worktreeCleanupStatus = { processed: 0, total: 0 };
-  var worktreeCleanupLog = [];
-  function numField(v2) {
-    return Number(v2 ?? 0) || 0;
-  }
-  var USAGE_LOADING_CSS = `
+		</div>`}var Mr=3600*1e3;function Er(e){return e==="account"||e==="both"?e:"workspace"}function _(e){let t=Number(e);return Number.isFinite(t)&&t>=0?t:0}function vt(e){let t=typeof e=="string"?e.trim():"";try{let o=new URL(t);if(o.protocol==="http:"||o.protocol==="https:")return o.toString()}catch{}return"#"}function yn(e){let t=e&&typeof e=="object"?e:{},o=Array.isArray(t.repos)?t.repos:[];return{authenticated:!!t.authenticated,since:typeof t.since=="string"?d(t.since):new Date(Date.now()-720*60*60*1e3).toISOString(),fetchedAt:typeof t.fetchedAt=="string"?t.fetchedAt:"",totalTasks:_(t.totalTasks),totalSessions:_(t.totalSessions),totalCredits:_(t.totalCredits),totalPremiumRequests:_(t.totalPremiumRequests),accountTasksAvailable:!!t.accountTasksAvailable,refreshIntervalMs:_(t.refreshIntervalMs)||Mr,accountTasksError:typeof t.accountTasksError=="string"?d(t.accountTasksError):void 0,partial:!!t.partial,repos:o.map(n=>{let s=n&&typeof n=="object"?n:{},r=d(typeof s.owner=="string"?s.owner:""),i=d(typeof s.repo=="string"?s.repo:""),a=!!s.unassigned||!r||!i;return{owner:r,repo:i,repoUrl:a?"#":vt(`https://github.com/${r}/${i}`),totalTasks:_(s.totalTasks),totalSessions:_(s.totalSessions),totalCredits:_(s.totalCredits),totalPremiumRequests:_(s.totalPremiumRequests),tasksScanned:_(s.tasksScanned),tasksTotal:_(s.tasksTotal),partial:!!s.partial,discovery:Er(s.discovery),unassigned:a,error:typeof s.error=="string"?d(s.error):void 0}})}}var Rr=new Set(["activity","sessions","tools","health","repos","agent","worktrees","insights","corrections"]);function hn(e){return Rr.has(String(e))}function no(e,t){if(!Number.isFinite(e)||e<=0||!Number.isFinite(t)||t<=0)return 5;let o=Math.min(e/t,1);return 5+Math.sqrt(o)*11}function be(e,t,o,n){let s=Math.max(18,Array.from(e.label).length*6),r=n==="start"?t:n==="end"?t-s:t-s/2;return{x:t,y:o,textAnchor:n,bounds:{left:r,right:r+s,top:o-10,bottom:o-10+12}}}function _r(e,t){let o=e.x+e.radius+4,n=e.x-e.radius-4,s=e.y-e.radius-6,r=e.y+e.radius+12,i=e.y<t.top+22?[e.y+18,e.y-10]:[e.y-10,e.y+18];return[be(e,o,i[0],"start"),be(e,o,i[1],"start"),be(e,n,i[0],"end"),be(e,n,i[1],"end"),be(e,e.x,s,"middle"),be(e,e.x,r,"middle")]}function Pr(e,t){return e.left<t.right+2&&e.right+2>t.left&&e.top<t.bottom+2&&e.bottom+2>t.top}function Dr(e,t){let o=Math.max(e.left,Math.min(t.x,e.right)),n=Math.max(e.top,Math.min(t.y,e.bottom)),s=t.x-o,r=t.y-n;return s*s+r*r<(t.radius+2)**2}function vn(e,t,o,n){let s=e.bounds,r=Math.max(0,n.left-s.left)+Math.max(0,s.right-n.right)+Math.max(0,n.top-s.top)+Math.max(0,s.bottom-n.bottom),i=t.filter(l=>Pr(s,l.bounds)).length,a=o.filter(l=>Dr(s,l)).length;return r*1e4+a*1e3+i*100}function xn(e,t){let o=[];for(let n of e){let r=_r(n,t).reduce((i,a)=>vn(a,o,e,t)<vn(i,o,e,t)?a:i);o.push(r)}return o}var kn=/^mcp__[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}__(.+)$/i;function wn(e){return e.replace(/_/g," ").replace(/\b\w/g,t=>t.toUpperCase())}function Cn(e){let t=kn.exec(e);if(t)return`Claude MCP: M365 Connector - ${wn(t[1])}`}function Sn(e){return kn.test(e)}var Lr=[{displayName:"GitHub MCP",keywords:["github"],actions:new Set(["actions_list","add_comment_to_pending_review","add_issue_comment","add_reply_to_pull_request_comment","assign_copilot_to_issue","create_or_update_file","create_pull_request","create_repository","get_commit","get_file_contents","get_job_logs","get_label","get_latest_release","get_me","get_release_by_tag","get_repository_tree","get_tag","issue_read","issue_write","label_write","list_branches","list_code_scanning_alerts","list_commits","list_issue_fields","list_issue_types","list_issues","list_label","list_pull_requests","list_tags","projects_list","pull_request_read","pull_request_review_write","request_copilot_review","search_code","search_issues","search_pull_requests","search_repositories","search_users","semantic_issue_similarity_search","semantic_issues_search","sub_issue_write","update_pull_request"])},{displayName:"Playwright MCP",keywords:["playwright"],actions:new Set(["browser_click","browser_close","browser_console_messages","browser_evaluate","browser_fill_form","browser_find","browser_hover","browser_install","browser_navigate","browser_network_request","browser_network_requests","browser_press_key","browser_resize","browser_run_code","browser_run_code_unsafe","browser_snapshot","browser_tabs","browser_take_screenshot","browser_type","browser_wait_for"])},{displayName:"Context7 MCP",keywords:["context7"],actions:new Set(["get_library_docs","query_docs","resolve_library_id"])},{displayName:"Tavily MCP",keywords:["tavily"],actions:new Set(["tavily_crawl","tavily_extract","tavily_research","tavily_search","crawl","extract","research","search"])},{displayName:"Microsoft Docs MCP",keywords:["microsoft_doc","microsoftdocs","microsoft_learn"],actions:new Set(["docs_fetch","docs_search","code_sample_search"])},{displayName:"Claude Browser MCP",keywords:["claude_browser","claude_in_chrome"],actions:new Set(["computer","find","get_page_text","javascript_tool","navigate","preview_list","preview_logs","preview_start","preview_stop","read_console_messages","read_network_requests","read_page","resize_window","tabs_close","tabs_context","tabs_create","tabs_select"])}];function Ur(e){return e.toLowerCase().replace(/[.-]/g,"_")}function so(e){let t=Ur(e);for(let o of Lr)if(o.keywords.some(n=>t.includes(n))){for(let n of o.actions)if(t===n||t.endsWith(`_${n}`))return`${o.displayName}: ${wn(n)}`}}function Tn(e){return so(e)!==void 0}function j(e,t){let o=t?` title="${d(t)}"`:"",n="display:inline-flex;align-items:center;justify-content:center;width:20px;height:20px;border-radius:4px;font-weight:700;flex-shrink:0;";return e==="\u2705"?`<span style="${n}background:rgba(34,197,94,0.2);border:1px solid rgba(34,197,94,0.5);color:#4ade80;font-size:12px;"${o} aria-label="${d(t??"Present and fresh")}">\u2713</span>`:e==="\u26A0\uFE0F"?`<span style="${n}background:rgba(251,191,36,0.2);border:1px solid rgba(251,191,36,0.5);color:#fbbf24;font-size:12px;"${o} aria-label="${d(t??"Present but stale")}">!</span>`:`<span style="${n}background:rgba(239,68,68,0.2);border:1px solid rgba(239,68,68,0.5);color:#f87171;font-size:12px;"${o} aria-label="${d(t??"Missing")}">\u2715</span>`}var f=acquireVsCodeApi(),bs=new Set,V=f.getState()?.aboutCollapsed??!1;function Z(e,t){try{f.postMessage({command:"traceUsageCuration",stage:e,details:t??{}})}catch{}}function pe(e,t,o){bs.has(e)||(bs.add(e),Z(t,o))}var E=q("__INITIAL_USAGE__");if(E?.localization){Qo(E.localization);let e=E.localization.__language__||"en";tn(e)}var H=null,ct=new Map,$e=new Set,B=null,ge=!1,me=!1,st=!1,_s=[],$="activity",Lt=null,Ut=null,Bo=[],It=null,U=E?.worktreeScanRoots?[...E.worktreeScanRoots]:[],L=E?.worktreeBackgroundScan?E.worktreeBackgroundScan.worktrees.map(qo):[],Ge=E?.worktreeBackgroundScan?{scannedAt:E.worktreeBackgroundScan.scannedAt,totalBytes:E.worktreeBackgroundScan.totalBytes}:null,R=!1,D={root:"",checked:0,total:0,foundCount:0,elapsedMs:0},rt=null,$o=!1,zt=new Set,Ve=!1,it="count",Ye="desc",W=!1,fe=!1,Oo={processed:0,total:0},re=[];function A(e){return Number(e??0)||0}var ei=`
 <style id="usage-loading-css">
 :root {
   --ul-bg: var(--vscode-sideBar-background, #181825);
@@ -4106,48 +1798,13 @@ background: var(--bg-tertiary);
 .ul-cnt { font-size: 11px; opacity: 0.75; font-variant-numeric: tabular-nums; }
 @keyframes ul-pop { 0% { transform: scale(0.4); opacity: 0; } 60% { transform: scale(1.3); } 100% { transform: scale(1); opacity: 1; } }
 .ul-pop { animation: ul-pop 0.3s ease both; }
-</style>`;
-  var USAGE_LOADING_STEPS = [
-    { id: "ul-s-start", label: "Starting usage analysis" },
-    { id: "ul-s-tools", label: "Collecting runtime tools" },
-    { id: "ul-s-mcp", label: "Discovering MCP servers" },
-    { id: "ul-s-skills", label: "Scanning skill directories" },
-    { id: "ul-s-crunch", label: "Computing curation analysis" },
-    { id: "ul-s-ready", label: "Ready!" }
-  ];
-  var USAGE_STAGE_MAP = {
-    start: { pct: 5, stepId: "ul-s-start", subtitle: "Starting usage analysis\u2026" },
-    "curation:start": { pct: 20, stepId: "ul-s-tools", subtitle: "Collecting tools and skills\u2026" },
-    "curation:runtimeTools": { pct: 32, stepId: "ul-s-tools", subtitle: "Collected runtime tools" },
-    "curation:mcpJson": { pct: 44, stepId: "ul-s-mcp", subtitle: "Scanning MCP config files\u2026" },
-    "curation:mcpSources": { pct: 55, stepId: "ul-s-mcp", subtitle: "Collected MCP servers" },
-    "curation:skillsScanStart": { pct: 63, stepId: "ul-s-skills", subtitle: "Scanning skill directories\u2026" },
-    "curation:skillsScanDone": { pct: 75, stepId: "ul-s-skills", subtitle: "Skill discovery complete" },
-    "curation:analyzing": { pct: 85, stepId: "ul-s-crunch", subtitle: "Analyzing tool usage patterns\u2026" },
-    "curation:done": { pct: 96, stepId: "ul-s-crunch", subtitle: "Curation analysis complete" },
-    ready: { pct: 100, stepId: "ul-s-ready", subtitle: "Usage analysis ready" },
-    error: { pct: 100, stepId: "ul-s-ready", subtitle: "Analysis completed with errors" },
-    "curation:error": { pct: 85, stepId: "ul-s-crunch", subtitle: "Curation analysis skipped" }
-  };
-  function renderUsageLoadingState(initialMessage = "Loading usage analysis...") {
-    const root = document.getElementById("root");
-    if (!root) {
-      return;
-    }
-    _ulLoadingActive = true;
-    const stepsHtml = USAGE_LOADING_STEPS.map((s4, i6) => {
-      const isFirst = i6 === 0;
-      const cls = isFirst ? "ul-step ul-active" : "ul-step";
-      const ico = isFirst ? '<span class="ul-spin">\u21BB</span>' : "\u25CB";
-      return `<div class="${cls}" id="${s4.id}"><span class="ul-ico">${ico}</span><span class="ul-lbl">${escapeHtml(s4.label)}</span><span class="ul-cnt" id="${s4.id}-cnt"></span></div>`;
-    }).join("");
-    setHtml(root, `${USAGE_LOADING_CSS}
+</style>`,Je=[{id:"ul-s-start",label:"Starting usage analysis"},{id:"ul-s-tools",label:"Collecting runtime tools"},{id:"ul-s-mcp",label:"Discovering MCP servers"},{id:"ul-s-skills",label:"Scanning skill directories"},{id:"ul-s-crunch",label:"Computing curation analysis"},{id:"ul-s-ready",label:"Ready!"}],ti={start:{pct:5,stepId:"ul-s-start",subtitle:"Starting usage analysis\u2026"},"curation:start":{pct:20,stepId:"ul-s-tools",subtitle:"Collecting tools and skills\u2026"},"curation:runtimeTools":{pct:32,stepId:"ul-s-tools",subtitle:"Collected runtime tools"},"curation:mcpJson":{pct:44,stepId:"ul-s-mcp",subtitle:"Scanning MCP config files\u2026"},"curation:mcpSources":{pct:55,stepId:"ul-s-mcp",subtitle:"Collected MCP servers"},"curation:skillsScanStart":{pct:63,stepId:"ul-s-skills",subtitle:"Scanning skill directories\u2026"},"curation:skillsScanDone":{pct:75,stepId:"ul-s-skills",subtitle:"Skill discovery complete"},"curation:analyzing":{pct:85,stepId:"ul-s-crunch",subtitle:"Analyzing tool usage patterns\u2026"},"curation:done":{pct:96,stepId:"ul-s-crunch",subtitle:"Curation analysis complete"},ready:{pct:100,stepId:"ul-s-ready",subtitle:"Usage analysis ready"},error:{pct:100,stepId:"ul-s-ready",subtitle:"Analysis completed with errors"},"curation:error":{pct:85,stepId:"ul-s-crunch",subtitle:"Curation analysis skipped"}};function No(e="Loading usage analysis..."){let t=document.getElementById("root");if(!t)return;Ho=!0;let o=Je.map((n,s)=>{let r=s===0,i=r?"ul-step ul-active":"ul-step",a=r?'<span class="ul-spin">\u21BB</span>':"\u25CB";return`<div class="${i}" id="${n.id}"><span class="ul-ico">${a}</span><span class="ul-lbl">${d(n.label)}</span><span class="ul-cnt" id="${n.id}-cnt"></span></div>`}).join("");k(t,`${ei}
 <div id="usage-loading-wrap">
   <div id="usage-loading-card">
     <div id="ul-header">
       <div>
         <div id="ul-badge">\u{1F4CA} Analyzing Usage Data</div>
-        <div id="ul-title">${escapeHtml(initialMessage)}</div>
+        <div id="ul-title">${d(e)}</div>
         <div id="ul-subtitle">Initializing\u2026</div>
       </div>
       <div id="ul-right">
@@ -4156,362 +1813,109 @@ background: var(--bg-tertiary);
       </div>
     </div>
     <div id="ul-track"><div id="ul-fill" class="ul-indeterminate"></div></div>
-    <div id="ul-steps">${stepsHtml}</div>
+    <div id="ul-steps">${o}</div>
   </div>
-</div>`);
-  }
-  function _ulSetDone(id) {
-    const el2 = document.getElementById(id);
-    if (!el2) {
-      return;
-    }
-    el2.className = "ul-step ul-done";
-    const ico = el2.querySelector(".ul-ico");
-    if (ico) {
-      setHtml(ico, '<span class="ul-pop">\u2713</span>');
-    }
-  }
-  function _ulSetActive(id) {
-    const el2 = document.getElementById(id);
-    if (!el2) {
-      return;
-    }
-    el2.className = "ul-step ul-active";
-    const ico = el2.querySelector(".ul-ico");
-    if (ico) {
-      setHtml(ico, '<span class="ul-spin">\u21BB</span>');
-    }
-  }
-  function _ulSetCnt(id, text) {
-    const el2 = document.getElementById(`${id}-cnt`);
-    if (el2) {
-      el2.textContent = text;
-    }
-  }
-  var _ulLastStepIdx = 0;
-  var _ulLoadingActive = false;
-  function _ulAdvanceSteps(targetIdx, pct) {
-    for (let i6 = _ulLastStepIdx; i6 < targetIdx; i6++) {
-      _ulSetDone(USAGE_LOADING_STEPS[i6].id);
-    }
-    if (targetIdx > _ulLastStepIdx) {
-      _ulLastStepIdx = targetIdx;
-    }
-    if (pct < 100) {
-      _ulSetActive(USAGE_LOADING_STEPS[targetIdx].id);
-    } else {
-      _ulSetDone(USAGE_LOADING_STEPS[targetIdx].id);
-    }
-  }
-  function _ulDetailCnt(details) {
-    if (typeof details.count === "number") {
-      return `${details.count}`;
-    }
-    if (typeof details.skills === "number") {
-      return `${details.skills} skills`;
-    }
-    if (typeof details.availableTools === "number") {
-      return `${details.availableTools} tools`;
-    }
-    return "";
-  }
-  function _ulEnsureCard() {
-    const root = document.getElementById("root");
-    if (!root) {
-      return false;
-    }
-    if (root.querySelector("#usage-loading-card")) {
-      return true;
-    }
-    if (!_ulLoadingActive) {
-      return false;
-    }
-    renderUsageLoadingState("Building Usage Analysis");
-    _ulLastStepIdx = 0;
-    return true;
-  }
-  function updateUsageLoadingProgress(message) {
-    if (!_ulEnsureCard()) {
-      return;
-    }
-    const stage = typeof message?.stage === "string" ? message.stage : "";
-    const mapped = USAGE_STAGE_MAP[stage];
-    if (!mapped) {
-      return;
-    }
-    const pct = mapped.pct;
-    const fill = document.getElementById("ul-fill");
-    if (fill) {
-      fill.classList.remove("ul-indeterminate");
-      fill.style.width = `${Math.max(pct, 3)}%`;
-    }
-    const pctEl = document.getElementById("ul-pct");
-    if (pctEl) {
-      pctEl.textContent = pct === 100 ? "100%" : `${pct}%`;
-    }
-    const subtitleEl = document.getElementById("ul-subtitle");
-    if (subtitleEl) {
-      subtitleEl.textContent = mapped.subtitle;
-    }
-    const targetIdx = USAGE_LOADING_STEPS.findIndex((s4) => s4.id === mapped.stepId);
-    if (targetIdx >= 0) {
-      _ulAdvanceSteps(targetIdx, pct);
-    }
-    const details = message?.details;
-    if (details && typeof details === "object") {
-      const cnt = _ulDetailCnt(details);
-      if (cnt) {
-        _ulSetCnt(mapped.stepId, `(${cnt})`);
-      }
-    }
-  }
-  function clearLoadingTimeout() {
-    if (loadingTimeoutId !== null) {
-      clearTimeout(loadingTimeoutId);
-      loadingTimeoutId = null;
-    }
-  }
-  function createRefreshButton() {
-    const btn = document.createElement("button");
-    btn.textContent = "\u{1F504} Refresh";
-    btn.style.cssText = "padding: 6px 16px; cursor: pointer; border: 1px solid var(--vscode-button-border, transparent); background: var(--vscode-button-background, #0e639c); color: var(--vscode-button-foreground, #fff); border-radius: 2px; font-size: 13px;";
-    btn.addEventListener("click", () => vscode.postMessage({ command: "refresh" }));
-    return btn;
-  }
-  function showLoadError(message) {
-    const root = document.getElementById("root");
-    if (!root) {
-      return;
-    }
-    const container = document.createElement("div");
-    container.style.cssText = "padding: 32px; text-align: center; font-size: 14px;";
-    const icon = document.createElement("div");
-    icon.style.cssText = "font-size: 24px; margin-bottom: 12px;";
-    setHtml(icon, statusBadgeHtml("\u274C", "Error"));
-    const msg = document.createElement("div");
-    msg.style.cssText = "color: var(--vscode-errorForeground, #f48771); margin-bottom: 16px;";
-    msg.textContent = message;
-    container.append(icon, msg, createRefreshButton());
-    root.textContent = "";
-    root.append(container);
-  }
-  var repoPrStatsLoaded = false;
-  var repoPrStatsData = null;
-  var agentSessionsLoaded = false;
-  var agentSessionsData = null;
-  var EFFORT_DISPLAY_NAMES = {
-    xhigh: "Extra High"
-  };
-  function getEffortDisplayName(level) {
-    return EFFORT_DISPLAY_NAMES[level] ?? level;
-  }
-  var TOOL_NAME_MAP = getWindowData("__TOOL_NAMES__") ?? null;
-  var _automaticToolIds = getWindowData("__AUTOMATIC_TOOLS__") ?? [];
-  var AUTOMATIC_TOOL_SET_WV = new Set(_automaticToolIds.map((id) => id.toLowerCase()));
-  function lookupToolName(id) {
-    if (!TOOL_NAME_MAP) {
-      return id;
-    }
-    return TOOL_NAME_MAP[id] ?? TOOL_NAME_MAP[id.toLowerCase()] ?? resolveGuidMcpToolName(id) ?? resolveMcpFamilyToolName(id) ?? id;
-  }
-  function lookupMcpToolName(id) {
-    const full = lookupToolName(id);
-    const colonIdx = full.indexOf(":");
-    if (colonIdx !== -1) {
-      return full.substring(colonIdx + 1).trim();
-    }
-    return full;
-  }
-  function getUnknownMcpTools(stats) {
-    const allTools = /* @__PURE__ */ new Set();
-    Object.entries(stats.today.mcpTools.byTool).forEach(([tool]) => allTools.add(tool));
-    Object.entries(stats.last30Days.mcpTools.byTool).forEach(([tool]) => allTools.add(tool));
-    Object.entries(stats.month.mcpTools.byTool).forEach(([tool]) => allTools.add(tool));
-    Object.keys(stats.today.mcpTools.byServer).forEach((server) => allTools.add(server));
-    Object.keys(stats.last30Days.mcpTools.byServer).forEach((server) => allTools.add(server));
-    Object.keys(stats.month.mcpTools.byServer).forEach((server) => allTools.add(server));
-    Object.entries(stats.today.toolCalls.byTool).forEach(([tool]) => allTools.add(tool));
-    Object.entries(stats.last30Days.toolCalls.byTool).forEach(([tool]) => allTools.add(tool));
-    Object.entries(stats.month.toolCalls.byTool).forEach(([tool]) => allTools.add(tool));
-    const suppressed = new Set(stats.suppressedUnknownTools ?? []);
-    return Array.from(allTools).filter((tool) => !TOOL_NAME_MAP?.[tool] && !TOOL_NAME_MAP?.[tool.toLowerCase()] && !isGuidMcpTool(tool) && !isMcpFamilyResolvedTool(tool) && !suppressed.has(tool)).sort();
-  }
-  function createMcpToolIssueUrl(unknownTools) {
-    const repoUrl = "https://github.com/rajbos/ai-engineering-fluency";
-    const title = encodeURIComponent("Add missing friendly names for tools");
-    const toolList = unknownTools.map((tool) => `- \`${tool}\``).join("\n");
-    const body = encodeURIComponent(
-      `## Unknown Tools Found
+</div>`)}function ys(e){let t=document.getElementById(e);if(!t)return;t.className="ul-step ul-done";let o=t.querySelector(".ul-ico");o&&k(o,'<span class="ul-pop">\u2713</span>')}function oi(e){let t=document.getElementById(e);if(!t)return;t.className="ul-step ul-active";let o=t.querySelector(".ul-ico");o&&k(o,'<span class="ul-spin">\u21BB</span>')}function ni(e,t){let o=document.getElementById(`${e}-cnt`);o&&(o.textContent=t)}var Xe=0,Ho=!1;function si(e,t){for(let o=Xe;o<e;o++)ys(Je[o].id);e>Xe&&(Xe=e),t<100?oi(Je[e].id):ys(Je[e].id)}function ri(e){return typeof e.count=="number"?`${e.count}`:typeof e.skills=="number"?`${e.skills} skills`:typeof e.availableTools=="number"?`${e.availableTools} tools`:""}function ii(){let e=document.getElementById("root");return e?e.querySelector("#usage-loading-card")?!0:Ho?(No("Building Usage Analysis"),Xe=0,!0):!1:!1}function ai(e){if(!ii())return;let t=typeof e?.stage=="string"?e.stage:"",o=ti[t];if(!o)return;let n=o.pct,s=document.getElementById("ul-fill");s&&(s.classList.remove("ul-indeterminate"),s.style.width=`${Math.max(n,3)}%`);let r=document.getElementById("ul-pct");r&&(r.textContent=n===100?"100%":`${n}%`);let i=document.getElementById("ul-subtitle");i&&(i.textContent=o.subtitle);let a=Je.findIndex(u=>u.id===o.stepId);a>=0&&si(a,n);let l=e?.details;if(l&&typeof l=="object"){let u=ri(l);u&&ni(o.stepId,`(${u})`)}}function Po(){Ut!==null&&(clearTimeout(Ut),Ut=null)}function Kt(){let e=document.createElement("button");return e.textContent="\u{1F504} Refresh",e.style.cssText="padding: 6px 16px; cursor: pointer; border: 1px solid var(--vscode-button-border, transparent); background: var(--vscode-button-background, #0e639c); color: var(--vscode-button-foreground, #fff); border-radius: 2px; font-size: 13px;",e.addEventListener("click",()=>f.postMessage({command:"refresh"})),e}function Ps(e){let t=document.getElementById("root");if(!t)return;let o=document.createElement("div");o.style.cssText="padding: 32px; text-align: center; font-size: 14px;";let n=document.createElement("div");n.style.cssText="font-size: 24px; margin-bottom: 12px;",k(n,j("\u274C","Error"));let s=document.createElement("div");s.style.cssText="color: var(--vscode-errorForeground, #f48771); margin-bottom: 16px;",s.textContent=e,o.append(n,s,Kt()),t.textContent="",t.append(o)}var Do=!1,Ze=null,Lo=!1,Qe=null,li={xhigh:"Extra High"};function di(e){return li[e]??e}var et=q("__TOOL_NAMES__")??null,ci=q("__AUTOMATIC_TOOLS__")??[],hs=new Set(ci.map(e=>e.toLowerCase()));function tt(e){return et?et[e]??et[e.toLowerCase()]??Cn(e)??so(e)??e:e}function Ao(e){let t=tt(e),o=t.indexOf(":");return o!==-1?t.substring(o+1).trim():t}function ui(e){let t=new Set;Object.entries(e.today.mcpTools.byTool).forEach(([n])=>t.add(n)),Object.entries(e.last30Days.mcpTools.byTool).forEach(([n])=>t.add(n)),Object.entries(e.month.mcpTools.byTool).forEach(([n])=>t.add(n)),Object.keys(e.today.mcpTools.byServer).forEach(n=>t.add(n)),Object.keys(e.last30Days.mcpTools.byServer).forEach(n=>t.add(n)),Object.keys(e.month.mcpTools.byServer).forEach(n=>t.add(n)),Object.entries(e.today.toolCalls.byTool).forEach(([n])=>t.add(n)),Object.entries(e.last30Days.toolCalls.byTool).forEach(([n])=>t.add(n)),Object.entries(e.month.toolCalls.byTool).forEach(([n])=>t.add(n));let o=new Set(e.suppressedUnknownTools??[]);return Array.from(t).filter(n=>!et?.[n]&&!et?.[n.toLowerCase()]&&!Sn(n)&&!Tn(n)&&!o.has(n)).sort()}function pi(e){let t="https://github.com/rajbos/ai-engineering-fluency",o=encodeURIComponent("Add missing friendly names for tools"),n=e.map(i=>`- \`${i}\``).join(`
+`),s=encodeURIComponent(`## Unknown Tools Found
 
 The following tools were detected but don't have friendly display names:
 
-${toolList}
+${n}
 
-Please add friendly names for these tools to improve the user experience.`
-    );
-    const labels = encodeURIComponent("MCP Toolnames");
-    return `${repoUrl}/issues/new?title=${title}&body=${body}&labels=${labels}`;
-  }
-  var MODE_BAR_CONFIGS = [
-    { label: "\u{1F4AC} Ask Mode", key: "ask", gradient: "linear-gradient(90deg, #3b82f6, #60a5fa)" },
-    { label: "\u270F\uFE0F Edit Mode", key: "edit", gradient: "linear-gradient(90deg, #10b981, #34d399)" },
-    { label: "\u{1F916} Agent Mode", key: "agent", gradient: "linear-gradient(90deg, #7c3aed, #a855f7)" },
-    { label: "\u{1F4CB} Plan Mode", key: "plan", gradient: "linear-gradient(90deg, #f59e0b, #fbbf24)" },
-    { label: "\u26A1 Custom Agent", key: "customAgent", gradient: "linear-gradient(90deg, #ec4899, #f472b6)" },
-    { label: "\u{1F5A5}\uFE0F CLI", key: "cli", gradient: "linear-gradient(90deg, #06b6d4, #22d3ee)" },
-    { label: "\u2728 Copilot App", key: "cliApp", gradient: "linear-gradient(90deg, #6366f1, #818cf8)" }
-  ];
-  function renderModeBarItem(label, count, total, gradient) {
-    const pct = total > 0 ? count / total * 100 : 0;
-    return `
+Please add friendly names for these tools to improve the user experience.`),r=encodeURIComponent("MCP Toolnames");return`${t}/issues/new?title=${o}&body=${s}&labels=${r}`}var gi=[{label:"\u{1F4AC} Ask Mode",key:"ask",gradient:"linear-gradient(90deg, #3b82f6, #60a5fa)"},{label:"\u270F\uFE0F Edit Mode",key:"edit",gradient:"linear-gradient(90deg, #10b981, #34d399)"},{label:"\u{1F916} Agent Mode",key:"agent",gradient:"linear-gradient(90deg, #7c3aed, #a855f7)"},{label:"\u{1F4CB} Plan Mode",key:"plan",gradient:"linear-gradient(90deg, #f59e0b, #fbbf24)"},{label:"\u26A1 Custom Agent",key:"customAgent",gradient:"linear-gradient(90deg, #ec4899, #f472b6)"},{label:"\u{1F5A5}\uFE0F CLI",key:"cli",gradient:"linear-gradient(90deg, #06b6d4, #22d3ee)"},{label:"\u2728 Copilot App",key:"cliApp",gradient:"linear-gradient(90deg, #6366f1, #818cf8)"}];function mi(e,t,o,n){let s=o>0?t/o*100:0;return`
 <div class="bar-item">
-<div class="bar-label"><span>${label}</span><span><strong>${formatNumber(count)}</strong> (${formatPercent(pct, 0)})</span></div>
-<div class="bar-track"><div class="bar-fill" style="width: ${pct.toFixed(1)}%; background: ${gradient};"></div></div>
-</div>`;
-  }
-  function renderModeBarChart(modeUsage, title) {
-    const total = modeUsage.ask + modeUsage.edit + modeUsage.agent + modeUsage.plan + modeUsage.customAgent + modeUsage.cli + (modeUsage.cliApp ?? 0);
-    const bars = MODE_BAR_CONFIGS.map(({ label, key, gradient }) => renderModeBarItem(label, modeUsage[key] ?? 0, total, gradient)).join("");
-    return `
+<div class="bar-label"><span>${e}</span><span><strong>${g(t)}</strong> (${Q(s,0)})</span></div>
+<div class="bar-track"><div class="bar-fill" style="width: ${s.toFixed(1)}%; background: ${n};"></div></div>
+</div>`}function vs(e,t){let o=e.ask+e.edit+e.agent+e.plan+e.customAgent+e.cli+(e.cliApp??0),n=gi.map(({label:s,key:r,gradient:i})=>mi(s,e[r]??0,o,i)).join("");return`
 <div>
-<h4 style="color: var(--text-primary); font-size: 13px; margin-bottom: 8px;">${title}</h4>
-<div class="bar-chart">${bars}
+<h4 style="color: var(--text-primary); font-size: 13px; margin-bottom: 8px;">${t}</h4>
+<div class="bar-chart">${n}
 </div>
-</div>`;
-  }
-  function _renderMultiModelStatCards(switching) {
-    return `
+</div>`}function fi(e){return`
 <div class="stats-grid" style="grid-template-columns: 1fr;">
 <div class="stat-card">
 <div class="stat-label">\u{1F4CA} Avg Models per Conversation</div>
-<div class="stat-value">${formatFixed(switching.averageModelsPerSession, 1)}</div>
+<div class="stat-value">${w(e.averageModelsPerSession,1)}</div>
 </div>
 <div class="stat-card">
 <div class="stat-label">\u{1F504} Switching Frequency</div>
-<div class="stat-value">${formatPercent(switching.switchingFrequency, 0)}</div>
+<div class="stat-value">${Q(e.switchingFrequency,0)}</div>
 <div style="font-size: 10px; color: var(--text-muted); margin-top: 4px;">Sessions with &gt;1 model</div>
 </div>
 <div class="stat-card">
 <div class="stat-label">\u{1F4C8} Max Models in Session</div>
-<div class="stat-value">${formatNumber(switching.maxModelsPerSession || 0)}</div>
+<div class="stat-value">${g(e.maxModelsPerSession||0)}</div>
 </div>
-</div>`;
-  }
-  function _renderMultiModelCostLevelBreakdown(allLowCostModels, allMediumCostModels, allHighCostModels, allUnknownModels) {
-    return `
+</div>`}function bi(e,t,o,n){return`
 <div style="min-height: 110px;">
-${allLowCostModels.length > 0 ? `
+${e.length>0?`
 <div style="margin-bottom: 6px;">
 <span style="color: #4ade80;">\u{1F49A} Low cost:</span>
-<span style="font-size: 11px; color: var(--text-primary);">${allLowCostModels.map(escapeHtml).join(", ")}</span>
+<span style="font-size: 11px; color: var(--text-primary);">${e.map(d).join(", ")}</span>
 </div>
-` : '<div style="margin-bottom: 6px; height: 21px;"></div>'}
-${allMediumCostModels.length > 0 ? `
+`:'<div style="margin-bottom: 6px; height: 21px;"></div>'}
+${t.length>0?`
 <div style="margin-bottom: 6px;">
 <span style="color: var(--link-color);">\u{1F7E1} Medium cost:</span>
-<span style="font-size: 11px; color: var(--text-primary);">${allMediumCostModels.map(escapeHtml).join(", ")}</span>
+<span style="font-size: 11px; color: var(--text-primary);">${t.map(d).join(", ")}</span>
 </div>
-` : '<div style="margin-bottom: 6px; height: 21px;"></div>'}
-${allHighCostModels.length > 0 ? `
+`:'<div style="margin-bottom: 6px; height: 21px;"></div>'}
+${o.length>0?`
 <div style="margin-bottom: 6px;">
 <span style="color: var(--warning-fg);">\u{1F4B8} High cost:</span>
-<span style="font-size: 11px; color: var(--text-primary);">${allHighCostModels.map(escapeHtml).join(", ")}</span>
+<span style="font-size: 11px; color: var(--text-primary);">${o.map(d).join(", ")}</span>
 </div>
-` : '<div style="margin-bottom: 6px; height: 21px;"></div>'}
-${allUnknownModels.length > 0 ? `
+`:'<div style="margin-bottom: 6px; height: 21px;"></div>'}
+${n.length>0?`
 <div style="margin-bottom: 6px;">
 <span style="color: var(--text-muted);">\u2753 Unknown:</span>
-<span style="font-size: 11px; color: var(--text-primary);">${allUnknownModels.map(escapeHtml).join(", ")}</span>
+<span style="font-size: 11px; color: var(--text-primary);">${n.map(d).join(", ")}</span>
 </div>
-` : ""}
-</div>`;
-  }
-  function _renderMultiModelRequestCountBreakdown(switching) {
-    if (switching.totalRequests <= 0) {
-      return "";
-    }
-    return `
+`:""}
+</div>`}function yi(e){return e.totalRequests<=0?"":`
 <div style="padding-top: 8px; border-top: 1px solid var(--border-subtle); min-height: 85px;">
 <div style="font-size: 11px; font-weight: 600; color: var(--text-primary); margin-bottom: 4px;">Request Count:</div>
-${switching.lowCostRequests > 0 ? `
+${e.lowCostRequests>0?`
 <div style="margin-bottom: 4px; font-size: 11px;">
 <span style="color: #4ade80;">\u{1F49A} Low cost: </span>
-<span style="color: var(--text-primary);">${formatNumber(switching.lowCostRequests)} (${formatPercent(switching.lowCostRequests / switching.totalRequests * 100)})</span>
+<span style="color: var(--text-primary);">${g(e.lowCostRequests)} (${Q(e.lowCostRequests/e.totalRequests*100)})</span>
 </div>
-` : ""}
-${switching.mediumCostRequests > 0 ? `
+`:""}
+${e.mediumCostRequests>0?`
 <div style="margin-bottom: 4px; font-size: 11px;">
 <span style="color: var(--link-color);">\u{1F7E1} Medium cost: </span>
-<span style="color: var(--text-primary);">${formatNumber(switching.mediumCostRequests)} (${formatPercent(switching.mediumCostRequests / switching.totalRequests * 100)})</span>
+<span style="color: var(--text-primary);">${g(e.mediumCostRequests)} (${Q(e.mediumCostRequests/e.totalRequests*100)})</span>
 </div>
-` : ""}
-${switching.highCostRequests > 0 ? `
+`:""}
+${e.highCostRequests>0?`
 <div style="margin-bottom: 4px; font-size: 11px;">
 <span style="color: var(--warning-fg);">\u{1F4B8} High cost: </span>
-<span style="color: var(--text-primary);">${formatNumber(switching.highCostRequests)} (${formatPercent(switching.highCostRequests / switching.totalRequests * 100)})</span>
+<span style="color: var(--text-primary);">${g(e.highCostRequests)} (${Q(e.highCostRequests/e.totalRequests*100)})</span>
 </div>
-` : ""}
-${switching.unknownRequests > 0 ? `
+`:""}
+${e.unknownRequests>0?`
 <div style="margin-bottom: 4px; font-size: 11px;">
 <span style="color: var(--text-muted);">\u2753 Unknown: </span>
-<span style="color: var(--text-primary);">${formatNumber(switching.unknownRequests)} (${formatPercent(switching.unknownRequests / switching.totalRequests * 100)})</span>
+<span style="color: var(--text-primary);">${g(e.unknownRequests)} (${Q(e.unknownRequests/e.totalRequests*100)})</span>
 </div>
-` : ""}
-</div>`;
-  }
-  function _renderMultiModelMixedCostSessions(switching) {
-    if (switching.mixedCostSessions <= 0) {
-      return "";
-    }
-    return `
+`:""}
+</div>`}function hi(e){return e.mixedCostSessions<=0?"":`
 <div style="margin-top: 8px; padding-top: 8px; border-top: 1px solid var(--border-subtle);">
-<span style="font-size: 11px; color: var(--link-color);">\u{1F500} Mixed cost sessions: ${formatNumber(switching.mixedCostSessions)}</span>
-</div>`;
-  }
-  function renderMultiModelPeriod(title, switching, allLowCostModels, allMediumCostModels, allHighCostModels, allUnknownModels) {
-    return `
+<span style="font-size: 11px; color: var(--link-color);">\u{1F500} Mixed cost sessions: ${g(e.mixedCostSessions)}</span>
+</div>`}function Mo(e,t,o,n,s,r){return`
 <div>
-<h4 style="color: var(--text-primary); font-size: 13px; margin-bottom: 8px;">${title}</h4>
-${_renderMultiModelStatCards(switching)}
+<h4 style="color: var(--text-primary); font-size: 13px; margin-bottom: 8px;">${e}</h4>
+${fi(t)}
 <div style="margin-top: 12px; padding: 12px; background: var(--bg-tertiary); border: 1px solid var(--border-subtle); border-radius: 6px;">
 <div style="font-size: 12px; font-weight: 600; color: var(--text-primary); margin-bottom: 8px;">Models by Cost Level:</div>
-${_renderMultiModelCostLevelBreakdown(allLowCostModels, allMediumCostModels, allHighCostModels, allUnknownModels)}
-${_renderMultiModelRequestCountBreakdown(switching)}
-${_renderMultiModelMixedCostSessions(switching)}
+${bi(o,n,s,r)}
+${yi(t)}
+${hi(t)}
 </div>
-</div>`;
-  }
-  function updateProgressPanel(selector, progressClass, messagePrefix, done, total) {
-    const container = document.querySelector(selector);
-    if (!container) {
-      return;
-    }
-    const pct = total > 0 ? Math.round(done / total * 100) : 0;
-    const message = `${messagePrefix} ${done}/${total} repos (${pct}%)`;
-    const existing = container.querySelector(`.${progressClass}`);
-    if (existing) {
-      existing.textContent = message;
-    } else {
-      Array.from(container.children).forEach((child) => {
-        const htmlEl = child;
-        if (!htmlEl.classList.contains("section-title") && !htmlEl.classList.contains("section-subtitle")) {
-          htmlEl.remove();
-        }
-      });
-      const div = document.createElement("div");
-      div.className = progressClass;
-      div.style.cssText = "margin-top:8px; font-size:12px; color:var(--text-secondary);";
-      div.textContent = message;
-      container.appendChild(div);
-    }
-  }
-  function renderMissedPotential(stats) {
-    const missed = stats.missedPotential || initialData?.missedPotential || [];
-    if (missed.length === 0) {
-      return `
+</div>`}function xs(e,t,o,n,s){let r=document.querySelector(e);if(!r)return;let i=s>0?Math.round(n/s*100):0,a=`${o} ${n}/${s} repos (${i}%)`,l=r.querySelector(`.${t}`);if(l)l.textContent=a;else{Array.from(r.children).forEach(c=>{let p=c;!p.classList.contains("section-title")&&!p.classList.contains("section-subtitle")&&p.remove()});let u=document.createElement("div");u.className=t,u.style.cssText="margin-top:8px; font-size:12px; color:var(--text-secondary);",u.textContent=a,r.appendChild(u)}}function vi(e){let t=e.missedPotential||E?.missedPotential||[];return t.length===0?`
 			<div style="margin-top: 16px; margin-bottom: 16px; padding: 12px; background: rgba(34, 197, 94, 0.1); border: 1px solid rgba(34, 197, 94, 0.3); border-radius: 6px;">
 				<div style="font-size: 13px; font-weight: 600; color: var(--success-fg); margin-bottom: 8px; display: flex; align-items: center; gap: 6px;">
-					${statusBadgeHtml("\u2705")} No other AI tool configs missing a Copilot counterpart
+					${j("\u2705")} No other AI tool configs missing a Copilot counterpart
 				</div>
 				<div style="font-size: 11px; color: var(--text-secondary); margin-bottom: 8px;">
 					All active workspaces that contain instruction files for other AI tools (e.g. .cursorrules, CLAUDE.md, AGENTS.md) also have Copilot customization files configured.
@@ -4520,12 +1924,10 @@ ${_renderMultiModelMixedCostSessions(switching)}
 					A workspace appears here when it has instruction files for other AI tools but no Copilot customization files \u2014 indicating Copilot may be under-configured compared to other tools. <a href="https://code.visualstudio.com/docs/copilot/customization/custom-instructions" style="color: var(--link-color);" target="_blank">Learn how to add Copilot instructions</a>.
 				</div>
 			</div>
-		`;
-    }
-    return `
+		`:`
         <div style="margin-top: 16px; margin-bottom: 16px; padding: 12px; background: rgba(251, 191, 36, 0.1); border: 1px solid rgba(251, 191, 36, 0.3); border-radius: 6px;">
             <div style="font-size: 13px; font-weight: 600; color: var(--warning-fg); margin-bottom: 8px; display: flex; align-items: center; gap: 6px;">
-                ${statusBadgeHtml("\u26A0\uFE0F")} Missed Potential: Non-Copilot Instruction Files
+                ${j("\u26A0\uFE0F")} Missed Potential: Non-Copilot Instruction Files
             </div>
             <div style="font-size: 11px; color: var(--text-secondary); margin-bottom: 12px;">
                 These active workspaces use other AI tools but lack Copilot customizations. <a href="https://code.visualstudio.com/docs/copilot/customization/custom-instructions" style="color: var(--link-color);" target="_blank">Learn how to add Copilot instructions</a>.
@@ -4541,24 +1943,24 @@ ${_renderMultiModelMixedCostSessions(switching)}
                         </tr>
                     </thead>
                     <tbody>
-                        ${missed.map((ws) => `
+                        ${t.map(o=>`
                             <tr style="background: rgba(251, 191, 36, 0.05);">
                                 <td style="padding: 6px 8px; border-bottom: 1px solid rgba(251, 191, 36, 0.2); font-family: 'Courier New', monospace; font-size: 12px;">
-                                    ${escapeHtml(ws.workspaceName)}
+                                    ${d(o.workspaceName)}
                                 </td>
                                 <td style="padding: 6px 8px; border-bottom: 1px solid rgba(251, 191, 36, 0.2); text-align: center; color: var(--text-primary);">
-                                    ${formatNumber(ws.sessionCount)}
+                                    ${g(o.sessionCount)}
                                 </td>
                                 <td style="padding: 6px 8px; border-bottom: 1px solid rgba(251, 191, 36, 0.2); text-align: center; color: var(--text-primary);">
-                                    ${formatNumber(ws.interactionCount)}
+                                    ${g(o.interactionCount)}
                                 </td>
                                 <td style="padding: 6px 8px; border-bottom: 1px solid rgba(251, 191, 36, 0.2);">
                                     <div style="display: flex; flex-direction: column; gap: 4px;">
-                                        ${ws.nonCopilotFiles.map((f3) => `
+                                        ${o.nonCopilotFiles.map(n=>`
                                             <div style="font-size: 11px; display: flex; align-items: center; gap: 6px;">
-                                                <span>${escapeHtml(f3.icon || "\u{1F4C4}")}</span>
-                                                <span style="font-weight: 500;">${escapeHtml(f3.label || "")}:</span>
-                                                <span style="font-family: monospace; color: var(--text-muted);">${escapeHtml(f3.relativePath)}</span>
+                                                <span>${d(n.icon||"\u{1F4C4}")}</span>
+                                                <span style="font-weight: 500;">${d(n.label||"")}:</span>
+                                                <span style="font-family: monospace; color: var(--text-muted);">${d(n.relativePath)}</span>
                                             </div>
                                         `).join("")}
                                     </div>
@@ -4569,26 +1971,7 @@ ${_renderMultiModelMixedCostSessions(switching)}
                 </table>
             </div>
         </div>
-    `;
-  }
-  function renderToolsTable(byTool, limit = 10, nameResolver = lookupToolName, applyAutoFilter = false) {
-    const entries = applyAutoFilter && hideAutomaticToolCalls ? Object.entries(byTool).filter(([tool]) => !AUTOMATIC_TOOL_SET_WV.has(tool.toLowerCase())) : Object.entries(byTool);
-    const sortedTools = entries.sort(([, a3], [, b3]) => b3 - a3).slice(0, limit);
-    if (sortedTools.length === 0) {
-      return applyAutoFilter && hideAutomaticToolCalls ? '<div style="color: var(--text-muted);">No purposeful tools used yet (automatic tool calls are hidden)</div>' : '<div style="color: var(--text-muted);">No tools used yet</div>';
-    }
-    const rows = sortedTools.map(([tool, count], idx) => {
-      const friendly = escapeHtml(nameResolver(tool));
-      const idEscaped = escapeHtml(tool);
-      const autoBadge = AUTOMATIC_TOOL_SET_WV.has(tool.toLowerCase()) ? `<span class="auto-badge" title="Automatic tool \u2014 Copilot uses this internally and it does not count toward fluency scoring">auto</span>` : "";
-      return `
-		    <tr>
-			    <td style="padding:8px 12px; border-bottom:1px solid var(--border-subtle); width:40px; max-width:40px; text-align:center;">${idx + 1}</td>
-			    <td style="padding:8px 12px; border-bottom:1px solid var(--border-subtle); word-break:break-word; overflow-wrap:break-word; max-width:0;"> <strong title="${idEscaped}">${friendly}</strong>${autoBadge}</td>
-			    <td style="padding:8px 12px; border-bottom:1px solid var(--border-subtle); text-align:right; width:90px; white-space:nowrap;">${formatNumber(count)}</td>
-		    </tr>`;
-    }).join("");
-    return `
+    `}function Y(e,t=10,o=tt,n=!1){let r=(n&&at?Object.entries(e).filter(([a])=>!hs.has(a.toLowerCase())):Object.entries(e)).sort(([,a],[,l])=>l-a).slice(0,t);return r.length===0?n&&at?'<div style="color: var(--text-muted);">No purposeful tools used yet (automatic tool calls are hidden)</div>':'<div style="color: var(--text-muted);">No tools used yet</div>':`
 		<table style="width:100%; border-collapse:collapse; table-layout:fixed;">
 			<thead>
 				<tr style="color:var(--text-secondary); font-size:12px; text-align:left;">
@@ -4598,1122 +1981,69 @@ ${_renderMultiModelMixedCostSessions(switching)}
 				</tr>
 			</thead>
 			<tbody>
-				${rows}
+				${r.map(([a,l],u)=>{let c=d(o(a)),p=d(a),b=hs.has(a.toLowerCase())?'<span class="auto-badge" title="Automatic tool \u2014 Copilot uses this internally and it does not count toward fluency scoring">auto</span>':"";return`
+		    <tr>
+			    <td style="padding:8px 12px; border-bottom:1px solid var(--border-subtle); width:40px; max-width:40px; text-align:center;">${u+1}</td>
+			    <td style="padding:8px 12px; border-bottom:1px solid var(--border-subtle); word-break:break-word; overflow-wrap:break-word; max-width:0;"> <strong title="${p}">${c}</strong>${b}</td>
+			    <td style="padding:8px 12px; border-bottom:1px solid var(--border-subtle); text-align:right; width:90px; white-space:nowrap;">${g(l)}</td>
+		    </tr>`}).join("")}
 			</tbody>
-		</table>`;
-  }
-  var SESSION_COLUMN_DEFS = [
-    { id: "interactions", label: "Turns", sortKey: "interactions", align: "right", render: (s4) => ({ html: formatNumber(s4.interactions) }) },
-    { id: "toolCalls", label: "Tools", sortKey: "toolCalls", align: "right", render: (s4) => ({ html: formatNumber(s4.toolCalls) }) },
-    { id: "subAgentCalls", label: "Sub-Agents", sortKey: "subAgentCalls", align: "right", render: (s4) => s4.subAgentCalls ? { html: formatNumber(s4.subAgentCalls), title: `${s4.subAgentCalls} sub-agent tool call${s4.subAgentCalls === 1 ? "" : "s"} detected in this session` } : { html: "\u2014", title: "No sub-agent calls detected in this session" } },
-    { id: "inputTokens", label: "Input", sortKey: "inputTokens", align: "right", render: (s4) => ({ html: formatNumber(s4.inputTokens) }) },
-    { id: "outputTokens", label: "Output", sortKey: "outputTokens", align: "right", render: (s4) => ({ html: formatNumber(s4.outputTokens) }) },
-    { id: "thinkingTokens", label: "Thinking", sortKey: "thinkingTokens", align: "right", render: (s4) => ({ html: formatNumber(s4.thinkingTokens) }) },
-    { id: "cachedTokens", label: "Cached", sortKey: "cachedTokens", align: "right", render: (s4) => ({ html: formatNumber(s4.cachedTokens) }) },
-    { id: "totalTokens", label: "Total", sortKey: "totalTokens", align: "right", render: (s4) => ({ html: formatNumber(s4.totalTokens) }) },
-    { id: "estimatedCost", label: "Cost", sortKey: "estimatedCost", align: "right", render: (s4) => ({ html: s4.estimatedCost > 0 ? `$${s4.estimatedCost.toFixed(4)}` : "\u2014" }) },
-    { id: "editor", label: "Editor", sortKey: "editor", align: "left", render: (s4) => ({ html: escapeHtml(s4.editor || "unknown") }) },
-    { id: "workspace", label: "Workspace", sortKey: "workspace", align: "left", cellStyle: "max-width:140px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;", render: (s4) => {
-      const workspace = escapeHtml(s4.workspace || "\u2014");
-      return { html: workspace, title: workspace };
-    } },
-    { id: "models", label: "Models", align: "left", cellStyle: "font-size:11px; max-width:180px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;", render: (s4) => {
-      const models = s4.models.map((m2) => escapeHtml(getModelDisplayName(m2))).join(", ") || "\u2014";
-      return { html: models, title: models };
-    } },
-    { id: "durationMs", label: "Duration", sortKey: "durationMs", align: "right", cellStyle: "white-space:nowrap;", render: (s4) => {
-      const net = s4.activeDurationMs ?? s4.durationMs;
-      const wallLabel = s4.durationMs !== void 0 ? `Wall time: ${formatDurationShort(s4.durationMs)}` : void 0;
-      return { html: formatDurationShort(net), ...wallLabel ? { title: wallLabel } : {} };
-    } },
-    {
-      id: "lastActivity",
-      label: "Last Active",
-      sortKey: "lastActivity",
-      align: "right",
-      cellStyle: "white-space:nowrap;",
-      render: (s4) => ({
-        html: s4.lastActivity ? sessionsLookback === "today" ? new Date(s4.lastActivity).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: !use24HourTime }) : new Date(s4.lastActivity).toLocaleString([], { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit", hour12: !use24HourTime }) : "\u2014"
-      })
-    }
-  ];
-  var ALL_SESSION_COLUMN_IDS = SESSION_COLUMN_DEFS.map((c4) => c4.id);
-  var sessionSortColumn = "interactions";
-  var sessionSortDirection = "desc";
-  var cachedTodaySessions = [];
-  var use24HourTime = true;
-  var hideAutomaticToolCalls = true;
-  var sessionsLookback = "today";
-  var latestTodaySessions = [];
-  var recentSessionsCache = {};
-  var enabledSessionColumns = new Set(ALL_SESSION_COLUMN_IDS);
-  function saveSessionColumnSettings() {
-    vscode.postMessage({ command: "saveSessionColumnSettings", settings: { enabledColumns: Array.from(enabledSessionColumns) } });
-  }
-  function getSessionSortIndicator(column) {
-    if (sessionSortColumn !== column) {
-      return "";
-    }
-    return sessionSortDirection === "desc" ? " \u25BC" : " \u25B2";
-  }
-  var _todaySessionColumnComparators = {
-    title: (a3, b3) => (a3.title || "").localeCompare(b3.title || ""),
-    editor: (a3, b3) => (a3.editor || "").localeCompare(b3.editor || ""),
-    workspace: (a3, b3) => (a3.workspace || "").localeCompare(b3.workspace || ""),
-    durationMs: (a3, b3) => (a3.activeDurationMs ?? a3.durationMs ?? -1) - (b3.activeDurationMs ?? b3.durationMs ?? -1),
-    subAgentCalls: (a3, b3) => (a3.subAgentCalls ?? 0) - (b3.subAgentCalls ?? 0),
-    lastActivity: (a3, b3) => (a3.lastActivity || "").localeCompare(b3.lastActivity || "")
-  };
-  function _compareTodaySessionsByColumn(a3, b3) {
-    const comparator = _todaySessionColumnComparators[sessionSortColumn];
-    if (comparator) {
-      return comparator(a3, b3);
-    }
-    return a3[sessionSortColumn] - b3[sessionSortColumn];
-  }
-  function sortTodaySessions(sessions) {
-    return [...sessions].sort((a3, b3) => {
-      const cmp = _compareTodaySessionsByColumn(a3, b3);
-      return sessionSortDirection === "desc" ? -cmp : cmp;
-    });
-  }
-  function renderTodaySessionsTable(sessions) {
-    cachedTodaySessions = sessions;
-    if (!sessions || sessions.length === 0) {
-      const emptyMessage = sessionsLookback === "today" ? "No sessions recorded today yet." : "No sessions recorded in this period.";
-      return `<div style="color: var(--text-secondary); font-size: 13px; padding: 16px;">${emptyMessage}</div>`;
-    }
-    return `<div id="sessions-table-container">${buildSessionsTableHtml(sessions)}</div>`;
-  }
-  function buildSessionsTableHtml(sessions) {
-    const sorted = sortTodaySessions(sessions);
-    const visibleColumns = SESSION_COLUMN_DEFS.filter((c4) => enabledSessionColumns.has(c4.id));
-    const rows = sorted.map((s4, idx) => {
-      const title = escapeHtml(s4.title || "Untitled session");
-      const filePath = escapeHtml(s4.filePath || "");
-      const optionalCells = visibleColumns.map((col) => {
-        const { html, title: cellTitle } = col.render(s4);
-        const alignStyle = col.align === "right" ? "text-align:right;" : "";
-        const titleAttr = cellTitle !== void 0 ? ` title="${cellTitle}"` : "";
-        return `<td style="padding:6px 8px; border-bottom:1px solid var(--border-subtle); font-size:12px; ${alignStyle}${col.cellStyle || ""}"${titleAttr}>${html}</td>`;
-      }).join("");
-      return `<tr>
-			<td style="padding:6px 8px; border-bottom:1px solid var(--border-subtle); font-size:12px; color:var(--text-secondary);">${idx + 1}</td>
-			<td style="padding:6px 8px; border-bottom:1px solid var(--border-subtle); font-size:12px; max-width:200px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;" title="Open viewer for session &quot;${title}&quot;"><a href="#" class="session-title-link" data-file="${filePath}" style="color:var(--link-color, #4fc1ff); text-decoration:none; cursor:pointer;">${title}</a></td>
-			${optionalCells}
-		</tr>`;
-    }).join("");
-    const headerCells = visibleColumns.map((col) => {
-      const alignStyle = col.align === "right" ? " text-align:right;" : "";
-      if (!col.sortKey) {
-        return `<th style="padding:6px 8px;${alignStyle}">${col.label}</th>`;
-      }
-      return `<th class="sortable" data-sort="${col.sortKey}" style="padding:6px 8px;${alignStyle}">${col.label}${getSessionSortIndicator(col.sortKey)}</th>`;
-    }).join("");
-    return `
+		</table>`}var jo=[{id:"interactions",label:"Turns",sortKey:"interactions",align:"right",render:e=>({html:g(e.interactions)})},{id:"toolCalls",label:"Tools",sortKey:"toolCalls",align:"right",render:e=>({html:g(e.toolCalls)})},{id:"subAgentCalls",label:"Sub-Agents",sortKey:"subAgentCalls",align:"right",render:e=>e.subAgentCalls?{html:g(e.subAgentCalls),title:`${e.subAgentCalls} sub-agent tool call${e.subAgentCalls===1?"":"s"} detected in this session`}:{html:"\u2014",title:"No sub-agent calls detected in this session"}},{id:"inputTokens",label:"Input",sortKey:"inputTokens",align:"right",render:e=>({html:g(e.inputTokens)})},{id:"outputTokens",label:"Output",sortKey:"outputTokens",align:"right",render:e=>({html:g(e.outputTokens)})},{id:"thinkingTokens",label:"Thinking",sortKey:"thinkingTokens",align:"right",render:e=>({html:g(e.thinkingTokens)})},{id:"cachedTokens",label:"Cached",sortKey:"cachedTokens",align:"right",render:e=>({html:g(e.cachedTokens)})},{id:"totalTokens",label:"Total",sortKey:"totalTokens",align:"right",render:e=>({html:g(e.totalTokens)})},{id:"estimatedCost",label:"Cost",sortKey:"estimatedCost",align:"right",render:e=>({html:e.estimatedCost>0?`$${e.estimatedCost.toFixed(4)}`:"\u2014"})},{id:"editor",label:"Editor",sortKey:"editor",align:"left",render:e=>({html:d(e.editor||"unknown")})},{id:"workspace",label:"Workspace",sortKey:"workspace",align:"left",cellStyle:"max-width:140px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;",render:e=>{let t=d(e.workspace||"\u2014");return{html:t,title:t}}},{id:"models",label:"Models",align:"left",cellStyle:"font-size:11px; max-width:180px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;",render:e=>{let t=e.models.map(o=>d(ee(o))).join(", ")||"\u2014";return{html:t,title:t}}},{id:"durationMs",label:"Duration",sortKey:"durationMs",align:"right",cellStyle:"white-space:nowrap;",render:e=>{let t=e.activeDurationMs??e.durationMs,o=e.durationMs!==void 0?`Wall time: ${Zt(e.durationMs)}`:void 0;return{html:Zt(t),...o?{title:o}:{}}}},{id:"lastActivity",label:"Last Active",sortKey:"lastActivity",align:"right",cellStyle:"white-space:nowrap;",render:e=>({html:e.lastActivity?I==="today"?new Date(e.lastActivity).toLocaleTimeString([],{hour:"2-digit",minute:"2-digit",hour12:!Ot}):new Date(e.lastActivity).toLocaleString([],{month:"short",day:"numeric",hour:"2-digit",minute:"2-digit",hour12:!Ot}):"\u2014"})}],Ds=jo.map(e=>e.id),Te="interactions",ot="desc",Fo=[],Ot=!0,at=!0,I="today",Uo=[],Ae={},Me=new Set(Ds);function xi(){f.postMessage({command:"saveSessionColumnSettings",settings:{enabledColumns:Array.from(Me)}})}function ks(e){return Te!==e?"":ot==="desc"?" \u25BC":" \u25B2"}var ki={title:(e,t)=>(e.title||"").localeCompare(t.title||""),editor:(e,t)=>(e.editor||"").localeCompare(t.editor||""),workspace:(e,t)=>(e.workspace||"").localeCompare(t.workspace||""),durationMs:(e,t)=>(e.activeDurationMs??e.durationMs??-1)-(t.activeDurationMs??t.durationMs??-1),subAgentCalls:(e,t)=>(e.subAgentCalls??0)-(t.subAgentCalls??0),lastActivity:(e,t)=>(e.lastActivity||"").localeCompare(t.lastActivity||"")};function wi(e,t){let o=ki[Te];return o?o(e,t):e[Te]-t[Te]}function Ci(e){return[...e].sort((t,o)=>{let n=wi(t,o);return ot==="desc"?-n:n})}function Io(e){return Fo=e,!e||e.length===0?`<div style="color: var(--text-secondary); font-size: 13px; padding: 16px;">${I==="today"?"No sessions recorded today yet.":"No sessions recorded in this period."}</div>`:`<div id="sessions-table-container">${Wo(e)}</div>`}function Wo(e){let t=Ci(e),o=jo.filter(r=>Me.has(r.id)),n=t.map((r,i)=>{let a=d(r.title||"Untitled session"),l=d(r.filePath||""),u=o.map(c=>{let{html:p,title:b}=c.render(r),h=c.align==="right"?"text-align:right;":"",S=b!==void 0?` title="${b}"`:"";return`<td style="padding:6px 8px; border-bottom:1px solid var(--border-subtle); font-size:12px; ${h}${c.cellStyle||""}"${S}>${p}</td>`}).join("");return`<tr>
+			<td style="padding:6px 8px; border-bottom:1px solid var(--border-subtle); font-size:12px; color:var(--text-secondary);">${i+1}</td>
+			<td style="padding:6px 8px; border-bottom:1px solid var(--border-subtle); font-size:12px; max-width:200px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;" title="Open viewer for session &quot;${a}&quot;"><a href="#" class="session-title-link" data-file="${l}" style="color:var(--link-color, #4fc1ff); text-decoration:none; cursor:pointer;">${a}</a></td>
+			${u}
+		</tr>`}).join(""),s=o.map(r=>{let i=r.align==="right"?" text-align:right;":"";return r.sortKey?`<th class="sortable" data-sort="${r.sortKey}" style="padding:6px 8px;${i}">${r.label}${ks(r.sortKey)}</th>`:`<th style="padding:6px 8px;${i}">${r.label}</th>`}).join("");return`
 		<div style="overflow-x:auto;">
 		<table class="sessions-table" style="width:100%; border-collapse:collapse; min-width:1050px;">
 			<thead>
 				<tr style="color:var(--text-secondary); font-size:11px; text-align:left;">
 					<th style="padding:6px 8px;">#</th>
-					<th class="sortable" data-sort="title" style="padding:6px 8px;">Title${getSessionSortIndicator("title")}</th>
-					${headerCells}
+					<th class="sortable" data-sort="title" style="padding:6px 8px;">Title${ks("title")}</th>
+					${s}
 				</tr>
 			</thead>
 			<tbody>
-				${rows}
+				${n}
 			</tbody>
 		</table>
-		</div>`;
-  }
-  function buildSessionColumnsMenuHtml() {
-    const items = SESSION_COLUMN_DEFS.map((col) => `
-		<label style="display:flex; align-items:center; gap:6px; padding:4px 8px; font-size:12px; white-space:nowrap; cursor:pointer;">
-			<input type="checkbox" data-column="${col.id}"${enabledSessionColumns.has(col.id) ? " checked" : ""} />
-			<span>${col.label}</span>
-		</label>`).join("");
-    return `
+		</div>`}function Si(){return`
 		<div class="columns-menu-wrap" style="position:relative;">
 			<button id="sessions-columns-toggle" type="button" style="font-size:12px; padding:2px 8px; background:var(--vscode-dropdown-background, var(--bg-secondary)); color:var(--vscode-dropdown-foreground, var(--text-primary)); border:1px solid var(--border-subtle); border-radius:4px; cursor:pointer;">\u2699 Columns</button>
 			<div id="sessions-columns-menu" style="display:none; position:absolute; right:0; top:100%; margin-top:4px; z-index:20; background:var(--bg-secondary); border:1px solid var(--border-color); border-radius:6px; box-shadow:0 4px 10px var(--shadow-color); padding:4px 0; min-width:160px;">
-				${items}
+				${jo.map(t=>`
+		<label style="display:flex; align-items:center; gap:6px; padding:4px 8px; font-size:12px; white-space:nowrap; cursor:pointer;">
+			<input type="checkbox" data-column="${t.id}"${Me.has(t.id)?" checked":""} />
+			<span>${t.label}</span>
+		</label>`).join("")}
 			</div>
-		</div>`;
-  }
-  function setupSessionsTableSort() {
-    const body = document.getElementById("sessions-panel-body");
-    if (!body) {
-      return;
-    }
-    body.addEventListener("click", (e7) => {
-      const link = e7.target.closest("a.session-title-link");
-      if (link) {
-        e7.preventDefault();
-        const file = link.getAttribute("data-file");
-        if (file) {
-          vscode.postMessage({ command: "openSessionFile", file });
-        }
-        return;
-      }
-      const th = e7.target.closest("th.sortable");
-      if (!th) {
-        return;
-      }
-      const col = th.getAttribute("data-sort");
-      if (!col) {
-        return;
-      }
-      if (sessionSortColumn === col) {
-        sessionSortDirection = sessionSortDirection === "desc" ? "asc" : "desc";
-      } else {
-        sessionSortColumn = col;
-        sessionSortDirection = "desc";
-      }
-      const container = document.getElementById("sessions-table-container");
-      if (container) {
-        setHtml(container, buildSessionsTableHtml(cachedTodaySessions));
-      }
-    });
-    renderSessionsLookbackSelector();
-    setupSessionColumnsMenu();
-  }
-  var _documentClickClosesColumnsMenu = false;
-  function setupSessionColumnsMenu() {
-    const toggle = document.getElementById("sessions-columns-toggle");
-    const menu = document.getElementById("sessions-columns-menu");
-    if (!toggle || !menu) {
-      return;
-    }
-    toggle.addEventListener("click", (e7) => {
-      e7.stopPropagation();
-      menu.style.display = menu.style.display === "none" ? "block" : "none";
-    });
-    menu.addEventListener("click", (e7) => e7.stopPropagation());
-    menu.addEventListener("change", (e7) => {
-      const checkbox = e7.target;
-      const columnId = checkbox.getAttribute("data-column");
-      if (!columnId) {
-        return;
-      }
-      if (checkbox.checked) {
-        enabledSessionColumns.add(columnId);
-      } else {
-        enabledSessionColumns.delete(columnId);
-      }
-      const container = document.getElementById("sessions-table-container");
-      if (container) {
-        setHtml(container, buildSessionsTableHtml(cachedTodaySessions));
-      }
-      saveSessionColumnSettings();
-    });
-    if (!_documentClickClosesColumnsMenu) {
-      _documentClickClosesColumnsMenu = true;
-      document.addEventListener("click", () => {
-        const liveMenu = document.getElementById("sessions-columns-menu");
-        if (liveMenu) {
-          liveMenu.style.display = "none";
-        }
-      });
-    }
-  }
-  function renderSessionsLookbackSelector() {
-    const wrapper = document.getElementById("sessions-lookback-wrapper");
-    if (!wrapper) {
-      return;
-    }
-    wrapper.replaceChildren();
-    const { wrapper: selectorWrapper } = createPeriodSelector({
-      id: "sessions-lookback",
-      selected: sessionsLookback,
-      disabled: ["allTime"],
-      disabledTitle: "All-time sessions are not loaded yet",
-      label: "",
-      onChange: (value) => {
-        sessionsLookback = value;
-        refreshSessionsPanelBody();
-      }
-    });
-    wrapper.append(selectorWrapper);
-    if (sessionsLookback !== "today" && !recentSessionsCache[sessionsLookback]) {
-      refreshSessionsPanelBody();
-    }
-  }
-  function refreshSessionsPanelBody() {
-    const body = document.getElementById("sessions-panel-body");
-    if (!body) {
-      return;
-    }
-    if (sessionsLookback === "today") {
-      setHtml(body, renderTodaySessionsTable(latestTodaySessions));
-      return;
-    }
-    const cached = recentSessionsCache[sessionsLookback];
-    if (cached) {
-      setHtml(body, renderTodaySessionsTable(cached));
-      return;
-    }
-    setHtml(body, `<div style="color: var(--text-secondary); font-size: 13px; padding: 16px;">Loading sessions for ${PERIOD_LABELS[sessionsLookback]}\u2026</div>`);
-    vscode.postMessage({ command: "loadRecentSessions", period: sessionsLookback });
-  }
-  function handleRecentSessionsLoaded(message) {
-    const period = message.period;
-    if (!period) {
-      return;
-    }
-    const sessions = Array.isArray(message.sessions) ? message.sessions.filter((s4) => s4 && typeof s4 === "object" && typeof s4.interactions === "number") : [];
-    recentSessionsCache[period] = sessions;
-    if (sessionsLookback === period) {
-      refreshSessionsPanelBody();
-    }
-  }
-  function unionFill(map, keys) {
-    const result = { ...map };
-    for (const k2 of keys) {
-      if (!(k2 in result)) {
-        result[k2] = 0;
-      }
-    }
-    return result;
-  }
-  function coerceNumber2(value) {
-    const n5 = Number(value);
-    return Number.isFinite(n5) ? n5 : 0;
-  }
-  function sanitizeModeUsage(mode) {
-    const m2 = mode && typeof mode === "object" ? mode : {};
-    return {
-      ask: coerceNumber2(m2.ask),
-      edit: coerceNumber2(m2.edit),
-      agent: coerceNumber2(m2.agent),
-      plan: coerceNumber2(m2.plan),
-      customAgent: coerceNumber2(m2.customAgent),
-      cli: coerceNumber2(m2.cli),
-      cliApp: coerceNumber2(m2.cliApp)
-    };
-  }
-  function sanitizeContextRefs(refs) {
-    const r6 = refs && typeof refs === "object" ? refs : {};
-    return {
-      file: coerceNumber2(r6.file),
-      selection: coerceNumber2(r6.selection),
-      implicitSelection: coerceNumber2(r6.implicitSelection),
-      symbol: coerceNumber2(r6.symbol),
-      codebase: coerceNumber2(r6.codebase),
-      workspace: coerceNumber2(r6.workspace),
-      terminal: coerceNumber2(r6.terminal),
-      vscode: coerceNumber2(r6.vscode),
-      terminalLastCommand: coerceNumber2(r6.terminalLastCommand),
-      terminalSelection: coerceNumber2(r6.terminalSelection),
-      clipboard: coerceNumber2(r6.clipboard),
-      changes: coerceNumber2(r6.changes),
-      outputPanel: coerceNumber2(r6.outputPanel),
-      problemsPanel: coerceNumber2(r6.problemsPanel),
-      pullRequest: coerceNumber2(r6.pullRequest),
-      byKind: r6.byKind ?? {},
-      copilotInstructions: coerceNumber2(r6.copilotInstructions),
-      agentsMd: coerceNumber2(r6.agentsMd),
-      byPath: r6.byPath ?? {}
-    };
-  }
-  function sanitizePeriod(period) {
-    const p3 = period && typeof period === "object" ? period : {};
-    const toolCalls = p3.toolCalls && typeof p3.toolCalls === "object" ? p3.toolCalls : {};
-    const mcpTools = p3.mcpTools && typeof p3.mcpTools === "object" ? p3.mcpTools : {};
-    return {
-      sessions: coerceNumber2(p3.sessions),
-      modeUsage: sanitizeModeUsage(p3.modeUsage),
-      contextReferences: sanitizeContextRefs(p3.contextReferences),
-      toolCalls: {
-        total: coerceNumber2(toolCalls.total),
-        byTool: toolCalls.byTool ?? {}
-      },
-      mcpTools: {
-        total: coerceNumber2(mcpTools.total),
-        byServer: mcpTools.byServer ?? {},
-        byTool: mcpTools.byTool ?? {}
-      },
-      modelSwitching: {
-        modelsPerSession: [],
-        totalSessions: 0,
-        averageModelsPerSession: 0,
-        maxModelsPerSession: 0,
-        minModelsPerSession: 0,
-        switchingFrequency: 0,
-        standardModels: [],
-        premiumModels: [],
-        unknownModels: [],
-        mixedTierSessions: 0,
-        lowCostModels: [],
-        mediumCostModels: [],
-        highCostModels: [],
-        mixedCostSessions: 0,
-        standardRequests: 0,
-        premiumRequests: 0,
-        lowCostRequests: 0,
-        mediumCostRequests: 0,
-        highCostRequests: 0,
-        unknownRequests: 0,
-        totalRequests: 0,
-        ...p3.modelSwitching ?? {}
-      },
-      thinkingEffortUsage: p3.thinkingEffortUsage,
-      modelEfficiency: p3.modelEfficiency
-    };
-  }
-  function sanitizeInsights(rawInsights) {
-    return rawInsights.filter((i6) => i6 && typeof i6 === "object" && typeof i6.id === "string").map((i6) => ({
-      id: String(i6.id),
-      category: typeof i6.category === "string" ? i6.category : "general",
-      severity: ["tip", "opportunity", "celebration"].includes(i6.severity) ? i6.severity : "tip",
-      title: typeof i6.title === "string" ? i6.title : "",
-      body: typeof i6.body === "string" ? i6.body : "",
-      actionLabel: typeof i6.actionLabel === "string" ? i6.actionLabel : void 0,
-      actionCommand: typeof i6.actionCommand === "string" ? i6.actionCommand : void 0,
-      status: ["new", "seen", "dismissed", "snoozed", "done"].includes(i6.status) ? i6.status : "new",
-      allowToast: !!i6.allowToast
-    }));
-  }
-  var CORRECTION_MOMENT_TYPES = ["user-correction", "edit-retry", "edit-self-correction", "tool-error", "agent-self-correction"];
-  function sanitizeCorrectionMoment(raw) {
-    if (!raw || typeof raw !== "object") {
-      return null;
-    }
-    if (!CORRECTION_MOMENT_TYPES.includes(raw.type) || typeof raw.snippet !== "string") {
-      return null;
-    }
-    return {
-      type: raw.type,
-      turnNumber: typeof raw.turnNumber === "number" ? raw.turnNumber : 0,
-      timestamp: typeof raw.timestamp === "string" ? raw.timestamp : null,
-      snippet: raw.snippet,
-      tool: typeof raw.tool === "string" ? raw.tool : void 0,
-      file: typeof raw.file === "string" ? raw.file : void 0,
-      retried: raw.retried === true ? true : void 0,
-      matchedPattern: typeof raw.matchedPattern === "string" ? raw.matchedPattern : void 0
-    };
-  }
-  function sanitizeCorrectionCounts(raw) {
-    const num = (v2) => typeof v2 === "number" && isFinite(v2) && v2 >= 0 ? v2 : 0;
-    return {
-      userCorrections: num(raw?.userCorrections),
-      editRetries: num(raw?.editRetries),
-      editSelfCorrections: num(raw?.editSelfCorrections),
-      toolErrors: num(raw?.toolErrors),
-      toolErrorsRetried: num(raw?.toolErrorsRetried),
-      agentSelfCorrections: num(raw?.agentSelfCorrections)
-    };
-  }
-  function sanitizeCorrectionSession(raw) {
-    if (!raw || typeof raw !== "object" || typeof raw.file !== "string" || !Array.isArray(raw.moments)) {
-      return null;
-    }
-    const moments = raw.moments.map(sanitizeCorrectionMoment).filter((m2) => m2 !== null);
-    if (moments.length === 0) {
-      return null;
-    }
-    return {
-      file: raw.file,
-      title: typeof raw.title === "string" ? raw.title : null,
-      lastInteraction: typeof raw.lastInteraction === "string" ? raw.lastInteraction : null,
-      moments,
-      totalMoments: typeof raw.totalMoments === "number" && isFinite(raw.totalMoments) ? Math.max(moments.length, raw.totalMoments) : moments.length
-    };
-  }
-  function sanitizeCorrectionRepoGroup(raw) {
-    if (!raw || typeof raw !== "object" || typeof raw.repository !== "string" || !Array.isArray(raw.sessions)) {
-      return null;
-    }
-    const sessions = raw.sessions.map(sanitizeCorrectionSession).filter((s4) => s4 !== null);
-    if (sessions.length === 0) {
-      return null;
-    }
-    return {
-      repository: raw.repository,
-      sessions,
-      counts: sanitizeCorrectionCounts(raw.counts),
-      sessionsWithMoments: typeof raw.sessionsWithMoments === "number" ? raw.sessionsWithMoments : sessions.length
-    };
-  }
-  function sanitizeCorrectionReport(raw) {
-    if (!raw || typeof raw !== "object" || !Array.isArray(raw.repos)) {
-      return null;
-    }
-    const repos = raw.repos.map(sanitizeCorrectionRepoGroup).filter((r6) => r6 !== null);
-    if (repos.length === 0) {
-      return null;
-    }
-    return {
-      sessionsPerRepo: typeof raw.sessionsPerRepo === "number" ? raw.sessionsPerRepo : 25,
-      repos,
-      counts: sanitizeCorrectionCounts(raw.counts),
-      sessionsWithMoments: typeof raw.sessionsWithMoments === "number" ? raw.sessionsWithMoments : repos.reduce((n5, g2) => n5 + g2.sessionsWithMoments, 0)
-    };
-  }
-  function sanitizeRepeatedTaskCluster(raw) {
-    if (!raw || typeof raw !== "object") {
-      return null;
-    }
-    if (typeof raw.representativePrompt !== "string" || typeof raw.sessionCount !== "number" || !Array.isArray(raw.sessions)) {
-      return null;
-    }
-    const sessions = raw.sessions.filter((s4) => s4 && typeof s4 === "object" && typeof s4.file === "string").map((s4) => ({
-      file: s4.file,
-      title: typeof s4.title === "string" ? s4.title : null,
-      lastInteraction: typeof s4.lastInteraction === "string" ? s4.lastInteraction : null,
-      repository: typeof s4.repository === "string" ? s4.repository : void 0
-    }));
-    if (sessions.length === 0) {
-      return null;
-    }
-    return {
-      representativePrompt: raw.representativePrompt,
-      // Derive from the sanitized session list so the UI count can never
-      // disagree with it (and NaN/float counts are impossible).
-      sessionCount: sessions.length,
-      repositories: Array.isArray(raw.repositories) ? raw.repositories.filter((r6) => typeof r6 === "string") : [],
-      sessions,
-      sharedKeywords: Array.isArray(raw.sharedKeywords) ? raw.sharedKeywords.filter((k2) => typeof k2 === "string") : []
-    };
-  }
-  function sanitizeRepeatedTaskReport(raw) {
-    if (!raw || typeof raw !== "object" || !Array.isArray(raw.clusters)) {
-      return null;
-    }
-    const clusters = raw.clusters.map(sanitizeRepeatedTaskCluster).filter((c4) => c4 !== null);
-    if (clusters.length === 0) {
-      return null;
-    }
-    return {
-      minClusterSize: typeof raw.minClusterSize === "number" ? raw.minClusterSize : 2,
-      sessionsScanned: typeof raw.sessionsScanned === "number" ? raw.sessionsScanned : 0,
-      clusters
-    };
-  }
-  function _sanitizeCurationAnalysis(rawCa) {
-    if (!rawCa || typeof rawCa !== "object") {
-      return null;
-    }
-    const ca = rawCa;
-    return {
-      windowDays: typeof ca.windowDays === "number" ? ca.windowDays : 30,
-      availableTools: Array.isArray(ca.availableTools) ? ca.availableTools : [],
-      usedTools: Array.isArray(ca.usedTools) ? ca.usedTools : [],
-      unusedTools: Array.isArray(ca.unusedTools) ? ca.unusedTools : [],
-      underusedMcpServers: Array.isArray(ca.underusedMcpServers) ? ca.underusedMcpServers : [],
-      underusedAgentPlugins: Array.isArray(ca.underusedAgentPlugins) ? ca.underusedAgentPlugins : [],
-      estimatedPromptBloat: ca.estimatedPromptBloat && typeof ca.estimatedPromptBloat === "object" ? ca.estimatedPromptBloat : { totalTokens: 0, byServer: {} },
-      recommendations: Array.isArray(ca.recommendations) ? ca.recommendations : []
-    };
-  }
-  function sanitizeOptionalReports(sanitized, raw) {
-    sanitized.correctionReport = sanitizeCorrectionReport(raw.correctionReport);
-    sanitized.repeatedTasks = sanitizeRepeatedTaskReport(raw.repeatedTasks);
-  }
-  function sanitizeStats(raw) {
-    if (!raw || typeof raw !== "object") {
-      traceCurationOnce("sanitize-invalid-root", "sanitizeStats.invalidRoot");
-      return null;
-    }
-    try {
-      const sanitized = {
-        today: sanitizePeriod(raw.today),
-        last30Days: sanitizePeriod(raw.last30Days),
-        month: sanitizePeriod(raw.month),
-        lastMonth: sanitizePeriod(raw.lastMonth),
-        lastUpdated: typeof raw.lastUpdated === "string" ? raw.lastUpdated : "",
-        backendConfigured: !!raw.backendConfigured,
-        locale: typeof raw.locale === "string" ? raw.locale : void 0,
-        currentWorkspacePaths: Array.isArray(raw.currentWorkspacePaths) ? raw.currentWorkspacePaths.filter((p3) => typeof p3 === "string") : void 0,
-        suppressedUnknownTools: Array.isArray(raw.suppressedUnknownTools) ? raw.suppressedUnknownTools.filter((t4) => typeof t4 === "string") : void 0
-      };
-      const safeMatrix = sanitizeCustomizationMatrix(raw.customizationMatrix);
-      if (safeMatrix) {
-        sanitized.customizationMatrix = safeMatrix;
-      }
-      if (Array.isArray(raw.missedPotential)) {
-        sanitized.missedPotential = raw.missedPotential.filter(
-          (w2) => w2 && typeof w2 === "object" && typeof w2.workspacePath === "string"
-        );
-      }
-      if (Array.isArray(raw.todaySessions)) {
-        sanitized.todaySessions = raw.todaySessions.filter(
-          (s4) => s4 && typeof s4 === "object" && typeof s4.interactions === "number"
-        );
-      }
-      if (Array.isArray(raw.insights)) {
-        sanitized.insights = sanitizeInsights(raw.insights);
-      }
-      sanitizeOptionalReports(sanitized, raw);
-      const curationAnalysis = _sanitizeCurationAnalysis(raw.curationAnalysis);
-      if (curationAnalysis) {
-        sanitized.curationAnalysis = curationAnalysis;
-        traceCuration("sanitizeStats.curation.present", {
-          availableTools: curationAnalysis.availableTools.length,
-          unusedTools: curationAnalysis.unusedTools.length,
-          unusedServers: curationAnalysis.underusedMcpServers.filter((s4) => s4 && s4.usedToolCount === 0).length
-        });
-      } else {
-        traceCurationOnce("sanitize-no-curation", "sanitizeStats.curation.missing");
-      }
-      applyBillingFields(sanitized, raw);
-      return sanitized;
-    } catch (error) {
-      traceCurationOnce("sanitize-error", "sanitizeStats.error", {
-        error: error instanceof Error ? error.message : String(error)
-      });
-      return null;
-    }
-  }
-  function updateWorktreeControls() {
-    const controlsEl = document.getElementById("worktree-controls");
-    if (controlsEl) {
-      setHtml(controlsEl, renderWorktreeControls());
-    }
-  }
-  function updateWorktreeResults() {
-    const resultsEl = document.getElementById("worktree-results");
-    if (resultsEl) {
-      setHtml(resultsEl, renderWorktreeResults());
-    }
-  }
-  function updateWorktreeProgressArea() {
-    const el2 = document.getElementById("worktree-progress-area");
-    if (el2) {
-      setHtml(el2, renderWorktreeProgress());
-    }
-  }
-  function scheduleWorktreeResultsRender() {
-    if (worktreeRenderPending) {
-      return;
-    }
-    worktreeRenderPending = true;
-    requestAnimationFrame(() => {
-      worktreeRenderPending = false;
-      updateWorktreeResults();
-    });
-  }
-  function addWorktreeRootFromInput() {
-    const input = document.getElementById("worktree-root-input");
-    const value = input?.value.trim();
-    if (!value) {
-      return;
-    }
-    if (!worktreeRoots.some((r6) => r6.toLowerCase() === value.toLowerCase())) {
-      worktreeRoots.push(value);
-    }
-    if (input) {
-      input.value = "";
-    }
-    updateWorktreeControls();
-  }
-  function startWorktreeScan() {
-    if (worktreeRoots.length === 0 || worktreeScanInProgress || worktreeCleanupInProgress) {
-      return;
-    }
-    worktreeScanInProgress = true;
-    worktreeResults = [];
-    worktreeBackgroundScanMeta = null;
-    worktreeScanError = null;
-    worktreeScanStatus = { root: "", checked: 0, total: 0, foundCount: 0, elapsedMs: 0 };
-    worktreeCleanupLog = [];
-    updateWorktreeControls();
-    updateWorktreeResults();
-    vscode.postMessage({ command: "scanWorktrees", rootPaths: worktreeRoots });
-  }
-  function startWorktreeCleanup() {
-    if (worktreeCleanupInProgress || worktreeCleanupConfirmPending || worktreeScanInProgress) {
-      return;
-    }
-    const targets = getCleanupCandidates();
-    if (targets.length === 0) {
-      return;
-    }
-    worktreeCleanupConfirmPending = true;
-    updateWorktreeResults();
-    vscode.postMessage({
-      command: "cleanupPushedWorktrees",
-      worktrees: targets.map((w2) => ({ path: w2.path, branch: w2.branch, repoLabel: w2.repoLabel }))
-    });
-  }
-  function _handleWorktreeActionButtonClick(target) {
-    if (target.id === "btn-browse-worktree-root") {
-      vscode.postMessage({ command: "pickWorktreeRoot" });
-      return true;
-    }
-    if (target.id === "btn-add-worktree-root") {
-      addWorktreeRootFromInput();
-      return true;
-    }
-    if (target.id === "btn-scan-worktrees") {
-      startWorktreeScan();
-      return true;
-    }
-    if (target.id === "btn-cancel-worktree-scan") {
-      vscode.postMessage({ command: "cancelWorktreeScan" });
-      return true;
-    }
-    if (target.id === "btn-cleanup-pushed-worktrees") {
-      startWorktreeCleanup();
-      return true;
-    }
-    if (target.id === "btn-cancel-cleanup") {
-      vscode.postMessage({ command: "cancelCleanupPushedWorktrees" });
-      return true;
-    }
-    return false;
-  }
-  function _handleWorktreeRootsListClick(target) {
-    if (target.closest("#btn-toggle-worktree-roots")) {
-      worktreeRootsExpanded = !worktreeRootsExpanded;
-      updateWorktreeControls();
-      return true;
-    }
-    if (target.classList.contains("worktree-remove-root")) {
-      const idx = Number(target.getAttribute("data-index"));
-      if (!isNaN(idx)) {
-        worktreeRoots.splice(idx, 1);
-        updateWorktreeControls();
-      }
-      return true;
-    }
-    return false;
-  }
-  function _handleWorktreeRowLinkClick(event, target) {
-    const revealLink = target.closest(".worktree-reveal-link");
-    if (revealLink) {
-      event.preventDefault();
-      const p3 = decodeURIComponent(revealLink.getAttribute("data-path") || "");
-      if (p3) {
-        vscode.postMessage({ command: "revealPath", path: p3 });
-      }
-      return true;
-    }
-    const deleteLink = target.closest(".worktree-delete-link");
-    if (deleteLink) {
-      event.preventDefault();
-      const p3 = decodeURIComponent(deleteLink.getAttribute("data-path") || "");
-      const branch = decodeURIComponent(deleteLink.getAttribute("data-branch") || "");
-      const repoLabel = decodeURIComponent(deleteLink.getAttribute("data-repo") || "");
-      const pushed = deleteLink.getAttribute("data-pushed") || "?";
-      if (p3) {
-        vscode.postMessage({ command: "deleteWorktree", path: p3, branch, repoLabel, pushed });
-      }
-      return true;
-    }
-    return false;
-  }
-  function _handleWorktreeSortHeaderClick(target) {
-    const sortHeader = target.closest("[data-wt-sort]");
-    if (!sortHeader) {
-      return false;
-    }
-    const col = sortHeader.getAttribute("data-wt-sort");
-    if (!col) {
-      return true;
-    }
-    if (worktreeSortColumn === col) {
-      worktreeSortDir = worktreeSortDir === "desc" ? "asc" : "desc";
-    } else {
-      worktreeSortColumn = col;
-      worktreeSortDir = col === "repo" ? "asc" : "desc";
-    }
-    updateWorktreeResults();
-    return true;
-  }
-  function _handleWorktreeRepoRowClick(target) {
-    const repoRow = target.closest(".worktree-repo-row");
-    if (!repoRow) {
-      return false;
-    }
-    const repo = repoRow.getAttribute("data-repo") ?? "";
-    if (worktreeExpandedRepos.has(repo)) {
-      worktreeExpandedRepos.delete(repo);
-    } else {
-      worktreeExpandedRepos.add(repo);
-    }
-    updateWorktreeResults();
-    return true;
-  }
-  function _handleWorktreeTableInteractionClick(target) {
-    if (_handleWorktreeSortHeaderClick(target)) {
-      return true;
-    }
-    return _handleWorktreeRepoRowClick(target);
-  }
-  function handleWorktreeTabClick(event) {
-    const target = event.target;
-    if (!target) {
-      return;
-    }
-    if (_handleWorktreeActionButtonClick(target)) {
-      return;
-    }
-    if (_handleWorktreeRootsListClick(target)) {
-      return;
-    }
-    if (_handleWorktreeRowLinkClick(event, target)) {
-      return;
-    }
-    _handleWorktreeTableInteractionClick(target);
-  }
-  function setupWorktreesHandlers() {
-    const tabEl = document.getElementById("tab-panel-worktrees");
-    if (!tabEl) {
-      return;
-    }
-    tabEl.addEventListener("click", handleWorktreeTabClick);
-    tabEl.addEventListener("keydown", (event) => {
-      const target = event.target;
-      if (target?.id === "worktree-root-input" && event.key === "Enter") {
-        event.preventDefault();
-        addWorktreeRootFromInput();
-      }
-    });
-  }
-  function sanitizeWorktreeResult(item) {
-    const w2 = item ?? {};
-    const pushedRaw = String(w2.pushed ?? "?");
-    const pushed = pushedRaw === "yes" || pushedRaw === "no" ? pushedRaw : "?";
-    return {
-      path: String(w2.path ?? ""),
-      repoLabel: String(w2.repoLabel ?? "Unknown"),
-      branch: String(w2.branch ?? "?"),
-      lastCommit: String(w2.lastCommit ?? "?"),
-      lastCommitDate: w2.lastCommitDate ? String(w2.lastCommitDate) : null,
-      pushed,
-      files: numField(w2.files),
-      folders: numField(w2.folders),
-      bytes: numField(w2.bytes)
-    };
-  }
-  function handleWorktreeRootPicked(message) {
-    if (!message.folderPath) {
-      return;
-    }
-    const folderPath = String(message.folderPath);
-    if (!worktreeRoots.some((r6) => r6.toLowerCase() === folderPath.toLowerCase())) {
-      worktreeRoots.push(folderPath);
-    }
-    updateWorktreeControls();
-  }
-  function handleWorktreeRootsDiscovered(message) {
-    if (worktreeScanInProgress || !Array.isArray(message.roots)) {
-      return;
-    }
-    let added = false;
-    for (const raw of message.roots) {
-      if (typeof raw !== "string") {
-        continue;
-      }
-      const root = raw.trim();
-      if (!root) {
-        continue;
-      }
-      if (!worktreeRoots.some((r6) => r6.toLowerCase() === root.toLowerCase())) {
-        worktreeRoots.push(root);
-        added = true;
-      }
-    }
-    if (added) {
-      updateWorktreeControls();
-    }
-  }
-  function handleWorktreeScanStarted() {
-    worktreeScanInProgress = true;
-    worktreeResults = [];
-    worktreeScanError = null;
-    worktreeScanStatus = { root: "", checked: 0, total: 0, foundCount: 0, elapsedMs: 0 };
-    updateWorktreeControls();
-    updateWorktreeResults();
-  }
-  function handleWorktreeScanRootStarted(message) {
-    worktreeScanStatus = { ...worktreeScanStatus, root: String(message.root || ""), checked: 0, total: 0, phase: "walking", dirsScanned: 0 };
-    updateWorktreeProgressArea();
-  }
-  function handleWorktreeScanWalkProgress(message) {
-    worktreeScanStatus = {
-      ...worktreeScanStatus,
-      root: String(message.root ?? worktreeScanStatus.root),
-      phase: "walking",
-      dirsScanned: numField(message.dirsScanned),
-      elapsedMs: numField(message.elapsedMs)
-    };
-    updateWorktreeProgressArea();
-  }
-  function handleWorktreeScanRootMarkersFound(message) {
-    worktreeScanStatus = { ...worktreeScanStatus, total: numField(message.count), phase: "checking" };
-    updateWorktreeProgressArea();
-  }
-  function handleWorktreeScanRootSkipped(message) {
-    worktreeScanError = `Skipped "${message.root}": ${message.reason || "not accessible"}`;
-    updateWorktreeControls();
-  }
-  function handleWorktreeScanProgress(message) {
-    worktreeScanStatus = {
-      root: String(message.root ?? worktreeScanStatus.root),
-      checked: numField(message.checked),
-      total: message.total !== void 0 ? numField(message.total) : worktreeScanStatus.total,
-      foundCount: numField(message.foundCount),
-      elapsedMs: numField(message.elapsedMs)
-    };
-    updateWorktreeProgressArea();
-  }
-  function handleWorktreeFound(message) {
-    if (!message.worktree) {
-      return;
-    }
-    worktreeResults.push(sanitizeWorktreeResult(message.worktree));
-    scheduleWorktreeResultsRender();
-  }
-  function handleWorktreeDeleted(message) {
-    const targetPath = String(message.path ?? "");
-    if (!targetPath) {
-      return;
-    }
-    const idx = worktreeResults.findIndex((w2) => w2.path === targetPath);
-    if (idx === -1) {
-      return;
-    }
-    worktreeResults.splice(idx, 1);
-    updateWorktreeResults();
-  }
-  function handleCleanupDeclined() {
-    worktreeCleanupConfirmPending = false;
-    updateWorktreeResults();
-  }
-  function handleCleanupStarted(message) {
-    worktreeCleanupConfirmPending = false;
-    worktreeCleanupInProgress = true;
-    worktreeCleanupStatus = { processed: 0, total: numField(message.total) };
-    worktreeCleanupLog = [];
-    updateWorktreeResults();
-  }
-  function handleCleanupWorktreeResult(message) {
-    worktreeCleanupStatus = { processed: numField(message.processed), total: numField(message.total) };
-    const rawStatus = message.status;
-    const status = rawStatus === "deleted" || rawStatus === "skipped" ? rawStatus : "error";
-    worktreeCleanupLog.push({
-      path: String(message.path ?? ""),
-      branch: String(message.branch ?? "?"),
-      repoLabel: String(message.repoLabel ?? ""),
-      status,
-      reason: typeof message.reason === "string" ? message.reason : void 0
-    });
-    updateWorktreeResults();
-  }
-  function handleCleanupComplete() {
-    worktreeCleanupInProgress = false;
-    updateWorktreeResults();
-  }
-  function handleCleanupCancelled() {
-    worktreeCleanupInProgress = false;
-    worktreeCleanupConfirmPending = false;
-    updateWorktreeResults();
-  }
-  function handleWorktreeEnrichStarted(message) {
-    worktreeScanStatus = { ...worktreeScanStatus, phase: "enriching", enriched: 0, enrichTotal: numField(message.total), elapsedMs: numField(message.elapsedMs) };
-    updateWorktreeProgressArea();
-  }
-  function handleWorktreeEnrichProgress(message) {
-    worktreeScanStatus = { ...worktreeScanStatus, phase: "enriching", enriched: numField(message.enriched), enrichTotal: numField(message.total), elapsedMs: numField(message.elapsedMs) };
-    updateWorktreeProgressArea();
-  }
-  function handleWorktreeEnriched(message) {
-    const targetPath = String(message.path ?? "");
-    if (!targetPath) {
-      return;
-    }
-    const wt = worktreeResults.find((w2) => w2.path === targetPath);
-    if (!wt) {
-      return;
-    }
-    wt.files = numField(message.files);
-    wt.folders = numField(message.folders);
-    wt.bytes = numField(message.bytes);
-    const pushedRaw = String(message.pushed ?? "?");
-    wt.pushed = pushedRaw === "yes" || pushedRaw === "no" ? pushedRaw : "?";
-    scheduleWorktreeResultsRender();
-  }
-  function handleWorktreeScanComplete() {
-    worktreeScanInProgress = false;
-    updateWorktreeControls();
-    updateWorktreeResults();
-  }
-  function handleWorktreeScanCancelled() {
-    worktreeScanInProgress = false;
-    updateWorktreeControls();
-  }
-  function handleWorktreeBackgroundResults(message) {
-    if (worktreeScanInProgress || worktreeCleanupInProgress) {
-      return;
-    }
-    const worktrees = Array.isArray(message.worktrees) ? message.worktrees : [];
-    worktreeResults = worktrees.map(sanitizeWorktreeResult);
-    worktreeBackgroundScanMeta = { scannedAt: String(message.scannedAt ?? ""), totalBytes: numField(message.totalBytes) };
-    updateWorktreeControls();
-    updateWorktreeResults();
-  }
-  var _worktreeMessageHandlers = {
-    worktreeRootPicked: handleWorktreeRootPicked,
-    worktreeRootsDiscovered: handleWorktreeRootsDiscovered,
-    worktreeScanStarted: () => handleWorktreeScanStarted(),
-    worktreeScanRootStarted: handleWorktreeScanRootStarted,
-    worktreeScanWalkProgress: handleWorktreeScanWalkProgress,
-    worktreeScanRootMarkersFound: handleWorktreeScanRootMarkersFound,
-    worktreeScanRootSkipped: handleWorktreeScanRootSkipped,
-    worktreeScanProgress: handleWorktreeScanProgress,
-    worktreeFound: handleWorktreeFound,
-    worktreeEnrichStarted: handleWorktreeEnrichStarted,
-    worktreeEnrichProgress: handleWorktreeEnrichProgress,
-    worktreeEnriched: handleWorktreeEnriched,
-    worktreeDeleted: handleWorktreeDeleted,
-    worktreeScanComplete: () => handleWorktreeScanComplete(),
-    worktreeScanCancelled: () => handleWorktreeScanCancelled(),
-    worktreeBackgroundResults: handleWorktreeBackgroundResults,
-    cleanupDeclined: () => handleCleanupDeclined(),
-    cleanupStarted: handleCleanupStarted,
-    cleanupWorktreeResult: handleCleanupWorktreeResult,
-    cleanupComplete: () => handleCleanupComplete(),
-    cleanupCancelled: () => handleCleanupCancelled()
-  };
-  function handleWorktreeMessage(message) {
-    const handler = _worktreeMessageHandlers[message.command];
-    if (handler) {
-      handler(message);
-    }
-  }
-  function setupTabs() {
-    const tabButtons = document.querySelectorAll(".tab-button");
-    tabButtons.forEach((button) => {
-      button.addEventListener("click", () => {
-        const tab = button.getAttribute("data-tab");
-        if (!tab) {
-          return;
-        }
-        activeTab = tab;
-        tabButtons.forEach((btn) => btn.classList.toggle("active", btn.getAttribute("data-tab") === tab));
-        document.querySelectorAll(".tab-panel").forEach((panel) => {
-          panel.style.display = "none";
-        });
-        const activePanel = document.getElementById(`tab-panel-${tab}`);
-        if (activePanel) {
-          activePanel.style.display = "block";
-        }
-        if (tab === "repos" && !repoPrStatsLoaded) {
-          repoPrStatsLoaded = true;
-          vscode.postMessage({ command: "loadRepoPrStats" });
-        }
-        if (tab === "agent" && !agentSessionsLoaded) {
-          agentSessionsLoaded = true;
-          vscode.postMessage({ command: "loadAgentSessions" });
-        }
-        if (tab === "insights") {
-          currentInsights.filter((i6) => i6.status === "new").forEach((i6) => vscode.postMessage({ command: "insightAction", id: i6.id, action: "seen" }));
-        }
-      });
-    });
-  }
-  function sanitizeRepoPrStatsData(input) {
-    const src = input && typeof input === "object" ? input : {};
-    const repos = Array.isArray(src.repos) ? src.repos : [];
-    return {
-      authenticated: Boolean(src.authenticated),
-      since: typeof src.since === "string" || typeof src.since === "number" ? src.since : Date.now(),
-      error: typeof src.error === "string" ? escapeHtml(src.error) : void 0,
-      repos: repos.map((repo) => {
-        const r6 = repo && typeof repo === "object" ? repo : {};
-        const aiDetails = Array.isArray(r6.aiDetails) ? r6.aiDetails : [];
-        return {
-          repoUrl: toSafeHttpUrl(r6.repoUrl),
-          owner: escapeHtml(typeof r6.owner === "string" ? r6.owner : ""),
-          repo: escapeHtml(typeof r6.repo === "string" ? r6.repo : ""),
-          error: typeof r6.error === "string" ? escapeHtml(r6.error) : "",
-          totalPrs: toSafeNumber(r6.totalPrs),
-          aiAuthoredPrs: toSafeNumber(r6.aiAuthoredPrs),
-          aiReviewRequestedPrs: toSafeNumber(r6.aiReviewRequestedPrs),
-          userAuthoredPrs: toSafeNumber(r6.userAuthoredPrs),
-          userMergedPrs: toSafeNumber(r6.userMergedPrs),
-          aiDetails: aiDetails.map((d3) => {
-            const detail = d3 && typeof d3 === "object" ? d3 : {};
-            const validAiTypes = ["copilot", "claude", "openai", "other-ai"];
-            const validRoles = ["author", "reviewer-requested"];
-            const aiType = validAiTypes.includes(detail.aiType) ? detail.aiType : "other-ai";
-            const role = validRoles.includes(detail.role) ? detail.role : "author";
-            return {
-              number: toSafeNumber(detail.number),
-              title: escapeHtml(typeof detail.title === "string" ? detail.title : ""),
-              url: toSafeHttpUrl(detail.url),
-              aiType,
-              role
-            };
-          })
-        };
-      })
-    };
-  }
-  var AI_PR_LABEL = {
-    copilot: "\u{1F916} Copilot",
-    claude: "\u{1F9E0} Claude",
-    openai: "\u2728 Codex",
-    "other-ai": "\u{1F916} AI"
-  };
-  function renderRepoPrRow(r6, cell, cellCenter) {
-    const repoLink = `<a href="${escapeHtml(r6.repoUrl)}" target="_blank" rel="noopener noreferrer" style="color:var(--link-color); font-family:'Courier New',monospace; font-size:12px;">${escapeHtml(r6.owner)}/${escapeHtml(r6.repo)}</a>`;
-    if (r6.error) {
-      return `<tr>
-			<td style="${cell} font-family:'Courier New',monospace; font-size:12px;">${repoLink}</td>
-			<td colspan="4" style="${cell} color:var(--text-secondary); font-style:italic; font-size:12px;">${escapeHtml(r6.error)}</td>
-		</tr>`;
-    }
-    let detailsHtml = "";
-    if (r6.aiDetails.length > 0) {
-      const items = r6.aiDetails.map(
-        (d3) => `<li><a href="${escapeHtml(d3.url)}" target="_blank" rel="noopener noreferrer" style="color:var(--link-color);">#${d3.number} ${escapeHtml(d3.title)}</a> \u2014 ${AI_PR_LABEL[d3.aiType] ?? escapeHtml(String(d3.aiType))} (${d3.role === "author" ? "authored" : "review requested"})</li>`
-      ).join("");
-      detailsHtml = `
+		</div>`}function Ls(){let e=document.getElementById("sessions-panel-body");e&&(e.addEventListener("click",t=>{let o=t.target.closest("a.session-title-link");if(o){t.preventDefault();let i=o.getAttribute("data-file");i&&f.postMessage({command:"openSessionFile",file:i});return}let n=t.target.closest("th.sortable");if(!n)return;let s=n.getAttribute("data-sort");if(!s)return;Te===s?ot=ot==="desc"?"asc":"desc":(Te=s,ot="desc");let r=document.getElementById("sessions-table-container");r&&k(r,Wo(Fo))}),Us(),Ti())}var ws=!1;function Ti(){let e=document.getElementById("sessions-columns-toggle"),t=document.getElementById("sessions-columns-menu");!e||!t||(e.addEventListener("click",o=>{o.stopPropagation(),t.style.display=t.style.display==="none"?"block":"none"}),t.addEventListener("click",o=>o.stopPropagation()),t.addEventListener("change",o=>{let n=o.target,s=n.getAttribute("data-column");if(!s)return;n.checked?Me.add(s):Me.delete(s);let r=document.getElementById("sessions-table-container");r&&k(r,Wo(Fo)),xi()}),ws||(ws=!0,document.addEventListener("click",()=>{let o=document.getElementById("sessions-columns-menu");o&&(o.style.display="none")})))}function Us(){let e=document.getElementById("sessions-lookback-wrapper");if(!e)return;e.replaceChildren();let{wrapper:t}=Yt({id:"sessions-lookback",selected:I,disabled:["allTime"],disabledTitle:"All-time sessions are not loaded yet",label:"",onChange:o=>{I=o,zo()}});e.append(t),I!=="today"&&!Ae[I]&&zo()}function zo(){let e=document.getElementById("sessions-panel-body");if(!e)return;if(I==="today"){k(e,Io(Uo));return}let t=Ae[I];if(t){k(e,Io(t));return}k(e,`<div style="color: var(--text-secondary); font-size: 13px; padding: 16px;">Loading sessions for ${pt[I]}\u2026</div>`),f.postMessage({command:"loadRecentSessions",period:I})}function $i(e){let t=e.period;if(!t)return;let o=Array.isArray(e.sessions)?e.sessions.filter(n=>n&&typeof n=="object"&&typeof n.interactions=="number"):[];Ae[t]=o,I===t&&zo()}function Is(e){for(let o of mt)delete Ae[o];let t=Qt(e);if(t)for(let o of mt)Ae[o]=t[o]}function J(e,t){let o={...e};for(let n of t)n in o||(o[n]=0);return o}function x(e){let t=Number(e);return Number.isFinite(t)?t:0}function Ai(e){let t=e&&typeof e=="object"?e:{};return{ask:x(t.ask),edit:x(t.edit),agent:x(t.agent),plan:x(t.plan),customAgent:x(t.customAgent),cli:x(t.cli),cliApp:x(t.cliApp)}}function Mi(e){let t=e&&typeof e=="object"?e:{};return{file:x(t.file),selection:x(t.selection),implicitSelection:x(t.implicitSelection),symbol:x(t.symbol),codebase:x(t.codebase),workspace:x(t.workspace),terminal:x(t.terminal),vscode:x(t.vscode),terminalLastCommand:x(t.terminalLastCommand),terminalSelection:x(t.terminalSelection),clipboard:x(t.clipboard),changes:x(t.changes),outputPanel:x(t.outputPanel),problemsPanel:x(t.problemsPanel),pullRequest:x(t.pullRequest),byKind:t.byKind??{},copilotInstructions:x(t.copilotInstructions),agentsMd:x(t.agentsMd),byPath:t.byPath??{}}}function Pt(e){let t=e&&typeof e=="object"?e:{},o=t.toolCalls&&typeof t.toolCalls=="object"?t.toolCalls:{},n=t.mcpTools&&typeof t.mcpTools=="object"?t.mcpTools:{};return{sessions:x(t.sessions),modeUsage:Ai(t.modeUsage),contextReferences:Mi(t.contextReferences),toolCalls:{total:x(o.total),byTool:o.byTool??{}},mcpTools:{total:x(n.total),byServer:n.byServer??{},byTool:n.byTool??{}},modelSwitching:{modelsPerSession:[],totalSessions:0,averageModelsPerSession:0,maxModelsPerSession:0,minModelsPerSession:0,switchingFrequency:0,standardModels:[],premiumModels:[],unknownModels:[],mixedTierSessions:0,lowCostModels:[],mediumCostModels:[],highCostModels:[],mixedCostSessions:0,standardRequests:0,premiumRequests:0,lowCostRequests:0,mediumCostRequests:0,highCostRequests:0,unknownRequests:0,totalRequests:0,...t.modelSwitching??{}},thinkingEffortUsage:t.thinkingEffortUsage,modelEfficiency:t.modelEfficiency}}function zs(e){return e.filter(t=>t&&typeof t=="object"&&typeof t.id=="string").map(t=>({id:String(t.id),category:typeof t.category=="string"?t.category:"general",severity:["tip","opportunity","celebration"].includes(t.severity)?t.severity:"tip",title:typeof t.title=="string"?t.title:"",body:typeof t.body=="string"?t.body:"",actionLabel:typeof t.actionLabel=="string"?t.actionLabel:void 0,actionCommand:typeof t.actionCommand=="string"?t.actionCommand:void 0,status:["new","seen","dismissed","snoozed","done"].includes(t.status)?t.status:"new",allowToast:!!t.allowToast}))}var Ei=["user-correction","edit-retry","edit-self-correction","tool-error","agent-self-correction"];function Ri(e){return!e||typeof e!="object"||!Ei.includes(e.type)||typeof e.snippet!="string"?null:{type:e.type,turnNumber:typeof e.turnNumber=="number"?e.turnNumber:0,timestamp:typeof e.timestamp=="string"?e.timestamp:null,snippet:e.snippet,tool:typeof e.tool=="string"?e.tool:void 0,file:typeof e.file=="string"?e.file:void 0,retried:e.retried===!0?!0:void 0,matchedPattern:typeof e.matchedPattern=="string"?e.matchedPattern:void 0}}function Bs(e){let t=o=>typeof o=="number"&&isFinite(o)&&o>=0?o:0;return{userCorrections:t(e?.userCorrections),editRetries:t(e?.editRetries),editSelfCorrections:t(e?.editSelfCorrections),toolErrors:t(e?.toolErrors),toolErrorsRetried:t(e?.toolErrorsRetried),agentSelfCorrections:t(e?.agentSelfCorrections)}}function _i(e){if(!e||typeof e!="object"||typeof e.file!="string"||!Array.isArray(e.moments))return null;let t=e.moments.map(Ri).filter(o=>o!==null);return t.length===0?null:{file:e.file,title:typeof e.title=="string"?e.title:null,lastInteraction:typeof e.lastInteraction=="string"?e.lastInteraction:null,moments:t,totalMoments:typeof e.totalMoments=="number"&&isFinite(e.totalMoments)?Math.max(t.length,e.totalMoments):t.length}}function Pi(e){if(!e||typeof e!="object"||typeof e.repository!="string"||!Array.isArray(e.sessions))return null;let t=e.sessions.map(_i).filter(o=>o!==null);return t.length===0?null:{repository:e.repository,sessions:t,counts:Bs(e.counts),sessionsWithMoments:typeof e.sessionsWithMoments=="number"?e.sessionsWithMoments:t.length}}function Di(e){if(!e||typeof e!="object"||!Array.isArray(e.repos))return null;let t=e.repos.map(Pi).filter(o=>o!==null);return t.length===0?null:{sessionsPerRepo:typeof e.sessionsPerRepo=="number"?e.sessionsPerRepo:25,repos:t,counts:Bs(e.counts),sessionsWithMoments:typeof e.sessionsWithMoments=="number"?e.sessionsWithMoments:t.reduce((o,n)=>o+n.sessionsWithMoments,0)}}function Li(e){if(!e||typeof e!="object"||typeof e.representativePrompt!="string"||typeof e.sessionCount!="number"||!Array.isArray(e.sessions))return null;let t=e.sessions.filter(o=>o&&typeof o=="object"&&typeof o.file=="string").map(o=>({file:o.file,title:typeof o.title=="string"?o.title:null,lastInteraction:typeof o.lastInteraction=="string"?o.lastInteraction:null,repository:typeof o.repository=="string"?o.repository:void 0}));return t.length===0?null:{representativePrompt:e.representativePrompt,sessionCount:t.length,repositories:Array.isArray(e.repositories)?e.repositories.filter(o=>typeof o=="string"):[],sessions:t,sharedKeywords:Array.isArray(e.sharedKeywords)?e.sharedKeywords.filter(o=>typeof o=="string"):[]}}function Ui(e){if(!e||typeof e!="object"||!Array.isArray(e.clusters))return null;let t=e.clusters.map(Li).filter(o=>o!==null);return t.length===0?null:{minClusterSize:typeof e.minClusterSize=="number"?e.minClusterSize:2,sessionsScanned:typeof e.sessionsScanned=="number"?e.sessionsScanned:0,clusters:t}}function Ii(e){if(!e||typeof e!="object")return null;let t=e;return{windowDays:typeof t.windowDays=="number"?t.windowDays:30,availableTools:Array.isArray(t.availableTools)?t.availableTools:[],usedTools:Array.isArray(t.usedTools)?t.usedTools:[],unusedTools:Array.isArray(t.unusedTools)?t.unusedTools:[],underusedMcpServers:Array.isArray(t.underusedMcpServers)?t.underusedMcpServers:[],underusedAgentPlugins:Array.isArray(t.underusedAgentPlugins)?t.underusedAgentPlugins:[],estimatedPromptBloat:t.estimatedPromptBloat&&typeof t.estimatedPromptBloat=="object"?t.estimatedPromptBloat:{totalTokens:0,byServer:{}},recommendations:Array.isArray(t.recommendations)?t.recommendations:[]}}function zi(e,t){e.correctionReport=Di(t.correctionReport),e.repeatedTasks=Ui(t.repeatedTasks)}function Bi(e,t){Array.isArray(t.todaySessions)&&(e.todaySessions=t.todaySessions.filter(n=>n&&typeof n=="object"&&typeof n.interactions=="number"));let o=Qt(t.recentSessions);o&&(e.recentSessions=o)}function Oi(e){if(!e||typeof e!="object")return pe("sanitize-invalid-root","sanitizeStats.invalidRoot"),null;try{let t={today:Pt(e.today),last30Days:Pt(e.last30Days),month:Pt(e.month),lastMonth:Pt(e.lastMonth),lastUpdated:typeof e.lastUpdated=="string"?e.lastUpdated:"",backendConfigured:!!e.backendConfigured,locale:typeof e.locale=="string"?e.locale:void 0,currentWorkspacePaths:Array.isArray(e.currentWorkspacePaths)?e.currentWorkspacePaths.filter(s=>typeof s=="string"):void 0,suppressedUnknownTools:Array.isArray(e.suppressedUnknownTools)?e.suppressedUnknownTools.filter(s=>typeof s=="string"):void 0},o=mn(e.customizationMatrix);o&&(t.customizationMatrix=o),Array.isArray(e.missedPotential)&&(t.missedPotential=e.missedPotential.filter(s=>s&&typeof s=="object"&&typeof s.workspacePath=="string")),Bi(t,e),Array.isArray(e.insights)&&(t.insights=zs(e.insights)),zi(t,e);let n=Ii(e.curationAnalysis);return n?(t.curationAnalysis=n,Z("sanitizeStats.curation.present",{availableTools:n.availableTools.length,unusedTools:n.unusedTools.length,unusedServers:n.underusedMcpServers.filter(s=>s&&s.usedToolCount===0).length})):pe("sanitize-no-curation","sanitizeStats.curation.missing"),fn(t,e),t}catch(t){return pe("sanitize-error","sanitizeStats.error",{error:t instanceof Error?t.message:String(t)}),null}}function F(){let e=document.getElementById("worktree-controls");e&&k(e,qs())}function z(){let e=document.getElementById("worktree-results");e&&k(e,Gs())}function Ee(){let e=document.getElementById("worktree-progress-area");e&&k(e,Ws())}function Os(){$o||($o=!0,requestAnimationFrame(()=>{$o=!1,z()}))}function Ns(){let e=document.getElementById("worktree-root-input"),t=e?.value.trim();t&&(U.some(o=>o.toLowerCase()===t.toLowerCase())||U.push(t),e&&(e.value=""),F())}function Ni(){U.length===0||R||W||(R=!0,L=[],Ge=null,rt=null,D={root:"",checked:0,total:0,foundCount:0,elapsedMs:0},re=[],F(),z(),f.postMessage({command:"scanWorktrees",rootPaths:U}))}function Hi(){if(W||fe||R)return;let e=Ks();e.length!==0&&(fe=!0,z(),f.postMessage({command:"cleanupPushedWorktrees",worktrees:e.map(t=>({path:t.path,branch:t.branch,repoLabel:t.repoLabel}))}))}function ji(e){return e.id==="btn-browse-worktree-root"?(f.postMessage({command:"pickWorktreeRoot"}),!0):e.id==="btn-add-worktree-root"?(Ns(),!0):e.id==="btn-scan-worktrees"?(Ni(),!0):e.id==="btn-cancel-worktree-scan"?(f.postMessage({command:"cancelWorktreeScan"}),!0):e.id==="btn-cleanup-pushed-worktrees"?(Hi(),!0):e.id==="btn-cancel-cleanup"?(f.postMessage({command:"cancelCleanupPushedWorktrees"}),!0):!1}function Fi(e){if(e.closest("#btn-toggle-worktree-roots"))return Ve=!Ve,F(),!0;if(e.classList.contains("worktree-remove-root")){let t=Number(e.getAttribute("data-index"));return isNaN(t)||(U.splice(t,1),F()),!0}return!1}function Wi(e,t){let o=t.closest(".worktree-reveal-link");if(o){e.preventDefault();let s=decodeURIComponent(o.getAttribute("data-path")||"");return s&&f.postMessage({command:"revealPath",path:s}),!0}let n=t.closest(".worktree-delete-link");if(n){e.preventDefault();let s=decodeURIComponent(n.getAttribute("data-path")||""),r=decodeURIComponent(n.getAttribute("data-branch")||""),i=decodeURIComponent(n.getAttribute("data-repo")||""),a=n.getAttribute("data-pushed")||"?";return s&&f.postMessage({command:"deleteWorktree",path:s,branch:r,repoLabel:i,pushed:a}),!0}return!1}function qi(e){let t=e.closest("[data-wt-sort]");if(!t)return!1;let o=t.getAttribute("data-wt-sort");return o&&(it===o?Ye=Ye==="desc"?"asc":"desc":(it=o,Ye=o==="repo"?"asc":"desc"),z()),!0}function Ki(e){let t=e.closest(".worktree-repo-row");if(!t)return!1;let o=t.getAttribute("data-repo")??"";return zt.has(o)?zt.delete(o):zt.add(o),z(),!0}function Gi(e){return qi(e)?!0:Ki(e)}function Vi(e){let t=e.target;t&&(ji(t)||Fi(t)||Wi(e,t)||Gi(t))}function Yi(){let e=document.getElementById("tab-panel-worktrees");e&&(e.addEventListener("click",Vi),e.addEventListener("keydown",t=>{t.target?.id==="worktree-root-input"&&t.key==="Enter"&&(t.preventDefault(),Ns())}))}function qo(e){let t=e??{},o=String(t.pushed??"?"),n=o==="yes"||o==="no"?o:"?";return{path:String(t.path??""),repoLabel:String(t.repoLabel??"Unknown"),branch:String(t.branch??"?"),lastCommit:String(t.lastCommit??"?"),lastCommitDate:t.lastCommitDate?String(t.lastCommitDate):null,pushed:n,files:A(t.files),folders:A(t.folders),bytes:A(t.bytes)}}function Ji(e){if(!e.folderPath)return;let t=String(e.folderPath);U.some(o=>o.toLowerCase()===t.toLowerCase())||U.push(t),F()}function Xi(e){if(R||!Array.isArray(e.roots))return;let t=!1;for(let o of e.roots){if(typeof o!="string")continue;let n=o.trim();n&&(U.some(s=>s.toLowerCase()===n.toLowerCase())||(U.push(n),t=!0))}t&&F()}function Zi(){R=!0,L=[],rt=null,D={root:"",checked:0,total:0,foundCount:0,elapsedMs:0},F(),z()}function Qi(e){D={...D,root:String(e.root||""),checked:0,total:0,phase:"walking",dirsScanned:0},Ee()}function ea(e){D={...D,root:String(e.root??D.root),phase:"walking",dirsScanned:A(e.dirsScanned),elapsedMs:A(e.elapsedMs)},Ee()}function ta(e){D={...D,total:A(e.count),phase:"checking"},Ee()}function oa(e){rt=`Skipped "${e.root}": ${e.reason||"not accessible"}`,F()}function na(e){D={root:String(e.root??D.root),checked:A(e.checked),total:e.total!==void 0?A(e.total):D.total,foundCount:A(e.foundCount),elapsedMs:A(e.elapsedMs)},Ee()}function sa(e){e.worktree&&(L.push(qo(e.worktree)),Os())}function ra(e){let t=String(e.path??"");if(!t)return;let o=L.findIndex(n=>n.path===t);o!==-1&&(L.splice(o,1),z())}function ia(){fe=!1,z()}function aa(e){fe=!1,W=!0,Oo={processed:0,total:A(e.total)},re=[],z()}function la(e){Oo={processed:A(e.processed),total:A(e.total)};let t=e.status,o=t==="deleted"||t==="skipped"?t:"error";re.push({path:String(e.path??""),branch:String(e.branch??"?"),repoLabel:String(e.repoLabel??""),status:o,reason:typeof e.reason=="string"?e.reason:void 0}),z()}function da(){W=!1,z()}function ca(){W=!1,fe=!1,z()}function ua(e){D={...D,phase:"enriching",enriched:0,enrichTotal:A(e.total),elapsedMs:A(e.elapsedMs)},Ee()}function pa(e){D={...D,phase:"enriching",enriched:A(e.enriched),enrichTotal:A(e.total),elapsedMs:A(e.elapsedMs)},Ee()}function ga(e){let t=String(e.path??"");if(!t)return;let o=L.find(s=>s.path===t);if(!o)return;o.files=A(e.files),o.folders=A(e.folders),o.bytes=A(e.bytes);let n=String(e.pushed??"?");o.pushed=n==="yes"||n==="no"?n:"?",Os()}function ma(){R=!1,F(),z()}function fa(){R=!1,F()}function ba(e){if(R||W)return;L=(Array.isArray(e.worktrees)?e.worktrees:[]).map(qo),Ge={scannedAt:String(e.scannedAt??""),totalBytes:A(e.totalBytes)},F(),z()}var ya={worktreeRootPicked:Ji,worktreeRootsDiscovered:Xi,worktreeScanStarted:()=>Zi(),worktreeScanRootStarted:Qi,worktreeScanWalkProgress:ea,worktreeScanRootMarkersFound:ta,worktreeScanRootSkipped:oa,worktreeScanProgress:na,worktreeFound:sa,worktreeEnrichStarted:ua,worktreeEnrichProgress:pa,worktreeEnriched:ga,worktreeDeleted:ra,worktreeScanComplete:()=>ma(),worktreeScanCancelled:()=>fa(),worktreeBackgroundResults:ba,cleanupDeclined:()=>ia(),cleanupStarted:aa,cleanupWorktreeResult:la,cleanupComplete:()=>da(),cleanupCancelled:()=>ca()};function ha(e){let t=ya[e.command];t&&t(e)}function va(){let e=document.querySelectorAll(".tab-button");e.forEach(t=>{t.addEventListener("click",()=>{let o=t.getAttribute("data-tab");if(!o)return;$=o,e.forEach(s=>s.classList.toggle("active",s.getAttribute("data-tab")===o)),document.querySelectorAll(".tab-panel").forEach(s=>{s.style.display="none"});let n=document.getElementById(`tab-panel-${o}`);n&&(n.style.display="block"),o==="repos"&&!Do&&(Do=!0,f.postMessage({command:"loadRepoPrStats"})),o==="agent"&&!Lo&&(Lo=!0,f.postMessage({command:"loadAgentSessions"})),o==="insights"&&Bo.filter(s=>s.status==="new").forEach(s=>f.postMessage({command:"insightAction",id:s.id,action:"seen"}))})})}function xa(e){let t=e&&typeof e=="object"?e:{},o=Array.isArray(t.repos)?t.repos:[];return{authenticated:!!t.authenticated,since:typeof t.since=="string"||typeof t.since=="number"?t.since:Date.now(),error:typeof t.error=="string"?d(t.error):void 0,repos:o.map(n=>{let s=n&&typeof n=="object"?n:{},r=Array.isArray(s.aiDetails)?s.aiDetails:[];return{repoUrl:vt(s.repoUrl),owner:d(typeof s.owner=="string"?s.owner:""),repo:d(typeof s.repo=="string"?s.repo:""),error:typeof s.error=="string"?d(s.error):"",totalPrs:_(s.totalPrs),aiAuthoredPrs:_(s.aiAuthoredPrs),aiReviewRequestedPrs:_(s.aiReviewRequestedPrs),userAuthoredPrs:_(s.userAuthoredPrs),userMergedPrs:_(s.userMergedPrs),aiDetails:r.map(i=>{let a=i&&typeof i=="object"?i:{},l=["copilot","claude","openai","other-ai"],u=["author","reviewer-requested"],c=l.includes(a.aiType)?a.aiType:"other-ai",p=u.includes(a.role)?a.role:"author";return{number:_(a.number),title:d(typeof a.title=="string"?a.title:""),url:vt(a.url),aiType:c,role:p}})}})}}var ka={copilot:"\u{1F916} Copilot",claude:"\u{1F9E0} Claude",openai:"\u2728 Codex","other-ai":"\u{1F916} AI"};function wa(e,t,o){let n=`<a href="${d(e.repoUrl)}" target="_blank" rel="noopener noreferrer" style="color:var(--link-color); font-family:'Courier New',monospace; font-size:12px;">${d(e.owner)}/${d(e.repo)}</a>`;if(e.error)return`<tr>
+			<td style="${t} font-family:'Courier New',monospace; font-size:12px;">${n}</td>
+			<td colspan="4" style="${t} color:var(--text-secondary); font-style:italic; font-size:12px;">${d(e.error)}</td>
+		</tr>`;let s="";if(e.aiDetails.length>0){let i=e.aiDetails.map(a=>`<li><a href="${d(a.url)}" target="_blank" rel="noopener noreferrer" style="color:var(--link-color);">#${a.number} ${d(a.title)}</a> \u2014 ${ka[a.aiType]??d(String(a.aiType))} (${a.role==="author"?"authored":"review requested"})</li>`).join("");s=`
 			<details style="margin-top:4px; font-size:11px;">
-				<summary style="cursor:pointer; color:var(--text-secondary);">Show ${r6.aiDetails.length} detail(s)</summary>
-				<ul style="margin:4px 0 0 16px; padding:0; list-style:disc;">${items}</ul>
-			</details>`;
-    }
-    const yours = (r6.userAuthoredPrs ?? 0) > 0 ? `<span style="font-weight:600;">${r6.userMergedPrs ?? 0} / ${r6.userAuthoredPrs}</span>` : "0";
-    return `<tr>
-		<td style="${cell} font-family:'Courier New',monospace; font-size:12px;">${repoLink}${detailsHtml}</td>
-		<td style="${cellCenter} font-weight:600;">${r6.totalPrs}</td>
-		<td style="${cellCenter}">${yours}</td>
-		<td style="${cellCenter}">${r6.aiAuthoredPrs > 0 ? `<span style="font-weight:600;">${r6.aiAuthoredPrs}</span>` : "0"}</td>
-		<td style="${cellCenter}">${r6.aiReviewRequestedPrs > 0 ? `<span style="font-weight:600;">${r6.aiReviewRequestedPrs}</span>` : "0"}</td>
-	</tr>`;
-  }
-  function renderReposPrContent(data) {
-    const sinceDate = escapeHtml(new Date(data.since).toLocaleDateString());
-    if (data.error) {
-      return `
+				<summary style="cursor:pointer; color:var(--text-secondary);">Show ${e.aiDetails.length} detail(s)</summary>
+				<ul style="margin:4px 0 0 16px; padding:0; list-style:disc;">${i}</ul>
+			</details>`}let r=(e.userAuthoredPrs??0)>0?`<span style="font-weight:600;">${e.userMergedPrs??0} / ${e.userAuthoredPrs}</span>`:"0";return`<tr>
+		<td style="${t} font-family:'Courier New',monospace; font-size:12px;">${n}${s}</td>
+		<td style="${o} font-weight:600;">${e.totalPrs}</td>
+		<td style="${o}">${r}</td>
+		<td style="${o}">${e.aiAuthoredPrs>0?`<span style="font-weight:600;">${e.aiAuthoredPrs}</span>`:"0"}</td>
+		<td style="${o}">${e.aiReviewRequestedPrs>0?`<span style="font-weight:600;">${e.aiReviewRequestedPrs}</span>`:"0"}</td>
+	</tr>`}function Ca(e){let t=d(new Date(e.since).toLocaleDateString());if(e.error)return`
 			<div style="margin-top:12px; padding:12px; background:var(--bg-tertiary); border:1px solid var(--border-color); border-radius:6px; font-size:12px; color:var(--text-secondary);">
 				<strong>\u26A0\uFE0F Failed to load repository PR activity</strong><br/>
-				${data.error}<br/>
+				${e.error}<br/>
 				Switch to another tab and back to retry \u2014 details are in the extension Output channel.
-			</div>`;
-    }
-    if (!data.authenticated) {
-      return `
+			</div>`;if(!e.authenticated)return`
 			<div style="margin-top:12px; padding:12px; background:var(--bg-tertiary); border:1px solid var(--border-color); border-radius:6px; font-size:12px; color:var(--text-secondary);">
 				<strong>\u{1F512} GitHub authentication required</strong><br/>
 				Sign in with GitHub (via the Diagnostics tab) to see AI PR activity across your repositories.
-			</div>`;
-    }
-    if (data.repos.length === 0) {
-      return `
+			</div>`;if(e.repos.length===0)return`
 			<div style="margin-top:12px; font-size:12px; color:var(--text-secondary);">
 				No GitHub repositories detected in your workspace folders.
-			</div>`;
-    }
-    const cell = "padding: 6px 8px; border-bottom: 1px solid var(--border-subtle);";
-    const cellCenter = `${cell} text-align: center;`;
-    const rows = data.repos.map((r6) => renderRepoPrRow(r6, cell, cellCenter)).join("");
-    return `
+			</div>`;let o="padding: 6px 8px; border-bottom: 1px solid var(--border-subtle);",n=`${o} text-align: center;`,s=e.repos.map(r=>wa(r,o,n)).join("");return`
 		<div style="font-size:11px; color:var(--text-secondary); margin-bottom:12px;">
-			Showing PRs created since ${sinceDate}.
+			Showing PRs created since ${t}.
 			Reviewer requests are only visible for <strong>open</strong> PRs \u2014 the GitHub API clears this field after a PR is merged or closed.
 		</div>
 		<div class="customization-matrix-container">
@@ -5728,124 +2058,64 @@ ${_renderMultiModelMixedCostSessions(switching)}
 					</tr>
 				</thead>
 				<tbody>
-					${rows}
+					${s}
 				</tbody>
 			</table>
 		</div>
 		<div style="margin-top:8px; font-size:10px; color:var(--text-muted); border-top:1px solid var(--border-subtle); padding-top:8px;">
 			\u2020 Copilot Review Agent requested counts are for open PRs only. GitHub removes reviewer data after a PR is merged or closed.<br/>
 			\u{1F916} Cloud Agent Authored = PR author's GitHub login matches a known cloud agent (e.g. <code>copilot-swe-agent</code>, <code>claude-code-action</code>, <code>openai-code-agent</code>).
-		</div>`;
-  }
-  function updateReposPrPanel(data) {
-    const container = document.querySelector("#repos-pr-content");
-    if (!container) {
-      return;
-    }
-    setHtml(container, `
+		</div>`}function Hs(e){let t=document.querySelector("#repos-pr-content");t&&k(t,`
 		<div class="section-title"><span>\u{1F916}</span><span>AI Activity in Repository PRs</span></div>
 		<div class="section-subtitle">
 			PRs from the last 30 days across your known repositories, showing how many were <strong>authored by cloud agents</strong>
 			(i.e. opened by a bot account like <code>copilot-swe-agent</code>, <code>claude-code-action</code>, or <code>openai-code-agent</code>)
 			or had an AI agent requested as a reviewer.
 		</div>
-		${renderReposPrContent(data)}
-	`);
-  }
-  function agentRepoLabelHtml(r6) {
-    const mono = "font-family:'Courier New',monospace; font-size:12px;";
-    if (r6.unassigned) {
-      return `<span style="${mono} color:var(--text-secondary);" title="Tasks the agents API reported without a repository \u2014 typically ad-hoc sessions started from cloud chat">no repository (cloud chat)</span>`;
-    }
-    const link = `<a href="${r6.repoUrl}" target="_blank" rel="noopener noreferrer" style="color:var(--link-color); ${mono}">${r6.owner}/${r6.repo}</a>`;
-    const accountOnly = r6.discovery === "account" ? ` <span title="Found through your account-wide agent tasks \u2014 this repo is not open in any workspace folder" style="color:var(--text-muted); font-size:10px;">(not in workspace)</span>` : "";
-    return `${link}${accountOnly}`;
-  }
-  function buildAgentSessionRows(data, cell, cellCenter) {
-    return data.repos.map((r6) => {
-      const label = agentRepoLabelHtml(r6);
-      if (r6.error) {
-        return `<tr>
-        <td style="${cell}">${label}</td>
-        <td colspan="3" style="${cell} color:var(--text-secondary); font-style:italic; font-size:12px;">${r6.error}</td>
-      </tr>`;
-      }
-      const partialNote = r6.partial ? ` <span title="Showing ${r6.tasksScanned} of ${r6.tasksTotal} tasks \u2014 capped to limit API usage" style="color:var(--text-muted); font-size:10px;">(${r6.tasksScanned}/${r6.tasksTotal} tasks scanned)</span>` : "";
-      const credits = r6.totalCredits > 0 ? r6.totalCredits.toFixed(1) : r6.totalPremiumRequests > 0 ? `${r6.totalPremiumRequests.toFixed(1)} PR` : "\u2014";
-      return `<tr>
-      <td style="${cell}">${label}${partialNote}</td>
-      <td style="${cellCenter} font-weight:600;">${r6.totalTasks}</td>
-      <td style="${cellCenter} font-weight:600;">${r6.totalSessions}</td>
-      <td style="${cellCenter}">${credits}</td>
-    </tr>`;
-    }).join("");
-  }
-  function agentSnapshotFreshnessHtml(data) {
-    const box = "margin-bottom:12px; padding:8px 10px; background:var(--bg-tertiary); border:1px solid var(--border-color); border-radius:6px; font-size:11px; color:var(--text-secondary);";
-    if (!data.fetchedAt) {
-      return `<div style="${box}">\u{1F552} <strong>Not fetched yet.</strong> The snapshot is refreshed hourly by the main VS Code window \u2014 it will appear here once that first refresh completes.</div>`;
-    }
-    const fetchedMs = Date.parse(data.fetchedAt);
-    const nextRefresh = Number.isFinite(fetchedMs) ? new Date(fetchedMs + data.refreshIntervalMs).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }) : "unknown";
-    return `<div style="${box}">
-    \u{1F552} Updated <strong>${escapeHtml(getTimeSince(data.fetchedAt))}</strong> \xB7 next refresh after ${escapeHtml(nextRefresh)}.
+		${Ca(e)}
+	`)}function Sa(e){let t="font-family:'Courier New',monospace; font-size:12px;";if(e.unassigned)return`<span style="${t} color:var(--text-secondary);" title="Tasks the agents API reported without a repository \u2014 typically ad-hoc sessions started from cloud chat">no repository (cloud chat)</span>`;let o=`<a href="${e.repoUrl}" target="_blank" rel="noopener noreferrer" style="color:var(--link-color); ${t}">${e.owner}/${e.repo}</a>`,n=e.discovery==="account"?' <span title="Found through your account-wide agent tasks \u2014 this repo is not open in any workspace folder" style="color:var(--text-muted); font-size:10px;">(not in workspace)</span>':"";return`${o}${n}`}function Ta(e,t,o){return e.repos.map(n=>{let s=Sa(n);if(n.error)return`<tr>
+        <td style="${t}">${s}</td>
+        <td colspan="3" style="${t} color:var(--text-secondary); font-style:italic; font-size:12px;">${n.error}</td>
+      </tr>`;let r=n.partial?` <span title="Showing ${n.tasksScanned} of ${n.tasksTotal} tasks \u2014 capped to limit API usage" style="color:var(--text-muted); font-size:10px;">(${n.tasksScanned}/${n.tasksTotal} tasks scanned)</span>`:"",i=n.totalCredits>0?n.totalCredits.toFixed(1):n.totalPremiumRequests>0?`${n.totalPremiumRequests.toFixed(1)} PR`:"\u2014";return`<tr>
+      <td style="${t}">${s}${r}</td>
+      <td style="${o} font-weight:600;">${n.totalTasks}</td>
+      <td style="${o} font-weight:600;">${n.totalSessions}</td>
+      <td style="${o}">${i}</td>
+    </tr>`}).join("")}function Cs(e){let t="margin-bottom:12px; padding:8px 10px; background:var(--bg-tertiary); border:1px solid var(--border-color); border-radius:6px; font-size:11px; color:var(--text-secondary);";if(!e.fetchedAt)return`<div style="${t}">\u{1F552} <strong>Not fetched yet.</strong> The snapshot is refreshed hourly by the main VS Code window \u2014 it will appear here once that first refresh completes.</div>`;let o=Date.parse(e.fetchedAt),n=Number.isFinite(o)?new Date(o+e.refreshIntervalMs).toLocaleTimeString([],{hour:"2-digit",minute:"2-digit"}):"unknown";return`<div style="${t}">
+    \u{1F552} Updated <strong>${d(rn(e.fetchedAt))}</strong> \xB7 next refresh after ${d(n)}.
     Cached and refreshed at most once an hour, by a single VS Code window, to keep GitHub API usage low.
-  </div>`;
-  }
-  function renderAgentSessionsContent(data) {
-    if (!data.authenticated) {
-      return `
+  </div>`}function $a(e){if(!e.authenticated)return`
 			<div style="margin-top:12px; padding:12px; background:var(--bg-tertiary); border:1px solid var(--border-color); border-radius:6px; font-size:12px; color:var(--text-secondary);">
 				<strong>\u{1F512} GitHub authentication required</strong><br/>
 				Sign in with GitHub (via the Diagnostics tab) to see Copilot cloud agent session data.
-			</div>`;
-    }
-    if (data.repos.length === 0) {
-      return `${agentSnapshotFreshnessHtml(data)}
+			</div>`;if(e.repos.length===0)return`${Cs(e)}
 			<div style="margin-top:12px; font-size:12px; color:var(--text-secondary);">
 				No cloud agent tasks found \u2014 neither in your workspace repositories nor anywhere else in your account.
-			</div>`;
-    }
-    const sinceDate = new Date(data.since).toLocaleDateString();
-    const cell = "padding: 6px 8px; border-bottom: 1px solid var(--border-subtle);";
-    const cellCenter = `${cell} text-align: center;`;
-    const summaryTotals = data.repos.reduce((acc, r6) => {
-      if (!r6.error) {
-        acc.tasks += r6.totalTasks;
-        acc.sessions += r6.totalSessions;
-        acc.credits += r6.totalCredits;
-        acc.premiumRequests += r6.totalPremiumRequests;
-      }
-      return acc;
-    }, { tasks: 0, sessions: 0, credits: 0, premiumRequests: 0 });
-    const hasPartial = data.repos.some((r6) => r6.partial && !r6.error);
-    const rows = buildAgentSessionRows(data, cell, cellCenter);
-    const tile = "background:var(--bg-tertiary); border:1px solid var(--border-color); border-radius:6px; padding:12px 20px; text-align:center; min-width:80px;";
-    return `
-		${agentSnapshotFreshnessHtml(data)}
+			</div>`;let t=new Date(e.since).toLocaleDateString(),o="padding: 6px 8px; border-bottom: 1px solid var(--border-subtle);",n=`${o} text-align: center;`,s=e.repos.reduce((l,u)=>(u.error||(l.tasks+=u.totalTasks,l.sessions+=u.totalSessions,l.credits+=u.totalCredits,l.premiumRequests+=u.totalPremiumRequests),l),{tasks:0,sessions:0,credits:0,premiumRequests:0}),r=e.repos.some(l=>l.partial&&!l.error),i=Ta(e,o,n),a="background:var(--bg-tertiary); border:1px solid var(--border-color); border-radius:6px; padding:12px 20px; text-align:center; min-width:80px;";return`
+		${Cs(e)}
 		<div style="margin-bottom:12px; display:flex; gap:24px; flex-wrap:wrap;">
-			<div style="${tile}">
-				<div style="font-size:22px; font-weight:700; color:var(--text-primary);">${summaryTotals.tasks}</div>
+			<div style="${a}">
+				<div style="font-size:22px; font-weight:700; color:var(--text-primary);">${s.tasks}</div>
 				<div style="font-size:11px; color:var(--text-secondary); margin-top:2px;">Tasks</div>
 			</div>
-			<div style="${tile}">
-				<div style="font-size:22px; font-weight:700; color:var(--text-primary);">${summaryTotals.sessions}</div>
+			<div style="${a}">
+				<div style="font-size:22px; font-weight:700; color:var(--text-primary);">${s.sessions}</div>
 				<div style="font-size:11px; color:var(--text-secondary); margin-top:2px;">Sessions</div>
 			</div>
-			<div style="${tile}">
-				<div style="font-size:22px; font-weight:700; color:var(--text-primary);">${summaryTotals.credits > 0 ? summaryTotals.credits.toFixed(1) : "\u2014"}</div>
+			<div style="${a}">
+				<div style="font-size:22px; font-weight:700; color:var(--text-primary);">${s.credits>0?s.credits.toFixed(1):"\u2014"}</div>
 				<div style="font-size:11px; color:var(--text-secondary); margin-top:2px;">AI Credits</div>
 			</div>
-			${summaryTotals.premiumRequests > 0 ? `
-			<div style="${tile}">
-				<div style="font-size:22px; font-weight:700; color:var(--text-primary);">${summaryTotals.premiumRequests.toFixed(1)}</div>
+			${s.premiumRequests>0?`
+			<div style="${a}">
+				<div style="font-size:22px; font-weight:700; color:var(--text-primary);">${s.premiumRequests.toFixed(1)}</div>
 				<div style="font-size:11px; color:var(--text-secondary); margin-top:2px;" title="Sessions that ran before the June 2026 switch to AI credits are billed in premium requests">Premium Requests</div>
-			</div>` : ""}
+			</div>`:""}
 		</div>
 		<div style="font-size:11px; color:var(--text-secondary); margin-bottom:12px;">
-			Showing cloud-agent sessions from ${sinceDate} to now.
-			${hasPartial ? "<strong>Note:</strong> Some repos were capped \u2014 totals are lower bounds. " : ""}
-			${data.accountTasksAvailable ? "" : `<strong>Account-wide tasks unavailable:</strong> ${data.accountTasksError ?? "the /agents/tasks endpoint could not be read"} \u2014 only workspace repositories are shown.`}
+			Showing cloud-agent sessions from ${t} to now.
+			${r?"<strong>Note:</strong> Some repos were capped \u2014 totals are lower bounds. ":""}
+			${e.accountTasksAvailable?"":`<strong>Account-wide tasks unavailable:</strong> ${e.accountTasksError??"the /agents/tasks endpoint could not be read"} \u2014 only workspace repositories are shown.`}
 		</div>
 		<div class="customization-matrix-container">
 			<table class="customization-matrix" style="width:100%; border-collapse:collapse;">
@@ -5857,69 +2127,46 @@ ${_renderMultiModelMixedCostSessions(switching)}
 						<th style="text-align:center; padding:8px; border-bottom:2px solid var(--border-color); font-size:12px; color:var(--text-secondary); opacity:0.9;" title="AI credits consumed (1 credit = $0.01). Only available when the API reports usage data.">AI Credits</th>
 					</tr>
 				</thead>
-				<tbody>${rows}</tbody>
+				<tbody>${i}</tbody>
 			</table>
 		</div>
 		<div style="margin-top:8px; font-size:10px; color:var(--text-muted); border-top:1px solid var(--border-subtle); padding-top:8px;">
 			\u2139\uFE0F <strong>No double-counting:</strong> These are cloud agent sessions only. CLI/remote sessions and local IDE chat sessions (shown in "My Activity") are excluded.<br/>
 			\u2139\uFE0F <strong>Two sources:</strong> your workspace repositories (which also surface tasks other people started there) plus your account-wide agent tasks, which cover repos you don't have open and ad-hoc cloud chat sessions. Tasks seen in both are counted once.<br/>
 			\u2139\uFE0F <strong>Action minutes</strong> (GitHub Actions compute used by the agent) are not shown here \u2014 they require additional per-branch API calls.
-		</div>`;
-  }
-  function updateAgentSessionsPanel(data) {
-    const container = document.querySelector("#agent-sessions-content");
-    if (!container) {
-      return;
-    }
-    setHtml(container, `
+		</div>`}function js(e){let t=document.querySelector("#agent-sessions-content");t&&k(t,`
 		<div class="section-title"><span>\u{1F916}</span><span>Copilot Cloud Agent Sessions</span></div>
 		<div class="section-subtitle">
 			Cloud agent tasks and sessions from the last 30 days. Each <strong>task</strong> is a user request to the agent;
 			each <strong>session</strong> is an autonomous coding run within that task.
 			<strong>CLI/remote sessions are excluded</strong> \u2014 they are separate from these cloud agent sessions.
 		</div>
-		${renderAgentSessionsContent(data)}
-	`);
-  }
-  function buildCustomizationSectionHtml(matrix) {
-    if (!matrix || !matrix.workspaces || matrix.workspaces.length === 0) {
-      return `
+		${$a(e)}
+	`)}function Aa(e){if(!e||!e.workspaces||e.workspaces.length===0)return`
 			<div class="section">
 				<div class="section-title"><span>\u{1F6E0}\uFE0F</span><span>Copilot Customization Files</span></div>
 				<div class="section-subtitle">Showing workspace customization status for active workspaces</div>
 				<div style="color: var(--text-muted); padding:12px;">No workspaces with customization files detected in the last 30 days.</div>
-			</div>`;
-    }
-    const workspaceRows = matrix.workspaces.map((ws) => {
-      const statuses = ws.typeStatuses ?? {};
-      const hasNoCustomization = Object.values(statuses).every((s4) => s4 === "\u274C");
-      const typeCells = (matrix.customizationTypes ?? []).map((type) => {
-        const status = statuses[type.id] || "\u2753";
-        const statusLabel = status === "\u2705" ? "Present and fresh" : status === "\u26A0\uFE0F" ? "Present but stale" : status === "\u274C" ? "Missing" : "Status unknown";
-        return `
+			</div>`;let t=e.workspaces.map(o=>{let n=o.typeStatuses??{},s=Object.values(n).every(i=>i==="\u274C"),r=(e.customizationTypes??[]).map(i=>{let a=n[i.id]||"\u2753";return`
 				<td style="position: relative; padding: 6px 8px; border-bottom: 1px solid var(--border-subtle); text-align: center;">
-					${statusBadgeHtml(status, statusLabel)}
-				</td>`;
-      }).join("");
-      return `
+					${j(a,a==="\u2705"?"Present and fresh":a==="\u26A0\uFE0F"?"Present but stale":a==="\u274C"?"Missing":"Status unknown")}
+				</td>`}).join("");return`
 			<tr>
 				<td style="padding: 6px 8px; border-bottom: 1px solid var(--border-subtle); font-family: 'Courier New', monospace; font-size: 12px;">
-					${escapeHtml(ws.workspaceName)}${hasNoCustomization ? ` <span style="font-family: sans-serif; vertical-align: middle;">${statusBadgeHtml("\u26A0\uFE0F", "No customization files")}</span>` : ""}
+					${d(o.workspaceName)}${s?` <span style="font-family: sans-serif; vertical-align: middle;">${j("\u26A0\uFE0F","No customization files")}</span>`:""}
 				</td>
 				<td style="padding: 6px 8px; border-bottom: 1px solid var(--border-subtle); text-align: center; color: var(--link-color); font-weight: 600;">
-					${ws.sessionCount}
+					${o.sessionCount}
 				</td>
-				${typeCells}
-			</tr>`;
-    }).join("");
-    return `
+				${r}
+			</tr>`}).join("");return`
 		<div style="margin-top: 16px; margin-bottom: 16px; padding: 12px; background: var(--bg-tertiary); border: 1px solid var(--border-color); border-radius: 6px;">
 			<div style="font-size: 13px; font-weight: 600; color: var(--text-primary); margin-bottom: 8px;">
 				\u{1F6E0}\uFE0F Copilot Customization Files
 			</div>
 			<div style="font-size: 11px; color: var(--text-secondary); margin-bottom: 12px; display: flex; align-items: center; gap: 6px; flex-wrap: wrap;">
-				Showing ${matrix.totalWorkspaces} workspace(s) with Copilot activity in the last 30 days.
-				${matrix.workspacesWithIssues > 0 ? `<span class="stale-warning" style="display:inline-flex;align-items:center;gap:4px;">${statusBadgeHtml("\u26A0\uFE0F")} ${matrix.workspacesWithIssues} workspace(s) have no customization files.</span>` : `<span style="display:inline-flex;align-items:center;gap:4px;">${statusBadgeHtml("\u2705")} All workspaces have up-to-date customizations.</span>`}
+				Showing ${e.totalWorkspaces} workspace(s) with Copilot activity in the last 30 days.
+				${e.workspacesWithIssues>0?`<span class="stale-warning" style="display:inline-flex;align-items:center;gap:4px;">${j("\u26A0\uFE0F")} ${e.workspacesWithIssues} workspace(s) have no customization files.</span>`:`<span style="display:inline-flex;align-items:center;gap:4px;">${j("\u2705")} All workspaces have up-to-date customizations.</span>`}
 			</div>
 			<div class="customization-matrix-container">
 				<table class="customization-matrix">
@@ -5927,65 +2174,39 @@ ${_renderMultiModelMixedCostSessions(switching)}
 						<tr>
 							<th style="text-align: left; padding: 8px; border-bottom: 2px solid var(--border-color);">\u{1F4C2} Workspace</th>
 							<th style="text-align: center; padding: 8px; border-bottom: 2px solid var(--border-color);">Sessions</th>
-							${(matrix.customizationTypes ?? []).map((type) => `
-								<th style="text-align: center; padding: 8px; border-bottom: 2px solid var(--border-color);" title="${escapeHtml(type.label)}">
-									${escapeHtml(type.icon)}
+							${(e.customizationTypes??[]).map(o=>`
+								<th style="text-align: center; padding: 8px; border-bottom: 2px solid var(--border-color);" title="${d(o.label)}">
+									${d(o.icon)}
 								</th>
 							`).join("")}
 						</tr>
 					</thead>
 					<tbody>
-						${workspaceRows}
+						${t}
 					</tbody>
 				</table>
 			</div>
 			<div style="margin-top: 12px; font-size: 10px; color: var(--text-muted); border-top: 1px solid var(--border-subtle); padding-top: 8px;">
 				<div style="display: flex; gap: 16px; flex-wrap: wrap;">
-					${(matrix.customizationTypes ?? []).map((type) => `
-						<span>${escapeHtml(type.icon)} ${escapeHtml(type.label)}</span>
+					${(e.customizationTypes??[]).map(o=>`
+						<span>${d(o.icon)} ${d(o.label)}</span>
 					`).join("")}
 				</div>
 				<div style="margin-top: 8px; display: flex; align-items: center; gap: 8px; flex-wrap: wrap;">
-					<span style="display:inline-flex;align-items:center;gap:4px;">${statusBadgeHtml("\u2705")} = Present &amp; Fresh</span>
+					<span style="display:inline-flex;align-items:center;gap:4px;">${j("\u2705")} = Present &amp; Fresh</span>
 					<span style="color: var(--text-muted);">\u2022</span>
-					<span style="display:inline-flex;align-items:center;gap:4px;">${statusBadgeHtml("\u26A0\uFE0F")} = Present but Stale</span>
+					<span style="display:inline-flex;align-items:center;gap:4px;">${j("\u26A0\uFE0F")} = Present but Stale</span>
 					<span style="color: var(--text-muted);">\u2022</span>
-					<span style="display:inline-flex;align-items:center;gap:4px;">${statusBadgeHtml("\u274C")} = Missing</span>
+					<span style="display:inline-flex;align-items:center;gap:4px;">${j("\u274C")} = Missing</span>
 				</div>
 			</div>
-		</div>`;
-  }
-  function buildModelCostSectionHtml(stats) {
-    const p30 = stats.last30Days.modelSwitching;
-    const today = stats.today.modelSwitching;
-    if ((p30.totalRequests ?? 0) === 0 && (today.totalRequests ?? 0) === 0) {
-      return "";
-    }
-    function renderCostPeriod(ms) {
-      const total = ms.totalRequests ?? 0;
-      if (total === 0) {
-        return '<div style="color: var(--text-muted); font-size: 11px;">No data</div>';
-      }
-      const buckets = [
-        { label: "\u{1F49A} Low cost", count: ms.lowCostRequests ?? 0, color: "#4ade80" },
-        { label: "\u{1F535} Medium cost", count: ms.mediumCostRequests ?? 0, color: "var(--link-color)" },
-        { label: "\u{1F4B8} High cost", count: ms.highCostRequests ?? 0, color: "var(--warning-fg)" },
-        { label: "\u2753 Unknown", count: ms.unknownRequests ?? 0, color: "var(--text-muted)" }
-      ].filter((b3) => b3.count > 0);
-      const rows = buckets.map((b3) => {
-        const pct = total > 0 ? Math.round(b3.count / total * 100) : 0;
-        return `<div style="display: flex; align-items: center; gap: 8px; margin-bottom: 8px;">
-				<span style="width: 90px; font-size: 12px; font-weight: 600; color: ${b3.color};">${b3.label}</span>
+		</div>`}function Ma(e){let t=e.last30Days.modelSwitching,o=e.today.modelSwitching;if((t.totalRequests??0)===0&&(o.totalRequests??0)===0)return"";function n(s){let r=s.totalRequests??0;if(r===0)return'<div style="color: var(--text-muted); font-size: 11px;">No data</div>';let a=[{label:"\u{1F49A} Low cost",count:s.lowCostRequests??0,color:"#4ade80"},{label:"\u{1F535} Medium cost",count:s.mediumCostRequests??0,color:"var(--link-color)"},{label:"\u{1F4B8} High cost",count:s.highCostRequests??0,color:"var(--warning-fg)"},{label:"\u2753 Unknown",count:s.unknownRequests??0,color:"var(--text-muted)"}].filter(u=>u.count>0).map(u=>{let c=r>0?Math.round(u.count/r*100):0;return`<div style="display: flex; align-items: center; gap: 8px; margin-bottom: 8px;">
+				<span style="width: 90px; font-size: 12px; font-weight: 600; color: ${u.color};">${u.label}</span>
 				<div style="flex: 1; background: var(--bg-secondary); border-radius: 4px; height: 12px; overflow: hidden;">
-					<div style="width: ${pct}%; background: ${b3.color}; height: 100%; border-radius: 4px;"></div>
+					<div style="width: ${c}%; background: ${u.color}; height: 100%; border-radius: 4px;"></div>
 				</div>
-				<span style="font-size: 12px; font-weight: 600; color: var(--text-primary); min-width: 70px; text-align: right;">${formatNumber(b3.count)} <span style="color: var(--text-secondary); font-weight: 400;">(${pct}%)</span></span>
-			</div>`;
-      }).join("");
-      const mixedNote = (ms.mixedCostSessions ?? 0) > 0 ? `<div style="font-size: 11px; color: var(--link-color); margin-top: 6px;">\u{1F500} ${formatNumber(ms.mixedCostSessions)} mixed-cost session${ms.mixedCostSessions !== 1 ? "s" : ""}</div>` : "";
-      return `${rows}<div style="font-size: 11px; color: var(--text-muted); margin-top: 6px;">${formatNumber(total)} total requests</div>${mixedNote}`;
-    }
-    return `
+				<span style="font-size: 12px; font-weight: 600; color: var(--text-primary); min-width: 70px; text-align: right;">${g(u.count)} <span style="color: var(--text-secondary); font-weight: 400;">(${c}%)</span></span>
+			</div>`}).join(""),l=(s.mixedCostSessions??0)>0?`<div style="font-size: 11px; color: var(--link-color); margin-top: 6px;">\u{1F500} ${g(s.mixedCostSessions)} mixed-cost session${s.mixedCostSessions!==1?"s":""}</div>`:"";return`${a}<div style="font-size: 11px; color: var(--text-muted); margin-top: 6px;">${g(r)} total requests</div>${l}`}return`
 		<!-- Model Cost Section -->
 		<div class="section">
 			<div class="section-title"><span>\u{1F4B0}</span><span>Model Cost Usage</span></div>
@@ -5993,25 +2214,18 @@ ${_renderMultiModelMixedCostSessions(switching)}
 			<div class="three-column">
 				<div>
 					<h4 style="color: var(--text-primary); font-size: 13px; margin-bottom: 8px;">\u{1F4C5} Today</h4>
-					${renderCostPeriod(today)}
+					${n(o)}
 				</div>
 				<div>
 					<h4 style="color: var(--text-primary); font-size: 13px; margin-bottom: 8px;">\u{1F4C6} Last 30 Days</h4>
-					${renderCostPeriod(p30)}
+					${n(t)}
 				</div>
 				<div>
 					<h4 style="color: var(--text-primary); font-size: 13px; margin-bottom: 8px;">\u{1F4C5} Previous Month</h4>
-					${renderCostPeriod(stats.month.modelSwitching)}
+					${n(e.month.modelSwitching)}
 				</div>
 			</div>
-		</div>`;
-  }
-  function buildThinkingEffortSectionHtml(stats) {
-    const effortData = stats.last30Days.thinkingEffortUsage || stats.today.thinkingEffortUsage || stats.month.thinkingEffortUsage;
-    if (!effortData) {
-      return "";
-    }
-    return `
+		</div>`}function Ea(e){return e.last30Days.thinkingEffortUsage||e.today.thinkingEffortUsage||e.month.thinkingEffortUsage?`
 		<!-- Thinking Effort Section -->
 		<div class="section">
 			<div class="section-title"><span>\u{1F4A1}</span><span>Thinking Effort (Reasoning)</span></div>
@@ -6019,58 +2233,30 @@ ${_renderMultiModelMixedCostSessions(switching)}
 			<div class="three-column">
 				<div>
 					<h4 style="color: var(--text-primary); font-size: 13px; margin-bottom: 8px;">\u{1F4C5} Today</h4>
-					${renderEffortPeriodHtml(stats.today.thinkingEffortUsage)}
+					${Eo(e.today.thinkingEffortUsage)}
 				</div>
 				<div>
 					<h4 style="color: var(--text-primary); font-size: 13px; margin-bottom: 8px;">\u{1F4C6} Last 30 Days</h4>
-					${renderEffortPeriodHtml(stats.last30Days.thinkingEffortUsage)}
+					${Eo(e.last30Days.thinkingEffortUsage)}
 				</div>
 				<div>
 					<h4 style="color: var(--text-primary); font-size: 13px; margin-bottom: 8px;">\u{1F4C5} Previous Month</h4>
-					${renderEffortPeriodHtml(stats.month.thinkingEffortUsage)}
+					${Eo(e.month.thinkingEffortUsage)}
 				</div>
 			</div>
-		</div>`;
-  }
-  function renderEffortPeriodHtml(teu) {
-    const EFFORT_ORDER = ["minimal", "low", "medium", "high", "max", "xhigh"];
-    if (!teu || teu.sessionCount === 0) {
-      return '<div style="color: var(--text-muted); font-size: 11px;">No data</div>';
-    }
-    const total = Object.values(teu.byEffort).reduce((s4, v2) => s4 + v2, 0);
-    const sorted = EFFORT_ORDER.filter((k2) => teu.byEffort[k2] > 0).concat(Object.keys(teu.byEffort).filter((k2) => !EFFORT_ORDER.includes(k2) && teu.byEffort[k2] > 0));
-    return `
-		${sorted.map((level) => {
-      const count = teu.byEffort[level] || 0;
-      const pct = total > 0 ? Math.round(count / total * 100) : 0;
-      return `<div style="display: flex; align-items: center; gap: 8px; margin-bottom: 8px;">
-				<span style="width: 56px; font-size: 12px; font-weight: 600; color: var(--text-primary); text-transform: capitalize;">${escapeHtml(getEffortDisplayName(level))}</span>
+		</div>`:""}function Eo(e){let t=["minimal","low","medium","high","max","xhigh"];if(!e||e.sessionCount===0)return'<div style="color: var(--text-muted); font-size: 11px;">No data</div>';let o=Object.values(e.byEffort).reduce((s,r)=>s+r,0);return`
+		${t.filter(s=>e.byEffort[s]>0).concat(Object.keys(e.byEffort).filter(s=>!t.includes(s)&&e.byEffort[s]>0)).map(s=>{let r=e.byEffort[s]||0,i=o>0?Math.round(r/o*100):0;return`<div style="display: flex; align-items: center; gap: 8px; margin-bottom: 8px;">
+				<span style="width: 56px; font-size: 12px; font-weight: 600; color: var(--text-primary); text-transform: capitalize;">${d(di(s))}</span>
 				<div style="flex: 1; background: var(--bg-secondary); border-radius: 4px; height: 12px; overflow: hidden;">
-					<div style="width: ${pct}%; background: var(--link-color); height: 100%; border-radius: 4px;"></div>
+					<div style="width: ${i}%; background: var(--link-color); height: 100%; border-radius: 4px;"></div>
 				</div>
-				<span style="font-size: 12px; font-weight: 600; color: var(--text-primary); min-width: 70px; text-align: right;">${count} <span style="color: var(--text-secondary); font-weight: 400;">(${pct}%)</span></span>
-			</div>`;
-    }).join("")}
-		<div style="font-size: 11px; color: var(--text-muted); margin-top: 6px;">${teu.sessionCount} session${teu.sessionCount !== 1 ? "s" : ""} \xB7 ${teu.switchCount} effort switch${teu.switchCount !== 1 ? "es" : ""}</div>
-	`;
-  }
-  function buildUsageAllKeysSets(stats) {
-    return {
-      allToolKeys: [.../* @__PURE__ */ new Set([...Object.keys(stats.today.toolCalls.byTool), ...Object.keys(stats.last30Days.toolCalls.byTool), ...Object.keys(stats.month.toolCalls.byTool)])].sort(),
-      allMcpToolKeys: [.../* @__PURE__ */ new Set([...Object.keys(stats.today.mcpTools.byTool), ...Object.keys(stats.last30Days.mcpTools.byTool), ...Object.keys(stats.month.mcpTools.byTool)])].sort(),
-      allMcpServerKeys: [.../* @__PURE__ */ new Set([...Object.keys(stats.today.mcpTools.byServer), ...Object.keys(stats.last30Days.mcpTools.byServer), ...Object.keys(stats.month.mcpTools.byServer)])].sort(),
-      allStandardModels: [.../* @__PURE__ */ new Set([...stats.today.modelSwitching.standardModels, ...stats.last30Days.modelSwitching.standardModels, ...stats.month.modelSwitching.standardModels])].sort(),
-      allHighCostModels: [.../* @__PURE__ */ new Set([...stats.today.modelSwitching.highCostModels, ...stats.last30Days.modelSwitching.highCostModels, ...stats.month.modelSwitching.highCostModels])].sort(),
-      allLowCostModels: [.../* @__PURE__ */ new Set([...stats.today.modelSwitching.lowCostModels, ...stats.last30Days.modelSwitching.lowCostModels, ...stats.month.modelSwitching.lowCostModels])].sort(),
-      allMediumCostModels: [.../* @__PURE__ */ new Set([...stats.today.modelSwitching.mediumCostModels, ...stats.last30Days.modelSwitching.mediumCostModels, ...stats.month.modelSwitching.mediumCostModels])].sort(),
-      allUnknownModels: [.../* @__PURE__ */ new Set([...stats.today.modelSwitching.unknownModels, ...stats.last30Days.modelSwitching.unknownModels, ...stats.month.modelSwitching.unknownModels])].sort()
-    };
-  }
-  function buildHealthTabPanelHtml(customizationHtml, stats) {
-    return `
-		<div id="tab-panel-health" class="tab-panel"${activeTab !== "health" ? ' style="display:none"' : ""}>
-			${customizationHtml}
-			${renderMissedPotential(stats)}
+				<span style="font-size: 12px; font-weight: 600; color: var(--text-primary); min-width: 70px; text-align: right;">${r} <span style="color: var(--text-secondary); font-weight: 400;">(${i}%)</span></span>
+			</div>`}).join("")}
+		<div style="font-size: 11px; color: var(--text-muted); margin-top: 6px;">${e.sessionCount} session${e.sessionCount!==1?"s":""} \xB7 ${e.switchCount} effort switch${e.switchCount!==1?"es":""}</div>
+	`}function Ra(e){return{allToolKeys:[...new Set([...Object.keys(e.today.toolCalls.byTool),...Object.keys(e.last30Days.toolCalls.byTool),...Object.keys(e.month.toolCalls.byTool)])].sort(),allMcpToolKeys:[...new Set([...Object.keys(e.today.mcpTools.byTool),...Object.keys(e.last30Days.mcpTools.byTool),...Object.keys(e.month.mcpTools.byTool)])].sort(),allMcpServerKeys:[...new Set([...Object.keys(e.today.mcpTools.byServer),...Object.keys(e.last30Days.mcpTools.byServer),...Object.keys(e.month.mcpTools.byServer)])].sort(),allStandardModels:[...new Set([...e.today.modelSwitching.standardModels,...e.last30Days.modelSwitching.standardModels,...e.month.modelSwitching.standardModels])].sort(),allHighCostModels:[...new Set([...e.today.modelSwitching.highCostModels,...e.last30Days.modelSwitching.highCostModels,...e.month.modelSwitching.highCostModels])].sort(),allLowCostModels:[...new Set([...e.today.modelSwitching.lowCostModels,...e.last30Days.modelSwitching.lowCostModels,...e.month.modelSwitching.lowCostModels])].sort(),allMediumCostModels:[...new Set([...e.today.modelSwitching.mediumCostModels,...e.last30Days.modelSwitching.mediumCostModels,...e.month.modelSwitching.mediumCostModels])].sort(),allUnknownModels:[...new Set([...e.today.modelSwitching.unknownModels,...e.last30Days.modelSwitching.unknownModels,...e.month.modelSwitching.unknownModels])].sort()}}function _a(e,t){return`
+		<div id="tab-panel-health" class="tab-panel"${$!=="health"?' style="display:none"':""}>
+			${e}
+			${vi(t)}
 
 			<!-- Repository Setup Section -->
 			<div class="repo-hygiene-section" style="margin-top: 16px; margin-bottom: 16px; padding: 12px; background: var(--bg-tertiary); border: 1px solid var(--border-color); border-radius: 6px;">
@@ -6080,9 +2266,9 @@ ${_renderMultiModelMixedCostSessions(switching)}
 				<div style="font-size: 11px; color: var(--text-secondary); margin-bottom: 12px;">
 					Analyze repository hygiene and structure to identify missing configuration files and best practices.
 				</div>
-				${hygieneMatrixState && hygieneMatrixState.workspaces && hygieneMatrixState.workspaces.length > 0 ? `
+				${H&&H.workspaces&&H.workspaces.length>0?`
 					<div style="margin-bottom: 12px;">
-						<vscode-button id="btn-analyse-all" style="margin-bottom: 8px;" ${isBatchAnalysisInProgress ? 'disabled="true" appearance="secondary"' : ""}>${isBatchAnalysisInProgress ? "Analyzing All..." : `Analyze All Repositories (${hygieneMatrixState.workspaces.length})`}</vscode-button>
+						<vscode-button id="btn-analyse-all" style="margin-bottom: 8px;" ${me?'disabled="true" appearance="secondary"':""}>${me?"Analyzing All...":`Analyze All Repositories (${H.workspaces.length})`}</vscode-button>
 					</div>
 					<div id="repo-list-pane-container" class="repo-hygiene-pane">
 						<div class="repo-hygiene-pane-header">\u{1F4C1} Repository List</div>
@@ -6092,214 +2278,109 @@ ${_renderMultiModelMixedCostSessions(switching)}
 						<div class="repo-hygiene-pane-header">\u{1F4CA} Repository Details</div>
 						<div id="repo-details-pane" class="repo-hygiene-pane-body"></div>
 					</div>
-				` : `
-					<vscode-button id="btn-analyse-repo" ${isSingleRepoAnalysisInProgress ? 'disabled="true" appearance="secondary"' : ""}>${isSingleRepoAnalysisInProgress ? "Analyzing..." : "Analyze Repo for Best Practices"}</vscode-button>
+				`:`
+					<vscode-button id="btn-analyse-repo" ${st?'disabled="true" appearance="secondary"':""}>${st?"Analyzing...":"Analyze Repo for Best Practices"}</vscode-button>
 					<div id="repo-analysis-results" class="repo-hygiene-results" style="margin-top: 12px;"></div>
 				`}
 			</div>
-		</div>`;
-  }
-  function buildMcpToolsSectionHtml(stats, allMcpToolKeys, allMcpServerKeys) {
-    return `
+		</div>`}function Pa(e,t,o){return`
 		<!-- MCP Tools Section -->
 		<div class="section">
 			<div class="section-title"><span>\u{1F50C}</span><span>MCP Tools</span></div>
 			<div class="section-subtitle">Model Context Protocol (MCP) server and tool usage</div>
-			${buildUnknownMcpToolsBannerHtml(stats)}
+			${zl(e)}
 			<div class="three-column">
 				<div>
 					<h4 style="color: var(--text-primary); font-size: 13px; margin-bottom: 8px;">\u{1F4C5} Today</h4>
 					<div class="list">
-						<div style="font-size: 14px; font-weight: 600; color: var(--text-primary); margin-bottom: 8px;">Total MCP Calls: ${formatNumber(stats.today.mcpTools.total)}</div>
-						${allMcpServerKeys.length > 0 ? `
-							<div style="margin-top: 12px;"><strong>By Server:</strong><div style="margin-top: 8px;">${renderToolsTable(unionFill(stats.today.mcpTools.byServer, allMcpServerKeys), 200)}</div></div>
-						` : '<div style="color: var(--text-muted); margin-top: 8px;">No MCP tools used yet</div>'}
+						<div style="font-size: 14px; font-weight: 600; color: var(--text-primary); margin-bottom: 8px;">Total MCP Calls: ${g(e.today.mcpTools.total)}</div>
+						${o.length>0?`
+							<div style="margin-top: 12px;"><strong>By Server:</strong><div style="margin-top: 8px;">${Y(J(e.today.mcpTools.byServer,o),200)}</div></div>
+						`:'<div style="color: var(--text-muted); margin-top: 8px;">No MCP tools used yet</div>'}
 					</div>
 				</div>
 				<div>
 					<h4 style="color: var(--text-primary); font-size: 13px; margin-bottom: 8px;">\u{1F4C6} Last 30 Days</h4>
 					<div class="list">
-						<div style="font-size: 14px; font-weight: 600; color: var(--text-primary); margin-bottom: 8px;">Total MCP Calls: ${formatNumber(stats.last30Days.mcpTools.total)}</div>
-						${allMcpServerKeys.length > 0 ? `
-							<div style="margin-top: 12px;"><strong>By Server:</strong><div style="margin-top: 8px;">${renderToolsTable(unionFill(stats.last30Days.mcpTools.byServer, allMcpServerKeys), 200)}</div></div>
-						` : '<div style="color: var(--text-muted); margin-top: 8px;">No MCP tools used yet</div>'}
+						<div style="font-size: 14px; font-weight: 600; color: var(--text-primary); margin-bottom: 8px;">Total MCP Calls: ${g(e.last30Days.mcpTools.total)}</div>
+						${o.length>0?`
+							<div style="margin-top: 12px;"><strong>By Server:</strong><div style="margin-top: 8px;">${Y(J(e.last30Days.mcpTools.byServer,o),200)}</div></div>
+						`:'<div style="color: var(--text-muted); margin-top: 8px;">No MCP tools used yet</div>'}
 					</div>
 				</div>
 				<div>
 					<h4 style="color: var(--text-primary); font-size: 13px; margin-bottom: 8px;">\u{1F4C5} Previous Month</h4>
 					<div class="list">
-						<div style="font-size: 14px; font-weight: 600; color: var(--text-primary); margin-bottom: 8px;">Total MCP Calls: ${formatNumber(stats.month.mcpTools.total)}</div>
-						${allMcpServerKeys.length > 0 ? `
-							<div style="margin-top: 12px;"><strong>By Server:</strong><div style="margin-top: 8px;">${renderToolsTable(unionFill(stats.month.mcpTools.byServer, allMcpServerKeys), 200)}</div></div>
-						` : '<div style="color: var(--text-muted); margin-top: 8px;">No MCP tools used yet</div>'}
+						<div style="font-size: 14px; font-weight: 600; color: var(--text-primary); margin-bottom: 8px;">Total MCP Calls: ${g(e.month.mcpTools.total)}</div>
+						${o.length>0?`
+							<div style="margin-top: 12px;"><strong>By Server:</strong><div style="margin-top: 8px;">${Y(J(e.month.mcpTools.byServer,o),200)}</div></div>
+						`:'<div style="color: var(--text-muted); margin-top: 8px;">No MCP tools used yet</div>'}
 					</div>
 				</div>
 			</div>
 			<div class="three-column" style="margin-top: 12px;">
 				<div>
-					${allMcpToolKeys.length > 0 ? `
+					${t.length>0?`
 						<div class="list">
-							<div style="margin-top: 4px;"><strong>By Tool:</strong><div style="margin-top: 8px;">${renderToolsTable(unionFill(stats.today.mcpTools.byTool, allMcpToolKeys), 10, lookupMcpToolName)}</div></div>
+							<div style="margin-top: 4px;"><strong>By Tool:</strong><div style="margin-top: 8px;">${Y(J(e.today.mcpTools.byTool,t),10,Ao)}</div></div>
 						</div>
-					` : ""}
+					`:""}
 				</div>
 				<div>
-					${allMcpToolKeys.length > 0 ? `
+					${t.length>0?`
 						<div class="list">
-							<div style="margin-top: 4px;"><strong>By Tool:</strong><div style="margin-top: 8px;">${renderToolsTable(unionFill(stats.last30Days.mcpTools.byTool, allMcpToolKeys), 10, lookupMcpToolName)}</div></div>
+							<div style="margin-top: 4px;"><strong>By Tool:</strong><div style="margin-top: 8px;">${Y(J(e.last30Days.mcpTools.byTool,t),10,Ao)}</div></div>
 						</div>
-					` : ""}
+					`:""}
 				</div>
 				<div>
-					${allMcpToolKeys.length > 0 ? `
+					${t.length>0?`
 						<div class="list">
-							<div style="margin-top: 4px;"><strong>By Tool:</strong><div style="margin-top: 8px;">${renderToolsTable(unionFill(stats.month.mcpTools.byTool, allMcpToolKeys), 10, lookupMcpToolName)}</div></div>
+							<div style="margin-top: 4px;"><strong>By Tool:</strong><div style="margin-top: 8px;">${Y(J(e.month.mcpTools.byTool,t),10,Ao)}</div></div>
 						</div>
-					` : ""}
+					`:""}
 				</div>
 			</div>
-		</div>`;
-  }
-  function buildCurationSummaryHtml(availableTools, unusedTools, bloat) {
-    const usedCount = availableTools.length - unusedTools.length;
-    const severityColor = unusedTools.length > 0 ? "rgba(251,191,36,0.12)" : "rgba(74,222,128,0.12)";
-    const severityBorder = unusedTools.length > 0 ? "rgba(251,191,36,0.4)" : "rgba(74,222,128,0.4)";
-    const unusedColor = unusedTools.length > 0 ? "#fbbf24" : "#4ade80";
-    const totalBloat = bloat.totalTokens;
-    const skillBloat = bloat.byServer["skill"] ?? 0;
-    const builtinBloat = bloat.byServer["builtin"] ?? 0;
-    const mcpBloat = totalBloat - skillBloat - builtinBloat;
-    const fmt = (n5) => n5 >= 1e3 ? `~${Math.round(n5 / 1e3)}K` : `~${n5}`;
-    const actionableBloat = mcpBloat + skillBloat;
-    const actionableParts = [];
-    if (mcpBloat > 0) {
-      actionableParts.push(`${fmt(mcpBloat)} MCP`);
-    }
-    if (skillBloat > 0) {
-      actionableParts.push(`${fmt(skillBloat)} skills`);
-    }
-    return `<div style="display:flex; gap:16px; flex-wrap:wrap; margin:12px 0;">
+		</div>`}function Da(e,t,o){let n=e.length-t.length,s=t.length>0?"rgba(251,191,36,0.12)":"rgba(74,222,128,0.12)",r=t.length>0?"rgba(251,191,36,0.4)":"rgba(74,222,128,0.4)",i=t.length>0?"#fbbf24":"#4ade80",a=o.totalTokens,l=o.byServer.skill??0,u=o.byServer.builtin??0,c=a-l-u,p=S=>S>=1e3?`~${Math.round(S/1e3)}K`:`~${S}`,b=c+l,h=[];return c>0&&h.push(`${p(c)} MCP`),l>0&&h.push(`${p(l)} skills`),`<div style="display:flex; gap:16px; flex-wrap:wrap; margin:12px 0;">
 		<div style="background:var(--bg-tertiary); border:1px solid var(--border-color); border-radius:6px; padding:10px 16px; min-width:120px; text-align:center;">
-			<div style="font-size:20px; font-weight:700; color:var(--text-primary);">${formatNumber(availableTools.length)}</div>
+			<div style="font-size:20px; font-weight:700; color:var(--text-primary);">${g(e.length)}</div>
 			<div style="font-size:11px; color:var(--text-primary); opacity:0.75;">Available</div>
 		</div>
 		<div style="background:var(--bg-tertiary); border:1px solid var(--border-color); border-radius:6px; padding:10px 16px; min-width:120px; text-align:center;">
-			<div style="font-size:20px; font-weight:700; color:#4ade80;">${formatNumber(usedCount)}</div>
+			<div style="font-size:20px; font-weight:700; color:#4ade80;">${g(n)}</div>
 			<div style="font-size:11px; color:var(--text-primary); opacity:0.75;">Used</div>
 		</div>
-		<div style="background:${severityColor}; border:1px solid ${severityBorder}; border-radius:6px; padding:10px 16px; min-width:120px; text-align:center;">
-			<div style="font-size:20px; font-weight:700; color:${unusedColor};">${formatNumber(unusedTools.length)}</div>
+		<div style="background:${s}; border:1px solid ${r}; border-radius:6px; padding:10px 16px; min-width:120px; text-align:center;">
+			<div style="font-size:20px; font-weight:700; color:${i};">${g(t.length)}</div>
 			<div style="font-size:11px; color:var(--text-primary); opacity:0.75;">Unused</div>
 		</div>
-		${actionableBloat > 0 ? `<div style="background:rgba(239,68,68,0.1); border:1px solid rgba(239,68,68,0.3); border-radius:6px; padding:10px 16px; min-width:140px; text-align:center;" title="Overhead you can reduce by disabling unused MCP servers or removing unused skills">
-			<div style="font-size:20px; font-weight:700; color:#f87171;">${fmt(actionableBloat)}</div>
+		${b>0?`<div style="background:rgba(239,68,68,0.1); border:1px solid rgba(239,68,68,0.3); border-radius:6px; padding:10px 16px; min-width:140px; text-align:center;" title="Overhead you can reduce by disabling unused MCP servers or removing unused skills">
+			<div style="font-size:20px; font-weight:700; color:#f87171;">${p(b)}</div>
 			<div style="font-size:11px; color:var(--text-primary); opacity:0.75;">Actionable overhead</div>
-			${actionableParts.length > 0 ? `<div style="font-size:10px; color:var(--text-secondary); margin-top:2px;">${escapeHtml(actionableParts.join(" + "))}</div>` : ""}
-		</div>` : ""}
-		${builtinBloat > 0 ? `<div style="background:var(--bg-tertiary); border:1px solid var(--border-color); border-radius:6px; padding:10px 16px; min-width:140px; text-align:center; opacity:0.7;" title="Overhead from VS Code built-in tools \u2014 cannot be disabled">
-			<div style="font-size:20px; font-weight:700; color:var(--text-secondary);">${fmt(builtinBloat)}</div>
+			${h.length>0?`<div style="font-size:10px; color:var(--text-secondary); margin-top:2px;">${d(h.join(" + "))}</div>`:""}
+		</div>`:""}
+		${u>0?`<div style="background:var(--bg-tertiary); border:1px solid var(--border-color); border-radius:6px; padding:10px 16px; min-width:140px; text-align:center; opacity:0.7;" title="Overhead from VS Code built-in tools \u2014 cannot be disabled">
+			<div style="font-size:20px; font-weight:700; color:var(--text-secondary);">${p(u)}</div>
 			<div style="font-size:11px; color:var(--text-primary); opacity:0.75;">Built-in overhead</div>
 			<div style="font-size:10px; color:var(--text-secondary); margin-top:2px;">not actionable</div>
-		</div>` : ""}
-	</div>`;
-  }
-  function _mcpSourceLabel(s4) {
-    if (s4.extensionId) {
-      return "Extension";
-    }
-    if (!s4.configFiles || s4.configFiles.length === 0) {
-      return "Settings";
-    }
-    const labels = /* @__PURE__ */ new Set();
-    for (const f3 of s4.configFiles) {
-      const p3 = f3.replace(/\\/g, "/");
-      if (p3.includes("/.vscode/")) {
-        labels.add("Workspace");
-      } else if (p3.includes("/.vs/")) {
-        labels.add("Workspace (VS)");
-      } else if (p3.includes("/.cursor/")) {
-        labels.add("Workspace (Cursor)");
-      } else if (p3.endsWith("/.mcp.json")) {
-        labels.add(p3.split("/").slice(-2).join("/"));
-      } else {
-        labels.add("Config file");
-      }
-    }
-    return [...labels].join(", ");
-  }
-  function _buildMcpSourceOpenBtn(s4, sourceTip) {
-    if (s4.configFiles && s4.configFiles.length === 1) {
-      return ` <button class="curation-file-btn" data-command="openFile" data-path="${escapeHtml(s4.configFiles[0])}" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:11px;text-decoration:underline;" title="Open ${escapeHtml(s4.configFiles[0])}">open</button>`;
-    }
-    if (s4.configFiles && s4.configFiles.length > 1) {
-      return ` <button class="curation-file-btn" data-command="openFileFromList" data-paths="${escapeHtml(JSON.stringify(s4.configFiles))}" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:11px;text-decoration:underline;" title="${escapeHtml(sourceTip)}">open</button>`;
-    }
-    if (s4.extensionId) {
-      return ` <button class="curation-file-btn" data-command="manageExtension" data-extension-id="${escapeHtml(s4.extensionId)}" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:11px;text-decoration:underline;" title="Open Extensions view for ${escapeHtml(s4.extensionId)}">open</button>`;
-    }
-    return ` <button class="curation-file-btn" data-command="searchMcpExtensions" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:11px;text-decoration:underline;" title="Browse MCP extensions in the marketplace">open</button>`;
-  }
-  function _buildMcpActionCell(s4) {
-    if (s4.extensionId) {
-      return `<button class="curation-file-btn" data-command="manageExtension" data-extension-id="${escapeHtml(s4.extensionId)}" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:11px;text-decoration:underline;" title="Open the Extensions view for ${escapeHtml(s4.extensionId)} (disable or uninstall to reclaim prompt budget)">Manage Extension</button>`;
-    }
-    if (!s4.configFiles || s4.configFiles.length === 0) {
-      return `<button class="curation-file-btn" data-command="openToolPicker" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:11px;text-decoration:underline;" title="Open VS Code tool selection menu">Change Tools</button>`;
-    }
-    if (s4.configFiles.length === 1) {
-      return `<button class="curation-file-btn" data-command="openFile" data-path="${escapeHtml(s4.configFiles[0])}" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:11px;text-decoration:underline;" title="Open ${escapeHtml(s4.configFiles[0])}">Change Tools</button>`;
-    }
-    return `<button class="curation-file-btn" data-command="openFileFromList" data-paths="${escapeHtml(JSON.stringify(s4.configFiles))}" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:11px;text-decoration:underline;" title="Defined in ${s4.configFiles.length} config files">Change Tools</button>`;
-  }
-  function _buildMcpServerRowHtml(s4, bloat) {
-    const b3 = bloat.byServer[s4.server] ?? 0;
-    const sourceLabel = _mcpSourceLabel(s4);
-    const sourceTip = s4.configFiles?.join("\n") ?? s4.extensionId ?? "";
-    const sourceOpenBtn = _buildMcpSourceOpenBtn(s4, sourceTip);
-    const actionCell = _buildMcpActionCell(s4);
-    const notConnected = s4.availableToolCount === 0;
-    return `<tr class="${s4.usedToolCount > 0 ? "mcp-has-usage" : ""}">
-		<td style="padding:5px 8px; color:var(--text-primary); font-size:12px; white-space:nowrap;">${escapeHtml(s4.server)}</td>
-		<td style="padding:5px 8px; color:var(--text-primary); font-size:12px; white-space:nowrap;" title="${escapeHtml(sourceTip)}">${escapeHtml(sourceLabel)}${sourceOpenBtn}</td>
-		<td style="padding:5px 8px; color:var(--text-primary); font-size:12px;">${notConnected ? '<em style="color:var(--text-secondary)">not connected</em>' : s4.availableToolCount}</td>
-		<td style="padding:5px 8px; color:var(--text-primary); font-size:12px;">${notConnected ? "\u2014" : s4.usedToolCount}</td>
-		<td style="padding:5px 8px; color:var(--text-primary); font-size:12px;">${b3 > 0 ? `~${b3.toLocaleString()} tokens` : "\u2014"}</td>
-		<td style="padding:5px 8px; font-size:12px;">${actionCell}</td>
-	</tr>`;
-  }
-  function _buildMcpJsonLink(allServers) {
-    const allConfigFiles = [...new Set(
-      allServers.filter((s4) => !s4.extensionId).flatMap((s4) => s4.configFiles ?? [])
-    )];
-    const preferredFile = allConfigFiles.find((f3) => f3.replace(/\\/g, "/").endsWith(".vscode/mcp.json")) ?? allConfigFiles[0];
-    if (!preferredFile) {
-      return `<code>.vscode/mcp.json</code>`;
-    }
-    const displayName = preferredFile.replace(/\\/g, "/").split("/").slice(-3).join("/");
-    return `<button class="curation-file-btn" data-command="openFile" data-path="${escapeHtml(preferredFile)}" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:11px;text-decoration:underline;" title="${escapeHtml(preferredFile)}">${escapeHtml(displayName)}</button>`;
-  }
-  function buildUnusedMcpHtml(underusedMcpServers, bloat, windowDays) {
-    const allServers = [...underusedMcpServers].sort((a3, b3) => {
-      const aKey = a3.usedToolCount === 0 ? 0 : a3.usedToolCount < a3.availableToolCount ? 1 : 2;
-      const bKey = b3.usedToolCount === 0 ? 0 : b3.usedToolCount < b3.availableToolCount ? 1 : 2;
-      return aKey !== bKey ? aKey - bKey : a3.usedToolCount - b3.usedToolCount;
-    });
-    if (allServers.length === 0) {
-      return "";
-    }
-    const rows = allServers.map((s4) => _buildMcpServerRowHtml(s4, bloat)).join("");
-    const mcpJsonLink = _buildMcpJsonLink(allServers);
-    const usedCount = allServers.filter((s4) => s4.usedToolCount > 0).length;
-    const unusedCount = allServers.length - usedCount;
-    return `<details style="margin-top:12px;" open>
+		</div>`:""}
+	</div>`}function La(e){if(e.extensionId)return"Extension";if(!e.configFiles||e.configFiles.length===0)return"Settings";let t=new Set;for(let o of e.configFiles){let n=o.replace(/\\/g,"/");n.includes("/.vscode/")?t.add("Workspace"):n.includes("/.vs/")?t.add("Workspace (VS)"):n.includes("/.cursor/")?t.add("Workspace (Cursor)"):n.endsWith("/.mcp.json")?t.add(n.split("/").slice(-2).join("/")):t.add("Config file")}return[...t].join(", ")}function Ua(e,t){return e.configFiles&&e.configFiles.length===1?` <button class="curation-file-btn" data-command="openFile" data-path="${d(e.configFiles[0])}" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:11px;text-decoration:underline;" title="Open ${d(e.configFiles[0])}">open</button>`:e.configFiles&&e.configFiles.length>1?` <button class="curation-file-btn" data-command="openFileFromList" data-paths="${d(JSON.stringify(e.configFiles))}" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:11px;text-decoration:underline;" title="${d(t)}">open</button>`:e.extensionId?` <button class="curation-file-btn" data-command="manageExtension" data-extension-id="${d(e.extensionId)}" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:11px;text-decoration:underline;" title="Open Extensions view for ${d(e.extensionId)}">open</button>`:' <button class="curation-file-btn" data-command="searchMcpExtensions" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:11px;text-decoration:underline;" title="Browse MCP extensions in the marketplace">open</button>'}function Ia(e){return e.extensionId?`<button class="curation-file-btn" data-command="manageExtension" data-extension-id="${d(e.extensionId)}" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:11px;text-decoration:underline;" title="Open the Extensions view for ${d(e.extensionId)} (disable or uninstall to reclaim prompt budget)">Manage Extension</button>`:!e.configFiles||e.configFiles.length===0?'<button class="curation-file-btn" data-command="openToolPicker" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:11px;text-decoration:underline;" title="Open VS Code tool selection menu">Change Tools</button>':e.configFiles.length===1?`<button class="curation-file-btn" data-command="openFile" data-path="${d(e.configFiles[0])}" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:11px;text-decoration:underline;" title="Open ${d(e.configFiles[0])}">Change Tools</button>`:`<button class="curation-file-btn" data-command="openFileFromList" data-paths="${d(JSON.stringify(e.configFiles))}" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:11px;text-decoration:underline;" title="Defined in ${e.configFiles.length} config files">Change Tools</button>`}function za(e,t){let o=t.byServer[e.server]??0,n=La(e),s=e.configFiles?.join(`
+`)??e.extensionId??"",r=Ua(e,s),i=Ia(e),a=e.availableToolCount===0;return`<tr class="${e.usedToolCount>0?"mcp-has-usage":""}">
+		<td style="padding:5px 8px; color:var(--text-primary); font-size:12px; white-space:nowrap;">${d(e.server)}</td>
+		<td style="padding:5px 8px; color:var(--text-primary); font-size:12px; white-space:nowrap;" title="${d(s)}">${d(n)}${r}</td>
+		<td style="padding:5px 8px; color:var(--text-primary); font-size:12px;">${a?'<em style="color:var(--text-secondary)">not connected</em>':e.availableToolCount}</td>
+		<td style="padding:5px 8px; color:var(--text-primary); font-size:12px;">${a?"\u2014":e.usedToolCount}</td>
+		<td style="padding:5px 8px; color:var(--text-primary); font-size:12px;">${o>0?`~${o.toLocaleString()} tokens`:"\u2014"}</td>
+		<td style="padding:5px 8px; font-size:12px;">${i}</td>
+	</tr>`}function Ba(e){let t=[...new Set(e.filter(s=>!s.extensionId).flatMap(s=>s.configFiles??[]))],o=t.find(s=>s.replace(/\\/g,"/").endsWith(".vscode/mcp.json"))??t[0];if(!o)return"<code>.vscode/mcp.json</code>";let n=o.replace(/\\/g,"/").split("/").slice(-3).join("/");return`<button class="curation-file-btn" data-command="openFile" data-path="${d(o)}" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:11px;text-decoration:underline;" title="${d(o)}">${d(n)}</button>`}function Oa(e,t,o){let n=[...e].sort((l,u)=>{let c=l.usedToolCount===0?0:l.usedToolCount<l.availableToolCount?1:2,p=u.usedToolCount===0?0:u.usedToolCount<u.availableToolCount?1:2;return c!==p?c-p:l.usedToolCount-u.usedToolCount});if(n.length===0)return"";let s=n.map(l=>za(l,t)).join(""),r=Ba(n),i=n.filter(l=>l.usedToolCount>0).length,a=n.length-i;return`<details style="margin-top:12px;" open>
 		<summary style="cursor:pointer; font-size:13px; font-weight:600; color:var(--text-primary); padding:6px 0;">
-			\u{1F50C} MCP Servers in Last ${windowDays} Days (${allServers.length})
+			\u{1F50C} MCP Servers in Last ${o} Days (${n.length})
 		</summary>
 		<style>#mcp-hide-toggle:checked ~ .mcp-table-wrap .mcp-has-usage { display: none; }</style>
 		<div style="display:flex; align-items:center; gap:6px; margin:6px 0;">
 			<input type="checkbox" id="mcp-hide-toggle" checked style="margin:0; cursor:pointer; flex-shrink:0;">
 			<label for="mcp-hide-toggle" style="font-size:12px; color:var(--text-primary); cursor:pointer; user-select:none;">Hide servers with usage</label>
-			<span style="font-size:11px; color:var(--text-secondary);">${unusedCount} with no usage \xB7 ${usedCount} with usage</span>
+			<span style="font-size:11px; color:var(--text-secondary);">${a} with no usage \xB7 ${i} with usage</span>
 		</div>
 		<div class="mcp-table-wrap" style="margin-top:8px; overflow-x:auto;">
 			<table style="width:100%; border-collapse:collapse; font-size:12px;">
@@ -6311,47 +2392,19 @@ ${_renderMultiModelMixedCostSessions(switching)}
 					<th style="padding:5px 8px; text-align:left; color:var(--text-primary); font-weight:600; font-size:12px;">Est. Overhead</th>
 					<th style="padding:5px 8px; text-align:left; color:var(--text-primary); font-weight:600; font-size:12px;">Action</th>
 				</tr></thead>
-				<tbody>${rows}</tbody>
+				<tbody>${s}</tbody>
 			</table>
-			<div style="margin-top:8px; font-size:11px; color:var(--text-secondary);">\u{1F4A1} Open ${mcpJsonLink} to disable file-configured servers, or use <em>Manage Extension</em> to disable or uninstall an MCP-providing extension. (VS Code does not expose per-server picker state to extensions, so servers you disabled in the chat tool picker may still appear here.)</div>
+			<div style="margin-top:8px; font-size:11px; color:var(--text-secondary);">\u{1F4A1} Open ${r} to disable file-configured servers, or use <em>Manage Extension</em> to disable or uninstall an MCP-providing extension. (VS Code does not expose per-server picker state to extensions, so servers you disabled in the chat tool picker may still appear here.)</div>
 		</div>
-	</details>`;
-  }
-  function buildUnusedSkillsHtml(unusedSkills) {
-    if (unusedSkills.length === 0) {
-      return "";
-    }
-    const rows = unusedSkills.map((s4) => {
-      const skillFile = s4.configFiles?.[0];
-      const viewLink = skillFile ? `<button class="curation-file-btn" data-command="openFile" data-path="${escapeHtml(skillFile)}" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:12px;text-decoration:underline;" title="Open ${escapeHtml(skillFile)}">View skill</button>` : "\u2014";
-      let sourceLabel = "\u2014";
-      let manageBtn = "";
-      if (s4.pluginName) {
-        sourceLabel = `Plugin: ${s4.pluginName}`;
-        manageBtn = ` <button class="curation-file-btn" data-command="openAgentPlugins" data-plugin-name="${escapeHtml(s4.pluginName)}" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:11px;text-decoration:underline;" title="Open Extensions view filtered to agent plugins">manage</button>`;
-      } else if (s4.skillPath) {
-        if (s4.skillPath.startsWith(".github/skills")) {
-          sourceLabel = "Workspace (.github)";
-        } else if (s4.skillPath.startsWith(".claude/skills")) {
-          sourceLabel = "Workspace (.claude)";
-        } else if (s4.skillPath.startsWith(".agents/skills")) {
-          sourceLabel = "Workspace (.agents)";
-        } else {
-          sourceLabel = "User (~)";
-        }
-      }
-      const estTokens = Math.round((s4.name.length + s4.description.length + 10) / 4);
-      return `<tr>
-		<td style="padding:5px 8px; color:var(--text-primary); font-size:12px; white-space:nowrap;">${escapeHtml(s4.name)}</td>
-		<td style="padding:5px 8px; color:var(--text-primary); font-size:12px; white-space:nowrap;">${escapeHtml(sourceLabel)}${manageBtn}</td>
-		<td style="padding:5px 8px; color:var(--text-primary); font-size:12px; max-width:320px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;" title="${escapeHtml(s4.description)}">${escapeHtml(s4.description)}</td>
-		<td style="padding:5px 8px; color:var(--text-primary); font-size:12px; white-space:nowrap;">~${estTokens.toLocaleString()} tokens</td>
-		<td style="padding:5px 8px; font-size:12px; white-space:nowrap;">${viewLink}</td>
-	</tr>`;
-    }).join("");
-    return `<details style="margin-top:8px;" open>
+	</details>`}function Na(e){if(e.length===0)return"";let t=e.map(o=>{let n=o.configFiles?.[0],s=n?`<button class="curation-file-btn" data-command="openFile" data-path="${d(n)}" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:12px;text-decoration:underline;" title="Open ${d(n)}">View skill</button>`:"\u2014",r="\u2014",i="";o.pluginName?(r=`Plugin: ${o.pluginName}`,i=` <button class="curation-file-btn" data-command="openAgentPlugins" data-plugin-name="${d(o.pluginName)}" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:11px;text-decoration:underline;" title="Open Extensions view filtered to agent plugins">manage</button>`):o.skillPath&&(o.skillPath.startsWith(".github/skills")?r="Workspace (.github)":o.skillPath.startsWith(".claude/skills")?r="Workspace (.claude)":o.skillPath.startsWith(".agents/skills")?r="Workspace (.agents)":r="User (~)");let a=Math.round((o.name.length+o.description.length+10)/4);return`<tr>
+		<td style="padding:5px 8px; color:var(--text-primary); font-size:12px; white-space:nowrap;">${d(o.name)}</td>
+		<td style="padding:5px 8px; color:var(--text-primary); font-size:12px; white-space:nowrap;">${d(r)}${i}</td>
+		<td style="padding:5px 8px; color:var(--text-primary); font-size:12px; max-width:320px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;" title="${d(o.description)}">${d(o.description)}</td>
+		<td style="padding:5px 8px; color:var(--text-primary); font-size:12px; white-space:nowrap;">~${a.toLocaleString()} tokens</td>
+		<td style="padding:5px 8px; font-size:12px; white-space:nowrap;">${s}</td>
+	</tr>`}).join("");return`<details style="margin-top:8px;" open>
 		<summary style="cursor:pointer; font-size:13px; font-weight:600; color:var(--text-primary); padding:6px 0;">
-			\u{1F4DA} Unused Skills (${unusedSkills.length})
+			\u{1F4DA} Unused Skills (${e.length})
 		</summary>
 		<div style="margin-top:8px; overflow-x:auto;">
 			<table style="width:100%; border-collapse:collapse; font-size:12px;">
@@ -6362,37 +2415,24 @@ ${_renderMultiModelMixedCostSessions(switching)}
 					<th style="padding:5px 8px; text-align:left; color:var(--text-primary); font-weight:600; font-size:12px;">Est. Overhead</th>
 					<th style="padding:5px 8px; text-align:left; color:var(--text-primary); font-weight:600; font-size:12px;">View</th>
 				</tr></thead>
-				<tbody>${rows}</tbody>
+				<tbody>${t}</tbody>
 			</table>
 			<div style="margin-top:8px; font-size:11px; color:var(--text-secondary);">\u{1F4A1} Est. overhead is per agent interaction. For plugin skills, click <em>manage</em> to open the agent plugins view where you can uninstall the plugin. For workspace skills, update the description or remove the SKILL.md.</div>
 		</div>
-	</details>`;
-  }
-  function buildUnderusedAgentPluginsHtml(underusedAgentPlugins, windowDays) {
-    if (underusedAgentPlugins.length === 0) {
-      return "";
-    }
-    const rows = underusedAgentPlugins.map((p3) => {
-      const manageBtn = `<button class="curation-file-btn" data-command="openAgentPlugins" data-plugin-name="${escapeHtml(p3.pluginName)}" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:11px;text-decoration:underline;" title="Open Extensions view filtered to @agentPlugins ${escapeHtml(p3.pluginName)}">Manage Plugin</button>`;
-      const usageClass = p3.usedSkillCount === 0 ? "" : "plugin-has-usage";
-      return `<tr class="${usageClass}">
-			<td style="padding:5px 8px; color:var(--text-primary); font-size:12px; white-space:nowrap;">${escapeHtml(p3.pluginName)}</td>
-			<td style="padding:5px 8px; color:var(--text-primary); font-size:12px;">${p3.availableSkillCount}</td>
-			<td style="padding:5px 8px; color:var(--text-primary); font-size:12px;">${p3.usedSkillCount}</td>
-			<td style="padding:5px 8px; font-size:12px;">${manageBtn}</td>
-		</tr>`;
-    }).join("");
-    const unusedCount = underusedAgentPlugins.filter((p3) => p3.usedSkillCount === 0).length;
-    const usedCount = underusedAgentPlugins.length - unusedCount;
-    return `<details style="margin-top:8px;" open>
+	</details>`}function Ha(e,t){if(e.length===0)return"";let o=e.map(r=>{let i=`<button class="curation-file-btn" data-command="openAgentPlugins" data-plugin-name="${d(r.pluginName)}" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:11px;text-decoration:underline;" title="Open Extensions view filtered to @agentPlugins ${d(r.pluginName)}">Manage Plugin</button>`;return`<tr class="${r.usedSkillCount===0?"":"plugin-has-usage"}">
+			<td style="padding:5px 8px; color:var(--text-primary); font-size:12px; white-space:nowrap;">${d(r.pluginName)}</td>
+			<td style="padding:5px 8px; color:var(--text-primary); font-size:12px;">${r.availableSkillCount}</td>
+			<td style="padding:5px 8px; color:var(--text-primary); font-size:12px;">${r.usedSkillCount}</td>
+			<td style="padding:5px 8px; font-size:12px;">${i}</td>
+		</tr>`}).join(""),n=e.filter(r=>r.usedSkillCount===0).length,s=e.length-n;return`<details style="margin-top:8px;" open>
 		<summary style="cursor:pointer; font-size:13px; font-weight:600; color:var(--text-primary); padding:6px 0;">
-			\u{1F9E9} Agent Plugins in Last ${windowDays} Days (${underusedAgentPlugins.length})
+			\u{1F9E9} Agent Plugins in Last ${t} Days (${e.length})
 		</summary>
 		<style>#plugin-hide-toggle:checked ~ .plugin-table-wrap .plugin-has-usage { display: none; }</style>
 		<div style="display:flex; align-items:center; gap:6px; margin:6px 0;">
 			<input type="checkbox" id="plugin-hide-toggle" checked style="margin:0; cursor:pointer; flex-shrink:0;">
 			<label for="plugin-hide-toggle" style="font-size:12px; color:var(--text-primary); cursor:pointer; user-select:none;">Hide plugins with usage</label>
-			<span style="font-size:11px; color:var(--text-secondary);">${unusedCount} with no usage \xB7 ${usedCount} with usage</span>
+			<span style="font-size:11px; color:var(--text-secondary);">${n} with no usage \xB7 ${s} with usage</span>
 		</div>
 		<div class="plugin-table-wrap" style="margin-top:8px; overflow-x:auto;">
 			<table style="width:100%; border-collapse:collapse; font-size:12px;">
@@ -6402,29 +2442,17 @@ ${_renderMultiModelMixedCostSessions(switching)}
 					<th style="padding:5px 8px; text-align:left; color:var(--text-primary); font-weight:600; font-size:12px;">Skills Used</th>
 					<th style="padding:5px 8px; text-align:left; color:var(--text-primary); font-weight:600; font-size:12px;">Action</th>
 				</tr></thead>
-				<tbody>${rows}</tbody>
+				<tbody>${o}</tbody>
 			</table>
 			<div style="margin-top:8px; font-size:11px; color:var(--text-secondary);">\u{1F4A1} Click <em>Manage Plugin</em> to open the Extensions view filtered to <code>@agentPlugins</code> where you can uninstall unused plugins to reclaim prompt budget.</div>
 		</div>
-	</details>`;
-  }
-  function buildBuiltinToolsHtml(builtinTools, bloat) {
-    if (builtinTools.length === 0) {
-      return "";
-    }
-    const builtinBloat = bloat.byServer["builtin"] ?? 0;
-    const rows = builtinTools.map((t4) => {
-      const overhead = Math.round((t4.name.length + (t4.description?.length ?? 0) + 10) / 4);
-      return `<tr>
-			<td style="padding:5px 8px; color:var(--text-primary); font-size:12px; white-space:nowrap;">${escapeHtml(t4.name)}</td>
-			<td style="padding:5px 8px; color:var(--text-primary); font-size:12px; max-width:400px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;" title="${escapeHtml(t4.description ?? "")}">${escapeHtml(t4.description ?? "\u2014")}</td>
-			<td style="padding:5px 8px; color:var(--text-primary); font-size:12px; white-space:nowrap;">~${overhead} tokens</td>
-		</tr>`;
-    }).join("");
-    const fmt = (n5) => n5 >= 1e3 ? `~${Math.round(n5 / 1e3)}K` : `~${n5}`;
-    return `<details style="margin-top:12px;">
+	</details>`}function ja(e,t){if(e.length===0)return"";let o=t.byServer.builtin??0,n=e.map(r=>{let i=Math.round((r.name.length+(r.description?.length??0)+10)/4);return`<tr>
+			<td style="padding:5px 8px; color:var(--text-primary); font-size:12px; white-space:nowrap;">${d(r.name)}</td>
+			<td style="padding:5px 8px; color:var(--text-primary); font-size:12px; max-width:400px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;" title="${d(r.description??"")}">${d(r.description??"\u2014")}</td>
+			<td style="padding:5px 8px; color:var(--text-primary); font-size:12px; white-space:nowrap;">~${i} tokens</td>
+		</tr>`}).join(""),s=r=>r>=1e3?`~${Math.round(r/1e3)}K`:`~${r}`;return`<details style="margin-top:12px;">
 		<summary style="cursor:pointer; font-size:13px; font-weight:600; color:var(--text-primary); padding:6px 0;">
-			\u{1F527} Built-in VS Code Tools (${builtinTools.length}) \u2014 ${fmt(builtinBloat)} tokens overhead, not actionable
+			\u{1F527} Built-in VS Code Tools (${e.length}) \u2014 ${s(o)} tokens overhead, not actionable
 		</summary>
 		<div style="margin-top:8px; overflow-x:auto;">
 			<table style="width:100%; border-collapse:collapse; font-size:12px;">
@@ -6433,247 +2461,131 @@ ${_renderMultiModelMixedCostSessions(switching)}
 					<th style="padding:5px 8px; text-align:left; color:var(--text-primary); font-weight:600; font-size:12px;">Description</th>
 					<th style="padding:5px 8px; text-align:left; color:var(--text-primary); font-weight:600; font-size:12px;">Est. Overhead</th>
 				</tr></thead>
-				<tbody>${rows}</tbody>
+				<tbody>${n}</tbody>
 			</table>
 			<div style="margin-top:8px; font-size:11px; color:var(--text-secondary);">\u{1F4A1} These tools are provided by VS Code itself and cannot be disabled. They are excluded from the actionable overhead total above.</div>
 		</div>
-	</details>`;
-  }
-  function buildCurationSectionHtml(curation) {
-    try {
-      if (!curation || curation.availableTools.length === 0) {
-        traceCurationOnce("render-hidden-empty", "buildCurationSectionHtml.hidden", {
-          hasCurationObject: !!curation,
-          availableTools: curation?.availableTools?.length ?? 0
-        });
-        return "";
-      }
-      const { availableTools, unusedTools, underusedMcpServers, underusedAgentPlugins, estimatedPromptBloat, windowDays } = curation;
-      const unusedSkills = unusedTools.filter((t4) => t4.source === "skill");
-      const builtinTools = availableTools.filter((t4) => t4.source === "builtin");
-      traceCuration("buildCurationSectionHtml.render", {
-        availableTools: availableTools.length,
-        unusedTools: unusedTools.length,
-        unusedSkills: unusedSkills.length,
-        mcpServers: underusedMcpServers.length
-      });
-      return `
+	</details>`}function Fa(e){try{if(!e||e.availableTools.length===0)return pe("render-hidden-empty","buildCurationSectionHtml.hidden",{hasCurationObject:!!e,availableTools:e?.availableTools?.length??0}),"";let{availableTools:t,unusedTools:o,underusedMcpServers:n,underusedAgentPlugins:s,estimatedPromptBloat:r,windowDays:i}=e,a=o.filter(u=>u.source==="skill"),l=t.filter(u=>u.source==="builtin");return Z("buildCurationSectionHtml.render",{availableTools:t.length,unusedTools:o.length,unusedSkills:a.length,mcpServers:n.length}),`
 			<!-- Tool Curation Section -->
 			<div id="section-tool-curation" class="section">
 				<div class="section-title"><span>\u2702\uFE0F</span><span>Tool Curation</span></div>
-				<div class="section-subtitle" style="color:var(--text-primary); opacity:0.75;">Compare available tools against actual usage to reduce prompt overhead (last ${windowDays} days)</div>
-				${buildCurationSummaryHtml(availableTools, unusedTools, estimatedPromptBloat)}
-				${buildUnusedMcpHtml(underusedMcpServers, estimatedPromptBloat, windowDays)}
-				${buildUnderusedAgentPluginsHtml(underusedAgentPlugins, windowDays)}
-				${buildBuiltinToolsHtml(builtinTools, estimatedPromptBloat)}
-				${buildUnusedSkillsHtml(unusedSkills)}
-			</div>`;
-    } catch (error) {
-      traceCuration("buildCurationSectionHtml.error", {
-        error: error instanceof Error ? error.message : String(error)
-      });
-      return `
+				<div class="section-subtitle" style="color:var(--text-primary); opacity:0.75;">Compare available tools against actual usage to reduce prompt overhead (last ${i} days)</div>
+				${Da(t,o,r)}
+				${Oa(n,r,i)}
+				${Ha(s,i)}
+				${ja(l,r)}
+				${Na(a)}
+			</div>`}catch(t){return Z("buildCurationSectionHtml.error",{error:t instanceof Error?t.message:String(t)}),`
 			<div id="section-tool-curation" class="section">
 				<div class="section-title"><span>\u2702\uFE0F</span><span>Tool Curation</span></div>
 				<div class="section-subtitle" style="color:var(--text-primary); opacity:0.75;">Tool curation is temporarily unavailable due to a rendering error. Try Refresh.</div>
-			</div>`;
-    }
-  }
-  function buildReposAndAgentTabPanelsHtml() {
-    return `
-		<div id="tab-panel-repos" class="tab-panel"${activeTab !== "repos" ? ' style="display:none"' : ""}>
+			</div>`}}function Wa(){return`
+		<div id="tab-panel-repos" class="tab-panel"${$!=="repos"?' style="display:none"':""}>
 			<div class="section" id="repos-pr-content">
 				<div class="section-title"><span>\u{1F916}</span><span>AI Activity in Repository PRs</span></div>
 				<div class="section-subtitle">PRs from the last 30 days across your known repositories \u2014 authored or reviewed by AI agents.</div>
 				<div style="margin-top:12px; color: var(--text-secondary); font-size:12px;">Loading\u2026 (sign in with GitHub to see data)</div>
 			</div>
 		</div>
-		<div id="tab-panel-agent" class="tab-panel"${activeTab !== "agent" ? ' style="display:none"' : ""}>
+		<div id="tab-panel-agent" class="tab-panel"${$!=="agent"?' style="display:none"':""}>
 			<div class="section" id="agent-sessions-content">
 				<div class="section-title"><span>\u{1F916}</span><span>Copilot Cloud Agent Sessions</span></div>
 				<div class="section-subtitle">Cloud agent tasks and sessions from the last 30 days, fetched from the GitHub API.</div>
 				<div style="margin-top:12px; color: var(--text-secondary); font-size:12px;">Loading\u2026 (sign in with GitHub to see data)</div>
 			</div>
-		</div>`;
-  }
-  function buildInsightCardHtml(insight) {
-    const severityColors = {
-      tip: "rgba(96,165,250,0.12)",
-      opportunity: "rgba(251,191,36,0.12)",
-      celebration: "rgba(74,222,128,0.12)"
-    };
-    const severityBorder = {
-      tip: "rgba(96,165,250,0.5)",
-      opportunity: "rgba(251,191,36,0.5)",
-      celebration: "rgba(74,222,128,0.5)"
-    };
-    const severityAccent = {
-      tip: "rgba(96,165,250,0.85)",
-      opportunity: "rgba(251,191,36,0.85)",
-      celebration: "rgba(74,222,128,0.85)"
-    };
-    const bg = severityColors[insight.severity] ?? severityColors.tip;
-    const border = severityBorder[insight.severity] ?? severityBorder.tip;
-    const accent = severityAccent[insight.severity] ?? severityAccent.tip;
-    const isNew = insight.status === "new";
-    const isDone = insight.status === "done";
-    const actionBtn = insight.actionLabel ? `<button class="insight-action-btn" data-insight-id="${escapeHtml(insight.id)}" data-action="execute" data-command="${escapeHtml(insight.actionCommand ?? "")}"
+		</div>`}function Nt(e){let t={tip:"rgba(96,165,250,0.12)",opportunity:"rgba(251,191,36,0.12)",celebration:"rgba(74,222,128,0.12)"},o={tip:"rgba(96,165,250,0.5)",opportunity:"rgba(251,191,36,0.5)",celebration:"rgba(74,222,128,0.5)"},n={tip:"rgba(96,165,250,0.85)",opportunity:"rgba(251,191,36,0.85)",celebration:"rgba(74,222,128,0.85)"},s=t[e.severity]??t.tip,r=o[e.severity]??o.tip,i=n[e.severity]??n.tip,a=e.status==="new",l=e.status==="done",u=e.actionLabel?`<button class="insight-action-btn" data-insight-id="${d(e.id)}" data-action="execute" data-command="${d(e.actionCommand??"")}"
 				style="padding:5px 14px; font-size:12px; font-weight:600; cursor:pointer;
-				border:1px solid ${border}; border-radius:5px;
-				background:${bg}; color:var(--text-primary);">${escapeHtml(insight.actionLabel)}</button>` : "";
-    const doneBtn = !isDone ? `<button class="insight-action-btn" data-insight-id="${escapeHtml(insight.id)}" data-action="done"
+				border:1px solid ${r}; border-radius:5px;
+				background:${s}; color:var(--text-primary);">${d(e.actionLabel)}</button>`:"",c=l?'<span style="font-size:12px; color:var(--text-secondary); opacity:0.5; padding:5px 6px;">\u2713 Done</span>':`<button class="insight-action-btn" data-insight-id="${d(e.id)}" data-action="done"
 				title="Mark as done"
 				style="padding:5px 14px; font-size:12px; font-weight:600; cursor:pointer;
-				border:1px solid ${border}; border-radius:5px;
-				background:${accent}; color:#0d1117;">\u2713 Done</button>` : `<span style="font-size:12px; color:var(--text-secondary); opacity:0.5; padding:5px 6px;">\u2713 Done</span>`;
-    const snoozeBtn = !isDone ? `<button class="insight-action-btn" data-insight-id="${escapeHtml(insight.id)}" data-action="snooze"
+				border:1px solid ${r}; border-radius:5px;
+				background:${i}; color:#0d1117;">\u2713 Done</button>`,p=l?"":`<button class="insight-action-btn" data-insight-id="${d(e.id)}" data-action="snooze"
 				title="Snooze for 7 days"
 				style="padding:5px 14px; font-size:12px; font-weight:500; cursor:pointer;
-				border:1px solid ${border}; border-radius:5px;
-				background:transparent; color:var(--text-primary);">\u23F8 Snooze</button>` : "";
-    const dismissBtn = !isDone ? `<button class="insight-action-btn" data-insight-id="${escapeHtml(insight.id)}" data-action="dismiss"
+				border:1px solid ${r}; border-radius:5px;
+				background:transparent; color:var(--text-primary);">\u23F8 Snooze</button>`,b=l?"":`<button class="insight-action-btn" data-insight-id="${d(e.id)}" data-action="dismiss"
 				title="Dismiss permanently"
 				style="padding:4px 8px; font-size:14px; line-height:1; cursor:pointer; border:none; border-radius:4px;
-				background:transparent; color:var(--text-primary); opacity:0.5;">\u2715</button>` : "";
-    return `
-		<div class="insight-card" data-insight-id="${escapeHtml(insight.id)}"
+				background:transparent; color:var(--text-primary); opacity:0.5;">\u2715</button>`;return`
+		<div class="insight-card" data-insight-id="${d(e.id)}"
 			style="margin-bottom:12px; padding:16px 18px; border-radius:8px;
-			background:${bg}; border:1px solid ${border};
-			${isNew ? "box-shadow:0 2px 8px " + bg + ";" : ""}
-			${isDone ? "opacity:0.45;" : ""}">
+			background:${s}; border:1px solid ${r};
+			${a?"box-shadow:0 2px 8px "+s+";":""}
+			${l?"opacity:0.45;":""}">
 			<div style="display:flex; align-items:flex-start; gap:10px;">
 				<div style="flex:1;">
 					<div style="font-size:13px; font-weight:700; color:var(--text-primary); margin-bottom:8px; display:flex; align-items:center; gap:8px;">
-						${isNew ? `<span style="font-size:10px; padding:2px 7px; border-radius:10px; background:${accent}; color:#0d1117; font-weight:700; letter-spacing:0.04em;">NEW</span>` : ""}
-						${escapeHtml(insight.title)}
+						${a?`<span style="font-size:10px; padding:2px 7px; border-radius:10px; background:${i}; color:#0d1117; font-weight:700; letter-spacing:0.04em;">NEW</span>`:""}
+						${d(e.title)}
 					</div>
-					<div style="font-size:12px; color:var(--text-primary); line-height:1.5; opacity:0.85; white-space:pre-wrap;">${escapeHtml(insight.body)}</div>
-					${actionBtn ? `<div style="margin-top:12px;">${actionBtn}</div>` : ""}
+					<div style="font-size:12px; color:var(--text-primary); line-height:1.5; opacity:0.85; white-space:pre-wrap;">${d(e.body)}</div>
+					${u?`<div style="margin-top:12px;">${u}</div>`:""}
 				</div>
 				<div style="flex-shrink:0; margin-top:-4px;">
-					${dismissBtn}
+					${b}
 				</div>
 			</div>
-			<div style="display:flex; gap:8px; margin-top:14px; justify-content:flex-end; border-top:1px solid ${border}; padding-top:10px;">
-				${doneBtn}
-				${snoozeBtn}
+			<div style="display:flex; gap:8px; margin-top:14px; justify-content:flex-end; border-top:1px solid ${r}; padding-top:10px;">
+				${c}
+				${p}
 			</div>
-		</div>`;
-  }
-  function buildInsightsTabPanelHtml(insights) {
-    const applicable = insights.filter((i6) => i6.status !== "dismissed");
-    const newInsights = applicable.filter((i6) => i6.status === "new");
-    const otherInsights = applicable.filter((i6) => i6.status !== "new" && i6.status !== "done");
-    const forYouSection = newInsights.length > 0 ? `<div style="margin-bottom:20px;">
+		</div>`}function qa(e){let t=e.filter(i=>i.status!=="dismissed"),o=t.filter(i=>i.status==="new"),n=t.filter(i=>i.status!=="new"&&i.status!=="done"),s=o.length>0?`<div style="margin-bottom:20px;">
 			<div style="font-size:12px; font-weight:600; text-transform:uppercase; color:var(--text-secondary); letter-spacing:0.05em; margin-bottom:10px;">\u2728 For You</div>
-			${newInsights.map(buildInsightCardHtml).join("")}
-		</div>` : `<div style="margin-bottom:20px; padding:16px; background:var(--bg-tertiary); border-radius:8px; font-size:12px; color:var(--text-secondary); text-align:center;">
+			${o.map(Nt).join("")}
+		</div>`:`<div style="margin-bottom:20px; padding:16px; background:var(--bg-tertiary); border-radius:8px; font-size:12px; color:var(--text-secondary); text-align:center;">
 			\u{1F389} No new insights right now \u2014 keep using Copilot and check back later!
-		</div>`;
-    const allSection = otherInsights.length > 0 ? `<div>
+		</div>`,r=n.length>0?`<div>
 			<div style="font-size:12px; font-weight:600; text-transform:uppercase; color:var(--text-secondary); letter-spacing:0.05em; margin-bottom:10px;">All Tips</div>
-			${otherInsights.map(buildInsightCardHtml).join("")}
-		</div>` : "";
-    return `
-		<div id="tab-panel-insights" class="tab-panel"${activeTab !== "insights" ? ' style="display:none"' : ""}>
+			${n.map(Nt).join("")}
+		</div>`:"";return`
+		<div id="tab-panel-insights" class="tab-panel"${$!=="insights"?' style="display:none"':""}>
 			<div class="section">
 				<div class="section-title"><span>\u{1F4A1}</span><span>Insights</span></div>
 				<div class="section-subtitle">
 					Personalized tips based on your usage patterns. Tips are data-driven \u2014 they only appear when relevant to how you code with AI.
 				</div>
 				<div id="insights-container" style="margin-top:16px;">
-					${forYouSection}
-					${allSection}
+					${s}
+					${r}
 				</div>
 			</div>
-		</div>`;
-  }
-  function correctionsCountBadgeHtml(report) {
-    if (!report || report.sessionsWithMoments === 0) {
-      return "";
-    }
-    return ` <span style="background:rgba(251,191,36,0.4);border-radius:10px;padding:1px 6px;font-size:11px;">${report.sessionsWithMoments}</span>`;
-  }
-  function correctionsTabButtonHtml(report) {
-    return `<button class="tab-button ${activeTab === "corrections" ? "active" : ""}" data-tab="corrections"><span class="codicon codicon-debug-restart"></span> Corrections${correctionsCountBadgeHtml(report)}</button>`;
-  }
-  function buildRepeatedTaskSessionLinkHtml(session) {
-    const title = session.title || session.file.split(/[\\/]/).pop() || session.file;
-    const date = session.lastInteraction ? new Date(session.lastInteraction) : null;
-    const dateLabel = date && !isNaN(date.getTime()) ? date.toLocaleDateString() : "";
-    const repo = session.repository ? ` \xB7 ${session.repository}` : "";
-    return `<div style="font-size:11px; color:var(--text-secondary); padding:2px 0; overflow-wrap:anywhere;">${escapeHtml(title)}${escapeHtml(dateLabel ? ` \xB7 ${dateLabel}` : "")}${escapeHtml(repo)}</div>`;
-  }
-  function buildRepeatedTaskClusterHtml(cluster) {
-    const keywords = cluster.sharedKeywords.length > 0 ? `<div style="margin-top:6px; display:flex; flex-wrap:wrap; gap:4px;">${cluster.sharedKeywords.map((k2) => `<span style="font-size:10px; padding:1px 7px; border-radius:8px; background:var(--bg-tertiary); color:var(--text-secondary);">${escapeHtml(k2)}</span>`).join("")}</div>` : "";
-    return `
+		</div>`}function Ka(e){return!e||e.sessionsWithMoments===0?"":` <span style="background:rgba(251,191,36,0.4);border-radius:10px;padding:1px 6px;font-size:11px;">${e.sessionsWithMoments}</span>`}function Ga(e){return`<button class="tab-button ${$==="corrections"?"active":""}" data-tab="corrections"><span class="codicon codicon-debug-restart"></span> Corrections${Ka(e)}</button>`}function Va(e){let t=e.title||e.file.split(/[\\/]/).pop()||e.file,o=e.lastInteraction?new Date(e.lastInteraction):null,n=o&&!isNaN(o.getTime())?o.toLocaleDateString():"",s=e.repository?` \xB7 ${e.repository}`:"";return`<div style="font-size:11px; color:var(--text-secondary); padding:2px 0; overflow-wrap:anywhere;">${d(t)}${d(n?` \xB7 ${n}`:"")}${d(s)}</div>`}function Ya(e){let t=e.sharedKeywords.length>0?`<div style="margin-top:6px; display:flex; flex-wrap:wrap; gap:4px;">${e.sharedKeywords.map(o=>`<span style="font-size:10px; padding:1px 7px; border-radius:8px; background:var(--bg-tertiary); color:var(--text-secondary);">${d(o)}</span>`).join("")}</div>`:"";return`
 		<div style="margin-top:10px; padding:12px 14px; border-radius:8px; background:var(--bg-tertiary); border:1px solid var(--border-color, transparent);">
 			<div style="display:flex; align-items:flex-start; gap:10px;">
-				<span style="flex-shrink:0; font-size:11px; font-weight:700; padding:2px 8px; border-radius:10px; background:rgba(74,222,128,0.15); border:1px solid rgba(74,222,128,0.5); color:var(--text-primary); white-space:nowrap;">${cluster.sessionCount}\xD7 repeated</span>
-				<div style="flex:1; min-width:0; font-size:12px; color:var(--text-primary); font-style:italic; overflow-wrap:anywhere;">&ldquo;${escapeHtml(cluster.representativePrompt)}&rdquo;</div>
+				<span style="flex-shrink:0; font-size:11px; font-weight:700; padding:2px 8px; border-radius:10px; background:rgba(74,222,128,0.15); border:1px solid rgba(74,222,128,0.5); color:var(--text-primary); white-space:nowrap;">${e.sessionCount}\xD7 repeated</span>
+				<div style="flex:1; min-width:0; font-size:12px; color:var(--text-primary); font-style:italic; overflow-wrap:anywhere;">&ldquo;${d(e.representativePrompt)}&rdquo;</div>
 			</div>
-			${keywords}
+			${t}
 			<details style="margin-top:8px;">
-				<summary style="font-size:11px; color:var(--text-secondary); cursor:pointer;">Sessions (${cluster.sessions.length})</summary>
-				<div style="margin-top:4px;">${cluster.sessions.map(buildRepeatedTaskSessionLinkHtml).join("")}</div>
+				<summary style="font-size:11px; color:var(--text-secondary); cursor:pointer;">Sessions (${e.sessions.length})</summary>
+				<div style="margin-top:4px;">${e.sessions.map(Va).join("")}</div>
 			</details>
-		</div>`;
-  }
-  function buildSkillSuggestionsSectionHtml(report) {
-    if (!report || report.clusters.length === 0) {
-      return "";
-    }
-    return `
+		</div>`}function Ja(e){return!e||e.clusters.length===0?"":`
 		<div class="section">
 			<div class="section-title"><span>\u{1F9E9}</span><span>Skill Suggestions</span></div>
 			<div class="section-subtitle">
-				Tasks you keep prompting for across sessions (first prompt per session, ${report.sessionsScanned} sessions scanned).
+				Tasks you keep prompting for across sessions (first prompt per session, ${e.sessionsScanned} sessions scanned).
 				A repeated task is a good candidate for a reusable skill, prompt file, or custom agent.
 			</div>
-			${report.clusters.map(buildRepeatedTaskClusterHtml).join("")}
-		</div>`;
-  }
-  var CORRECTION_TYPE_META = {
-    "user-correction": { label: "You corrected the agent", color: "rgba(251,191,36,0.85)" },
-    "tool-error": { label: "Tool failed", color: "rgba(248,113,113,0.85)" },
-    "edit-retry": { label: "Edit retry", color: "rgba(251,146,60,0.85)" },
-    "edit-self-correction": { label: "Edit self-correction", color: "rgba(251,146,60,0.85)" },
-    "agent-self-correction": { label: "Agent caught itself", color: "rgba(96,165,250,0.85)" }
-  };
-  function buildCorrectionMomentHtml(moment) {
-    const meta = CORRECTION_TYPE_META[moment.type] ?? { label: moment.type, color: "rgba(148,163,184,0.85)" };
-    const time = moment.timestamp ? new Date(moment.timestamp) : null;
-    const timeLabel = time && !isNaN(time.getTime()) ? time.toLocaleString() : "";
-    const detail = moment.type === "tool-error" ? `tool \`${moment.tool ?? "?"}\`${moment.retried ? " \u2014 retried shortly after" : ""}` : moment.matchedPattern ? `matched ${moment.matchedPattern}` : "";
-    return `
+			${e.clusters.map(Ya).join("")}
+		</div>`}var Xa={"user-correction":{label:"You corrected the agent",color:"rgba(251,191,36,0.85)"},"tool-error":{label:"Tool failed",color:"rgba(248,113,113,0.85)"},"edit-retry":{label:"Edit retry",color:"rgba(251,146,60,0.85)"},"edit-self-correction":{label:"Edit self-correction",color:"rgba(251,146,60,0.85)"},"agent-self-correction":{label:"Agent caught itself",color:"rgba(96,165,250,0.85)"}};function Za(e){let t=Xa[e.type]??{label:e.type,color:"rgba(148,163,184,0.85)"},o=e.timestamp?new Date(e.timestamp):null,n=o&&!isNaN(o.getTime())?o.toLocaleString():"",s=e.type==="tool-error"?`tool \`${e.tool??"?"}\`${e.retried?" \u2014 retried shortly after":""}`:e.matchedPattern?`matched ${e.matchedPattern}`:"";return`
 		<div style="display:flex; gap:10px; align-items:flex-start; padding:8px 0; border-bottom:1px solid var(--bg-tertiary);">
-			<span style="flex-shrink:0; font-size:10px; font-weight:700; letter-spacing:0.03em; padding:2px 8px; border-radius:10px; border:1px solid ${meta.color}; color:var(--text-primary); background:${meta.color.replace("0.85", "0.12")}; white-space:nowrap;">${escapeHtml(meta.label)}</span>
+			<span style="flex-shrink:0; font-size:10px; font-weight:700; letter-spacing:0.03em; padding:2px 8px; border-radius:10px; border:1px solid ${t.color}; color:var(--text-primary); background:${t.color.replace("0.85","0.12")}; white-space:nowrap;">${d(t.label)}</span>
 			<div style="flex:1; min-width:0;">
-				<div style="font-size:12px; color:var(--text-primary); opacity:0.9; overflow-wrap:anywhere;">${escapeHtml(moment.snippet)}</div>
+				<div style="font-size:12px; color:var(--text-primary); opacity:0.9; overflow-wrap:anywhere;">${d(e.snippet)}</div>
 				<div style="font-size:11px; color:var(--text-secondary); margin-top:3px;">
-					turn ${moment.turnNumber}${detail ? ` \xB7 ${escapeHtml(detail)}` : ""}${timeLabel ? ` \xB7 ${escapeHtml(timeLabel)}` : ""}
+					turn ${e.turnNumber}${s?` \xB7 ${d(s)}`:""}${n?` \xB7 ${d(n)}`:""}
 				</div>
 			</div>
-		</div>`;
-  }
-  function buildCorrectionSessionHtml(session) {
-    const title = session.title || session.file.split(/[\\/]/).pop() || session.file;
-    const date = session.lastInteraction ? new Date(session.lastInteraction) : null;
-    const dateLabel = date && !isNaN(date.getTime()) ? date.toLocaleDateString() : "";
-    const totalMoments = session.totalMoments ?? session.moments.length;
-    const truncatedLabel = totalMoments > session.moments.length ? ` \xB7 showing ${session.moments.length} of ${totalMoments} moments` : "";
-    return `
+		</div>`}function Qa(e){let t=e.title||e.file.split(/[\\/]/).pop()||e.file,o=e.lastInteraction?new Date(e.lastInteraction):null,n=o&&!isNaN(o.getTime())?o.toLocaleDateString():"",s=e.totalMoments??e.moments.length,r=s>e.moments.length?` \xB7 showing ${e.moments.length} of ${s} moments`:"";return`
 		<div style="margin:10px 0 4px; padding:10px 12px; background:var(--bg-tertiary); border-radius:6px;">
 			<div style="font-size:12px; font-weight:600; color:var(--text-primary); overflow-wrap:anywhere;">
-				${escapeHtml(title)}${dateLabel || truncatedLabel ? ` <span style="font-weight:400; color:var(--text-secondary);">${dateLabel ? `\xB7 ${escapeHtml(dateLabel)}` : ""}${escapeHtml(truncatedLabel)}</span>` : ""}
+				${d(t)}${n||r?` <span style="font-weight:400; color:var(--text-secondary);">${n?`\xB7 ${d(n)}`:""}${d(r)}</span>`:""}
 			</div>
-			${session.moments.map(buildCorrectionMomentHtml).join("")}
-		</div>`;
-  }
-  function buildCorrectionsTabPanelHtml(report) {
-    if (!report || report.repos.length === 0) {
-      return `
-		<div id="tab-panel-corrections" class="tab-panel"${activeTab !== "corrections" ? ' style="display:none"' : ""}>
+			${e.moments.map(Za).join("")}
+		</div>`}function el(e){if(!e||e.repos.length===0)return`
+		<div id="tab-panel-corrections" class="tab-panel"${$!=="corrections"?' style="display:none"':""}>
 			<div class="section">
 				<div class="section-title"><span>\u{1F501}</span><span>Corrections</span></div>
 				<div class="section-subtitle">Moments where the agent corrected itself after an error, or you had to correct the agent.</div>
@@ -6681,156 +2593,37 @@ ${_renderMultiModelMixedCostSessions(switching)}
 					\u2728 No correction moments detected in your recent sessions \u2014 nice and smooth!
 				</div>
 			</div>
-		</div>`;
-    }
-    const c4 = report.counts;
-    const chip = (n5, label) => n5 > 0 ? `<span style="font-size:11px; padding:2px 10px; border-radius:10px; background:var(--bg-tertiary); color:var(--text-primary);">${n5} ${escapeHtml(label)}</span>` : "";
-    const summaryChips = [
-      chip(c4.userCorrections, "user corrections"),
-      chip(c4.toolErrors, "tool errors"),
-      chip(c4.editRetries, "edit retries"),
-      chip(c4.editSelfCorrections, "edit self-corrections"),
-      chip(c4.agentSelfCorrections, "agent self-corrections")
-    ].filter(Boolean).join(" ");
-    const repoSections = report.repos.map((repo) => `
+		</div>`;let t=e.counts,o=(r,i)=>r>0?`<span style="font-size:11px; padding:2px 10px; border-radius:10px; background:var(--bg-tertiary); color:var(--text-primary);">${r} ${d(i)}</span>`:"",n=[o(t.userCorrections,"user corrections"),o(t.toolErrors,"tool errors"),o(t.editRetries,"edit retries"),o(t.editSelfCorrections,"edit self-corrections"),o(t.agentSelfCorrections,"agent self-corrections")].filter(Boolean).join(" "),s=e.repos.map(r=>`
 		<div style="margin-top:18px;">
 			<div style="font-size:12px; font-weight:700; color:var(--text-primary); margin-bottom:4px;">
-				${escapeHtml(repo.repository)}
-				<span style="font-weight:400; color:var(--text-secondary);">\u2014 ${repo.sessionsWithMoments} session${repo.sessionsWithMoments !== 1 ? "s" : ""} with moments</span>
+				${d(r.repository)}
+				<span style="font-weight:400; color:var(--text-secondary);">\u2014 ${r.sessionsWithMoments} session${r.sessionsWithMoments!==1?"s":""} with moments</span>
 			</div>
-			${repo.sessions.map(buildCorrectionSessionHtml).join("")}
-		</div>`).join("");
-    return `
-		<div id="tab-panel-corrections" class="tab-panel"${activeTab !== "corrections" ? ' style="display:none"' : ""}>
+			${r.sessions.map(Qa).join("")}
+		</div>`).join("");return`
+		<div id="tab-panel-corrections" class="tab-panel"${$!=="corrections"?' style="display:none"':""}>
 			<div class="section">
 				<div class="section-title"><span>\u{1F501}</span><span>Corrections</span></div>
 				<div class="section-subtitle">
 					Moments where the agent corrected itself after an error, or you had to correct the agent \u2014
-					heuristic detection over each repository's ${report.sessionsPerRepo} most recent sessions with detected moments \u2014
+					heuristic detection over each repository's ${e.sessionsPerRepo} most recent sessions with detected moments \u2014
 					sessions without corrections are not listed. Summary counts include all detected moments; long sessions show a capped detail sample.
 					Pattern-based matches are candidates, not verdicts; open the session in the log viewer for full context.
 				</div>
-				<div style="display:flex; flex-wrap:wrap; gap:6px; margin-top:12px;">${summaryChips}</div>
-				${repoSections}
+				<div style="display:flex; flex-wrap:wrap; gap:6px; margin-top:12px;">${n}</div>
+				${s}
 			</div>
-		</div>`;
-  }
-  function updateTabButtonCount(insights) {
-    const tabButton = document.querySelector('.tab-button[data-tab="insights"]');
-    if (!tabButton) {
-      return;
-    }
-    const newCount = insights.filter((i6) => i6.status === "new").length;
-    const badgeHtml = newCount > 0 ? ` <span style="background:rgba(96,165,250,0.4);border-radius:10px;padding:1px 6px;font-size:11px;">${newCount}</span>` : "";
-    const titleOnly = '<span class="codicon codicon-lightbulb"></span> Insights';
-    setHtml(tabButton, titleOnly + badgeHtml);
-  }
-  function refreshInsightsPanel(insights) {
-    const container = document.getElementById("insights-container");
-    if (!container) {
-      return;
-    }
-    currentInsights = insights;
-    const forYou = insights.filter((i6) => i6.status === "new");
-    const other = insights.filter((i6) => i6.status !== "new" && i6.status !== "dismissed" && i6.status !== "done");
-    const forYouSection = forYou.length > 0 ? `<div style="margin-bottom:20px;">
+		</div>`}function tl(e){let t=document.querySelector('.tab-button[data-tab="insights"]');if(!t)return;let o=e.filter(r=>r.status==="new").length,n=o>0?` <span style="background:rgba(96,165,250,0.4);border-radius:10px;padding:1px 6px;font-size:11px;">${o}</span>`:"";k(t,'<span class="codicon codicon-lightbulb"></span> Insights'+n)}function ol(e){let t=document.getElementById("insights-container");if(!t)return;Bo=e;let o=e.filter(i=>i.status==="new"),n=e.filter(i=>i.status!=="new"&&i.status!=="dismissed"&&i.status!=="done"),s=o.length>0?`<div style="margin-bottom:20px;">
 			<div style="font-size:12px; font-weight:600; text-transform:uppercase; color:var(--text-secondary); letter-spacing:0.05em; margin-bottom:10px;">\u2728 For You</div>
-			${forYou.map(buildInsightCardHtml).join("")}
-		</div>` : `<div style="margin-bottom:20px; padding:16px; background:var(--bg-tertiary); border-radius:8px; font-size:12px; color:var(--text-secondary); text-align:center;">
+			${o.map(Nt).join("")}
+		</div>`:`<div style="margin-bottom:20px; padding:16px; background:var(--bg-tertiary); border-radius:8px; font-size:12px; color:var(--text-secondary); text-align:center;">
 			\u{1F389} No new insights right now \u2014 keep using Copilot and check back later!
-		</div>`;
-    const allSection = other.length > 0 ? `<div>
+		</div>`,r=n.length>0?`<div>
 			<div style="font-size:12px; font-weight:600; text-transform:uppercase; color:var(--text-secondary); letter-spacing:0.05em; margin-bottom:10px;">All Tips</div>
-			${other.map(buildInsightCardHtml).join("")}
-		</div>` : "";
-    setHtml(container, forYouSection + allSection);
-    wireInsightCardButtons();
-    updateTabButtonCount(insights);
-  }
-  function _postOpenFileFromList(pathsJson) {
-    if (!pathsJson) {
-      return;
-    }
-    try {
-      const paths = JSON.parse(pathsJson);
-      vscode.postMessage({ command: "openFileFromList", paths });
-    } catch (error) {
-      traceCuration("wireCurationButtons.badPathsJson", { error: error instanceof Error ? error.message : String(error) });
-    }
-  }
-  function _handleCurationBtnClick(btn) {
-    const command = btn.getAttribute("data-command");
-    if (!command) {
-      return;
-    }
-    if (command === "openFile") {
-      const filePath = btn.getAttribute("data-path");
-      if (filePath) {
-        vscode.postMessage({ command: "openFile", path: filePath });
-      }
-    } else if (command === "openFileFromList") {
-      _postOpenFileFromList(btn.getAttribute("data-paths"));
-    } else if (command === "manageExtension") {
-      const extensionId = btn.getAttribute("data-extension-id");
-      if (extensionId) {
-        vscode.postMessage({ command: "manageExtension", extensionId });
-      }
-    } else if (command === "openAgentPlugins") {
-      const pluginName = btn.getAttribute("data-plugin-name") ?? "";
-      vscode.postMessage({ command: "openAgentPlugins", pluginName });
-    } else {
-      vscode.postMessage({ command });
-    }
-  }
-  function wireCurationButtons() {
-    try {
-      const section = document.getElementById("section-tool-curation");
-      if (!section) {
-        traceCurationOnce("wire-no-section", "wireCurationButtons.noSection");
-        return;
-      }
-      const buttons = section.querySelectorAll(".curation-file-btn");
-      traceCuration("wireCurationButtons.bind", { buttons: buttons.length });
-      buttons.forEach((btn) => {
-        btn.addEventListener("click", () => {
-          try {
-            _handleCurationBtnClick(btn);
-          } catch (error) {
-            traceCuration("wireCurationButtons.clickError", { error: error instanceof Error ? error.message : String(error) });
-          }
-        });
-      });
-    } catch (error) {
-      traceCuration("wireCurationButtons.error", { error: error instanceof Error ? error.message : String(error) });
-    }
-  }
-  function wireInsightCardButtons() {
-    const container = document.getElementById("insights-container");
-    if (!container) {
-      return;
-    }
-    container.querySelectorAll(".insight-action-btn").forEach((btn) => {
-      btn.addEventListener("click", () => {
-        const id = btn.getAttribute("data-insight-id");
-        const action = btn.getAttribute("data-action");
-        if (!id || !action) {
-          return;
-        }
-        if (action === "execute") {
-          const command = btn.getAttribute("data-command");
-          if (command) {
-            vscode.postMessage({ command });
-          }
-        } else {
-          vscode.postMessage({ command: "insightAction", id, action });
-        }
-      });
-    });
-  }
-  function buildUsageRootHtml(stats, customizationHtml, multiModelHtml, thinkingEffortHtml, sessionsSummaryHtml, todayTotalRefs, last30DaysTotalRefs, allToolKeys, allMcpToolKeys, allMcpServerKeys, allHighCostModels, allLowCostModels, allMediumCostModels, allUnknownModels) {
-    return `
-		<style>${theme_default}</style>
-		<style>${styles_default}</style>
+			${n.map(Nt).join("")}
+		</div>`:"";k(t,s+r),Fs(),tl(e)}function nl(e){if(e)try{let t=JSON.parse(e);f.postMessage({command:"openFileFromList",paths:t})}catch(t){Z("wireCurationButtons.badPathsJson",{error:t instanceof Error?t.message:String(t)})}}function sl(e){let t=e.getAttribute("data-command");if(t)if(t==="openFile"){let o=e.getAttribute("data-path");o&&f.postMessage({command:"openFile",path:o})}else if(t==="openFileFromList")nl(e.getAttribute("data-paths"));else if(t==="manageExtension"){let o=e.getAttribute("data-extension-id");o&&f.postMessage({command:"manageExtension",extensionId:o})}else if(t==="openAgentPlugins"){let o=e.getAttribute("data-plugin-name")??"";f.postMessage({command:"openAgentPlugins",pluginName:o})}else f.postMessage({command:t})}function rl(){try{let e=document.getElementById("section-tool-curation");if(!e){pe("wire-no-section","wireCurationButtons.noSection");return}let t=e.querySelectorAll(".curation-file-btn");Z("wireCurationButtons.bind",{buttons:t.length}),t.forEach(o=>{o.addEventListener("click",()=>{try{sl(o)}catch(n){Z("wireCurationButtons.clickError",{error:n instanceof Error?n.message:String(n)})}})})}catch(e){Z("wireCurationButtons.error",{error:e instanceof Error?e.message:String(e)})}}function Fs(){let e=document.getElementById("insights-container");e&&e.querySelectorAll(".insight-action-btn").forEach(t=>{t.addEventListener("click",()=>{let o=t.getAttribute("data-insight-id"),n=t.getAttribute("data-action");if(!(!o||!n))if(n==="execute"){let s=t.getAttribute("data-command");s&&f.postMessage({command:s})}else f.postMessage({command:"insightAction",id:o,action:n})})})}function il(e,t,o,n,s,r,i,a,l,u,c,p,b,h){return`
+		<style>${ln}</style>
+		<style>${dn}</style>
 		<div class="container">
 			<div class="header">
 				<div class="header-left">
@@ -6838,16 +2631,16 @@ ${_renderMultiModelMixedCostSessions(switching)}
 					<span class="header-title">Usage Analysis</span>
 				</div>
 				<div class="button-row">
-				${navButtonsHtml("btn-usage", !!stats.backendConfigured)}
+				${nn("btn-usage",!!e.backendConfigured)}
 				</div>
 			</div>
 
 			<div class="info-box">
-				<div class="info-box-title info-box-toggle" id="about-info-toggle" role="button" tabindex="0" aria-expanded="${!aboutCollapsed}" aria-controls="about-info-body">
+				<div class="info-box-title info-box-toggle" id="about-info-toggle" role="button" tabindex="0" aria-expanded="${!V}" aria-controls="about-info-body">
 					<span>\u{1F4CB} About This Dashboard</span>
-					<span class="info-box-chevron" aria-hidden="true">${aboutCollapsed ? "\u25B8" : "\u25BE"}</span>
+					<span class="info-box-chevron" aria-hidden="true">${V?"\u25B8":"\u25BE"}</span>
 				</div>
-				<div class="info-box-body" id="about-info-body"${aboutCollapsed ? ' style="display:none"' : ""}>
+				<div class="info-box-body" id="about-info-body"${V?' style="display:none"':""}>
 					This dashboard analyzes your GitHub Copilot usage patterns by examining session log files.
 					It tracks modes (ask/edit/agent), tool usage, context references (#file, @workspace, etc.),
 					and MCP (Model Context Protocol) tools to help you understand how you interact with Copilot.
@@ -6855,285 +2648,118 @@ ${_renderMultiModelMixedCostSessions(switching)}
 			</div>
 
 			<div class="tab-bar">
-				<button class="tab-button ${activeTab === "activity" ? "active" : ""}" data-tab="activity"><span class="codicon codicon-pulse"></span> My Activity</button>
-				<button class="tab-button ${activeTab === "sessions" ? "active" : ""}" data-tab="sessions"><span class="codicon codicon-history"></span> Recent Sessions</button>
-				<button class="tab-button ${activeTab === "tools" ? "active" : ""}" data-tab="tools"><span class="codicon codicon-tools"></span> Tools &amp; Integrations</button>
-				<button class="tab-button ${activeTab === "health" ? "active" : ""}" data-tab="health"><span class="codicon codicon-server-environment"></span> Workspace Health</button>
-				<button class="tab-button ${activeTab === "repos" ? "active" : ""}" data-tab="repos"><span class="codicon codicon-git-pull-request"></span> Repository PRs</button>
-				<button class="tab-button ${activeTab === "agent" ? "active" : ""}" data-tab="agent"><span class="codicon codicon-cloud"></span> Cloud Agent</button>
-				<button class="tab-button ${activeTab === "worktrees" ? "active" : ""}" data-tab="worktrees"><span class="codicon codicon-git-branch"></span> Worktrees</button>
-				<button class="tab-button ${activeTab === "insights" ? "active" : ""}" data-tab="insights"><span class="codicon codicon-lightbulb"></span> Insights${(stats.insights ?? []).filter((i6) => i6.status === "new").length > 0 ? ` <span style="background:rgba(96,165,250,0.4);border-radius:10px;padding:1px 6px;font-size:11px;">${(stats.insights ?? []).filter((i6) => i6.status === "new").length}</span>` : ""}</button>
-				${correctionsTabButtonHtml(stats.correctionReport ?? null)}
+				<button class="tab-button ${$==="activity"?"active":""}" data-tab="activity"><span class="codicon codicon-pulse"></span> My Activity</button>
+				<button class="tab-button ${$==="sessions"?"active":""}" data-tab="sessions"><span class="codicon codicon-history"></span> Recent Sessions</button>
+				<button class="tab-button ${$==="tools"?"active":""}" data-tab="tools"><span class="codicon codicon-tools"></span> Tools &amp; Integrations</button>
+				<button class="tab-button ${$==="health"?"active":""}" data-tab="health"><span class="codicon codicon-server-environment"></span> Workspace Health</button>
+				<button class="tab-button ${$==="repos"?"active":""}" data-tab="repos"><span class="codicon codicon-git-pull-request"></span> Repository PRs</button>
+				<button class="tab-button ${$==="agent"?"active":""}" data-tab="agent"><span class="codicon codicon-cloud"></span> Cloud Agent</button>
+				<button class="tab-button ${$==="worktrees"?"active":""}" data-tab="worktrees"><span class="codicon codicon-git-branch"></span> Worktrees</button>
+				<button class="tab-button ${$==="insights"?"active":""}" data-tab="insights"><span class="codicon codicon-lightbulb"></span> Insights${(e.insights??[]).filter(S=>S.status==="new").length>0?` <span style="background:rgba(96,165,250,0.4);border-radius:10px;padding:1px 6px;font-size:11px;">${(e.insights??[]).filter(S=>S.status==="new").length}</span>`:""}</button>
+				${Ga(e.correctionReport??null)}
 			</div>
 
-			${safeSectionHtml("Recent Sessions", () => buildSessionsTabPanelHtml(stats))}
-			${safeSectionHtml("My Activity", () => buildActivityTabPanelHtml(stats, multiModelHtml, thinkingEffortHtml, sessionsSummaryHtml, todayTotalRefs, last30DaysTotalRefs))}
-			${safeSectionHtml("Tools & Integrations", () => buildToolsTabPanelHtml(stats, allToolKeys, allMcpToolKeys, allMcpServerKeys, allHighCostModels, allLowCostModels, allMediumCostModels, allUnknownModels))}
-			${safeSectionHtml("Workspace Health", () => buildHealthTabPanelHtml(customizationHtml, stats))}
-			${safeSectionHtml("Repository PRs & Cloud Agent", () => buildReposAndAgentTabPanelsHtml())}
-			${safeSectionHtml("Worktrees", () => buildWorktreesTabPanelHtml())}
-			${safeSectionHtml("Insights", () => buildInsightsTabPanelHtml(stats.insights ?? []))}
-			${safeSectionHtml("Corrections", () => buildCorrectionsTabPanelHtml(stats.correctionReport ?? null))}
+			${P("Recent Sessions",()=>wl(e))}
+			${P("My Activity",()=>$l(e,o,n,s,r,i))}
+			${P("Tools & Integrations",()=>od(e,a,l,u,c,p,b,h))}
+			${P("Workspace Health",()=>_a(t,e))}
+			${P("Repository PRs & Cloud Agent",()=>Wa())}
+			${P("Worktrees",()=>xl())}
+			${P("Insights",()=>qa(e.insights??[]))}
+			${P("Corrections",()=>el(e.correctionReport??null))}
 			<div class="footer">
-				Last updated: ${escapeHtml(new Date(stats.lastUpdated).toLocaleString())} \xB7 Updates every 5 minutes
+				Last updated: ${d(new Date(e.lastUpdated).toLocaleString())} \xB7 Updates every 5 minutes
 			</div>
 		</div>
-`;
-  }
-  function renderWorktreeRootsList() {
-    if (worktreeRoots.length === 0) {
-      return `<div style="color: var(--text-muted); font-size: 12px; margin: 8px 0;">No root folders added yet. Add a folder to scan for worktrees.</div>`;
-    }
-    const collapsible = worktreeRoots.length > 2;
-    const showList = !collapsible || worktreeRootsExpanded;
-    const toggle = collapsible ? `<button class="worktree-roots-toggle" id="btn-toggle-worktree-roots" aria-expanded="${worktreeRootsExpanded}"><span class="worktree-caret">${worktreeRootsExpanded ? "\u25BC" : "\u25B6"}</span>${worktreeRoots.length} root folders found</button>` : "";
-    const list = showList ? `<div class="worktree-roots-list">${worktreeRoots.map(
-      (r6, i6) => `<div class="worktree-root-item"><span title="${escapeHtml(r6)}">${escapeHtml(r6)}</span><button class="button secondary worktree-remove-root" data-index="${i6}" ${worktreeScanInProgress ? "disabled" : ""}>\u2715</button></div>`
-    ).join("")}</div>` : "";
-    return toggle + list;
-  }
-  function _renderWorktreeEnrichingProgress(s4, seconds) {
-    const done = s4.enriched ?? 0;
-    const total = s4.enrichTotal ?? 0;
-    const pct = total > 0 ? Math.round(done / total * 100) : 0;
-    return `
+`}function al(){if(U.length===0)return'<div style="color: var(--text-muted); font-size: 12px; margin: 8px 0;">No root folders added yet. Add a folder to scan for worktrees.</div>';let e=U.length>2,t=!e||Ve,o=e?`<button class="worktree-roots-toggle" id="btn-toggle-worktree-roots" aria-expanded="${Ve}"><span class="worktree-caret">${Ve?"\u25BC":"\u25B6"}</span>${U.length} root folders found</button>`:"",n=t?`<div class="worktree-roots-list">${U.map((s,r)=>`<div class="worktree-root-item"><span title="${d(s)}">${d(s)}</span><button class="button secondary worktree-remove-root" data-index="${r}" ${R?"disabled":""}>\u2715</button></div>`).join("")}</div>`:"";return o+n}function ll(e,t){let o=e.enriched??0,n=e.enrichTotal??0,s=n>0?Math.round(o/n*100):0;return`
     <div class="info-box" style="margin-top: 12px;">
       <div class="info-box-title">\u{1F4E6} Computing sizes &amp; push status\u2026</div>
-      <div>${done} / ${total} worktree${total === 1 ? "" : "s"} analyzed (${seconds}s)</div>
-      <div class="worktree-progress-bar"><div class="worktree-progress-fill" style="width: ${pct}%;"></div></div>
-    </div>`;
-  }
-  function _renderWorktreeScanningProgress(s4, seconds) {
-    const walking = s4.phase === "walking";
-    const title = walking ? "\u{1F50D} Scanning folder\u2026" : "\u23F3 Checking markers\u2026";
-    const dirs = s4.dirsScanned ?? 0;
-    const detail = walking ? `Exploring for git worktrees \u2014 ${dirs} folder${dirs === 1 ? "" : "s"} scanned (${seconds}s)` : `${s4.checked} / ${s4.total || "?"} .git markers checked \u2014 ${s4.foundCount} worktree${s4.foundCount === 1 ? "" : "s"} found so far (${seconds}s)`;
-    const pct = walking ? 100 : s4.total > 0 ? Math.round(s4.checked / s4.total * 100) : 0;
-    const fillClass = walking ? "worktree-progress-fill indeterminate" : "worktree-progress-fill";
-    return `
+      <div>${o} / ${n} worktree${n===1?"":"s"} analyzed (${t}s)</div>
+      <div class="worktree-progress-bar"><div class="worktree-progress-fill" style="width: ${s}%;"></div></div>
+    </div>`}function dl(e,t){let o=e.phase==="walking",n=o?"\u{1F50D} Scanning folder\u2026":"\u23F3 Checking markers\u2026",s=e.dirsScanned??0,r=o?`Exploring for git worktrees \u2014 ${s} folder${s===1?"":"s"} scanned (${t}s)`:`${e.checked} / ${e.total||"?"} .git markers checked \u2014 ${e.foundCount} worktree${e.foundCount===1?"":"s"} found so far (${t}s)`,i=o?100:e.total>0?Math.round(e.checked/e.total*100):0,a=o?"worktree-progress-fill indeterminate":"worktree-progress-fill";return`
     <div class="info-box" style="margin-top: 12px;">
-      <div class="info-box-title">${title}</div>
-      <div>Folder: <span style="font-family: var(--vscode-editor-font-family, monospace);">${escapeHtml(s4.root || "\u2026")}</span></div>
-      <div>${detail}</div>
-      <div class="worktree-progress-bar"><div class="${fillClass}" style="width: ${pct}%;"></div></div>
-    </div>`;
-  }
-  function renderWorktreeProgress() {
-    if (!worktreeScanInProgress) {
-      return "";
-    }
-    const s4 = worktreeScanStatus;
-    const seconds = (s4.elapsedMs / 1e3).toFixed(1);
-    if (s4.phase === "enriching") {
-      return _renderWorktreeEnrichingProgress(s4, seconds);
-    }
-    return _renderWorktreeScanningProgress(s4, seconds);
-  }
-  function renderWorktreeBackgroundScanBanner() {
-    if (!worktreeBackgroundScanMeta || worktreeScanInProgress || worktreeResults.length === 0) {
-      return "";
-    }
-    const when = escapeHtml(new Date(worktreeBackgroundScanMeta.scannedAt).toLocaleString());
-    const size = formatFileSize(worktreeBackgroundScanMeta.totalBytes);
-    const count = worktreeResults.length;
-    return `<div class="info-box" style="margin-top: 12px;"><div>\u{1F333} Found automatically by the daily background scan: ${size} across ${count} worktree${count === 1 ? "" : "s"}, last checked ${when}. Scan again for the latest.</div></div>`;
-  }
-  function renderWorktreeControls() {
-    return `
+      <div class="info-box-title">${n}</div>
+      <div>Folder: <span style="font-family: var(--vscode-editor-font-family, monospace);">${d(e.root||"\u2026")}</span></div>
+      <div>${r}</div>
+      <div class="worktree-progress-bar"><div class="${a}" style="width: ${i}%;"></div></div>
+    </div>`}function Ws(){if(!R)return"";let e=D,t=(e.elapsedMs/1e3).toFixed(1);return e.phase==="enriching"?ll(e,t):dl(e,t)}function cl(){if(!Ge||R||L.length===0)return"";let e=d(new Date(Ge.scannedAt).toLocaleString()),t=Pe(Ge.totalBytes),o=L.length;return`<div class="info-box" style="margin-top: 12px;"><div>\u{1F333} Found automatically by the daily background scan: ${t} across ${o} worktree${o===1?"":"s"}, last checked ${e}. Scan again for the latest.</div></div>`}function qs(){return`
     <div class="section">
       <div class="section-title"><span class="codicon codicon-folder-opened"></span><span>Root Folders</span></div>
-      <div id="worktree-roots-list">${renderWorktreeRootsList()}</div>
+      <div id="worktree-roots-list">${al()}</div>
       <div class="folder-input-row" style="margin-top: 8px;">
         <input
           type="text"
           id="worktree-root-input"
           class="folder-input"
           placeholder="Paste a root folder path here, e.g. C:\\code\\repos"
-          ${worktreeScanInProgress ? "disabled" : ""}
+          ${R?"disabled":""}
         />
-        <button class="button secondary" id="btn-browse-worktree-root" ${worktreeScanInProgress ? "disabled" : ""}>\u{1F4C2} Browse\u2026</button>
-        <button class="button secondary" id="btn-add-worktree-root" ${worktreeScanInProgress ? "disabled" : ""}>\u2795 Add</button>
+        <button class="button secondary" id="btn-browse-worktree-root" ${R?"disabled":""}>\u{1F4C2} Browse\u2026</button>
+        <button class="button secondary" id="btn-add-worktree-root" ${R?"disabled":""}>\u2795 Add</button>
       </div>
       <div style="margin-top: 16px;">
-        <button class="button" id="btn-scan-worktrees" ${worktreeScanInProgress || worktreeCleanupInProgress || worktreeRoots.length === 0 ? "disabled" : ""}>\u{1F50D} Scan for Worktrees</button>
-        ${worktreeScanInProgress ? '<button class="button secondary" id="btn-cancel-worktree-scan">\u2715 Cancel</button>' : ""}
+        <button class="button" id="btn-scan-worktrees" ${R||W||U.length===0?"disabled":""}>\u{1F50D} Scan for Worktrees</button>
+        ${R?'<button class="button secondary" id="btn-cancel-worktree-scan">\u2715 Cancel</button>':""}
       </div>
-      ${renderWorktreeBackgroundScanBanner()}
-      ${worktreeScanError ? `<div class="info-box" style="margin-top: 12px; border-color: #d97706; background: rgba(217,119,6,0.08);"><div>\u26A0\uFE0F ${escapeHtml(worktreeScanError)}</div></div>` : ""}
-      <div id="worktree-progress-area">${renderWorktreeProgress()}</div>
-    </div>`;
-  }
-  function groupWorktreesByRepo(results) {
-    const groups = /* @__PURE__ */ new Map();
-    for (const wt of results) {
-      const key = wt.repoLabel || "Unknown";
-      if (!groups.has(key)) {
-        groups.set(key, []);
-      }
-      groups.get(key).push(wt);
-    }
-    return groups;
-  }
-  function isWorktreePending(w2) {
-    return w2.bytes < 0;
-  }
-  function knownBytes(w2) {
-    return w2.bytes > 0 ? w2.bytes : 0;
-  }
-  function buildWorktreeRowHtml(w2) {
-    const pending = isWorktreePending(w2);
-    const pendingLabel = (active) => `<span class="worktree-pending">${worktreeScanInProgress ? active : "\u2014"}</span>`;
-    const pushedIcon = w2.pushed === "yes" ? "\u2705" : w2.pushed === "no" ? "\u{1F534}" : "\u2753";
-    const pushedCell = pending ? pendingLabel("checking\u2026") : `${pushedIcon} ${escapeHtml(w2.pushed)}`;
-    const filesCell = pending ? pendingLabel("\u2026") : escapeHtml(String(w2.files));
-    const sizeCell = pending ? pendingLabel("computing\u2026") : `<span title="${w2.bytes.toLocaleString()} bytes">${formatFileSize(w2.bytes)}</span>`;
-    return `<tr>
-    <td title="${escapeHtml(w2.path)}" style="font-family: var(--vscode-editor-font-family, monospace); font-size: 11px; max-width: 380px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">${escapeHtml(w2.path)}</td>
-    <td>${escapeHtml(w2.branch)}</td>
-    <td>${escapeHtml(w2.lastCommit)}</td>
-    <td>${pushedCell}</td>
-    <td>${filesCell}</td>
-    <td>${sizeCell}</td>
+      ${cl()}
+      ${rt?`<div class="info-box" style="margin-top: 12px; border-color: #d97706; background: rgba(217,119,6,0.08);"><div>\u26A0\uFE0F ${d(rt)}</div></div>`:""}
+      <div id="worktree-progress-area">${Ws()}</div>
+    </div>`}function ul(e){let t=new Map;for(let o of e){let n=o.repoLabel||"Unknown";t.has(n)||t.set(n,[]),t.get(n).push(o)}return t}function Gt(e){return e.bytes<0}function lt(e){return e.bytes>0?e.bytes:0}function pl(e){let t=Gt(e),o=a=>`<span class="worktree-pending">${R?a:"\u2014"}</span>`,n=e.pushed==="yes"?"\u2705":e.pushed==="no"?"\u{1F534}":"\u2753",s=t?o("checking\u2026"):`${n} ${d(e.pushed)}`,r=t?o("\u2026"):d(String(e.files)),i=t?o("computing\u2026"):`<span title="${e.bytes.toLocaleString()} bytes">${Pe(e.bytes)}</span>`;return`<tr>
+    <td title="${d(e.path)}" style="font-family: var(--vscode-editor-font-family, monospace); font-size: 11px; max-width: 380px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">${d(e.path)}</td>
+    <td>${d(e.branch)}</td>
+    <td>${d(e.lastCommit)}</td>
+    <td>${s}</td>
+    <td>${r}</td>
+    <td>${i}</td>
     <td>
-      <a href="#" class="worktree-reveal-link" data-path="${encodeURIComponent(w2.path)}">Open</a>
-      <a href="#" class="worktree-delete-link" data-path="${encodeURIComponent(w2.path)}" data-branch="${encodeURIComponent(w2.branch)}" data-repo="${encodeURIComponent(w2.repoLabel)}" data-pushed="${escapeHtml(w2.pushed)}" title="Remove via git worktree remove (asks for confirmation)">\u{1F5D1}\uFE0F Delete</a>
+      <a href="#" class="worktree-reveal-link" data-path="${encodeURIComponent(e.path)}">Open</a>
+      <a href="#" class="worktree-delete-link" data-path="${encodeURIComponent(e.path)}" data-branch="${encodeURIComponent(e.branch)}" data-repo="${encodeURIComponent(e.repoLabel)}" data-pushed="${d(e.pushed)}" title="Remove via git worktree remove (asks for confirmation)">\u{1F5D1}\uFE0F Delete</a>
     </td>
-  </tr>`;
-  }
-  function buildWorktreeDetailsTableHtml(worktrees) {
-    const sorted = [...worktrees].sort((a3, b3) => knownBytes(b3) - knownBytes(a3));
-    const rows = sorted.map(buildWorktreeRowHtml).join("");
-    return `<div class="table-container">
+  </tr>`}function gl(e){return`<div class="table-container">
     <table class="session-table">
       <thead><tr><th>Path</th><th>Branch</th><th>Last Commit</th><th>Pushed</th><th>Files</th><th>Size</th><th>Actions</th></tr></thead>
-      <tbody>${rows}</tbody>
+      <tbody>${[...e].sort((n,s)=>lt(s)-lt(n)).map(pl).join("")}</tbody>
     </table>
-  </div>`;
-  }
-  function worktreeSizeText(worktrees) {
-    const totalBytes = worktrees.reduce((s4, w2) => s4 + knownBytes(w2), 0);
-    const pending = worktrees.some(isWorktreePending);
-    const size = `<span title="${totalBytes.toLocaleString()} bytes">${formatFileSize(totalBytes)}</span>`;
-    return pending ? `${size} <span class="worktree-pending">\u2026</span>` : size;
-  }
-  function buildWorktreeRepoRowsHtml(repoLabel, worktrees) {
-    const expanded = worktreeExpandedRepos.has(repoLabel);
-    const caret = expanded ? "\u25BC" : "\u25B6";
-    const repoAttr = escapeHtml(repoLabel);
-    const summaryRow = `<tr class="worktree-repo-row${expanded ? " expanded" : ""}" data-repo="${repoAttr}" aria-expanded="${expanded}">
-    <td><span class="worktree-caret">${caret}</span> ${escapeHtml(repoLabel)}</td>
-    <td>${worktrees.length}</td>
-    <td>${worktreeSizeText(worktrees)}</td>
-  </tr>`;
-    const detailsRow = `<tr class="worktree-repo-details" data-repo="${repoAttr}"${expanded ? "" : ' style="display: none;"'}>
-    <td colspan="3">${buildWorktreeDetailsTableHtml(worktrees)}</td>
-  </tr>`;
-    return summaryRow + detailsRow;
-  }
-  function getWorktreeSortIndicator(col) {
-    if (worktreeSortColumn !== col) {
-      return "";
-    }
-    return worktreeSortDir === "desc" ? " \u25BC" : " \u25B2";
-  }
-  function groupKnownBytes(worktrees) {
-    return worktrees.reduce((s4, w2) => s4 + knownBytes(w2), 0);
-  }
-  function compareWorktreeGroups(a3, b3) {
-    const dir = worktreeSortDir === "desc" ? -1 : 1;
-    if (worktreeSortColumn === "repo") {
-      return dir * a3[0].localeCompare(b3[0]);
-    }
-    const value = (g2) => worktreeSortColumn === "count" ? g2.length : groupKnownBytes(g2);
-    const diff = value(a3[1]) - value(b3[1]);
-    return diff !== 0 ? dir * diff : a3[0].localeCompare(b3[0]);
-  }
-  function getCleanupCandidates() {
-    return worktreeResults.filter((w2) => w2.pushed === "yes" && !isWorktreePending(w2));
-  }
-  function renderWorktreeCleanupCard() {
-    const pushedCount = getCleanupCandidates().length;
-    const disabled = worktreeCleanupInProgress || worktreeCleanupConfirmPending || worktreeScanInProgress || pushedCount === 0;
-    const label = worktreeCleanupConfirmPending ? "\u23F3 Waiting\u2026" : `\u{1F9F9} Clean Up (${pushedCount})`;
-    return `<div class="summary-card worktree-cleanup-card">
+  </div>`}function ml(e){let t=e.reduce((s,r)=>s+lt(r),0),o=e.some(Gt),n=`<span title="${t.toLocaleString()} bytes">${Pe(t)}</span>`;return o?`${n} <span class="worktree-pending">\u2026</span>`:n}function fl(e,t){let o=zt.has(e),n=o?"\u25BC":"\u25B6",s=d(e),r=`<tr class="worktree-repo-row${o?" expanded":""}" data-repo="${s}" aria-expanded="${o}">
+    <td><span class="worktree-caret">${n}</span> ${d(e)}</td>
+    <td>${t.length}</td>
+    <td>${ml(t)}</td>
+  </tr>`,i=`<tr class="worktree-repo-details" data-repo="${s}"${o?"":' style="display: none;"'}>
+    <td colspan="3">${gl(t)}</td>
+  </tr>`;return r+i}function Ro(e){return it!==e?"":Ye==="desc"?" \u25BC":" \u25B2"}function bl(e){return e.reduce((t,o)=>t+lt(o),0)}function yl(e,t){let o=Ye==="desc"?-1:1;if(it==="repo")return o*e[0].localeCompare(t[0]);let n=r=>it==="count"?r.length:bl(r),s=n(e[1])-n(t[1]);return s!==0?o*s:e[0].localeCompare(t[0])}function Ks(){return L.filter(e=>e.pushed==="yes"&&!Gt(e))}function hl(){let e=Ks().length,t=W||fe||R||e===0,o=fe?"\u23F3 Waiting\u2026":`\u{1F9F9} Clean Up (${e})`;return`<div class="summary-card worktree-cleanup-card">
     <div class="summary-label">Pushed Worktrees</div>
     <div class="worktree-cleanup-card-actions">
-      <button class="button secondary" id="btn-cleanup-pushed-worktrees" ${disabled ? "disabled" : ""}>${label}</button>
-      ${worktreeCleanupInProgress ? '<button class="button secondary" id="btn-cancel-cleanup">\u2715</button>' : ""}
+      <button class="button secondary" id="btn-cleanup-pushed-worktrees" ${t?"disabled":""}>${o}</button>
+      ${W?'<button class="button secondary" id="btn-cancel-cleanup">\u2715</button>':""}
     </div>
-  </div>`;
-  }
-  function renderWorktreeCleanupLog() {
-    const notable = worktreeCleanupLog.filter((e7) => e7.status !== "deleted");
-    if (notable.length === 0) {
-      return "";
-    }
-    const rows = notable.map((e7) => {
-      const icon = e7.status === "skipped" ? "\u23ED\uFE0F" : "\u274C";
-      return `<div class="worktree-cleanup-log-row">
-      <span>${icon}</span>
-      <span class="worktree-cleanup-log-branch">${escapeHtml(e7.branch)}</span>
-      <span class="worktree-cleanup-log-repo">${escapeHtml(e7.repoLabel)}</span>
-      <span class="worktree-cleanup-log-reason">${escapeHtml(e7.reason || "")}</span>
-    </div>`;
-    }).join("");
-    return `<div class="worktree-cleanup-log">${rows}</div>`;
-  }
-  function renderWorktreeCleanupStatus() {
-    if (worktreeCleanupInProgress) {
-      const { processed, total } = worktreeCleanupStatus;
-      const pct = total > 0 ? Math.round(processed / total * 100) : 0;
-      return `<div class="info-box" style="margin-top: 12px;">
+  </div>`}function Ss(){let e=re.filter(o=>o.status!=="deleted");return e.length===0?"":`<div class="worktree-cleanup-log">${e.map(o=>`<div class="worktree-cleanup-log-row">
+      <span>${o.status==="skipped"?"\u23ED\uFE0F":"\u274C"}</span>
+      <span class="worktree-cleanup-log-branch">${d(o.branch)}</span>
+      <span class="worktree-cleanup-log-repo">${d(o.repoLabel)}</span>
+      <span class="worktree-cleanup-log-reason">${d(o.reason||"")}</span>
+    </div>`).join("")}</div>`}function vl(){if(W){let{processed:n,total:s}=Oo,r=s>0?Math.round(n/s*100):0;return`<div class="info-box" style="margin-top: 12px;">
       <div class="info-box-title">\u{1F9F9} Cleaning up pushed worktrees\u2026</div>
-      <div>${processed} / ${total} processed</div>
-      <div class="worktree-progress-bar"><div class="worktree-progress-fill" style="width: ${pct}%;"></div></div>
-    </div>${renderWorktreeCleanupLog()}`;
-    }
-    if (worktreeCleanupLog.length === 0) {
-      return "";
-    }
-    const deleted = worktreeCleanupLog.filter((e7) => e7.status === "deleted").length;
-    const skipped = worktreeCleanupLog.filter((e7) => e7.status === "skipped").length;
-    const errors = worktreeCleanupLog.filter((e7) => e7.status === "error").length;
-    return `<div class="info-box" style="margin-top: 12px;">
+      <div>${n} / ${s} processed</div>
+      <div class="worktree-progress-bar"><div class="worktree-progress-fill" style="width: ${r}%;"></div></div>
+    </div>${Ss()}`}if(re.length===0)return"";let e=re.filter(n=>n.status==="deleted").length,t=re.filter(n=>n.status==="skipped").length,o=re.filter(n=>n.status==="error").length;return`<div class="info-box" style="margin-top: 12px;">
     <div class="info-box-title">\u{1F9F9} Cleanup finished</div>
-    <div>\u2705 ${deleted} deleted \xB7 \u23ED\uFE0F ${skipped} skipped (uncommitted/unpushed) \xB7 ${errors > 0 ? `\u274C ${errors} error${errors === 1 ? "" : "s"}` : "0 errors"}</div>
-  </div>${renderWorktreeCleanupLog()}`;
-  }
-  function renderWorktreeResults() {
-    if (worktreeResults.length === 0) {
-      if (worktreeScanInProgress) {
-        return '<div style="padding: 16px; color: var(--text-muted);">Discovering worktrees\u2026</div>';
-      }
-      return '<div style="padding: 16px; color: var(--text-muted);">No worktrees found yet. Add root folders above and click Scan.</div>';
-    }
-    const groups = groupWorktreesByRepo(worktreeResults);
-    const totalBytes = worktreeResults.reduce((s4, w2) => s4 + knownBytes(w2), 0);
-    const anyPending = worktreeResults.some(isWorktreePending);
-    const totalSizeHtml = `${formatFileSize(totalBytes)}${anyPending ? ' <span class="worktree-pending">\u2026</span>' : ""}`;
-    const summary = `<div class="summary-cards">
-    <div class="summary-card"><div class="summary-label">\u{1F333} Worktrees</div><div class="summary-value">${worktreeResults.length}</div></div>
-    <div class="summary-card"><div class="summary-label">\u{1F4E6} Repositories</div><div class="summary-value">${groups.size}</div></div>
-    <div class="summary-card"><div class="summary-label">\u{1F4BE} Total Size</div><div class="summary-value" title="${totalBytes.toLocaleString()} bytes">${totalSizeHtml}</div></div>
-    ${renderWorktreeCleanupCard()}
-  </div>`;
-    const sortedGroups = [...groups.entries()].sort(compareWorktreeGroups);
-    const repoRows = sortedGroups.map(([repo, wts]) => buildWorktreeRepoRowsHtml(repo, wts)).join("");
-    const table = `<div class="table-container">
+    <div>\u2705 ${e} deleted \xB7 \u23ED\uFE0F ${t} skipped (uncommitted/unpushed) \xB7 ${o>0?`\u274C ${o} error${o===1?"":"s"}`:"0 errors"}</div>
+  </div>${Ss()}`}function Gs(){if(L.length===0)return R?'<div style="padding: 16px; color: var(--text-muted);">Discovering worktrees\u2026</div>':'<div style="padding: 16px; color: var(--text-muted);">No worktrees found yet. Add root folders above and click Scan.</div>';let e=ul(L),t=L.reduce((l,u)=>l+lt(u),0),o=L.some(Gt),n=`${Pe(t)}${o?' <span class="worktree-pending">\u2026</span>':""}`,s=`<div class="summary-cards">
+    <div class="summary-card"><div class="summary-label">\u{1F333} Worktrees</div><div class="summary-value">${L.length}</div></div>
+    <div class="summary-card"><div class="summary-label">\u{1F4E6} Repositories</div><div class="summary-value">${e.size}</div></div>
+    <div class="summary-card"><div class="summary-label">\u{1F4BE} Total Size</div><div class="summary-value" title="${t.toLocaleString()} bytes">${n}</div></div>
+    ${hl()}
+  </div>`,i=[...e.entries()].sort(yl).map(([l,u])=>fl(l,u)).join(""),a=`<div class="table-container">
     <table class="session-table worktree-repo-table">
       <thead><tr>
-        <th class="sortable" data-wt-sort="repo">Repository${getWorktreeSortIndicator("repo")}</th>
-        <th class="sortable" data-wt-sort="count">Worktrees${getWorktreeSortIndicator("count")}</th>
-        <th class="sortable" data-wt-sort="size">Size${getWorktreeSortIndicator("size")}</th>
+        <th class="sortable" data-wt-sort="repo">Repository${Ro("repo")}</th>
+        <th class="sortable" data-wt-sort="count">Worktrees${Ro("count")}</th>
+        <th class="sortable" data-wt-sort="size">Size${Ro("size")}</th>
       </tr></thead>
-      <tbody>${repoRows}</tbody>
+      <tbody>${i}</tbody>
     </table>
-  </div>`;
-    return summary + renderWorktreeCleanupStatus() + table;
-  }
-  function buildWorktreesTabPanelHtml() {
-    return `
-    <div id="tab-panel-worktrees" class="tab-panel"${activeTab !== "worktrees" ? ' style="display:none"' : ""}>
+  </div>`;return s+vl()+a}function xl(){return`
+    <div id="tab-panel-worktrees" class="tab-panel"${$!=="worktrees"?' style="display:none"':""}>
       <div class="info-box">
         <div class="info-box-title">\u{1F333} Worktree Discovery</div>
         <div>
@@ -7141,306 +2767,129 @@ ${_renderMultiModelMixedCostSessions(switching)}
           worktree's git remote). Add one or more root folders below, then click Scan. Results stream in as they're found.
         </div>
       </div>
-      <div id="worktree-controls">${renderWorktreeControls()}</div>
-      <div id="worktree-results">${renderWorktreeResults()}</div>
-    </div>`;
-  }
-  function buildSubAgentSummaryHtml(sessions) {
-    const sessionsWithSubAgents = sessions.filter((s4) => (s4.subAgentCalls ?? 0) > 0).length;
-    if (sessionsWithSubAgents === 0) {
-      return "";
-    }
-    const totalCalls = sessions.reduce((sum, s4) => sum + (s4.subAgentCalls ?? 0), 0);
-    return `<div style="margin-top:8px; font-size:12px; color:var(--text-secondary);" title="Sessions that delegated work to sub-agents (task/read_agent/write_agent/list_agents, runSubagent, delegate_*, \u2026)">
-		\u{1F916} <strong>${sessionsWithSubAgents}</strong> session${sessionsWithSubAgents === 1 ? "" : "s"} used sub-agents (${formatNumber(totalCalls)} sub-agent call${totalCalls === 1 ? "" : "s"}) in this period
-	</div>`;
-  }
-  function buildSessionsTabPanelHtml(stats) {
-    if (Array.isArray(stats.todaySessions)) {
-      latestTodaySessions = stats.todaySessions;
-    }
-    const cachedForLookback = sessionsLookback === "today" ? latestTodaySessions : recentSessionsCache[sessionsLookback];
-    const bodyHtml = cachedForLookback ? renderTodaySessionsTable(cachedForLookback) : `<div style="color: var(--text-secondary); font-size: 13px; padding: 16px;">Loading sessions for ${PERIOD_LABELS[sessionsLookback]}\u2026</div>`;
-    const subAgentBanner = cachedForLookback ? buildSubAgentSummaryHtml(cachedForLookback) : "";
-    return `
-		<div id="tab-panel-sessions" class="tab-panel"${activeTab !== "sessions" ? ' style="display:none"' : ""}>
+      <div id="worktree-controls">${qs()}</div>
+      <div id="worktree-results">${Gs()}</div>
+    </div>`}function kl(e){let t=e.filter(n=>(n.subAgentCalls??0)>0).length;if(t===0)return"";let o=e.reduce((n,s)=>n+(s.subAgentCalls??0),0);return`<div style="margin-top:8px; font-size:12px; color:var(--text-secondary);" title="Sessions that delegated work to sub-agents (task/read_agent/write_agent/list_agents, runSubagent, delegate_*, \u2026)">
+		\u{1F916} <strong>${t}</strong> session${t===1?"":"s"} used sub-agents (${g(o)} sub-agent call${o===1?"":"s"}) in this period
+	</div>`}function wl(e){Array.isArray(e.todaySessions)&&(Uo=e.todaySessions);let t=I==="today"?Uo:Ae[I],o=t?Io(t):`<div style="color: var(--text-secondary); font-size: 13px; padding: 16px;">Loading sessions for ${pt[I]}\u2026</div>`,n=t?kl(t):"";return`
+		<div id="tab-panel-sessions" class="tab-panel"${$!=="sessions"?' style="display:none"':""}>
 			<div class="section">
 				<div class="section-title" style="display:flex; align-items:center; gap:8px;">
 					<span>\u{1F4CB}</span><span>Recent Sessions</span>
 					<span id="sessions-lookback-wrapper" style="margin-left:auto;"></span>
-					${buildSessionColumnsMenuHtml()}
+					${Si()}
 				</div>
 				<div class="section-subtitle">Individual session breakdown for the selected period \u2014 sorted by number of interactions (most active first).</div>
-				${subAgentBanner}
+				${n}
 				<div id="sessions-panel-body" style="margin-top: 12px;">
-					${bodyHtml}
+					${o}
 				</div>
 			</div>
-		</div>`;
-  }
-  function _billingApiBalanceHtml(api, copilotCostUsd) {
-    const apiUsedUsd = api.usedAiCredits * 0.01;
-    const trackedUsd = Math.max(0, Math.min(copilotCostUsd, apiUsedUsd));
-    const gapUsd = Math.max(0, apiUsedUsd - trackedUsd);
-    const budgetUsd = api.budgetUsd;
-    const trackedPct = budgetUsd > 0 ? Math.min(100, trackedUsd / budgetUsd * 100) : 0;
-    const gapPct = budgetUsd > 0 ? Math.min(100 - trackedPct, gapUsd / budgetUsd * 100) : 0;
-    const totalUsedPct = trackedPct + gapPct;
-    const usedPct = formatFixed(100 - api.pctAvailable, 1);
-    const pct = formatFixed(api.pctAvailable, 1);
-    const severityColor = totalUsedPct > 90 ? "var(--error-color, #f14c4c)" : totalUsedPct > 75 ? "var(--warning-color, #cca700)" : "var(--accent-color, #4d9cf8)";
-    const trackedSegment = trackedPct > 0 ? `<div style="height:100%; width:${formatFixed(trackedPct, 4)}%; background:${severityColor};"></div>` : "";
-    const gapSegment = gapPct > 0 ? `<div title="Usage the API reports but this device has no local session data for" style="height:100%; width:${formatFixed(gapPct, 4)}%; background:${severityColor}; background-image:repeating-linear-gradient(135deg, rgba(0,0,0,0.35) 0px, rgba(0,0,0,0.35) 3px, transparent 3px, transparent 6px);"></div>` : "";
-    const legend = gapPct > 0 ? `<div style="display:flex; gap:14px; flex-wrap:wrap; font-size:11px; color:var(--text-secondary); margin-top:6px;">
-				<span><span style="display:inline-block; width:9px; height:9px; border-radius:2px; background:${severityColor}; margin-right:4px; vertical-align:middle;"></span>Tracked here (${formatFixed(trackedPct, 1)}%)</span>
-				<span><span style="display:inline-block; width:9px; height:9px; border-radius:2px; background:${severityColor}; background-image:repeating-linear-gradient(135deg, rgba(0,0,0,0.35) 0px, rgba(0,0,0,0.35) 2px, transparent 2px, transparent 4px); margin-right:4px; vertical-align:middle;"></span>Other devices/cloud (${formatFixed(gapPct, 1)}%)</span>
-			</div>` : "";
-    return `
+		</div>`}function Cl(e,t){let o=e.usedAiCredits*.01,n=Math.max(0,Math.min(t,o)),s=Math.max(0,o-n),r=e.budgetUsd,i=r>0?Math.min(100,n/r*100):0,a=r>0?Math.min(100-i,s/r*100):0,l=i+a,u=w(100-e.pctAvailable,1),c=w(e.pctAvailable,1),p=l>90?"var(--error-color, #f14c4c)":l>75?"var(--warning-color, #cca700)":"var(--accent-color, #4d9cf8)",b=i>0?`<div style="height:100%; width:${w(i,4)}%; background:${p};"></div>`:"",h=a>0?`<div title="Usage the API reports but this device has no local session data for" style="height:100%; width:${w(a,4)}%; background:${p}; background-image:repeating-linear-gradient(135deg, rgba(0,0,0,0.35) 0px, rgba(0,0,0,0.35) 3px, transparent 3px, transparent 6px);"></div>`:"",S=a>0?`<div style="display:flex; gap:14px; flex-wrap:wrap; font-size:11px; color:var(--text-secondary); margin-top:6px;">
+				<span><span style="display:inline-block; width:9px; height:9px; border-radius:2px; background:${p}; margin-right:4px; vertical-align:middle;"></span>Tracked here (${w(i,1)}%)</span>
+				<span><span style="display:inline-block; width:9px; height:9px; border-radius:2px; background:${p}; background-image:repeating-linear-gradient(135deg, rgba(0,0,0,0.35) 0px, rgba(0,0,0,0.35) 2px, transparent 2px, transparent 4px); margin-right:4px; vertical-align:middle;"></span>Other devices/cloud (${w(a,1)}%)</span>
+			</div>`:"";return`
 		<div style="margin-bottom:12px;">
 			<div style="font-size:12px; font-weight:600; color:var(--text-secondary); margin-bottom:6px;">GitHub Copilot API (all channels)</div>
 			<div style="display:flex; gap:16px; flex-wrap:wrap; margin-bottom:8px;">
 				<div style="background:var(--bg-tertiary); border:1px solid var(--border-subtle); border-radius:6px; padding:10px 16px; text-align:center; min-width:80px;">
-					<div style="font-size:18px; font-weight:700; color:var(--text-primary);">${formatNumber(api.usedAiCredits)}</div>
+					<div style="font-size:18px; font-weight:700; color:var(--text-primary);">${g(e.usedAiCredits)}</div>
 					<div style="font-size:11px; color:var(--text-secondary); margin-top:2px;">Credits used</div>
 				</div>
 				<div style="background:var(--bg-tertiary); border:1px solid var(--border-subtle); border-radius:6px; padding:10px 16px; text-align:center; min-width:80px;">
-					<div style="font-size:18px; font-weight:700; color:var(--text-primary);">${formatNumber(api.remainingAiCredits)}</div>
+					<div style="font-size:18px; font-weight:700; color:var(--text-primary);">${g(e.remainingAiCredits)}</div>
 					<div style="font-size:11px; color:var(--text-secondary); margin-top:2px;">Credits remaining</div>
 				</div>
 				<div style="background:var(--bg-tertiary); border:1px solid var(--border-subtle); border-radius:6px; padding:10px 16px; text-align:center; min-width:80px;">
-					<div style="font-size:18px; font-weight:700; color:var(--text-primary);">${formatNumber(api.budgetAiCredits)}</div>
+					<div style="font-size:18px; font-weight:700; color:var(--text-primary);">${g(e.budgetAiCredits)}</div>
 					<div style="font-size:11px; color:var(--text-secondary); margin-top:2px;">Monthly budget</div>
 				</div>
 			</div>
 			<div style="margin-bottom:4px; font-size:11px; color:var(--text-secondary); display:flex; justify-content:space-between;">
-				<span>${usedPct}% used</span><span>${pct}% available</span>
+				<span>${u}% used</span><span>${c}% available</span>
 			</div>
 			<div style="height:8px; border-radius:4px; background:var(--border-subtle); overflow:hidden; display:flex;">
-				${trackedSegment}${gapSegment}
+				${b}${h}
 			</div>
-			${legend}
+			${S}
 			<div style="font-size:11px; color:var(--text-muted); margin-top:6px;">
-				1 AI Credit = $0.01 \xB7 Budget = $${formatFixed(api.budgetUsd, 2)}/month
+				1 AI Credit = $0.01 \xB7 Budget = $${w(e.budgetUsd,2)}/month
 			</div>
-		</div>`;
-  }
-  function _billingCoverageAnalysisHtml(api, copilotCostUsd, nonCopilotCostUsd) {
-    if (!api) {
-      return `
+		</div>`}function Sl(e,t,o){if(!e)return`
 			<div style="font-size:11px; color:var(--text-muted); margin-bottom:8px; line-height:1.5;">
 				\u2139\uFE0F No Copilot API quota data available yet. The API balance appears after the extension fetches your Copilot plan info.
 				The extension only tracks local IDE sessions \u2014 it cannot see web chat, cloud agent, or review agent usage.
-			</div>`;
-    }
-    if (copilotCostUsd <= 0) {
-      return "";
-    }
-    const apiUsedUsd = api.usedAiCredits * 0.01;
-    const gapUsd = apiUsedUsd - copilotCostUsd;
-    const gapCredits = Math.round(gapUsd * 100);
-    const gapRow = gapCredits > 0 ? `<div style="display:flex; justify-content:space-between; padding-top:6px; border-top:1px solid var(--border-subtle); color:var(--text-secondary);"><span>Gap (untracked Copilot usage)</span><span>$${formatFixed(gapUsd, 2)} (${formatNumber(gapCredits)} credits)</span></div>` : "";
-    const otherRow = nonCopilotCostUsd > 1e-3 ? `<div style="display:flex; justify-content:space-between;"><span>Other providers (not in Copilot API)</span><span>$${formatFixed(nonCopilotCostUsd, 2)}</span></div>` : "";
-    const note = gapCredits > 0 ? `<div style="margin-top:8px; font-size:11px; color:var(--text-muted); line-height:1.5;">\u2139\uFE0F The gap represents Copilot usage the extension cannot track: <strong>github.com/copilot</strong> web chat, <strong>cloud agent</strong> sessions, and <strong>Copilot review agent</strong> \u2014 all counted against your AI Credit budget.</div>` : `<div style="margin-top:8px; font-size:11px; color:var(--text-muted);">\u2705 Extension-tracked Copilot usage matches the API \u2014 no significant untracked usage from web chat, cloud agent, or review agent.</div>`;
-    return `
+			</div>`;if(t<=0)return"";let n=e.usedAiCredits*.01,s=n-t,r=Math.round(s*100),i=r>0?`<div style="display:flex; justify-content:space-between; padding-top:6px; border-top:1px solid var(--border-subtle); color:var(--text-secondary);"><span>Gap (untracked Copilot usage)</span><span>$${w(s,2)} (${g(r)} credits)</span></div>`:"",a=o>.001?`<div style="display:flex; justify-content:space-between;"><span>Other providers (not in Copilot API)</span><span>$${w(o,2)}</span></div>`:"",l=r>0?'<div style="margin-top:8px; font-size:11px; color:var(--text-muted); line-height:1.5;">\u2139\uFE0F The gap represents Copilot usage the extension cannot track: <strong>github.com/copilot</strong> web chat, <strong>cloud agent</strong> sessions, and <strong>Copilot review agent</strong> \u2014 all counted against your AI Credit budget.</div>':'<div style="margin-top:8px; font-size:11px; color:var(--text-muted);">\u2705 Extension-tracked Copilot usage matches the API \u2014 no significant untracked usage from web chat, cloud agent, or review agent.</div>';return`
 		<div style="background:var(--bg-tertiary); border:1px solid var(--border-subtle); border-radius:6px; padding:12px 14px; margin-bottom:12px;">
 			<div style="font-size:12px; font-weight:600; color:var(--text-secondary); margin-bottom:8px;">Coverage analysis</div>
 			<div style="display:flex; flex-direction:column; gap:6px; font-size:12px; color:var(--text-primary);">
-				<div style="display:flex; justify-content:space-between;"><span>API total Copilot usage</span><span style="font-weight:600;">$${formatFixed(apiUsedUsd, 2)} (${formatNumber(api.usedAiCredits)} credits)</span></div>
-				<div style="display:flex; justify-content:space-between;"><span>Extension tracked (Copilot IDE sessions)</span><span style="font-weight:600;">$${formatFixed(copilotCostUsd, 2)} (${formatNumber(Math.round(copilotCostUsd * 100))} credits)</span></div>
-				${gapRow}${otherRow}
+				<div style="display:flex; justify-content:space-between;"><span>API total Copilot usage</span><span style="font-weight:600;">$${w(n,2)} (${g(e.usedAiCredits)} credits)</span></div>
+				<div style="display:flex; justify-content:space-between;"><span>Extension tracked (Copilot IDE sessions)</span><span style="font-weight:600;">$${w(t,2)} (${g(Math.round(t*100))} credits)</span></div>
+				${i}${a}
 			</div>
-			${note}
-		</div>`;
-  }
-  function buildBillingComparisonSectionHtml(stats) {
-    const api = stats.copilotApiBalance;
-    const groupCosts = stats.monthBillingGroupCosts;
-    if (!api && (!groupCosts || Object.keys(groupCosts).length === 0)) {
-      return "";
-    }
-    const copilotCostUsd = groupCosts?.["GitHub Copilot"] ?? 0;
-    const totalCostUsd = groupCosts ? Object.values(groupCosts).reduce((s4, v2) => s4 + v2, 0) : 0;
-    const nonCopilotCostUsd = totalCostUsd - copilotCostUsd;
-    const apiHtml = api ? _billingApiBalanceHtml(api, copilotCostUsd) : "";
-    const extHtml = groupCosts && Object.keys(groupCosts).length > 0 ? billingExtGroupCostsHtml(groupCosts, api) : "";
-    const deltaHtml = _billingCoverageAnalysisHtml(api, copilotCostUsd, nonCopilotCostUsd);
-    return `
+			${l}
+		</div>`}function Tl(e){let t=e.copilotApiBalance,o=e.monthBillingGroupCosts;if(!t&&(!o||Object.keys(o).length===0))return"";let n=o?.["GitHub Copilot"]??0,r=(o?Object.values(o).reduce((u,c)=>u+c,0):0)-n,i=t?Cl(t,n):"",a=o&&Object.keys(o).length>0?bn(o,t):"",l=Sl(t,n,r);return`
 		<div class="section">
 			<div class="section-title"><span>\u{1F4B3}</span><span>AI Billing Coverage</span></div>
 			<div class="section-subtitle">Compare what the GitHub Copilot API reports across all channels with what the extension can track from local IDE session logs, alongside estimated costs from other AI providers.</div>
-			${apiHtml}
-			${extHtml}
-			${deltaHtml}
-		</div>`;
-  }
-  function buildActivityTabPanelHtml(stats, multiModelHtml, thinkingEffortHtml, sessionsSummaryHtml, todayTotalRefs, last30DaysTotalRefs) {
-    const modelCostHtml = safeSectionHtml("Model Cost", () => buildModelCostSectionHtml(stats));
-    const billingComparisonHtml = safeSectionHtml("AI Billing Coverage", () => buildBillingComparisonSectionHtml(stats));
-    const modeUsageHtml = safeSectionHtml("Interaction Modes", () => `
+			${i}
+			${a}
+			${l}
+		</div>`}function $l(e,t,o,n,s,r){let i=P("Model Cost",()=>Ma(e)),a=P("AI Billing Coverage",()=>Tl(e)),l=P("Interaction Modes",()=>`
 			<div class="section" id="section-interaction-modes">
 				<div class="section-title"><span>\u{1F3AF}</span><span>Interaction Modes</span></div>
 				<div class="section-subtitle">How you're using Copilot: Ask (chat), Edit (code edits), Agent (autonomous tasks), Plan, Custom Agent, CLI (terminal), or Copilot App (desktop-app CLI sessions)</div>
 				<div class="two-column">
-					${renderModeBarChart(stats.today.modeUsage, "\u{1F4C5} Today")}
-					${renderModeBarChart(stats.last30Days.modeUsage, "\u{1F4CA} Last 30 Days")}
+					${vs(e.today.modeUsage,"\u{1F4C5} Today")}
+					${vs(e.last30Days.modeUsage,"\u{1F4CA} Last 30 Days")}
 				</div>
-			</div>`);
-    const contextRefsHtml = safeSectionHtml("Context References", () => buildContextRefsHtml(stats, todayTotalRefs, last30DaysTotalRefs));
-    const modelEfficiencyHtml = safeSectionHtml("Model Efficiency", () => buildModelEfficiencySectionHtml(stats));
-    const contextWindowHtml = safeSectionHtml("Context Window", () => buildContextWindowSectionHtml(stats));
-    return `
-		<div id="tab-panel-activity" class="tab-panel"${activeTab !== "activity" ? ' style="display:none"' : ""}>
-			${sessionsSummaryHtml}
-			${billingComparisonHtml}
+			</div>`),u=P("Context References",()=>Il(e,s,r)),c=P("Model Efficiency",()=>Zl(e)),p=P("Context Window",()=>Dl(e));return`
+		<div id="tab-panel-activity" class="tab-panel"${$!=="activity"?' style="display:none"':""}>
+			${n}
+			${a}
 			<!-- Mode Usage Section -->
-			${modeUsageHtml}
-			${contextRefsHtml}
-			${multiModelHtml}
-			${modelCostHtml}
-			${modelEfficiencyHtml}
-			${thinkingEffortHtml}
-			${contextWindowHtml}
-		</div>`;
-  }
-  var _modelPricingData = getWindowData("__MODEL_PRICING__");
-  var MODEL_PRICING_MAP = _modelPricingData?.pricing ?? {};
-  function _tierInfoForModels(models) {
-    let best = null;
-    for (const model of models) {
-      const info = getLongContextInfo(model, MODEL_PRICING_MAP);
-      if (info && (!best || info.thresholdTokens < best.thresholdTokens)) {
-        best = { ...info, model };
-      }
-    }
-    return best;
-  }
-  function _defaultTierCapacityText(thresholdTokens) {
-    const mb = thresholdTokens * 4 / (1024 * 1024);
-    const lines = Math.round(thresholdTokens / 10 / 1e3);
-    return `\u2248${formatFixed(mb, 1)} MB of code (~${formatNumber(lines)}K lines)`;
-  }
-  function _renderContextWindowBar(maxTokens, tier) {
-    const pct = maxTokens / tier.thresholdTokens * 100;
-    const fillPct = Math.min(pct, 100);
-    const color = pct > 100 ? "var(--error-color, #f14c4c)" : pct >= 70 ? "var(--warning-color, #cca700)" : "var(--success-color, #89d185)";
-    const modelName = escapeHtml(getModelDisplayName(tier.model));
-    const rateNote = `above it, input billing goes $${tier.defaultInputCostPerMillion.toFixed(2)} \u2192 $${tier.longContextInputCostPerMillion.toFixed(2)} per 1M tokens`;
-    return `
+			${l}
+			${u}
+			${t}
+			${i}
+			${c}
+			${o}
+			${p}
+		</div>`}var Al=q("__MODEL_PRICING__"),Ml=Al?.pricing??{};function Vs(e){let t=null;for(let o of e){let n=un(o,Ml);n&&(!t||n.thresholdTokens<t.thresholdTokens)&&(t={...n,model:o})}return t}function El(e){let t=e*4/1048576,o=Math.round(e/10/1e3);return`\u2248${w(t,1)} MB of code (~${g(o)}K lines)`}function Rl(e,t){let o=e/t.thresholdTokens*100,n=Math.min(o,100),s=o>100?"var(--error-color, #f14c4c)":o>=70?"var(--warning-color, #cca700)":"var(--success-color, #89d185)",r=d(ee(t.model)),i=`above it, input billing goes $${t.defaultInputCostPerMillion.toFixed(2)} \u2192 $${t.longContextInputCostPerMillion.toFixed(2)} per 1M tokens`;return`
 		<div style="margin-top: 12px;">
 			<div style="display:flex; justify-content:space-between; font-size:12px; color:var(--text-secondary); margin-bottom:4px;">
-				<span>${formatNumber(maxTokens)} tokens \u2014 ${formatFixed(pct, 0)}% of the ${formatNumber(tier.thresholdTokens)}-token default tier for ${modelName}</span>
-				<span>${formatNumber(tier.thresholdTokens)}</span>
+				<span>${g(e)} tokens \u2014 ${w(o,0)}% of the ${g(t.thresholdTokens)}-token default tier for ${r}</span>
+				<span>${g(t.thresholdTokens)}</span>
 			</div>
 			<div style="height:8px; border-radius:4px; background:var(--border-subtle); overflow:hidden;">
-				<div style="height:100%; width:${formatFixed(fillPct, 0)}%; background:${color}; border-radius:4px;"></div>
+				<div style="height:100%; width:${w(n,0)}%; background:${s}; border-radius:4px;"></div>
 			</div>
-			<div style="font-size:11px; color:var(--text-muted); margin-top:4px;">Default tier fits ${_defaultTierCapacityText(tier.thresholdTokens)}; ${rateNote}.</div>
-		</div>`;
-  }
-  function _cwRow(label, value, subNote, labelTitle) {
-    const titleAttr = labelTitle ? ` title="${labelTitle}"` : "";
-    return `
+			<div style="font-size:11px; color:var(--text-muted); margin-top:4px;">Default tier fits ${El(t.thresholdTokens)}; ${i}.</div>
+		</div>`}function Ko(e,t,o,n){return`
 		<div style="margin-bottom: 10px;">
-			<div style="font-size: 12px; font-weight: 600; color: var(--text-secondary); margin-bottom: 2px;"${titleAttr}>${label}</div>
-			<div style="font-size: 13px; color: var(--text-primary);">${value}</div>
-			${subNote ? `<div style="font-size: 11px; color: var(--text-secondary); margin-top: 2px; line-height: 1.4;">${subNote}</div>` : ""}
-		</div>`;
-  }
-  function _cwLargestRequestRow(cw) {
-    if (cw.maxRequestInputTokens <= 0) {
-      return "";
-    }
-    const tier = _tierInfoForModels(cw.maxRequestModels);
-    const modelsLabel = escapeHtml(cw.maxRequestModels.map((m2) => getModelDisplayName(m2)).join(", ") || "\u2014");
-    const thresholdNote = tier ? `${formatFixed(cw.maxRequestInputTokens / tier.thresholdTokens * 100, 0)}% of the ${formatNumber(tier.thresholdTokens)}-token price line \xB7 ${modelsLabel}` : `${modelsLabel} \u2014 no long-context surcharge for ${cw.maxRequestModels.length > 1 ? "these models" : "this model"}`;
-    return _cwRow(
-      "\u{1F4CF} Largest request",
-      `${formatNumber(cw.maxRequestInputTokens)} input tokens`,
-      thresholdNote,
-      "The biggest single prompt (input incl. cached tokens) sent to a model in one request during this period"
-    );
-  }
-  function _cwFullestWindowRow(cw) {
-    if ((cw.maxReachedTokens ?? 0) <= 0) {
-      return "";
-    }
-    const limit = cw.maxReachedWindowLimit;
-    const value = limit ? `${formatNumber(cw.maxReachedTokens)} of ${formatNumber(limit)} (${formatFixed(cw.maxReachedTokens / limit * 100, 0)}%)` : formatNumber(cw.maxReachedTokens);
-    return _cwRow(
-      "\u{1FA9F} Fullest CLI window",
-      value,
-      void 0,
-      "The highest context fill recorded for a Copilot CLI session in this period, versus its window limit"
-    );
-  }
-  function renderContextWindowPeriodHtml(cw) {
-    const hasData = !!cw && (cw.maxRequestInputTokens > 0 || (cw.maxReachedTokens ?? 0) > 0 || Object.keys(cw.tierCounts).length > 0);
-    if (!hasData) {
-      return '<div style="color: var(--text-muted); font-size: 11px;">No data</div>';
-    }
-    const tierEntries = Object.entries(cw.tierCounts);
-    const tierSessionCount = tierEntries.reduce((sum, [, c4]) => sum + c4, 0);
-    const tierRow = tierEntries.length > 0 ? _cwRow(
-      "\u{1FA9C} Context tiers",
-      tierEntries.map(([t4, c4]) => `${escapeHtml(t4)} \xD7${c4}`).join(", "),
-      `${tierSessionCount} Copilot CLI session${tierSessionCount === 1 ? "" : "s"} grouped by chosen window size \u2014 "default" is the standard window at normal rates; larger tiers unlock more context at long-context prices`,
-      "Copilot CLI lets you pick a context-window tier per session; the count shows how many sessions used each tier"
-    ) : "";
-    return _cwLargestRequestRow(cw) + _cwFullestWindowRow(cw) + tierRow;
-  }
-  function buildContextWindowSectionHtml(stats) {
-    const cw30 = stats.last30Days.contextWindow;
-    const tier30 = cw30 && cw30.maxRequestInputTokens > 0 ? _tierInfoForModels(cw30.maxRequestModels) : null;
-    const bar = cw30 && tier30 ? _renderContextWindowBar(cw30.maxRequestInputTokens, tier30) : "";
-    return `
+			<div style="font-size: 12px; font-weight: 600; color: var(--text-secondary); margin-bottom: 2px;"${n?` title="${n}"`:""}>${e}</div>
+			<div style="font-size: 13px; color: var(--text-primary);">${t}</div>
+			${o?`<div style="font-size: 11px; color: var(--text-secondary); margin-top: 2px; line-height: 1.4;">${o}</div>`:""}
+		</div>`}function _l(e){if(e.maxRequestInputTokens<=0)return"";let t=Vs(e.maxRequestModels),o=d(e.maxRequestModels.map(s=>ee(s)).join(", ")||"\u2014"),n=t?`${w(e.maxRequestInputTokens/t.thresholdTokens*100,0)}% of the ${g(t.thresholdTokens)}-token price line \xB7 ${o}`:`${o} \u2014 no long-context surcharge for ${e.maxRequestModels.length>1?"these models":"this model"}`;return Ko("\u{1F4CF} Largest request",`${g(e.maxRequestInputTokens)} input tokens`,n,"The biggest single prompt (input incl. cached tokens) sent to a model in one request during this period")}function Pl(e){if((e.maxReachedTokens??0)<=0)return"";let t=e.maxReachedWindowLimit,o=t?`${g(e.maxReachedTokens)} of ${g(t)} (${w(e.maxReachedTokens/t*100,0)}%)`:g(e.maxReachedTokens);return Ko("\u{1FA9F} Fullest CLI window",o,void 0,"The highest context fill recorded for a Copilot CLI session in this period, versus its window limit")}function _o(e){if(!(!!e&&(e.maxRequestInputTokens>0||(e.maxReachedTokens??0)>0||Object.keys(e.tierCounts).length>0)))return'<div style="color: var(--text-muted); font-size: 11px;">No data</div>';let o=Object.entries(e.tierCounts),n=o.reduce((r,[,i])=>r+i,0),s=o.length>0?Ko("\u{1FA9C} Context tiers",o.map(([r,i])=>`${d(r)} \xD7${i}`).join(", "),`${n} Copilot CLI session${n===1?"":"s"} grouped by chosen window size \u2014 "default" is the standard window at normal rates; larger tiers unlock more context at long-context prices`,"Copilot CLI lets you pick a context-window tier per session; the count shows how many sessions used each tier"):"";return _l(e)+Pl(e)+s}function Dl(e){let t=e.last30Days.contextWindow,o=t&&t.maxRequestInputTokens>0?Vs(t.maxRequestModels):null,n=t&&o?Rl(t.maxRequestInputTokens,o):"";return`
 		<div class="section">
 			<div class="section-title"><span>\u{1FA9F}</span><span>Context Window &amp; Long-Context Pricing</span></div>
 			<div class="section-subtitle">How close your largest requests come to the long-context price line. Models with tiered pricing bill higher input rates once a request exceeds their default-tier threshold.</div>
 			<div class="three-column">
 				<div>
 					<h4 style="color: var(--text-primary); font-size: 13px; margin-bottom: 8px;">\u{1F4C5} Today</h4>
-					${renderContextWindowPeriodHtml(stats.today.contextWindow)}
+					${_o(e.today.contextWindow)}
 				</div>
 				<div>
 					<h4 style="color: var(--text-primary); font-size: 13px; margin-bottom: 8px;">\u{1F4C6} Last 30 Days</h4>
-					${renderContextWindowPeriodHtml(cw30)}
+					${_o(t)}
 				</div>
 				<div>
 					<h4 style="color: var(--text-primary); font-size: 13px; margin-bottom: 8px;">\u{1F4C5} Previous Month</h4>
-					${renderContextWindowPeriodHtml(stats.lastMonth.contextWindow)}
+					${_o(e.lastMonth.contextWindow)}
 				</div>
 			</div>
-			${bar}
-		</div>`;
-  }
-  function numCell(value, extraClass = "") {
-    const zeroClass = value > 0 ? "" : " ctx-ref-zero";
-    const cls = `ctx-ref-num${extraClass ? " " + extraClass : ""}${zeroClass}`;
-    return `<td class="${cls}">${value}</td>`;
-  }
-  function sparklineCell(lastMonth, month, today) {
-    const W = 60, H2 = 20, PAD = 2;
-    const values = [lastMonth, month, today];
-    const max = Math.max(...values);
-    const points = values.map((v2, i6) => {
-      const x2 = PAD + i6 * ((W - PAD * 2) / (values.length - 1));
-      const y3 = max === 0 ? H2 - PAD : PAD + (1 - v2 / max) * (H2 - PAD * 2);
-      return `${x2.toFixed(1)},${y3.toFixed(1)}`;
-    }).join(" ");
-    const isFlat = max === 0;
-    const color = isFlat ? "var(--text-muted)" : today >= month && month >= lastMonth ? "var(--link-color)" : today <= month && month <= lastMonth ? "#f87171" : "var(--text-secondary)";
-    return `<td class="ctx-ref-spark"><svg viewBox="0 0 ${W} ${H2}" width="${W}" height="${H2}" aria-hidden="true"><polyline points="${points}" fill="none" stroke="${color}" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round"/>${values.map((v2, i6) => {
-      const x2 = PAD + i6 * ((W - PAD * 2) / (values.length - 1));
-      const y3 = max === 0 ? H2 - PAD : PAD + (1 - v2 / max) * (H2 - PAD * 2);
-      return `<circle cx="${x2.toFixed(1)}" cy="${y3.toFixed(1)}" r="2" fill="${color}"/>`;
-    }).join("")}</svg></td>`;
-  }
-  function renderContextRefTable(rows, totals) {
-    const bodyRows = rows.slice().sort((a3, b3) => b3.last30 - a3.last30).map((row) => {
-      const titleAttr = row.title ? ` title="${escapeHtml(row.title)}"` : "";
-      return `<tr${titleAttr}><td class="ctx-ref-name">${row.label}</td>${numCell(row.today, row.today > 0 ? "ctx-ref-today-active" : "")}${numCell(row.month)}${numCell(row.lastMonth)}${numCell(row.last30)}${sparklineCell(row.lastMonth, row.month, row.today)}</tr>`;
-    }).join("");
-    return `
+			${n}
+		</div>`}function Dt(e,t=""){let o=e>0?"":" ctx-ref-zero";return`<td class="${`ctx-ref-num${t?" "+t:""}${o}`}">${e}</td>`}function Ts(e,t,o){let i=[e,t,o],a=Math.max(...i),l=i.map((p,b)=>{let h=2+b*(56/(i.length-1)),S=a===0?18:2+(1-p/a)*16;return`${h.toFixed(1)},${S.toFixed(1)}`}).join(" "),c=a===0?"var(--text-muted)":o>=t&&t>=e?"var(--link-color)":o<=t&&t<=e?"#f87171":"var(--text-secondary)";return`<td class="ctx-ref-spark"><svg viewBox="0 0 60 20" width="60" height="20" aria-hidden="true"><polyline points="${l}" fill="none" stroke="${c}" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round"/>${i.map((p,b)=>{let h=2+b*(56/(i.length-1)),S=a===0?18:2+(1-p/a)*16;return`<circle cx="${h.toFixed(1)}" cy="${S.toFixed(1)}" r="2" fill="${c}"/>`}).join("")}</svg></td>`}function Ll(e,t){return`
 		<div class="ctx-ref-table-wrap">
 			<table class="ctx-ref-table">
 				<thead>
@@ -7454,1414 +2903,191 @@ ${_renderMultiModelMixedCostSessions(switching)}
 					</tr>
 				</thead>
 				<tbody>
-					${bodyRows}
+					${e.slice().sort((n,s)=>s.last30-n.last30).map(n=>`<tr${n.title?` title="${d(n.title)}"`:""}><td class="ctx-ref-name">${n.label}</td>${Dt(n.today,n.today>0?"ctx-ref-today-active":"")}${Dt(n.month)}${Dt(n.lastMonth)}${Dt(n.last30)}${Ts(n.lastMonth,n.month,n.today)}</tr>`).join("")}
 				</tbody>
 				<tfoot>
 					<tr class="ctx-ref-total">
 						<td class="ctx-ref-name">\u{1F4CA} Total References</td>
-						<td class="ctx-ref-num">${totals.today}</td>
-						<td class="ctx-ref-num">${totals.month}</td>
-						<td class="ctx-ref-num">${totals.lastMonth}</td>
-						<td class="ctx-ref-num">${totals.last30}</td>
-						<td class="ctx-ref-spark">${sparklineCell(totals.lastMonth, totals.month, totals.today).replace(/^<td[^>]*>/, "").replace(/<\/td>$/, "")}</td>
+						<td class="ctx-ref-num">${t.today}</td>
+						<td class="ctx-ref-num">${t.month}</td>
+						<td class="ctx-ref-num">${t.lastMonth}</td>
+						<td class="ctx-ref-num">${t.last30}</td>
+						<td class="ctx-ref-spark">${Ts(t.lastMonth,t.month,t.today).replace(/^<td[^>]*>/,"").replace(/<\/td>$/,"")}</td>
 					</tr>
 				</tfoot>
 			</table>
-		</div>`;
-  }
-  function buildContextRefCardsHtml(stats, todayTotalRefs, last30DaysTotalRefs) {
-    const c4 = (v2) => v2 || 0;
-    const descriptors = [
-      { label: "\u{1F4C4} #file", get: (cr) => cr.file },
-      { label: "\u2702\uFE0F #selection", get: (cr) => cr.selection },
-      { label: "\u2728 Implicit Selection", title: "Text selected in your editor providing passive context to Copilot", get: (cr) => cr.implicitSelection },
-      { label: "\u{1F524} #symbol", get: (cr) => cr.symbol },
-      { label: "\u{1F5C2}\uFE0F #codebase", get: (cr) => cr.codebase },
-      { label: "\u{1F4C1} @workspace", get: (cr) => cr.workspace },
-      { label: "\u{1F4BB} @terminal", get: (cr) => cr.terminal },
-      { label: "\u{1F527} @vscode", get: (cr) => cr.vscode },
-      { label: "\u2328\uFE0F #terminalLastCommand", title: "Last command run in the terminal", get: (cr) => c4(cr.terminalLastCommand) },
-      { label: "\u{1F5B1}\uFE0F #terminalSelection", title: "Selected terminal output", get: (cr) => c4(cr.terminalSelection) },
-      { label: "\u{1F4CB} #clipboard", title: "Clipboard contents", get: (cr) => c4(cr.clipboard) },
-      { label: "\u{1F4DD} #changes", title: "Uncommitted git changes", get: (cr) => c4(cr.changes) },
-      { label: "\u{1F4E4} #outputPanel", title: "Output panel contents", get: (cr) => c4(cr.outputPanel) },
-      { label: "\u26A0\uFE0F #problemsPanel", title: "Problems panel contents", get: (cr) => c4(cr.problemsPanel) },
-      { label: "\u{1F500} #pr", title: "Pull request context references (#pr / #pullRequest) \u2014 Copilot PR chat understanding, review, and summary", get: (cr) => c4(cr.pullRequest) },
-      { label: "\u{1F4F7} Images", title: "Pasted images and vision context detected in session logs", get: (cr) => c4(cr.byKind["copilot.image"]) },
-      { label: "\u{1F4CB} Prompt Files", title: ".github/prompts/ prompt file uses detected in session logs", get: (cr) => c4(cr.byKind["promptFile"]) },
-      { label: "\u{1F4D0} Code Lines", title: "Total lines of code referenced via #file: range selections", get: (cr) => c4(cr.codeContextLines) },
-      { label: "\u{1F3AF} Custom Prompts", title: "Custom /command prompt uses detected in session logs", get: (cr) => c4(cr.byKind["prompt"]) },
-      { label: "\u{1F4CB} Copilot Instructions", title: "copilot-instructions.md file references detected in session logs", get: (cr) => cr.copilotInstructions },
-      { label: "\u{1F916} Agents.md", title: "agents.md file references detected in session logs", get: (cr) => cr.agentsMd }
-    ];
-    const r6 = stats.last30Days.contextReferences;
-    const m2 = stats.month.contextReferences;
-    const lm = stats.lastMonth.contextReferences;
-    const t4 = stats.today.contextReferences;
-    const rows = descriptors.map((d3) => ({
-      label: d3.label,
-      title: d3.title,
-      last30: d3.get(r6),
-      month: d3.get(m2),
-      lastMonth: d3.get(lm),
-      today: d3.get(t4)
-    }));
-    return renderContextRefTable(rows, {
-      last30: last30DaysTotalRefs,
-      month: getTotalContextRefs(m2),
-      lastMonth: getTotalContextRefs(lm),
-      today: todayTotalRefs
-    });
-  }
-  function buildContextRefsHtml(stats, todayTotalRefs, last30DaysTotalRefs) {
-    const byKindHtml = Object.keys(stats.last30Days.contextReferences.byKind).length > 0 ? `
+		</div>`}function Ul(e,t,o){let n=c=>c||0,s=[{label:"\u{1F4C4} #file",get:c=>c.file},{label:"\u2702\uFE0F #selection",get:c=>c.selection},{label:"\u2728 Implicit Selection",title:"Text selected in your editor providing passive context to Copilot",get:c=>c.implicitSelection},{label:"\u{1F524} #symbol",get:c=>c.symbol},{label:"\u{1F5C2}\uFE0F #codebase",get:c=>c.codebase},{label:"\u{1F4C1} @workspace",get:c=>c.workspace},{label:"\u{1F4BB} @terminal",get:c=>c.terminal},{label:"\u{1F527} @vscode",get:c=>c.vscode},{label:"\u2328\uFE0F #terminalLastCommand",title:"Last command run in the terminal",get:c=>n(c.terminalLastCommand)},{label:"\u{1F5B1}\uFE0F #terminalSelection",title:"Selected terminal output",get:c=>n(c.terminalSelection)},{label:"\u{1F4CB} #clipboard",title:"Clipboard contents",get:c=>n(c.clipboard)},{label:"\u{1F4DD} #changes",title:"Uncommitted git changes",get:c=>n(c.changes)},{label:"\u{1F4E4} #outputPanel",title:"Output panel contents",get:c=>n(c.outputPanel)},{label:"\u26A0\uFE0F #problemsPanel",title:"Problems panel contents",get:c=>n(c.problemsPanel)},{label:"\u{1F500} #pr",title:"Pull request context references (#pr / #pullRequest) \u2014 Copilot PR chat understanding, review, and summary",get:c=>n(c.pullRequest)},{label:"\u{1F4F7} Images",title:"Pasted images and vision context detected in session logs",get:c=>n(c.byKind["copilot.image"])},{label:"\u{1F4CB} Prompt Files",title:".github/prompts/ prompt file uses detected in session logs",get:c=>n(c.byKind.promptFile)},{label:"\u{1F4D0} Code Lines",title:"Total lines of code referenced via #file: range selections",get:c=>n(c.codeContextLines)},{label:"\u{1F3AF} Custom Prompts",title:"Custom /command prompt uses detected in session logs",get:c=>n(c.byKind.prompt)},{label:"\u{1F4CB} Copilot Instructions",title:"copilot-instructions.md file references detected in session logs",get:c=>c.copilotInstructions},{label:"\u{1F916} Agents.md",title:"agents.md file references detected in session logs",get:c=>c.agentsMd}],r=e.last30Days.contextReferences,i=e.month.contextReferences,a=e.lastMonth.contextReferences,l=e.today.contextReferences,u=s.map(c=>({label:c.label,title:c.title,last30:c.get(r),month:c.get(i),lastMonth:c.get(a),today:c.get(l)}));return Ll(u,{last30:o,month:Re(i),lastMonth:Re(a),today:t})}function Il(e,t,o){let n=Object.keys(e.last30Days.contextReferences.byKind).length>0?`
 		<div style="margin-top: 16px; padding: 12px; background: var(--bg-tertiary); border: 1px solid var(--border-subtle); border-radius: 6px;">
 			<div style="font-size: 13px; font-weight: 600; color: var(--text-primary); margin-bottom: 8px;">\u{1F4CE} Attached Files by Type (Last 30 Days)</div>
 			<div style="font-size: 12px; color: var(--text-primary);">
-				${Object.entries(stats.last30Days.contextReferences.byKind).sort(([, a3], [, b3]) => b3 - a3).slice(0, 5).map(([kind, count]) => `<div style="margin-bottom: 4px;"><span style="color: var(--link-color);">${escapeHtml(kind)}:</span> ${count}</div>`).join("")}
+				${Object.entries(e.last30Days.contextReferences.byKind).sort(([,r],[,i])=>i-r).slice(0,5).map(([r,i])=>`<div style="margin-bottom: 4px;"><span style="color: var(--link-color);">${d(r)}:</span> ${i}</div>`).join("")}
 			</div>
 		</div>
-	` : "";
-    const byPathHtml = Object.keys(stats.last30Days.contextReferences.byPath).length > 0 ? `
+	`:"",s=Object.keys(e.last30Days.contextReferences.byPath).length>0?`
 		<div style="margin-top: 16px; padding: 12px; background: var(--bg-tertiary); border: 1px solid var(--border-subtle); border-radius: 6px;">
 			<div style="font-size: 13px; font-weight: 600; color: var(--text-primary); margin-bottom: 8px;">\u{1F4C1} Most Referenced Files (Last 30 Days)</div>
 			<div style="font-size: 11px; color: var(--text-primary);">
-				${Object.entries(stats.last30Days.contextReferences.byPath).sort(([, a3], [, b3]) => b3 - a3).slice(0, 10).map(([path, count]) => `<div style="margin-bottom: 4px; font-family: 'Courier New', monospace;"><span style="color: var(--link-color);">${count}\xD7</span> ${escapeHtml(path)}</div>`).join("")}
+				${Object.entries(e.last30Days.contextReferences.byPath).sort(([,r],[,i])=>i-r).slice(0,10).map(([r,i])=>`<div style="margin-bottom: 4px; font-family: 'Courier New', monospace;"><span style="color: var(--link-color);">${i}\xD7</span> ${d(r)}</div>`).join("")}
 			</div>
 		</div>
-	` : "";
-    return `
+	`:"";return`
 		<!-- Context References Section -->
 		<div class="section">
 			<div class="section-title"><span>\u{1F517}</span><span>Context References</span></div>
 			<div class="section-subtitle">How often you reference files, selections, symbols, and workspace context</div>
-			${buildContextRefCardsHtml(stats, todayTotalRefs, last30DaysTotalRefs)}
-			${byKindHtml}
-			${byPathHtml}
-		</div>`;
-  }
-  function buildUnknownMcpToolsBannerHtml(stats) {
-    const unknownTools = getUnknownMcpTools(stats);
-    if (unknownTools.length === 0) {
-      return "";
-    }
-    const issueUrl = createMcpToolIssueUrl(unknownTools);
-    const toolListHtml = unknownTools.map((tool) => {
-      const todayCount = (stats.today.toolCalls.byTool[tool] || 0) + (stats.today.mcpTools.byTool[tool] || 0);
-      const last30Count = (stats.last30Days.toolCalls.byTool[tool] || 0) + (stats.last30Days.mcpTools.byTool[tool] || 0);
-      const monthCount = (stats.month.toolCalls.byTool[tool] || 0) + (stats.month.mcpTools.byTool[tool] || 0);
-      const countParts = [];
-      if (todayCount > 0) {
-        countParts.push(`${todayCount} today`);
-      }
-      if (last30Count > todayCount) {
-        countParts.push(`${last30Count} in the last 30d`);
-      }
-      if (monthCount > last30Count) {
-        countParts.push(`${monthCount} this month`);
-      }
-      const countHtml = countParts.length > 0 ? `<span style="color:var(--text-muted);"> (${countParts.join(" | ")})</span>` : "";
-      const suppressBtn = `<button data-suppress-tool="${escapeHtml(tool)}" title="Suppress this tool from the unknown list" style="background:none; border:none; cursor:pointer; padding:0 2px; color:var(--text-muted); font-size:11px; line-height:1;" aria-label="Suppress ${escapeHtml(tool)}">\u{1F507}</button>`;
-      return `<span style="display:inline-flex; align-items:center; gap:4px; padding:2px 6px; background:var(--bg-primary); border:1px solid var(--border-color); border-radius:3px; font-family:monospace; font-size:11px;">${escapeHtml(tool)}${countHtml}${suppressBtn}</span>`;
-    }).join(" ");
-    return `
+			${Ul(e,t,o)}
+			${n}
+			${s}
+		</div>`}function zl(e){let t=ui(e);if(t.length===0)return"";let o=pi(t);return`
 		<div id="unknown-mcp-tools-section" style="margin-bottom: 12px; padding: 10px; background: var(--bg-secondary); border: 1px solid var(--border-color); border-radius: 6px;">
 			<div style="display:flex; flex-wrap:wrap; gap:4px; margin-bottom:10px;">
-				${toolListHtml}
+				${t.map(s=>{let r=(e.today.toolCalls.byTool[s]||0)+(e.today.mcpTools.byTool[s]||0),i=(e.last30Days.toolCalls.byTool[s]||0)+(e.last30Days.mcpTools.byTool[s]||0),a=(e.month.toolCalls.byTool[s]||0)+(e.month.mcpTools.byTool[s]||0),l=[];r>0&&l.push(`${r} today`),i>r&&l.push(`${i} in the last 30d`),a>i&&l.push(`${a} this month`);let u=l.length>0?`<span style="color:var(--text-muted);"> (${l.join(" | ")})</span>`:"",c=`<button data-suppress-tool="${d(s)}" title="Suppress this tool from the unknown list" style="background:none; border:none; cursor:pointer; padding:0 2px; color:var(--text-muted); font-size:11px; line-height:1;" aria-label="Suppress ${d(s)}">\u{1F507}</button>`;return`<span style="display:inline-flex; align-items:center; gap:4px; padding:2px 6px; background:var(--bg-primary); border:1px solid var(--border-color); border-radius:3px; font-family:monospace; font-size:11px;">${d(s)}${u}${c}</span>`}).join(" ")}
 			</div>
-			<a href="${escapeHtml(issueUrl)}" target="_blank" rel="noopener noreferrer" style="display: inline-flex; align-items: center; gap: 6px; padding: 6px 12px; background: var(--button-bg); color: var(--button-fg); border-radius: 4px; text-decoration: none; font-size: 12px; font-weight: 500;">
+			<a href="${d(o)}" target="_blank" rel="noopener noreferrer" style="display: inline-flex; align-items: center; gap: 6px; padding: 6px 12px; background: var(--button-bg); color: var(--button-fg); border-radius: 4px; text-decoration: none; font-size: 12px; font-weight: 500;">
 				<span>\u{1F4DD}</span>
 				<span>Report Unknown Tools</span>
 			</a>
 		</div>
-	`;
-  }
-  var EFFICIENCY_PERIOD_TO_DATA_KEY = {
-    today: "today",
-    last30: "last30Days",
-    currentMonth: "month"
-  };
-  var efficiencySelectedPeriod = "last30";
-  var efficiencyPeriod = "last30Days";
-  var efficiencyMetric = "cost";
-  var efficiencyBubbleMetric = "calls";
-  var efficiencyColorMode = "vendor";
-  var efficiencySortColumn = "calls";
-  var efficiencySortDirection = "desc";
-  var cachedModelEfficiency = {};
-  var efficiencyFilterLowUsage = true;
-  function formatUnitCost(value) {
-    if (value === null) {
-      return "\u2014";
-    }
-    return value >= 0.01 ? formatCost(value) : `$${value.toFixed(3)}`;
-  }
-  function formatRatePercent(value) {
-    return value === null ? "\u2014" : formatPercent(value * 100);
-  }
-  function formatPerTurn(value) {
-    return value === null ? "\u2014" : formatFixed(value, 1);
-  }
-  var EFFICIENCY_METRICS = [
-    { key: "cost", label: "Cost", axisLabel: "Average cost per turn", value: (row) => row.rates.costPerCall, format: formatUnitCost },
-    { key: "outputTokens", label: "Output tokens", axisLabel: "Average output tokens per turn", value: (row) => row.rates.outputTokensPerCall, format: (value) => value === null ? "\u2014" : formatCompact(Math.round(value)) },
-    { key: "toolSteps", label: "Tool steps", axisLabel: "Average tool steps per turn", value: (row) => row.rates.toolCallsPerCall, format: formatPerTurn }
-  ];
-  var EFFICIENCY_BUBBLE_METRICS = [
-    { key: "calls", label: "Local use", value: (row) => row.counters.calls, format: (value) => `${formatNumber(value ?? 0)} turns` },
-    ...EFFICIENCY_METRICS.map(({ key, label, value, format }) => ({ key, label, value, format }))
-  ];
-  function buildLocalUsageCell(row, totalCalls) {
-    const share = totalCalls > 0 ? row.counters.calls / totalCalls : 0;
-    return `<div class="model-use-cell">
-		<div class="model-use-track" aria-hidden="true"><span style="width:${Math.max(2, share * 100).toFixed(1)}%"></span></div>
-		<strong>${formatRatePercent(share)}</strong>
-		<span>${formatNumber(row.counters.calls)} turns</span>
-	</div>`;
-  }
-  var EFFICIENCY_COLUMN_DEFS = [
-    { sortKey: "model", label: "Model", title: "Model identifier", sortValue: (row) => row.model, render: (row) => escapeHtml(getModelDisplayName(row.model)) },
-    { sortKey: "calls", label: "Local use", title: "Share of user-request turns attributed to this model", sortValue: (row) => row.counters.calls, render: buildLocalUsageCell },
-    { sortKey: "oneShotRate", label: "One-shot", title: "Share of edit turns completed without retries or self-corrections", sortValue: (row) => row.rates.oneShotRate, render: (row) => formatRatePercent(row.rates.oneShotRate) },
-    { sortKey: "retryRate", label: "Retries/edit", title: "Average immediate same-file retries per edit turn", sortValue: (row) => row.rates.retryRate, render: (row) => formatPerTurn(row.rates.retryRate) },
-    { sortKey: "selfCorrectionRate", label: "Self-corr/edit", title: "Average re-edits after intervening tool calls per edit turn", sortValue: (row) => row.rates.selfCorrectionRate, render: (row) => formatPerTurn(row.rates.selfCorrectionRate) },
-    { sortKey: "costPerCall", label: "Avg cost", title: "Average estimated provider cost per user-request turn", sortValue: (row) => row.rates.costPerCall, render: (row) => formatUnitCost(row.rates.costPerCall) },
-    { sortKey: "outputTokensPerCall", label: "Out tok", title: "Average output tokens per user-request turn", sortValue: (row) => row.rates.outputTokensPerCall, render: (row) => row.rates.outputTokensPerCall === null ? "\u2014" : formatCompact(Math.round(row.rates.outputTokensPerCall)) },
-    { sortKey: "toolCallsPerCall", label: "Steps", title: "Average tool invocations per user-request turn", sortValue: (row) => row.rates.toolCallsPerCall, render: (row) => formatPerTurn(row.rates.toolCallsPerCall) },
-    { sortKey: "cacheHitRate", label: "Cache hit", title: "Cache-read share of input tokens", sortValue: (row) => row.rates.cacheHitRate, render: (row) => formatRatePercent(row.rates.cacheHitRate) }
-  ];
-  function getEfficiencySortIndicator(column) {
-    if (efficiencySortColumn !== column) {
-      return "";
-    }
-    return efficiencySortDirection === "desc" ? " \u25BC" : " \u25B2";
-  }
-  function compareEfficiencyRows(a3, b3, column) {
-    const av = column.sortValue(a3);
-    const bv = column.sortValue(b3);
-    if (av === null && bv === null) {
-      return 0;
-    }
-    if (av === null) {
-      return 1;
-    }
-    if (bv === null) {
-      return -1;
-    }
-    const cmp = typeof av === "string" || typeof bv === "string" ? String(av).localeCompare(String(bv)) : av - bv;
-    return efficiencySortDirection === "desc" ? -cmp : cmp;
-  }
-  function buildEfficiencyRows(usage) {
-    const rows = Object.entries(usage).map(([model, counters]) => ({ model, counters, rates: deriveModelEfficiencyRates(counters) }));
-    const column = EFFICIENCY_COLUMN_DEFS.find((item) => item.sortKey === efficiencySortColumn) ?? EFFICIENCY_COLUMN_DEFS[1];
-    return rows.sort((a3, b3) => compareEfficiencyRows(a3, b3, column));
-  }
-  function filterLowUsageRows(rows, usage) {
-    if (!efficiencyFilterLowUsage) {
-      return { rows, hiddenNote: "" };
-    }
-    const threshold = computeEfficiencyLowUsageThreshold(usage);
-    if (threshold === null) {
-      return { rows, hiddenNote: "" };
-    }
-    const filtered = rows.filter((row) => row.counters.calls > threshold);
-    const hiddenCount = rows.length - filtered.length;
-    const noun = hiddenCount === 1 ? "model" : "models";
-    const turnNoun = threshold === 1 ? "turn" : "turns";
-    const hiddenNote = hiddenCount > 0 ? `${hiddenCount} low-usage ${noun} hidden (\u2264${threshold} ${turnNoun})` : "";
-    return { rows: filtered, hiddenNote };
-  }
-  var MODEL_COLOR_VARS = ["--stage-1-color", "--stage-2-color", "--stage-3-color", "--stage-4-color", "--success-fg", "--warning-fg", "--link-color"];
-  var PROVIDER_COLOR_VARS = {
-    Anthropic: "--warning-fg",
-    OpenAI: "--success-fg",
-    Google: "--stage-3-color",
-    "Mistral AI": "--stage-2-color",
-    xAI: "--stage-4-color",
-    Alibaba: "--stage-1-color",
-    Microsoft: "--link-color"
-  };
-  function getColorForKey(key) {
-    let hash = 0;
-    for (let i6 = 0; i6 < key.length; i6++) {
-      hash = (hash << 5) - hash + key.charCodeAt(i6) | 0;
-    }
-    return `var(${MODEL_COLOR_VARS[Math.abs(hash) % MODEL_COLOR_VARS.length]})`;
-  }
-  function getEfficiencyColor(model) {
-    if (efficiencyColorMode === "model") {
-      return getColorForKey(model);
-    }
-    const provider = getModelBillingProvider(model);
-    const colorVar = PROVIDER_COLOR_VARS[provider];
-    return colorVar ? `var(${colorVar})` : getColorForKey(provider);
-  }
-  function formatMetricTick(metric, value) {
-    if (metric.key === "cost") {
-      return formatUnitCost(value);
-    }
-    if (metric.key === "outputTokens") {
-      return formatCompact(Math.round(value));
-    }
-    return formatFixed(value, 1);
-  }
-  function buildEfficiencyGrid(metric, maxX) {
-    const vertical = [0, 0.25, 0.5, 0.75, 1].map((fraction) => {
-      const x2 = 76 + fraction * 760;
-      return `<line x1="${x2}" y1="24" x2="${x2}" y2="286"></line><text x="${x2}" y="310" text-anchor="middle">${escapeHtml(formatMetricTick(metric, maxX * fraction))}</text>`;
-    }).join("");
-    const horizontal = [0, 0.25, 0.5, 0.75, 1].map((fraction) => {
-      const y3 = 286 - fraction * 262;
-      return `<line x1="76" y1="${y3}" x2="836" y2="${y3}"></line><text x="64" y="${y3 + 4}" text-anchor="end">${Math.round(fraction * 100)}%</text>`;
-    }).join("");
-    return `<g class="efficiency-grid">${vertical}${horizontal}</g>`;
-  }
-  function buildEfficiencyPoint(row, metric, bubbleMetric, maxX, maxBubbleValue, labelPlacement) {
-    const value = metric.value(row) ?? 0;
-    const bubbleValue = bubbleMetric.value(row) ?? 0;
-    const rate = row.rates.oneShotRate ?? 0;
-    const x2 = 76 + value / maxX * 760;
-    const y3 = 286 - rate * 262;
-    const radius = scaleBubbleRadius(bubbleValue, maxBubbleValue);
-    const color = getEfficiencyColor(row.model);
-    const rawLabel = getModelDisplayName(row.model);
-    const label = escapeHtml(rawLabel);
-    const aria = `${rawLabel}: ${formatRatePercent(rate)} one-shot edit rate, ${metric.format(value)} ${metric.axisLabel.toLowerCase()}, bubble sized by ${bubbleMetric.label.toLowerCase()}: ${bubbleMetric.format(bubbleValue)}`;
-    return `<g class="efficiency-point" style="--model-color:${color}" tabindex="0" role="img" aria-label="${escapeHtml(aria)}">
-		<circle cx="${x2.toFixed(1)}" cy="${y3.toFixed(1)}" r="${radius.toFixed(1)}"><title>${escapeHtml(aria)}</title></circle>
-		<text x="${labelPlacement.x.toFixed(1)}" y="${labelPlacement.y.toFixed(1)}" text-anchor="${labelPlacement.textAnchor}">${label}</text>
-	</g>`;
-  }
-  function buildEfficiencyColorLegendHtml(rows) {
-    if (efficiencyColorMode !== "vendor") {
-      return "";
-    }
-    const providers = [...new Set(rows.map((row) => getModelBillingProvider(row.model)))].sort();
-    const items = providers.map((provider) => {
-      const model = rows.find((row) => getModelBillingProvider(row.model) === provider)?.model ?? "";
-      return `<span class="efficiency-legend-item" style="--model-color:${getEfficiencyColor(model)}"><span aria-hidden="true"></span>${escapeHtml(provider)}</span>`;
-    }).join("");
-    return `<div class="efficiency-vendor-legend" aria-label="Model vendor colors">${items}</div>`;
-  }
-  function buildEfficiencyChartHtml(rows) {
-    const metric = EFFICIENCY_METRICS.find((item) => item.key === efficiencyMetric) ?? EFFICIENCY_METRICS[0];
-    const bubbleMetric = EFFICIENCY_BUBBLE_METRICS.find((item) => item.key === efficiencyBubbleMetric) ?? EFFICIENCY_BUBBLE_METRICS[0];
-    const chartRows = rows.filter((row) => row.rates.oneShotRate !== null && metric.value(row) !== null).sort((a3, b3) => b3.counters.calls - a3.counters.calls).slice(0, 12);
-    if (chartRows.length === 0) {
-      return '<div class="model-leaderboard-empty"><strong>No comparable edit data yet.</strong><span>The chart appears after local sessions record both a model and structured edit turns.</span></div>';
-    }
-    const maxX = Math.max(...chartRows.map((row) => metric.value(row) ?? 0), 1e-4) * 1.08;
-    const maxBubbleValue = Math.max(...chartRows.map((row) => bubbleMetric.value(row) ?? 0), 0);
-    const labelInputs = chartRows.map((row) => {
-      const value = metric.value(row) ?? 0;
-      const bubbleValue = bubbleMetric.value(row) ?? 0;
-      return {
-        x: 76 + value / maxX * 760,
-        y: 286 - (row.rates.oneShotRate ?? 0) * 262,
-        radius: scaleBubbleRadius(bubbleValue, maxBubbleValue),
-        label: getModelDisplayName(row.model)
-      };
-    });
-    const labelPlacements = placeBubbleLabels(labelInputs, { left: 76, right: 836, top: 24, bottom: 286 });
-    const points = chartRows.map(
-      (row, index) => buildEfficiencyPoint(row, metric, bubbleMetric, maxX, maxBubbleValue, labelPlacements[index])
-    ).join("");
-    return `<div class="efficiency-chart-wrap">
-		<svg class="efficiency-chart" viewBox="0 0 900 350" role="img" aria-label="One-shot edit rate compared with ${escapeHtml(metric.axisLabel.toLowerCase())}; bubble size represents ${escapeHtml(bubbleMetric.label.toLowerCase())}">
-			${buildEfficiencyGrid(metric, maxX)}
-			<text class="efficiency-axis-title" x="456" y="344" text-anchor="middle">${escapeHtml(metric.axisLabel)}</text>
+	`}var Bl={today:"today",last30:"last30Days",currentMonth:"month"},$s="last30",Ys="last30Days",Ht="cost",Go="calls",Vt="vendor",jt="calls",nt="desc",Js={},Vo=!0;function Yo(e){return e===null?"\u2014":e>=.01?sn(e):`$${e.toFixed(3)}`}function Ft(e){return e===null?"\u2014":Q(e*100)}function Bt(e){return e===null?"\u2014":w(e,1)}var dt=[{key:"cost",label:"Cost",axisLabel:"Average cost per turn",value:e=>e.rates.costPerCall,format:Yo},{key:"outputTokens",label:"Output tokens",axisLabel:"Average output tokens per turn",value:e=>e.rates.outputTokensPerCall,format:e=>e===null?"\u2014":gt(Math.round(e))},{key:"toolSteps",label:"Tool steps",axisLabel:"Average tool steps per turn",value:e=>e.rates.toolCallsPerCall,format:Bt}],Wt=[{key:"calls",label:"Local use",value:e=>e.counters.calls,format:e=>`${g(e??0)} turns`},...dt.map(({key:e,label:t,value:o,format:n})=>({key:e,label:t,value:o,format:n}))];function Ol(e,t){let o=t>0?e.counters.calls/t:0;return`<div class="model-use-cell">
+		<div class="model-use-track" aria-hidden="true"><span style="width:${Math.max(2,o*100).toFixed(1)}%"></span></div>
+		<strong>${Ft(o)}</strong>
+		<span>${g(e.counters.calls)} turns</span>
+	</div>`}var qt=[{sortKey:"model",label:"Model",title:"Model identifier",sortValue:e=>e.model,render:e=>d(ee(e.model))},{sortKey:"calls",label:"Local use",title:"Share of user-request turns attributed to this model",sortValue:e=>e.counters.calls,render:Ol},{sortKey:"oneShotRate",label:"One-shot",title:"Share of edit turns completed without retries or self-corrections",sortValue:e=>e.rates.oneShotRate,render:e=>Ft(e.rates.oneShotRate)},{sortKey:"retryRate",label:"Retries/edit",title:"Average immediate same-file retries per edit turn",sortValue:e=>e.rates.retryRate,render:e=>Bt(e.rates.retryRate)},{sortKey:"selfCorrectionRate",label:"Self-corr/edit",title:"Average re-edits after intervening tool calls per edit turn",sortValue:e=>e.rates.selfCorrectionRate,render:e=>Bt(e.rates.selfCorrectionRate)},{sortKey:"costPerCall",label:"Avg cost",title:"Average estimated provider cost per user-request turn",sortValue:e=>e.rates.costPerCall,render:e=>Yo(e.rates.costPerCall)},{sortKey:"outputTokensPerCall",label:"Out tok",title:"Average output tokens per user-request turn",sortValue:e=>e.rates.outputTokensPerCall,render:e=>e.rates.outputTokensPerCall===null?"\u2014":gt(Math.round(e.rates.outputTokensPerCall))},{sortKey:"toolCallsPerCall",label:"Steps",title:"Average tool invocations per user-request turn",sortValue:e=>e.rates.toolCallsPerCall,render:e=>Bt(e.rates.toolCallsPerCall)},{sortKey:"cacheHitRate",label:"Cache hit",title:"Cache-read share of input tokens",sortValue:e=>e.rates.cacheHitRate,render:e=>Ft(e.rates.cacheHitRate)}];function Nl(e){return jt!==e?"":nt==="desc"?" \u25BC":" \u25B2"}function Hl(e,t,o){let n=o.sortValue(e),s=o.sortValue(t);if(n===null&&s===null)return 0;if(n===null)return 1;if(s===null)return-1;let r=typeof n=="string"||typeof s=="string"?String(n).localeCompare(String(s)):n-s;return nt==="desc"?-r:r}function jl(e){let t=Object.entries(e).map(([n,s])=>({model:n,counters:s,rates:pn(s)})),o=qt.find(n=>n.sortKey===jt)??qt[1];return t.sort((n,s)=>Hl(n,s,o))}function Fl(e,t){if(!Vo)return{rows:e,hiddenNote:""};let o=gn(t);if(o===null)return{rows:e,hiddenNote:""};let n=e.filter(l=>l.counters.calls>o),s=e.length-n.length,r=s===1?"model":"models",i=o===1?"turn":"turns",a=s>0?`${s} low-usage ${r} hidden (\u2264${o} ${i})`:"";return{rows:n,hiddenNote:a}}var As=["--stage-1-color","--stage-2-color","--stage-3-color","--stage-4-color","--success-fg","--warning-fg","--link-color"],Wl={Anthropic:"--warning-fg",OpenAI:"--success-fg",Google:"--stage-3-color","Mistral AI":"--stage-2-color",xAI:"--stage-4-color",Alibaba:"--stage-1-color",Microsoft:"--link-color"};function Ms(e){let t=0;for(let o=0;o<e.length;o++)t=(t<<5)-t+e.charCodeAt(o)|0;return`var(${As[Math.abs(t)%As.length]})`}function Jo(e){if(Vt==="model")return Ms(e);let t=yt(e),o=Wl[t];return o?`var(${o})`:Ms(t)}function ql(e,t){return e.key==="cost"?Yo(t):e.key==="outputTokens"?gt(Math.round(t)):w(t,1)}function Kl(e,t){let o=[0,.25,.5,.75,1].map(s=>{let r=76+s*760;return`<line x1="${r}" y1="24" x2="${r}" y2="286"></line><text x="${r}" y="310" text-anchor="middle">${d(ql(e,t*s))}</text>`}).join(""),n=[0,.25,.5,.75,1].map(s=>{let r=286-s*262;return`<line x1="76" y1="${r}" x2="836" y2="${r}"></line><text x="64" y="${r+4}" text-anchor="end">${Math.round(s*100)}%</text>`}).join("");return`<g class="efficiency-grid">${o}${n}</g>`}function Gl(e,t,o,n,s,r){let i=t.value(e)??0,a=o.value(e)??0,l=e.rates.oneShotRate??0,u=76+i/n*760,c=286-l*262,p=no(a,s),b=Jo(e.model),h=ee(e.model),S=d(h),ut=`${h}: ${Ft(l)} one-shot edit rate, ${t.format(i)} ${t.axisLabel.toLowerCase()}, bubble sized by ${o.label.toLowerCase()}: ${o.format(a)}`;return`<g class="efficiency-point" style="--model-color:${b}" tabindex="0" role="img" aria-label="${d(ut)}">
+		<circle cx="${u.toFixed(1)}" cy="${c.toFixed(1)}" r="${p.toFixed(1)}"><title>${d(ut)}</title></circle>
+		<text x="${r.x.toFixed(1)}" y="${r.y.toFixed(1)}" text-anchor="${r.textAnchor}">${S}</text>
+	</g>`}function Vl(e){return Vt!=="vendor"?"":`<div class="efficiency-vendor-legend" aria-label="Model vendor colors">${[...new Set(e.map(n=>yt(n.model)))].sort().map(n=>{let s=e.find(r=>yt(r.model)===n)?.model??"";return`<span class="efficiency-legend-item" style="--model-color:${Jo(s)}"><span aria-hidden="true"></span>${d(n)}</span>`}).join("")}</div>`}function Yl(e){let t=dt.find(u=>u.key===Ht)??dt[0],o=Wt.find(u=>u.key===Go)??Wt[0],n=e.filter(u=>u.rates.oneShotRate!==null&&t.value(u)!==null).sort((u,c)=>c.counters.calls-u.counters.calls).slice(0,12);if(n.length===0)return'<div class="model-leaderboard-empty"><strong>No comparable edit data yet.</strong><span>The chart appears after local sessions record both a model and structured edit turns.</span></div>';let s=Math.max(...n.map(u=>t.value(u)??0),1e-4)*1.08,r=Math.max(...n.map(u=>o.value(u)??0),0),i=n.map(u=>{let c=t.value(u)??0,p=o.value(u)??0;return{x:76+c/s*760,y:286-(u.rates.oneShotRate??0)*262,radius:no(p,r),label:ee(u.model)}}),a=xn(i,{left:76,right:836,top:24,bottom:286}),l=n.map((u,c)=>Gl(u,t,o,s,r,a[c])).join("");return`<div class="efficiency-chart-wrap">
+		<svg class="efficiency-chart" viewBox="0 0 900 350" role="img" aria-label="One-shot edit rate compared with ${d(t.axisLabel.toLowerCase())}; bubble size represents ${d(o.label.toLowerCase())}">
+			${Kl(t,s)}
+			<text class="efficiency-axis-title" x="456" y="344" text-anchor="middle">${d(t.axisLabel)}</text>
 			<text class="efficiency-axis-title" x="17" y="155" text-anchor="middle" transform="rotate(-90 17 155)">One-shot edit rate</text>
 			<text class="efficiency-chart-hint" x="836" y="17" text-anchor="end">higher is better \u2191</text>
-			${points}
+			${l}
 		</svg>
-	</div>${buildEfficiencyColorLegendHtml(chartRows)}`;
-  }
-  function buildChartControlsHtml() {
-    const buttons = EFFICIENCY_METRICS.map(
-      (metric) => `<button class="efficiency-metric-button${metric.key === efficiencyMetric ? " active" : ""}" type="button" data-eff-metric="${metric.key}" aria-pressed="${metric.key === efficiencyMetric}">${metric.label}</button>`
-    ).join("");
-    const bubbleOptions = EFFICIENCY_BUBBLE_METRICS.map(
-      (metric) => `<option value="${metric.key}"${metric.key === efficiencyBubbleMetric ? " selected" : ""}>${metric.label}</option>`
-    ).join("");
-    const colorOptions = [
-      { value: "vendor", label: "Vendor" },
-      { value: "model", label: "Model" }
-    ].map((option) => `<option value="${option.value}"${option.value === efficiencyColorMode ? " selected" : ""}>${option.label}</option>`).join("");
-    return `<div class="efficiency-chart-controls">
-		<div class="efficiency-control"><span>X-axis</span><div class="efficiency-metric-selector" role="group" aria-label="Efficiency comparison metric">${buttons}</div></div>
-		<label class="efficiency-control"><span>Bubble size</span><select id="eff-bubble-metric">${bubbleOptions}</select></label>
-		<label class="efficiency-control"><span>Color by</span><select id="eff-color-mode">${colorOptions}</select></label>
-	</div>`;
-  }
-  function buildEfficiencyTableHtml(rows, totalCalls) {
-    const tableRows = rows.map((row) => {
-      const cells = EFFICIENCY_COLUMN_DEFS.map((column) => `<td>${column.render(row, totalCalls)}</td>`).join("");
-      return `<tr style="--model-color:${getEfficiencyColor(row.model)}">${cells}</tr>`;
-    }).join("");
-    const headers = EFFICIENCY_COLUMN_DEFS.map(
-      (column) => `<th class="sortable" data-eff-sort="${column.sortKey}" title="${column.title}">${column.label}${getEfficiencySortIndicator(column.sortKey)}</th>`
-    ).join("");
-    return `<div class="model-leaderboard-table-wrap"><table class="model-leaderboard-table"><thead><tr>${headers}</tr></thead><tbody>${tableRows}</tbody></table></div>`;
-  }
-  function buildModelEfficiencyContentHtml() {
-    const usage = cachedModelEfficiency[efficiencyPeriod];
-    if (!usage || Object.keys(usage).length === 0) {
-      return '<div class="model-leaderboard-empty"><strong>No per-model efficiency data for this period.</strong><span>Run local agent sessions with model and tool-call metadata, then refresh the dashboard.</span></div>';
-    }
-    const allRows = buildEfficiencyRows(usage);
-    const totalCalls = allRows.reduce((sum, row) => sum + row.counters.calls, 0);
-    const filtered = filterLowUsageRows(allRows, usage);
-    const note = filtered.hiddenNote ? `<span class="model-leaderboard-filter-note">${filtered.hiddenNote}</span>` : "";
-    return `<div class="efficiency-chart-header"><div><strong>Efficiency frontier</strong><span>One-shot edit rate is a local quality proxy, not a benchmark pass rate.</span></div>${buildChartControlsHtml()}</div>
-		${buildEfficiencyChartHtml(filtered.rows)}
-		<div class="model-leaderboard-heading"><div><strong>Most used models locally</strong><span>Ranked by your local turns; all averages use the same selected period.</span></div>${note}</div>
-		${buildEfficiencyTableHtml(filtered.rows, totalCalls)}`;
-  }
-  function buildModelEfficiencySectionHtml(stats) {
-    cachedModelEfficiency = { today: stats.today.modelEfficiency, last30Days: stats.last30Days.modelEfficiency, month: stats.month.modelEfficiency };
-    return `<div class="section" id="section-model-efficiency">
+	</div>${Vl(n)}`}function Jl(){let e=dt.map(n=>`<button class="efficiency-metric-button${n.key===Ht?" active":""}" type="button" data-eff-metric="${n.key}" aria-pressed="${n.key===Ht}">${n.label}</button>`).join(""),t=Wt.map(n=>`<option value="${n.key}"${n.key===Go?" selected":""}>${n.label}</option>`).join(""),o=[{value:"vendor",label:"Vendor"},{value:"model",label:"Model"}].map(n=>`<option value="${n.value}"${n.value===Vt?" selected":""}>${n.label}</option>`).join("");return`<div class="efficiency-chart-controls">
+		<div class="efficiency-control"><span>X-axis</span><div class="efficiency-metric-selector" role="group" aria-label="Efficiency comparison metric">${e}</div></div>
+		<label class="efficiency-control"><span>Bubble size</span><select id="eff-bubble-metric">${t}</select></label>
+		<label class="efficiency-control"><span>Color by</span><select id="eff-color-mode">${o}</select></label>
+	</div>`}function Xl(e,t){let o=e.map(s=>{let r=qt.map(i=>`<td>${i.render(s,t)}</td>`).join("");return`<tr style="--model-color:${Jo(s.model)}">${r}</tr>`}).join("");return`<div class="model-leaderboard-table-wrap"><table class="model-leaderboard-table"><thead><tr>${qt.map(s=>`<th class="sortable" data-eff-sort="${s.sortKey}" title="${s.title}">${s.label}${Nl(s.sortKey)}</th>`).join("")}</tr></thead><tbody>${o}</tbody></table></div>`}function Xs(){let e=Js[Ys];if(!e||Object.keys(e).length===0)return'<div class="model-leaderboard-empty"><strong>No per-model efficiency data for this period.</strong><span>Run local agent sessions with model and tool-call metadata, then refresh the dashboard.</span></div>';let t=jl(e),o=t.reduce((r,i)=>r+i.counters.calls,0),n=Fl(t,e),s=n.hiddenNote?`<span class="model-leaderboard-filter-note">${n.hiddenNote}</span>`:"";return`<div class="efficiency-chart-header"><div><strong>Efficiency frontier</strong><span>One-shot edit rate is a local quality proxy, not a benchmark pass rate.</span></div>${Jl()}</div>
+		${Yl(n.rows)}
+		<div class="model-leaderboard-heading"><div><strong>Most used models locally</strong><span>Ranked by your local turns; all averages use the same selected period.</span></div>${s}</div>
+		${Xl(n.rows,o)}`}function Zl(e){return Js={today:e.today.modelEfficiency,last30Days:e.last30Days.modelEfficiency,month:e.month.modelEfficiency},`<div class="section" id="section-model-efficiency">
 		<div class="section-title"><span>\u{1F3AF}</span><span>Local Model Leaderboard</span></div>
 		<div class="section-subtitle">Compare the models in your own sessions by local usage, one-shot edits, cost, output tokens, and tool steps. Exactness depends on what each editor records; missing structured data is shown as unavailable rather than estimated.</div>
 		<div class="model-leaderboard-controls">
 			<span id="model-efficiency-period-selector"></span>
 			<label class="model-leaderboard-filter" title="Show only models above the 25th-percentile local turn count.">
-				<input type="checkbox" id="eff-filter-low-usage"${efficiencyFilterLowUsage ? " checked" : ""}>
+				<input type="checkbox" id="eff-filter-low-usage"${Vo?" checked":""}>
 				Hide low-usage models
 			</label>
 		</div>
-		<div id="model-efficiency-content">${buildModelEfficiencyContentHtml()}</div>
-	</div>`;
-  }
-  function renderModelEfficiencyPeriodSelector() {
-    const wrapper = document.getElementById("model-efficiency-period-selector");
-    if (!wrapper) {
-      return;
-    }
-    wrapper.replaceChildren();
-    const { wrapper: selectorWrapper } = createPeriodSelector({
-      selected: efficiencySelectedPeriod,
-      disabled: ["last7", "allTime"],
-      disabledTitle: "Not available for model efficiency",
-      label: "",
-      onChange: (value) => {
-        const dataKey = EFFICIENCY_PERIOD_TO_DATA_KEY[value];
-        if (!dataKey) {
-          return;
-        }
-        efficiencySelectedPeriod = value;
-        efficiencyPeriod = dataKey;
-        rerenderModelEfficiencyContent();
-      }
-    });
-    wrapper.append(selectorWrapper);
-  }
-  function rerenderModelEfficiencyContent() {
-    const content = document.getElementById("model-efficiency-content");
-    if (content) {
-      setHtml(content, buildModelEfficiencyContentHtml());
-    }
-  }
-  function handleEfficiencySortClick(th) {
-    const column = th.getAttribute("data-eff-sort");
-    if (!column) {
-      return;
-    }
-    if (efficiencySortColumn === column) {
-      efficiencySortDirection = efficiencySortDirection === "desc" ? "asc" : "desc";
-    } else {
-      efficiencySortColumn = column;
-      efficiencySortDirection = column === "model" ? "asc" : "desc";
-    }
-    rerenderModelEfficiencyContent();
-  }
-  function setupModelEfficiencySection() {
-    const section = document.getElementById("section-model-efficiency");
-    if (!section) {
-      return;
-    }
-    section.addEventListener("click", (event) => {
-      const target = event.target;
-      const header = target.closest("th[data-eff-sort]");
-      if (header) {
-        handleEfficiencySortClick(header);
-        return;
-      }
-      const metric = target.closest("button[data-eff-metric]")?.dataset.effMetric;
-      if (metric && EFFICIENCY_METRICS.some((item) => item.key === metric)) {
-        efficiencyMetric = metric;
-        rerenderModelEfficiencyContent();
-      }
-    });
-    section.addEventListener("change", (event) => {
-      const target = event.target;
-      if (target.id === "eff-filter-low-usage") {
-        efficiencyFilterLowUsage = target.checked;
-        rerenderModelEfficiencyContent();
-      } else if (target.id === "eff-bubble-metric" && EFFICIENCY_BUBBLE_METRICS.some((item) => item.key === target.value)) {
-        efficiencyBubbleMetric = target.value;
-        rerenderModelEfficiencyContent();
-      } else if (target.id === "eff-color-mode" && (target.value === "vendor" || target.value === "model")) {
-        efficiencyColorMode = target.value;
-        rerenderModelEfficiencyContent();
-      }
-    });
-  }
-  function buildToolsTabPanelHtml(stats, allToolKeys, allMcpToolKeys, allMcpServerKeys, allHighCostModels, allLowCostModels, allMediumCostModels, allUnknownModels) {
-    return `
-		<div id="tab-panel-tools" class="tab-panel"${activeTab !== "tools" ? ' style="display:none"' : ""}>
+		<div id="model-efficiency-content">${Xs()}</div>
+	</div>`}function Ql(){let e=document.getElementById("model-efficiency-period-selector");if(!e)return;e.replaceChildren();let{wrapper:t}=Yt({selected:$s,disabled:["last7","allTime"],disabledTitle:"Not available for model efficiency",label:"",onChange:o=>{let n=Bl[o];n&&($s=o,Ys=n,Se())}});e.append(t)}function Se(){let e=document.getElementById("model-efficiency-content");e&&k(e,Xs())}function ed(e){let t=e.getAttribute("data-eff-sort");t&&(jt===t?nt=nt==="desc"?"asc":"desc":(jt=t,nt=t==="model"?"asc":"desc"),Se())}function td(){let e=document.getElementById("section-model-efficiency");e&&(e.addEventListener("click",t=>{let o=t.target,n=o.closest("th[data-eff-sort]");if(n){ed(n);return}let s=o.closest("button[data-eff-metric]")?.dataset.effMetric;s&&dt.some(r=>r.key===s)&&(Ht=s,Se())}),e.addEventListener("change",t=>{let o=t.target;o.id==="eff-filter-low-usage"?(Vo=o.checked,Se()):o.id==="eff-bubble-metric"&&Wt.some(n=>n.key===o.value)?(Go=o.value,Se()):o.id==="eff-color-mode"&&(o.value==="vendor"||o.value==="model")&&(Vt=o.value,Se())}))}function od(e,t,o,n,s,r,i,a){return`
+		<div id="tab-panel-tools" class="tab-panel"${$!=="tools"?' style="display:none"':""}>
 			<!-- Tool Calls Section -->
 			<div class="section">
 				<div class="section-title"><span>\u{1F527}</span><span>Tool Usage</span></div>
-				<div class="section-subtitle">Functions and tools invoked by Copilot during interactions${hideAutomaticToolCalls ? ' (automatic tool calls hidden \u2014 disable "Hide Automatic Tool Calls" in settings to show them)' : ""}</div>
+				<div class="section-subtitle">Functions and tools invoked by Copilot during interactions${at?' (automatic tool calls hidden \u2014 disable "Hide Automatic Tool Calls" in settings to show them)':""}</div>
 				<div class="three-column">
 					<div>
 					<h4 style="color: var(--text-primary); font-size: 13px; margin-bottom: 8px;">\u{1F4C5} Today</h4>
 					<div class="list">
-						<div style="font-size: 14px; font-weight: 600; color: var(--text-primary); margin-bottom: 8px;">Total Tool Calls: ${formatNumber(stats.today.toolCalls.total)}</div>
-						${renderToolsTable(unionFill(stats.today.toolCalls.byTool, allToolKeys), 10, lookupToolName, true)}
+						<div style="font-size: 14px; font-weight: 600; color: var(--text-primary); margin-bottom: 8px;">Total Tool Calls: ${g(e.today.toolCalls.total)}</div>
+						${Y(J(e.today.toolCalls.byTool,t),10,tt,!0)}
 					</div>
 				</div>
 				<div>
 					<h4 style="color: var(--text-primary); font-size: 13px; margin-bottom: 8px;">\u{1F4C6} Last 30 Days</h4>
 					<div class="list">
-						<div style="font-size: 14px; font-weight: 600; color: var(--text-primary); margin-bottom: 8px;">Total Tool Calls: ${formatNumber(stats.last30Days.toolCalls.total)}</div>
-							${renderToolsTable(unionFill(stats.last30Days.toolCalls.byTool, allToolKeys), 10, lookupToolName, true)}
+						<div style="font-size: 14px; font-weight: 600; color: var(--text-primary); margin-bottom: 8px;">Total Tool Calls: ${g(e.last30Days.toolCalls.total)}</div>
+							${Y(J(e.last30Days.toolCalls.byTool,t),10,tt,!0)}
 						</div>
 					</div>
 				<div>
 					<h4 style="color: var(--text-primary); font-size: 13px; margin-bottom: 8px;">\u{1F4C5} Previous Month</h4>
 					<div class="list">
-						<div style="font-size: 14px; font-weight: 600; color: var(--text-primary); margin-bottom: 8px;">Total Tool Calls: ${formatNumber(stats.month.toolCalls.total)}</div>
-							${renderToolsTable(unionFill(stats.month.toolCalls.byTool, allToolKeys), 10, lookupToolName, true)}
+						<div style="font-size: 14px; font-weight: 600; color: var(--text-primary); margin-bottom: 8px;">Total Tool Calls: ${g(e.month.toolCalls.total)}</div>
+							${Y(J(e.month.toolCalls.byTool,t),10,tt,!0)}
 						</div>
 					</div>
 				</div>
 			</div>
 
-			${buildMcpToolsSectionHtml(stats, allMcpToolKeys, allMcpServerKeys)}
-			${buildCurationSectionHtml(currentCurationAnalysis ?? stats.curationAnalysis)}
-			${buildSkillSuggestionsSectionHtml(stats.repeatedTasks ?? null)}
+			${Pa(e,o,n)}
+			${Fa(It??e.curationAnalysis)}
+			${Ja(e.repeatedTasks??null)}
 			<!-- Multi-Model Usage Section -->
 			<div class="section">
 				<div class="section-title"><span>\u{1F500}</span><span>Multi-Model Usage</span></div>
 				<div class="section-subtitle">Track model diversity and switching patterns in your conversations</div>
 				<div class="three-column">
-					${renderMultiModelPeriod("\u{1F4C5} Today", stats.today.modelSwitching, allLowCostModels, allMediumCostModels, allHighCostModels, allUnknownModels)}
-					${renderMultiModelPeriod("\u{1F4C6} Last 30 Days", stats.last30Days.modelSwitching, allLowCostModels, allMediumCostModels, allHighCostModels, allUnknownModels)}
-					${renderMultiModelPeriod("\u{1F4C5} Previous Month", stats.month.modelSwitching, allLowCostModels, allMediumCostModels, allHighCostModels, allUnknownModels)}
+					${Mo("\u{1F4C5} Today",e.today.modelSwitching,r,i,s,a)}
+					${Mo("\u{1F4C6} Last 30 Days",e.last30Days.modelSwitching,r,i,s,a)}
+					${Mo("\u{1F4C5} Previous Month",e.month.modelSwitching,r,i,s,a)}
 				</div>
 			</div>
-		</div>`;
-  }
-  function assignUsageRootHtml(root, build) {
-    try {
-      setHtml(root, build());
-      return true;
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      console.error(`[usage-webview] renderLayout failed: ${message}`);
-      setHtml(root, `<div style="padding: 32px; text-align: center; font-size: 14px;">
+		</div>`}function nd(e,t){try{return k(e,t()),!0}catch(o){let n=o instanceof Error?o.message:String(o);return console.error(`[usage-webview] renderLayout failed: ${n}`),k(e,`<div style="padding: 32px; text-align: center; font-size: 14px;">
 			<div style="color: var(--vscode-foreground); opacity: 0.7; margin-bottom: 12px;">\u26A0\uFE0F Something went wrong rendering the dashboard.</div>
-			${createRefreshButton().outerHTML}
-		</div>`);
-      return false;
-    }
-  }
-  function syncRenderLayoutState(stats) {
-    const matrix = stats.customizationMatrix ?? initialData?.customizationMatrix ?? null;
-    hygieneMatrixState = matrix ?? null;
-    if (!hygieneMatrixState || hygieneMatrixState.workspaces.length === 0) {
-      selectedRepoPath = null;
-    }
-    if (Array.isArray(stats.currentWorkspacePaths)) {
-      currentWorkspacePaths = stats.currentWorkspacePaths;
-    }
-    if (stats.curationAnalysis) {
-      currentCurationAnalysis = stats.curationAnalysis;
-      traceCuration("renderLayout.curation.cached", {
-        availableTools: currentCurationAnalysis.availableTools.length,
-        unusedTools: currentCurationAnalysis.unusedTools.length
-      });
-    } else {
-      traceCurationOnce("render-no-curation-update", "renderLayout.curation.notProvidedInUpdate");
-    }
-    return matrix;
-  }
-  function renderLayout(stats) {
-    const root = document.getElementById("root");
-    if (!root) {
-      return;
-    }
-    const matrix = syncRenderLayoutState(stats);
-    const customizationHtml = safeSectionHtml("Workspace Customization", () => buildCustomizationSectionHtml(matrix));
-    const allKeys = buildUsageAllKeysSets(stats);
-    const todayTotalRefs = getTotalContextRefs(stats.today.contextReferences);
-    const last30DaysTotalRefs = getTotalContextRefs(stats.last30Days.contextReferences);
-    const thinkingEffortHtml = safeSectionHtml("Thinking Effort", () => buildThinkingEffortSectionHtml(stats));
-    const sessionsSummaryHtml = `
+			${Kt().outerHTML}
+		</div>`),!1}}function sd(e){let t=e.customizationMatrix??E?.customizationMatrix??null;return H=t??null,(!H||H.workspaces.length===0)&&(B=null),Array.isArray(e.currentWorkspacePaths)&&(_s=e.currentWorkspacePaths),e.curationAnalysis?(It=e.curationAnalysis,Z("renderLayout.curation.cached",{availableTools:It.availableTools.length,unusedTools:It.unusedTools.length})):pe("render-no-curation-update","renderLayout.curation.notProvidedInUpdate"),t}function Zs(e){let t=document.getElementById("root");if(!t)return;let o=sd(e),n=P("Workspace Customization",()=>Aa(o)),s=Ra(e),r=Re(e.today.contextReferences),i=Re(e.last30Days.contextReferences),a=P("Thinking Effort",()=>Ea(e)),l=`
 		<!-- Summary Section -->
 		<div class="section">
 			<div class="section-title"><span>\u{1F4C8}</span><span>Sessions Summary</span></div>
 			<div class="stats-grid">
-				<div class="stat-card"><div class="stat-label">\u{1F4C5} Today Sessions</div><div class="stat-value">${formatNumber(stats.today.sessions)}</div></div>
-				<div class="stat-card"><div class="stat-label">\u{1F4C6} Last 30 Days Sessions</div><div class="stat-value">${formatNumber(stats.last30Days.sessions)}</div></div>
-				<div class="stat-card"><div class="stat-label">\u{1F4C5} This Month Sessions</div><div class="stat-value">${formatNumber(stats.month.sessions)}</div></div>
-				<div class="stat-card"><div class="stat-label">\u{1F4C5} Last Month Sessions</div><div class="stat-value">${formatNumber(stats.lastMonth.sessions)}</div></div>
+				<div class="stat-card"><div class="stat-label">\u{1F4C5} Today Sessions</div><div class="stat-value">${g(e.today.sessions)}</div></div>
+				<div class="stat-card"><div class="stat-label">\u{1F4C6} Last 30 Days Sessions</div><div class="stat-value">${g(e.last30Days.sessions)}</div></div>
+				<div class="stat-card"><div class="stat-label">\u{1F4C5} This Month Sessions</div><div class="stat-value">${g(e.month.sessions)}</div></div>
+				<div class="stat-card"><div class="stat-label">\u{1F4C5} Last Month Sessions</div><div class="stat-value">${g(e.lastMonth.sessions)}</div></div>
 			</div>
-		</div>`;
-    const rendered = assignUsageRootHtml(root, () => buildUsageRootHtml(
-      stats,
-      customizationHtml,
-      "",
-      thinkingEffortHtml,
-      sessionsSummaryHtml,
-      todayTotalRefs,
-      last30DaysTotalRefs,
-      allKeys.allToolKeys,
-      allKeys.allMcpToolKeys,
-      allKeys.allMcpServerKeys,
-      allKeys.allHighCostModels,
-      allKeys.allLowCostModels,
-      allKeys.allMediumCostModels,
-      allKeys.allUnknownModels
-    ));
-    if (!rendered) {
-      return;
-    }
-    wireNavigationButtons();
-    wireAboutInfoToggle();
-    wireRepositoryButtons();
-    wireCurationButtons();
-    renderRepositoryHygienePanels();
-    setupTabs();
-    setupModelEfficiencySection();
-    renderModelEfficiencyPeriodSelector();
-    renderSessionsLookbackSelector();
-    setupWorktreesHandlers();
-    wireCopyButtons();
-    currentInsights = stats.insights ?? [];
-    wireInsightCardButtons();
-    scrollToPendingTabAnchor();
-  }
-  function wireAboutInfoToggle() {
-    const toggle = document.getElementById("about-info-toggle");
-    const body = document.getElementById("about-info-body");
-    if (!toggle || !body) {
-      return;
-    }
-    const chevron = toggle.querySelector(".info-box-chevron");
-    const applyToggle = () => {
-      aboutCollapsed = !aboutCollapsed;
-      body.style.display = aboutCollapsed ? "none" : "";
-      toggle.setAttribute("aria-expanded", String(!aboutCollapsed));
-      if (chevron) {
-        chevron.textContent = aboutCollapsed ? "\u25B8" : "\u25BE";
-      }
-      vscode.setState({ ...vscode.getState() ?? {}, aboutCollapsed });
-    };
-    toggle.addEventListener("click", applyToggle);
-    toggle.addEventListener("keydown", (event) => {
-      if (event.key === "Enter" || event.key === " ") {
-        event.preventDefault();
-        applyToggle();
-      }
-    });
-  }
-  function wireNavigationButtons() {
-    document.getElementById("btn-refresh")?.addEventListener("click", () => {
-      vscode.postMessage({ command: "refresh" });
-    });
-    document.getElementById("btn-details")?.addEventListener("click", () => {
-      vscode.postMessage({ command: "showDetails" });
-    });
-    document.getElementById("btn-chart")?.addEventListener("click", () => {
-      vscode.postMessage({ command: "showChart" });
-    });
-    document.getElementById("btn-diagnostics")?.addEventListener("click", () => {
-      vscode.postMessage({ command: "showDiagnostics" });
-    });
-    document.getElementById("btn-maturity")?.addEventListener("click", () => {
-      vscode.postMessage({ command: "showMaturity" });
-    });
-    document.getElementById("btn-dashboard")?.addEventListener("click", () => {
-      vscode.postMessage({ command: "showDashboard" });
-    });
-    document.getElementById("btn-environmental")?.addEventListener("click", () => {
-      vscode.postMessage({ command: "showEnvironmental" });
-    });
-    document.getElementById("btn-efficiency")?.addEventListener("click", () => {
-      vscode.postMessage({ command: "showEfficiency" });
-    });
-    wireExtensionPointButtons(vscode);
-  }
-  function setButtonAnalyzingState(btn, analyzingText) {
-    if (!btn) {
-      return;
-    }
-    btn.disabled = true;
-    btn.textContent = analyzingText;
-    btn.setAttribute("appearance", "secondary");
-  }
-  function wireRepositoryButtons() {
-    document.getElementById("btn-analyse-repo")?.addEventListener("click", () => {
-      const btn = document.getElementById("btn-analyse-repo");
-      isSingleRepoAnalysisInProgress = true;
-      setButtonAnalyzingState(btn, "Analyzing...");
-      vscode.postMessage({ command: "analyseRepository" });
-    });
-    document.getElementById("btn-analyse-all")?.addEventListener("click", () => {
-      const btn = document.getElementById("btn-analyse-all");
-      setButtonAnalyzingState(btn, "Analyzing All...");
-      isBatchAnalysisInProgress = true;
-      isSwitchingRepository = true;
-      selectedRepoPath = null;
-      for (const ws of hygieneMatrixState?.workspaces ?? []) {
-        if (!ws.workspacePath.startsWith("<unresolved:")) {
-          repoAnalysisInFlight.add(ws.workspacePath);
-        }
-      }
-      renderRepositoryHygienePanels();
-      vscode.postMessage({ command: "analyseAllRepositories" });
-    });
-    document.getElementById("repo-list-pane")?.addEventListener("click", (e7) => {
-      const target = e7.target;
-      const actionButton = target.closest(".btn-repo-action");
-      if (!actionButton) {
-        return;
-      }
-      const workspacePath = actionButton.getAttribute("data-workspace-path");
-      const action = actionButton.getAttribute("data-action");
-      if (!workspacePath || !action) {
-        return;
-      }
-      if (action === "details") {
-        selectedRepoPath = workspacePath;
-        isSwitchingRepository = false;
-        renderRepositoryHygienePanels();
-        return;
-      }
-      if (action === "analyze") {
-        repoAnalysisInFlight.add(workspacePath);
-        isBatchAnalysisInProgress = false;
-        renderRepositoryHygienePanels();
-        vscode.postMessage({ command: "analyseRepository", workspacePath });
-      }
-    });
-    document.getElementById("repo-details-pane")?.addEventListener("click", (e7) => {
-      const target = e7.target;
-      if (target.closest("#btn-switch-repository")) {
-        isSwitchingRepository = true;
-        renderRepositoryHygienePanels();
-      }
-    });
-  }
-  function wireCopyButtons() {
-    Array.from(document.getElementsByClassName("cf-copy")).forEach((el2) => {
-      el2.addEventListener("click", (ev) => {
-        const target = ev.currentTarget;
-        const path = target.getAttribute("data-path") || "";
-        if (navigator.clipboard && path) {
-          navigator.clipboard.writeText(path).then(() => {
-            target.textContent = "Copied";
-            setTimeout(() => {
-              target.textContent = "Copy";
-            }, 1200);
-          }).catch(() => {
-            vscode.postMessage({ command: "copyFailed", path });
-          });
-        }
-      });
-    });
-  }
-  function handleUpdateStats(message) {
-    clearLoadingTimeout();
-    if (message.data?.locale) {
-      setFormatLocale(message.data.locale);
-    }
-    if (typeof message.data?.use24HourTime === "boolean") {
-      use24HourTime = message.data.use24HourTime;
-    }
-    if (typeof message.data?.hideAutomaticToolCalls === "boolean") {
-      hideAutomaticToolCalls = message.data.hideAutomaticToolCalls;
-    }
-    const sanitized = sanitizeStats(message.data);
-    if (sanitized) {
-      _ulLoadingActive = false;
-      for (const key of Object.keys(recentSessionsCache)) {
-        delete recentSessionsCache[key];
-      }
-      renderLayout(sanitized);
-      setupSessionsTableSort();
-      renderRepositoryHygienePanels();
-      if (repoPrStatsData) {
-        updateReposPrPanel(repoPrStatsData);
-      }
-      if (agentSessionsData) {
-        updateAgentSessionsPanel(agentSessionsData);
-      }
-    } else {
-      traceCurationOnce("update-invalid-sanitized", "handleUpdateStats.sanitizeReturnedNull");
-      showLoadError("Received invalid data from the extension. Try refreshing.");
-    }
-  }
-  function handleToolSuppressed(toolName) {
-    if (!toolName) {
-      return;
-    }
-    const section = document.getElementById("unknown-mcp-tools-section");
-    if (!section) {
-      return;
-    }
-    section.querySelectorAll("button[data-suppress-tool]").forEach((btn) => {
-      if (btn.getAttribute("data-suppress-tool") === toolName) {
-        btn.closest("span")?.remove();
-      }
-    });
-    if (section.querySelectorAll("button[data-suppress-tool]").length === 0) {
-      section.remove();
-    }
-  }
-  function handleHighlightUnknownTools() {
-    activeTab = "tools";
-    document.querySelectorAll(".tab-button").forEach((btn) => {
-      btn.classList.toggle("active", btn.getAttribute("data-tab") === "tools");
-    });
-    document.querySelectorAll(".tab-panel").forEach((panel) => {
-      panel.style.display = "none";
-    });
-    const toolsPanel = document.getElementById("tab-panel-tools");
-    if (toolsPanel) {
-      toolsPanel.style.display = "block";
-    }
-    const el2 = document.getElementById("unknown-mcp-tools-section");
-    if (el2) {
-      el2.scrollIntoView({ behavior: "smooth", block: "center" });
-      el2.style.transition = "box-shadow 0.3s ease";
-      el2.style.boxShadow = "0 0 0 3px var(--vscode-focusBorder)";
-      setTimeout(() => {
-        el2.style.boxShadow = "";
-      }, 2e3);
-    }
-  }
-  function handleRepoPrStatsLoaded(data) {
-    repoPrStatsData = sanitizeRepoPrStatsData(data);
-    if (!repoPrStatsData.authenticated) {
-      repoPrStatsLoaded = false;
-    }
-    updateReposPrPanel(repoPrStatsData);
-  }
-  function handleAgentSessionsLoaded(data) {
-    if (!data || typeof data !== "object") {
-      return;
-    }
-    agentSessionsData = sanitizeAgentSessionsData(data);
-    if (!agentSessionsData.authenticated) {
-      agentSessionsLoaded = false;
-    }
-    updateAgentSessionsPanel(agentSessionsData);
-  }
-  function handleUpdateInsights(rawInsights) {
-    if (!Array.isArray(rawInsights)) {
-      return;
-    }
-    const sanitized = sanitizeInsights(rawInsights);
-    refreshInsightsPanel(sanitized);
-  }
-  function handleLoadingStateMessage(message) {
-    switch (message.command) {
-      case "usageLoadingProgress":
-        updateUsageLoadingProgress(message);
-        return true;
-      case "usageRefreshing":
-        clearLoadingTimeout();
-        _ulLastStepIdx = 0;
-        renderUsageLoadingState("Refreshing Usage Analysis");
-        return true;
-      case "updateStatsError":
-        clearLoadingTimeout();
-        showLoadError("Failed to calculate usage analysis. Check the Output panel for details.");
-        return true;
-    }
-    return false;
-  }
-  function handleRepoAnalysisMessage(message) {
-    switch (message.command) {
-      case "repoAnalysisResults":
-        try {
-          displayRepoAnalysisResults(message.data, message.workspacePath);
-        } catch (err) {
-          console.error("Failed to render repo analysis results", err);
-          displayRepoAnalysisError(err instanceof Error ? err.message : String(err), message.workspacePath);
-        }
-        return true;
-      case "repoAnalysisError":
-        displayRepoAnalysisError(message.error, message.workspacePath);
-        return true;
-      case "repoAnalysisBatchComplete":
-        handleBatchAnalysisComplete();
-        return true;
-    }
-    return false;
-  }
-  function handleExtensionMessage(message) {
-    if (handleLoadingStateMessage(message)) {
-      return;
-    }
-    if (handleRepoAnalysisMessage(message)) {
-      return;
-    }
-    switch (message.command) {
-      case "updateStats":
-        handleUpdateStats(message);
-        break;
-      case "toolSuppressed":
-        handleToolSuppressed(message.toolName);
-        break;
-      case "highlightUnknownTools":
-        handleHighlightUnknownTools();
-        break;
-      case "repoPrStatsLoaded":
-        handleRepoPrStatsLoaded(message.data);
-        break;
-      case "repoPrStatsProgress":
-        updateProgressPanel("#repos-pr-content", "repos-pr-progress", "Fetching PRs\u2026", message.done, message.total);
-        break;
-      case "agentSessionsLoaded":
-        handleAgentSessionsLoaded(message.data);
-        break;
-      case "recentSessionsLoaded":
-        handleRecentSessionsLoaded(message);
-        break;
-      case "agentSessionsProgress":
-        updateProgressPanel("#agent-sessions-content", "agent-sessions-progress", "Fetching agent sessions\u2026", message.done, message.total);
-        break;
-      case "updateInsights":
-        handleUpdateInsights(message.insights);
-        break;
-      case "switchTab":
-        handleSwitchTab(message);
-        break;
-      default:
-        handleWorktreeMessage(message);
-        break;
-    }
-  }
-  function handleSwitchTab(message) {
-    const tab = String(message.tab);
-    if (!isSwitchableTab(tab)) {
-      return;
-    }
-    activeTab = tab;
-    pendingTabAnchor = typeof message.anchor === "string" && message.anchor ? message.anchor : null;
-    const btn = document.querySelector(`.tab-button[data-tab="${tab}"]`);
-    btn?.click();
-    scrollToPendingTabAnchor();
-  }
-  function scrollToPendingTabAnchor() {
-    if (!pendingTabAnchor) {
-      return;
-    }
-    const anchor = document.getElementById(pendingTabAnchor);
-    if (anchor) {
-      pendingTabAnchor = null;
-      setTimeout(() => anchor.scrollIntoView({ behavior: "smooth", block: "start" }), 50);
-    }
-  }
-  registerMessageHandler((message) => {
-    handleExtensionMessage(message);
-  });
-  vscode.postMessage({ command: "usageWebviewReady" });
-  function getWorkspaceName(workspacePath) {
-    const workspace = hygieneMatrixState?.workspaces.find((ws) => ws.workspacePath === workspacePath);
-    return workspace?.workspaceName || workspacePath;
-  }
-  function getScoreLabel(workspacePath) {
-    const record = repoAnalysisState.get(workspacePath);
-    if (record?.data?.summary) {
-      const percentage = toFiniteNumber(record.data.summary.percentage);
-      return `${Math.round(percentage)}%`;
-    }
-    if (record?.error) {
-      return "Error";
-    }
-    return "\u2014";
-  }
-  function toFiniteNumber(value) {
-    const numeric = typeof value === "number" ? value : Number(value);
-    return Number.isFinite(numeric) ? numeric : 0;
-  }
-  var REPO_DOCS_LINKS = {
-    "git-repo": "https://docs.github.com/en/get-started/using-git/about-git",
-    "gitignore": "https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files",
-    "env-example": "https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions",
-    "editorconfig": "https://editorconfig.org/",
-    "linter": "https://docs.github.com/en/code-security/code-scanning/introduction-to-code-scanning/about-code-scanning",
-    "formatter": "https://docs.github.com/en/contributing/style-guide-and-content-model/style-guide",
-    "type-safety": "https://docs.github.com/en/code-security/code-scanning/reference/code-ql-built-in-queries/javascript-typescript-built-in-queries",
-    "commit-messages": "https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/about-commits",
-    "conventional-commits": "https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/available-rules-for-rulesets",
-    "ci-config": "https://docs.github.com/en/actions/about-github-actions/understanding-github-actions",
-    "scripts": "https://docs.github.com/en/actions/tutorials/build-and-test-code/nodejs",
-    "task-runner": "https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/add-scripts",
-    "devcontainer": "https://docs.github.com/en/codespaces/setting-up-your-project-for-codespaces/adding-a-dev-container-configuration",
-    "dockerfile": "https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry",
-    "version-pinning": "https://docs.github.com/en/codespaces/setting-up-your-project-for-codespaces/adding-a-dev-container-configuration/setting-up-your-nodejs-project-for-codespaces",
-    "license": "https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/licensing-a-repository"
-  };
-  var REPO_CATEGORY_LABELS = {
-    versionControl: "\u{1F504} Version Control",
-    codeQuality: "\u2728 Code Quality",
-    cicd: "\u{1F680} CI/CD",
-    environment: "\u{1F527} Environment",
-    documentation: "\u{1F4DA} Documentation"
-  };
-  function buildScoreHeaderElement(summary) {
-    const header = el("div");
-    header.setAttribute("style", "display: flex; justify-content: space-between; align-items: center; margin-bottom: 12px;");
-    const title = el("div");
-    title.setAttribute("style", "font-size: 14px; font-weight: 600; color: var(--text-primary);");
-    title.textContent = "\u{1F4CA} Repository Hygiene Score";
-    const score = el("div");
-    score.setAttribute("style", "font-size: 24px; font-weight: 700; color: var(--link-color);");
-    score.textContent = `${Math.round(toFiniteNumber(summary.percentage))}%`;
-    header.append(title, score);
-    return header;
-  }
-  function buildStatsGridElement(summary) {
-    const statsGrid = el("div");
-    statsGrid.setAttribute("style", "display: grid; grid-template-columns: repeat(3, 1fr); gap: 8px; margin-bottom: 12px;");
-    const statCards = [
-      { count: summary.passedChecks, label: "Passed", cardStyle: "text-align: center; padding: 8px; background: rgba(34, 197, 94, 0.1); border: 1px solid rgba(34, 197, 94, 0.3); border-radius: 4px;", countStyle: "font-size: 18px; font-weight: 600; color: var(--success-fg);" },
-      { count: summary.warningChecks, label: "Warnings", cardStyle: "text-align: center; padding: 8px; background: rgba(245, 158, 11, 0.1); border: 1px solid rgba(245, 158, 11, 0.3); border-radius: 4px;", countStyle: "font-size: 18px; font-weight: 600; color: var(--warning-fg);" },
-      { count: summary.failedChecks, label: "Failed", cardStyle: "text-align: center; padding: 8px; background: rgba(239, 68, 68, 0.1); border: 1px solid rgba(239, 68, 68, 0.3); border-radius: 4px;", countStyle: "font-size: 18px; font-weight: 600; color: #ef4444;" }
-    ];
-    for (const statCard of statCards) {
-      const card = el("div");
-      card.setAttribute("style", statCard.cardStyle);
-      const count = el("div");
-      count.setAttribute("style", statCard.countStyle);
-      count.textContent = String(toFiniteNumber(statCard.count));
-      const label = el("div");
-      label.setAttribute("style", "font-size: 10px; color: var(--text-secondary);");
-      label.textContent = statCard.label;
-      card.append(count, label);
-      statsGrid.appendChild(card);
-    }
-    return statsGrid;
-  }
-  function resolveCheckStatus(check) {
-    const status = check?.status === "pass" || check?.status === "warning" ? check.status : "fail";
-    const emoji = status === "pass" ? "\u2705" : status === "warning" ? "\u26A0\uFE0F" : "\u274C";
-    const color = status === "pass" ? "#22c55e" : status === "warning" ? "#f59e0b" : "#ef4444";
-    return { status, emoji, color };
-  }
-  function buildCheckContentElement(check, statusColor) {
-    const content = el("div");
-    content.setAttribute("style", "flex: 1;");
-    const checkLabel = el("div");
-    checkLabel.setAttribute("style", `font-size: 12px; font-weight: 600; color: ${statusColor};`);
-    checkLabel.textContent = typeof check?.label === "string" ? check.label : "";
-    const checkDetail = el("div");
-    checkDetail.setAttribute("style", "font-size: 11px; color: var(--text-secondary); margin-top: 2px;");
-    checkDetail.textContent = typeof check?.detail === "string" ? check.detail : "";
-    content.append(checkLabel, checkDetail);
-    if (typeof check?.hint === "string" && check.hint.length > 0) {
-      const hint = el("div");
-      hint.setAttribute("style", "font-size: 10px; color: var(--link-color); margin-top: 4px; font-style: italic;");
-      hint.textContent = `\u{1F4A1} ${check.hint}`;
-      content.appendChild(hint);
-    }
-    const docUrl = REPO_DOCS_LINKS[typeof check?.id === "string" ? check.id : ""];
-    if (docUrl) {
-      const docLink = el("a");
-      docLink.setAttribute("href", docUrl);
-      docLink.setAttribute("style", "font-size: 10px; color: var(--link-color); margin-top: 4px; display: inline-block;");
-      docLink.setAttribute("title", "View official documentation");
-      docLink.textContent = "\u{1F4D6} View documentation";
-      content.appendChild(docLink);
-    }
-    return content;
-  }
-  function buildCheckRowElement(check) {
-    const { emoji, color } = resolveCheckStatus(check);
-    const checkRow = el("div");
-    checkRow.setAttribute("style", "padding: 8px; border-bottom: 1px solid var(--border-subtle); display: flex; align-items: flex-start; gap: 8px;");
-    const icon = el("span");
-    icon.setAttribute("style", "flex-shrink: 0; padding-top: 1px;");
-    setHtml(icon, statusBadgeHtml(emoji));
-    const weight = el("span");
-    weight.setAttribute("style", "font-size: 10px; color: var(--text-muted); min-width: 30px; text-align: right;");
-    weight.textContent = `+${toFiniteNumber(check?.weight)}`;
-    checkRow.append(icon, buildCheckContentElement(check, color), weight);
-    return checkRow;
-  }
-  function buildCategorySectionElement(categoryId, categoryChecks, summary) {
-    const section = el("div");
-    section.setAttribute("style", "margin-bottom: 12px; background: var(--bg-secondary); border: 1px solid var(--border-color); border-radius: 4px; overflow: hidden;");
-    const sectionHeader = el("div");
-    sectionHeader.setAttribute("style", "padding: 8px 12px; background: var(--list-hover-bg); border-bottom: 1px solid var(--border-color); display: flex; justify-content: space-between; align-items: center;");
-    const categoryName = el("span");
-    categoryName.setAttribute("style", "font-size: 12px; font-weight: 600; color: var(--text-primary);");
-    categoryName.textContent = REPO_CATEGORY_LABELS[categoryId] || categoryId;
-    const categorySummary = summary?.categories?.[categoryId];
-    const categoryPct = el("span");
-    categoryPct.setAttribute("style", "font-size: 11px; color: var(--link-color); font-weight: 600;");
-    categoryPct.textContent = `${Math.round(toFiniteNumber(categorySummary?.percentage))}%`;
-    sectionHeader.append(categoryName, categoryPct);
-    section.appendChild(sectionHeader);
-    for (const check of categoryChecks) {
-      section.appendChild(buildCheckRowElement(check));
-    }
-    return section;
-  }
-  function buildRecommendationsSectionElement(recommendations) {
-    const section = el("div");
-    section.setAttribute("style", "margin-top: 16px; background: var(--bg-secondary); border: 1px solid var(--border-color); border-radius: 4px; overflow: hidden;");
-    const hdr = el("div");
-    hdr.setAttribute("style", "padding: 8px 12px; background: var(--list-hover-bg); border-bottom: 1px solid var(--border-color);");
-    const hdrTitle = el("span");
-    hdrTitle.setAttribute("style", "font-size: 12px; font-weight: 600; color: var(--text-primary);");
-    hdrTitle.textContent = "\u{1F4A1} Top Recommendations";
-    hdr.appendChild(hdrTitle);
-    section.appendChild(hdr);
-    for (const rec of recommendations.slice(0, 5)) {
-      const priority = rec?.priority === "high" || rec?.priority === "medium" ? rec.priority : "low";
-      const priorityColor = priority === "high" ? "#ef4444" : priority === "medium" ? "#f59e0b" : "#60a5fa";
-      const row = el("div");
-      row.setAttribute("style", "padding: 8px; border-bottom: 1px solid var(--border-subtle); display: flex; gap: 8px;");
-      const priorityLabel = el("span");
-      priorityLabel.setAttribute("style", `font-size: 10px; font-weight: 600; color: ${priorityColor}; min-width: 50px;`);
-      priorityLabel.textContent = String(priority).toUpperCase();
-      const content = el("div");
-      content.setAttribute("style", "flex: 1;");
-      const action = el("div");
-      action.setAttribute("style", "font-size: 11px; color: var(--text-primary);");
-      action.textContent = typeof rec?.action === "string" ? rec.action : "";
-      const impact = el("div");
-      impact.setAttribute("style", "font-size: 10px; color: var(--text-muted); margin-top: 2px;");
-      impact.textContent = typeof rec?.impact === "string" ? rec.impact : "";
-      content.append(action, impact);
-      const weight = el("span");
-      weight.setAttribute("style", "font-size: 10px; color: var(--text-muted); min-width: 30px; text-align: right;");
-      weight.textContent = `+${toFiniteNumber(rec?.weight)}`;
-      row.append(priorityLabel, content, weight);
-      section.appendChild(row);
-    }
-    return section;
-  }
-  function buildCopilotSectionElement(failedChecks, workspacePath) {
-    const copilotSection = el("div");
-    copilotSection.setAttribute("style", "margin-top: 16px; padding: 12px; background: rgba(96, 165, 250, 0.07); border: 1px solid rgba(96, 165, 250, 0.3); border-radius: 4px; display: flex; align-items: center; justify-content: space-between; gap: 12px;");
-    const copilotText = el("div");
-    copilotText.setAttribute("style", "font-size: 11px; color: var(--text-secondary); flex: 1;");
-    copilotText.textContent = "Let Copilot help you fix the identified issues in this repository.";
-    const copilotBtn = document.createElement("vscode-button");
-    copilotBtn.setAttribute("style", "min-width: 180px;");
-    copilotBtn.textContent = "\u{1F916} Ask Copilot to Improve";
-    copilotBtn.addEventListener("click", () => {
-      const failedLines = failedChecks.map((c4) => `- ${c4.label}: ${c4.detail || ""}${c4.hint ? ` (${c4.hint})` : ""}`).join("\n");
-      const prompt = `Please help me improve this repository by addressing the following best practice issues:
+		</div>`;nd(t,()=>il(e,n,"",a,l,r,i,s.allToolKeys,s.allMcpToolKeys,s.allMcpServerKeys,s.allHighCostModels,s.allLowCostModels,s.allMediumCostModels,s.allUnknownModels))&&(id(),rd(),ad(),rl(),X(),va(),td(),Ql(),Us(),Yi(),ld(),Bo=e.insights??[],Fs(),er())}function rd(){let e=document.getElementById("about-info-toggle"),t=document.getElementById("about-info-body");if(!e||!t)return;let o=e.querySelector(".info-box-chevron"),n=()=>{V=!V,t.style.display=V?"none":"",e.setAttribute("aria-expanded",String(!V)),o&&(o.textContent=V?"\u25B8":"\u25BE"),f.setState({...f.getState()??{},aboutCollapsed:V})};e.addEventListener("click",n),e.addEventListener("keydown",s=>{(s.key==="Enter"||s.key===" ")&&(s.preventDefault(),n())})}function id(){document.getElementById("btn-refresh")?.addEventListener("click",()=>{f.postMessage({command:"refresh"})}),document.getElementById("btn-details")?.addEventListener("click",()=>{f.postMessage({command:"showDetails"})}),document.getElementById("btn-chart")?.addEventListener("click",()=>{f.postMessage({command:"showChart"})}),document.getElementById("btn-diagnostics")?.addEventListener("click",()=>{f.postMessage({command:"showDiagnostics"})}),document.getElementById("btn-maturity")?.addEventListener("click",()=>{f.postMessage({command:"showMaturity"})}),document.getElementById("btn-dashboard")?.addEventListener("click",()=>{f.postMessage({command:"showDashboard"})}),document.getElementById("btn-environmental")?.addEventListener("click",()=>{f.postMessage({command:"showEnvironmental"})}),document.getElementById("btn-efficiency")?.addEventListener("click",()=>{f.postMessage({command:"showEfficiency"})}),an(f)}function Es(e,t){e&&(e.disabled=!0,e.textContent=t,e.setAttribute("appearance","secondary"))}function ad(){document.getElementById("btn-analyse-repo")?.addEventListener("click",()=>{let e=document.getElementById("btn-analyse-repo");st=!0,Es(e,"Analyzing..."),f.postMessage({command:"analyseRepository"})}),document.getElementById("btn-analyse-all")?.addEventListener("click",()=>{let e=document.getElementById("btn-analyse-all");Es(e,"Analyzing All..."),me=!0,ge=!0,B=null;for(let t of H?.workspaces??[])t.workspacePath.startsWith("<unresolved:")||$e.add(t.workspacePath);X(),f.postMessage({command:"analyseAllRepositories"})}),document.getElementById("repo-list-pane")?.addEventListener("click",e=>{let o=e.target.closest(".btn-repo-action");if(!o)return;let n=o.getAttribute("data-workspace-path"),s=o.getAttribute("data-action");if(!(!n||!s)){if(s==="details"){B=n,ge=!1,X();return}s==="analyze"&&($e.add(n),me=!1,X(),f.postMessage({command:"analyseRepository",workspacePath:n}))}}),document.getElementById("repo-details-pane")?.addEventListener("click",e=>{e.target.closest("#btn-switch-repository")&&(ge=!0,X())})}function ld(){Array.from(document.getElementsByClassName("cf-copy")).forEach(e=>{e.addEventListener("click",t=>{let o=t.currentTarget,n=o.getAttribute("data-path")||"";navigator.clipboard&&n&&navigator.clipboard.writeText(n).then(()=>{o.textContent="Copied",setTimeout(()=>{o.textContent="Copy"},1200)}).catch(()=>{f.postMessage({command:"copyFailed",path:n})})})})}function dd(e){Po(),e.data?.locale&&Xt(e.data.locale),typeof e.data?.use24HourTime=="boolean"&&(Ot=e.data.use24HourTime),typeof e.data?.hideAutomaticToolCalls=="boolean"&&(at=e.data.hideAutomaticToolCalls);let t=Oi(e.data);t?(Ho=!1,Is(t.recentSessions),Zs(t),Ls(),X(),Ze&&Hs(Ze),Qe&&js(Qe)):(pe("update-invalid-sanitized","handleUpdateStats.sanitizeReturnedNull"),Ps("Received invalid data from the extension. Try refreshing."))}function Qs(e){if(!e)return;let t=document.getElementById("unknown-mcp-tools-section");t&&(t.querySelectorAll("button[data-suppress-tool]").forEach(o=>{o.getAttribute("data-suppress-tool")===e&&o.closest("span")?.remove()}),t.querySelectorAll("button[data-suppress-tool]").length===0&&t.remove())}function cd(){$="tools",document.querySelectorAll(".tab-button").forEach(o=>{o.classList.toggle("active",o.getAttribute("data-tab")==="tools")}),document.querySelectorAll(".tab-panel").forEach(o=>{o.style.display="none"});let e=document.getElementById("tab-panel-tools");e&&(e.style.display="block");let t=document.getElementById("unknown-mcp-tools-section");t&&(t.scrollIntoView({behavior:"smooth",block:"center"}),t.style.transition="box-shadow 0.3s ease",t.style.boxShadow="0 0 0 3px var(--vscode-focusBorder)",setTimeout(()=>{t.style.boxShadow=""},2e3))}function ud(e){Ze=xa(e),Ze.authenticated||(Do=!1),Hs(Ze)}function pd(e){!e||typeof e!="object"||(Qe=yn(e),Qe.authenticated||(Lo=!1),js(Qe))}function gd(e){if(!Array.isArray(e))return;let t=zs(e);ol(t)}function md(e){switch(e.command){case"usageLoadingProgress":return ai(e),!0;case"usageRefreshing":return Po(),Xe=0,No("Refreshing Usage Analysis"),!0;case"updateStatsError":return Po(),Ps("Failed to calculate usage analysis. Check the Output panel for details."),!0}return!1}function fd(e){switch(e.command){case"repoAnalysisResults":try{Pd(e.data,e.workspacePath)}catch(t){console.error("Failed to render repo analysis results",t),Rs(t instanceof Error?t.message:String(t),e.workspacePath)}return!0;case"repoAnalysisError":return Rs(e.error,e.workspacePath),!0;case"repoAnalysisBatchComplete":return Dd(),!0}return!1}function bd(e){if(!md(e)&&!fd(e))switch(e.command){case"updateStats":dd(e);break;case"toolSuppressed":Qs(e.toolName);break;case"highlightUnknownTools":cd();break;case"repoPrStatsLoaded":ud(e.data);break;case"repoPrStatsProgress":xs("#repos-pr-content","repos-pr-progress","Fetching PRs\u2026",e.done,e.total);break;case"agentSessionsLoaded":pd(e.data);break;case"recentSessionsLoaded":$i(e);break;case"agentSessionsProgress":xs("#agent-sessions-content","agent-sessions-progress","Fetching agent sessions\u2026",e.done,e.total);break;case"updateInsights":gd(e.insights);break;case"switchTab":yd(e);break;default:ha(e);break}}function yd(e){let t=String(e.tab);if(!hn(t))return;$=t,Lt=typeof e.anchor=="string"&&e.anchor?e.anchor:null,document.querySelector(`.tab-button[data-tab="${t}"]`)?.click(),er()}function er(){if(!Lt)return;let e=document.getElementById(Lt);e&&(Lt=null,setTimeout(()=>e.scrollIntoView({behavior:"smooth",block:"start"}),50))}cn(e=>{bd(e)});f.postMessage({command:"usageWebviewReady"});function hd(e){return H?.workspaces.find(o=>o.workspacePath===e)?.workspaceName||e}function vd(e){let t=ct.get(e);if(t?.data?.summary){let o=ie(t.data.summary.percentage);return`${Math.round(o)}%`}return t?.error?"Error":"\u2014"}function ie(e){let t=typeof e=="number"?e:Number(e);return Number.isFinite(t)?t:0}var xd={"git-repo":"https://docs.github.com/en/get-started/using-git/about-git",gitignore:"https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files","env-example":"https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions",editorconfig:"https://editorconfig.org/",linter:"https://docs.github.com/en/code-security/code-scanning/introduction-to-code-scanning/about-code-scanning",formatter:"https://docs.github.com/en/contributing/style-guide-and-content-model/style-guide","type-safety":"https://docs.github.com/en/code-security/code-scanning/reference/code-ql-built-in-queries/javascript-typescript-built-in-queries","commit-messages":"https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/about-commits","conventional-commits":"https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/available-rules-for-rulesets","ci-config":"https://docs.github.com/en/actions/about-github-actions/understanding-github-actions",scripts:"https://docs.github.com/en/actions/tutorials/build-and-test-code/nodejs","task-runner":"https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/add-scripts",devcontainer:"https://docs.github.com/en/codespaces/setting-up-your-project-for-codespaces/adding-a-dev-container-configuration",dockerfile:"https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry","version-pinning":"https://docs.github.com/en/codespaces/setting-up-your-project-for-codespaces/adding-a-dev-container-configuration/setting-up-your-nodejs-project-for-codespaces",license:"https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/licensing-a-repository"},kd={versionControl:"\u{1F504} Version Control",codeQuality:"\u2728 Code Quality",cicd:"\u{1F680} CI/CD",environment:"\u{1F527} Environment",documentation:"\u{1F4DA} Documentation"};function wd(e){let t=m("div");t.setAttribute("style","display: flex; justify-content: space-between; align-items: center; margin-bottom: 12px;");let o=m("div");o.setAttribute("style","font-size: 14px; font-weight: 600; color: var(--text-primary);"),o.textContent="\u{1F4CA} Repository Hygiene Score";let n=m("div");return n.setAttribute("style","font-size: 24px; font-weight: 700; color: var(--link-color);"),n.textContent=`${Math.round(ie(e.percentage))}%`,t.append(o,n),t}function Cd(e){let t=m("div");t.setAttribute("style","display: grid; grid-template-columns: repeat(3, 1fr); gap: 8px; margin-bottom: 12px;");let o=[{count:e.passedChecks,label:"Passed",cardStyle:"text-align: center; padding: 8px; background: rgba(34, 197, 94, 0.1); border: 1px solid rgba(34, 197, 94, 0.3); border-radius: 4px;",countStyle:"font-size: 18px; font-weight: 600; color: var(--success-fg);"},{count:e.warningChecks,label:"Warnings",cardStyle:"text-align: center; padding: 8px; background: rgba(245, 158, 11, 0.1); border: 1px solid rgba(245, 158, 11, 0.3); border-radius: 4px;",countStyle:"font-size: 18px; font-weight: 600; color: var(--warning-fg);"},{count:e.failedChecks,label:"Failed",cardStyle:"text-align: center; padding: 8px; background: rgba(239, 68, 68, 0.1); border: 1px solid rgba(239, 68, 68, 0.3); border-radius: 4px;",countStyle:"font-size: 18px; font-weight: 600; color: #ef4444;"}];for(let n of o){let s=m("div");s.setAttribute("style",n.cardStyle);let r=m("div");r.setAttribute("style",n.countStyle),r.textContent=String(ie(n.count));let i=m("div");i.setAttribute("style","font-size: 10px; color: var(--text-secondary);"),i.textContent=n.label,s.append(r,i),t.appendChild(s)}return t}function Sd(e){let t=e?.status==="pass"||e?.status==="warning"?e.status:"fail";return{status:t,emoji:t==="pass"?"\u2705":t==="warning"?"\u26A0\uFE0F":"\u274C",color:t==="pass"?"#22c55e":t==="warning"?"#f59e0b":"#ef4444"}}function Td(e,t){let o=m("div");o.setAttribute("style","flex: 1;");let n=m("div");n.setAttribute("style",`font-size: 12px; font-weight: 600; color: ${t};`),n.textContent=typeof e?.label=="string"?e.label:"";let s=m("div");if(s.setAttribute("style","font-size: 11px; color: var(--text-secondary); margin-top: 2px;"),s.textContent=typeof e?.detail=="string"?e.detail:"",o.append(n,s),typeof e?.hint=="string"&&e.hint.length>0){let i=m("div");i.setAttribute("style","font-size: 10px; color: var(--link-color); margin-top: 4px; font-style: italic;"),i.textContent=`\u{1F4A1} ${e.hint}`,o.appendChild(i)}let r=xd[typeof e?.id=="string"?e.id:""];if(r){let i=m("a");i.setAttribute("href",r),i.setAttribute("style","font-size: 10px; color: var(--link-color); margin-top: 4px; display: inline-block;"),i.setAttribute("title","View official documentation"),i.textContent="\u{1F4D6} View documentation",o.appendChild(i)}return o}function $d(e){let{emoji:t,color:o}=Sd(e),n=m("div");n.setAttribute("style","padding: 8px; border-bottom: 1px solid var(--border-subtle); display: flex; align-items: flex-start; gap: 8px;");let s=m("span");s.setAttribute("style","flex-shrink: 0; padding-top: 1px;"),k(s,j(t));let r=m("span");return r.setAttribute("style","font-size: 10px; color: var(--text-muted); min-width: 30px; text-align: right;"),r.textContent=`+${ie(e?.weight)}`,n.append(s,Td(e,o),r),n}function Ad(e,t,o){let n=m("div");n.setAttribute("style","margin-bottom: 12px; background: var(--bg-secondary); border: 1px solid var(--border-color); border-radius: 4px; overflow: hidden;");let s=m("div");s.setAttribute("style","padding: 8px 12px; background: var(--list-hover-bg); border-bottom: 1px solid var(--border-color); display: flex; justify-content: space-between; align-items: center;");let r=m("span");r.setAttribute("style","font-size: 12px; font-weight: 600; color: var(--text-primary);"),r.textContent=kd[e]||e;let i=o?.categories?.[e],a=m("span");a.setAttribute("style","font-size: 11px; color: var(--link-color); font-weight: 600;"),a.textContent=`${Math.round(ie(i?.percentage))}%`,s.append(r,a),n.appendChild(s);for(let l of t)n.appendChild($d(l));return n}function Md(e){let t=m("div");t.setAttribute("style","margin-top: 16px; background: var(--bg-secondary); border: 1px solid var(--border-color); border-radius: 4px; overflow: hidden;");let o=m("div");o.setAttribute("style","padding: 8px 12px; background: var(--list-hover-bg); border-bottom: 1px solid var(--border-color);");let n=m("span");n.setAttribute("style","font-size: 12px; font-weight: 600; color: var(--text-primary);"),n.textContent="\u{1F4A1} Top Recommendations",o.appendChild(n),t.appendChild(o);for(let s of e.slice(0,5)){let r=s?.priority==="high"||s?.priority==="medium"?s.priority:"low",i=r==="high"?"#ef4444":r==="medium"?"#f59e0b":"#60a5fa",a=m("div");a.setAttribute("style","padding: 8px; border-bottom: 1px solid var(--border-subtle); display: flex; gap: 8px;");let l=m("span");l.setAttribute("style",`font-size: 10px; font-weight: 600; color: ${i}; min-width: 50px;`),l.textContent=String(r).toUpperCase();let u=m("div");u.setAttribute("style","flex: 1;");let c=m("div");c.setAttribute("style","font-size: 11px; color: var(--text-primary);"),c.textContent=typeof s?.action=="string"?s.action:"";let p=m("div");p.setAttribute("style","font-size: 10px; color: var(--text-muted); margin-top: 2px;"),p.textContent=typeof s?.impact=="string"?s.impact:"",u.append(c,p);let b=m("span");b.setAttribute("style","font-size: 10px; color: var(--text-muted); min-width: 30px; text-align: right;"),b.textContent=`+${ie(s?.weight)}`,a.append(l,u,b),t.appendChild(a)}return t}function Ed(e,t){let o=m("div");o.setAttribute("style","margin-top: 16px; padding: 12px; background: rgba(96, 165, 250, 0.07); border: 1px solid rgba(96, 165, 250, 0.3); border-radius: 4px; display: flex; align-items: center; justify-content: space-between; gap: 12px;");let n=m("div");n.setAttribute("style","font-size: 11px; color: var(--text-secondary); flex: 1;"),n.textContent="Let Copilot help you fix the identified issues in this repository.";let s=document.createElement("vscode-button");return s.setAttribute("style","min-width: 180px;"),s.textContent="\u{1F916} Ask Copilot to Improve",s.addEventListener("click",()=>{let i=`Please help me improve this repository by addressing the following best practice issues:
 
-${failedLines}
+${e.map(l=>`- ${l.label}: ${l.detail||""}${l.hint?` (${l.hint})`:""}`).join(`
+`)}
 
-For each issue, please provide specific steps or code changes to fix it.`;
-      const isRepoOpen = !workspacePath || currentWorkspacePaths.some((p3) => p3.toLowerCase() === workspacePath.toLowerCase());
-      if (isRepoOpen) {
-        vscode.postMessage({ command: "openCopilotChatWithPrompt", prompt });
-      } else {
-        const repoFolderName = workspacePath.split(/[/\\]/).filter(Boolean).pop() ?? workspacePath;
-        copilotSection.replaceChildren();
-        copilotSection.setAttribute("style", "margin-top: 16px; padding: 12px; background: rgba(251, 191, 36, 0.07); border: 1px solid rgba(251, 191, 36, 0.4); border-radius: 4px; display: flex; flex-direction: column; gap: 8px;");
-        const instructions = el("div");
-        instructions.setAttribute("style", "font-size: 11px; color: var(--warning-fg);");
-        instructions.textContent = `\u26A0\uFE0F Open "${repoFolderName}" in VS Code first, then paste this prompt into Copilot Chat:`;
-        const promptBox = el("pre");
-        promptBox.setAttribute("style", "font-size: 10px; color: var(--text-secondary); background: var(--bg-secondary); border: 1px solid var(--border-color); border-radius: 4px; padding: 8px; white-space: pre-wrap; word-break: break-word; max-height: 120px; overflow-y: auto; font-family: monospace; margin: 0;");
-        promptBox.textContent = prompt;
-        const copyBtn = document.createElement("vscode-button");
-        copyBtn.setAttribute("appearance", "secondary");
-        copyBtn.textContent = "\u{1F4CB} Copy prompt";
-        copyBtn.addEventListener("click", () => {
-          navigator.clipboard.writeText(prompt).then(() => {
-            copyBtn.textContent = "\u2705 Copied!";
-            setTimeout(() => {
-              copyBtn.textContent = "\u{1F4CB} Copy prompt";
-            }, 2e3);
-          });
-        });
-        copilotSection.append(instructions, promptBox, copyBtn);
-      }
-    });
-    copilotSection.append(copilotText, copilotBtn);
-    return copilotSection;
-  }
-  function buildRepoAnalysisBodyElement(data, workspacePath) {
-    const summary = data?.summary || {};
-    const checks = Array.isArray(data?.checks) ? data.checks : [];
-    const recommendations = Array.isArray(data?.recommendations) ? [...data.recommendations] : [];
-    const container = el("div");
-    container.appendChild(buildScoreHeaderElement(summary));
-    container.appendChild(buildStatsGridElement(summary));
-    const scoreSummary = el("div");
-    scoreSummary.setAttribute("style", "font-size: 11px; color: var(--text-muted); text-align: center; margin-bottom: 16px;");
-    scoreSummary.textContent = `Score: ${toFiniteNumber(summary.totalScore)} / ${toFiniteNumber(summary.maxScore)} points`;
-    container.appendChild(scoreSummary);
-    const priorityOrder = { high: 1, medium: 2, low: 3 };
-    recommendations.sort((a3, b3) => (priorityOrder[a3?.priority] || 99) - (priorityOrder[b3?.priority] || 99));
-    const categories = {};
-    for (const check of checks) {
-      const categoryId = typeof check?.category === "string" && check.category.length > 0 ? check.category : "other";
-      if (!categories[categoryId]) {
-        categories[categoryId] = [];
-      }
-      categories[categoryId].push(check);
-    }
-    for (const [categoryId, categoryChecks] of Object.entries(categories)) {
-      container.appendChild(buildCategorySectionElement(categoryId, categoryChecks, summary));
-    }
-    if (recommendations.length > 0) {
-      container.appendChild(buildRecommendationsSectionElement(recommendations));
-    }
-    const failedChecks = checks.filter((c4) => c4?.status === "fail" || c4?.status === "warning");
-    if (failedChecks.length > 0) {
-      container.appendChild(buildCopilotSectionElement(failedChecks, workspacePath));
-    }
-    return container;
-  }
-  function renderRepoListPane(listPane, visibleWorkspaces, hasSelectedRepository) {
-    const colStyles = {
-      sessions: "width: 60px; text-align: right; flex-shrink: 0; font-size: 11px; color: var(--text-primary);",
-      interactions: "width: 80px; text-align: right; flex-shrink: 0; font-size: 11px; color: var(--text-primary);",
-      score: "width: 60px; text-align: right; flex-shrink: 0; font-size: 11px; color: var(--text-primary);"
-    };
-    const headerHtml = `
+For each issue, please provide specific steps or code changes to fix it.`;if(!t||_s.some(l=>l.toLowerCase()===t.toLowerCase()))f.postMessage({command:"openCopilotChatWithPrompt",prompt:i});else{let l=t.split(/[/\\]/).filter(Boolean).pop()??t;o.replaceChildren(),o.setAttribute("style","margin-top: 16px; padding: 12px; background: rgba(251, 191, 36, 0.07); border: 1px solid rgba(251, 191, 36, 0.4); border-radius: 4px; display: flex; flex-direction: column; gap: 8px;");let u=m("div");u.setAttribute("style","font-size: 11px; color: var(--warning-fg);"),u.textContent=`\u26A0\uFE0F Open "${l}" in VS Code first, then paste this prompt into Copilot Chat:`;let c=m("pre");c.setAttribute("style","font-size: 10px; color: var(--text-secondary); background: var(--bg-secondary); border: 1px solid var(--border-color); border-radius: 4px; padding: 8px; white-space: pre-wrap; word-break: break-word; max-height: 120px; overflow-y: auto; font-family: monospace; margin: 0;"),c.textContent=i;let p=document.createElement("vscode-button");p.setAttribute("appearance","secondary"),p.textContent="\u{1F4CB} Copy prompt",p.addEventListener("click",()=>{navigator.clipboard.writeText(i).then(()=>{p.textContent="\u2705 Copied!",setTimeout(()=>{p.textContent="\u{1F4CB} Copy prompt"},2e3)})}),o.append(u,c,p)}}),o.append(n,s),o}function tr(e,t){let o=e?.summary||{},n=Array.isArray(e?.checks)?e.checks:[],s=Array.isArray(e?.recommendations)?[...e.recommendations]:[],r=m("div");r.appendChild(wd(o)),r.appendChild(Cd(o));let i=m("div");i.setAttribute("style","font-size: 11px; color: var(--text-muted); text-align: center; margin-bottom: 16px;"),i.textContent=`Score: ${ie(o.totalScore)} / ${ie(o.maxScore)} points`,r.appendChild(i);let a={high:1,medium:2,low:3};s.sort((c,p)=>(a[c?.priority]||99)-(a[p?.priority]||99));let l={};for(let c of n){let p=typeof c?.category=="string"&&c.category.length>0?c.category:"other";l[p]||(l[p]=[]),l[p].push(c)}for(let[c,p]of Object.entries(l))r.appendChild(Ad(c,p,o));s.length>0&&r.appendChild(Md(s));let u=n.filter(c=>c?.status==="fail"||c?.status==="warning");return u.length>0&&r.appendChild(Ed(u,t)),r}function Rd(e,t,o){let n={sessions:"width: 60px; text-align: right; flex-shrink: 0; font-size: 11px; color: var(--text-primary);",interactions:"width: 80px; text-align: right; flex-shrink: 0; font-size: 11px; color: var(--text-primary);",score:"width: 60px; text-align: right; flex-shrink: 0; font-size: 11px; color: var(--text-primary);"},s=`
 		<div style="padding: 4px 12px; display: flex; align-items: center; gap: 10px; border-bottom: 1px solid var(--border-color); background: var(--bg-secondary);">
 			<div style="flex: 1; min-width: 0; font-size: 10px; font-weight: 600; color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.04em;">Repository</div>
-			<div style="${colStyles.sessions} font-weight: 600; color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.04em;">Sessions</div>
-			<div style="${colStyles.interactions} font-weight: 600; color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.04em;">Interactions</div>
-			<div style="${colStyles.score} font-weight: 600; color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.04em;">Score</div>
+			<div style="${n.sessions} font-weight: 600; color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.04em;">Sessions</div>
+			<div style="${n.interactions} font-weight: 600; color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.04em;">Interactions</div>
+			<div style="${n.score} font-weight: 600; color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.04em;">Score</div>
 			<div style="width: 110px; flex-shrink: 0;"></div>
 		</div>
-	`;
-    setHtml(listPane, headerHtml + visibleWorkspaces.map((ws, idx) => {
-      const record = repoAnalysisState.get(ws.workspacePath);
-      const inFlight = repoAnalysisInFlight.has(ws.workspacePath);
-      const hasResult = !!record?.data?.summary;
-      const scoreLabel = getScoreLabel(ws.workspacePath);
-      const buttonLabel = inFlight ? "Analyzing\u2026" : hasResult ? "Details" : "Analyze";
-      const buttonAction = hasResult && !inFlight ? "details" : "analyze";
-      const isCurrentSelection = selectedRepoPath === ws.workspacePath && hasSelectedRepository;
-      const buttonDisabled = inFlight || isCurrentSelection;
-      const buttonAppearance = inFlight ? ' appearance="secondary"' : "";
-      const sessions = Number(ws.sessionCount) || 0;
-      const interactions = Number(ws.interactionCount) || 0;
-      return `
-			<div class="repo-item" style="padding: 6px 12px; border-bottom: ${idx < visibleWorkspaces.length - 1 ? "1px solid var(--border-subtle)" : "none"}; display: flex; align-items: center; gap: 10px;">
+	`;k(e,s+t.map((r,i)=>{let a=ct.get(r.workspacePath),l=$e.has(r.workspacePath),u=!!a?.data?.summary,c=vd(r.workspacePath),p=l?"Analyzing\u2026":u?"Details":"Analyze",b=u&&!l?"details":"analyze",h=B===r.workspacePath&&o,S=l||h,ut=l?' appearance="secondary"':"",or=Number(r.sessionCount)||0,nr=Number(r.interactionCount)||0;return`
+			<div class="repo-item" style="padding: 6px 12px; border-bottom: ${i<t.length-1?"1px solid var(--border-subtle)":"none"}; display: flex; align-items: center; gap: 10px;">
 				<div style="flex: 1; min-width: 0;">
-					<div class="repo-name" style="font-size: 12px; font-weight: 600; color: var(--text-primary); font-family: 'Courier New', monospace; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;" title="${escapeHtml(ws.workspacePath)}">
-						${escapeHtml(ws.workspaceName)}
+					<div class="repo-name" style="font-size: 12px; font-weight: 600; color: var(--text-primary); font-family: 'Courier New', monospace; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;" title="${d(r.workspacePath)}">
+						${d(r.workspaceName)}
 					</div>
 				</div>
-				<div style="${colStyles.sessions}">${sessions}</div>
-				<div style="${colStyles.interactions}">${interactions}</div>
-				<div style="${colStyles.score}">${escapeHtml(scoreLabel)}</div>
-				<vscode-button class="btn-repo-action" data-action="${buttonAction}" data-workspace-path="${escapeHtml(ws.workspacePath)}" ${buttonDisabled ? 'disabled="true"' : ""}${buttonAppearance} style="width: 110px; flex-shrink: 0;">
-					${buttonLabel}
+				<div style="${n.sessions}">${or}</div>
+				<div style="${n.interactions}">${nr}</div>
+				<div style="${n.score}">${d(c)}</div>
+				<vscode-button class="btn-repo-action" data-action="${b}" data-workspace-path="${d(r.workspacePath)}" ${S?'disabled="true"':""}${ut} style="width: 110px; flex-shrink: 0;">
+					${p}
 				</vscode-button>
 			</div>
-		`;
-    }).join(""));
-  }
-  function renderRepoDetailSuccess(detailsPane, record, workspaceName) {
-    detailsPane.replaceChildren();
-    const card = el("div", "repo-details-card");
-    card.setAttribute("style", "padding: 12px; background: var(--bg-secondary); border: 1px solid var(--border-color); border-radius: 6px;");
-    const header = el("div", "repo-details-card-header");
-    header.setAttribute("style", "display: flex; justify-content: space-between; align-items: center; gap: 8px; margin-bottom: 10px;");
-    const label = el("div");
-    label.setAttribute("style", "font-size: 12px; color: var(--text-secondary);");
-    label.textContent = "Repository: ";
-    const repoName = el("span");
-    repoName.setAttribute("style", "color: var(--text-primary); font-weight: 600; font-family: 'Courier New', monospace;");
-    repoName.textContent = workspaceName;
-    label.appendChild(repoName);
-    const switchButton = document.createElement("vscode-button");
-    switchButton.id = "btn-switch-repository";
-    switchButton.setAttribute("style", "min-width: 120px;");
-    switchButton.textContent = "Switch Repository";
-    header.append(label, switchButton);
-    card.append(header, buildRepoAnalysisBodyElement(record.data, selectedRepoPath ?? void 0));
-    detailsPane.appendChild(card);
-  }
-  function renderRepositoryHygienePanels() {
-    const listPane = document.getElementById("repo-list-pane");
-    const listContainer = document.getElementById("repo-list-pane-container");
-    const detailsPane = document.getElementById("repo-details-pane");
-    const detailsContainer = document.getElementById("repo-details-pane-container");
-    if (!listPane || !listContainer || !detailsPane || !detailsContainer || !hygieneMatrixState) {
-      return;
-    }
-    const hasSelectedRepository = !!selectedRepoPath && !isSwitchingRepository;
-    const visibleWorkspaces = hasSelectedRepository ? hygieneMatrixState.workspaces.filter((ws) => ws.workspacePath === selectedRepoPath) : hygieneMatrixState.workspaces;
-    listContainer.classList.remove("repo-hygiene-pane-collapsed");
-    detailsContainer.classList.toggle("repo-hygiene-pane-collapsed", !hasSelectedRepository);
-    renderRepoListPane(listPane, visibleWorkspaces, hasSelectedRepository);
-    if (!hasSelectedRepository || !selectedRepoPath) {
-      detailsPane.replaceChildren();
-      return;
-    }
-    const workspaceName = getWorkspaceName(selectedRepoPath);
-    const record = repoAnalysisState.get(selectedRepoPath);
-    if (record?.data) {
-      renderRepoDetailSuccess(detailsPane, record, workspaceName);
-      return;
-    }
-    if (record?.error) {
-      setHtml(detailsPane, `
+		`}).join(""))}function _d(e,t,o){e.replaceChildren();let n=m("div","repo-details-card");n.setAttribute("style","padding: 12px; background: var(--bg-secondary); border: 1px solid var(--border-color); border-radius: 6px;");let s=m("div","repo-details-card-header");s.setAttribute("style","display: flex; justify-content: space-between; align-items: center; gap: 8px; margin-bottom: 10px;");let r=m("div");r.setAttribute("style","font-size: 12px; color: var(--text-secondary);"),r.textContent="Repository: ";let i=m("span");i.setAttribute("style","color: var(--text-primary); font-weight: 600; font-family: 'Courier New', monospace;"),i.textContent=o,r.appendChild(i);let a=document.createElement("vscode-button");a.id="btn-switch-repository",a.setAttribute("style","min-width: 120px;"),a.textContent="Switch Repository",s.append(r,a),n.append(s,tr(t.data,B??void 0)),e.appendChild(n)}function X(){let e=document.getElementById("repo-list-pane"),t=document.getElementById("repo-list-pane-container"),o=document.getElementById("repo-details-pane"),n=document.getElementById("repo-details-pane-container");if(!e||!t||!o||!n||!H)return;let s=!!B&&!ge,r=s?H.workspaces.filter(l=>l.workspacePath===B):H.workspaces;if(t.classList.remove("repo-hygiene-pane-collapsed"),n.classList.toggle("repo-hygiene-pane-collapsed",!s),Rd(e,r,s),!s||!B){o.replaceChildren();return}let i=hd(B),a=ct.get(B);if(a?.data){_d(o,a,i);return}if(a?.error){k(o,`
 			<div style="padding: 12px; background: rgba(239, 68, 68, 0.1); border: 1px solid rgba(239, 68, 68, 0.3); border-radius: 6px;">
 				<div style="display: flex; justify-content: space-between; align-items: center; gap: 8px; margin-bottom: 8px;">
-					<div style="font-size: 11px; color: #fca5a5;">Repository: ${escapeHtml(workspaceName)}</div>
+					<div style="font-size: 11px; color: #fca5a5;">Repository: ${d(i)}</div>
 					<vscode-button id="btn-switch-repository" style="min-width: 120px;">Switch Repository</vscode-button>
 				</div>
 				<div style="font-size: 12px; font-weight: 600; color: #ef4444; margin-bottom: 4px;">\u274C Analysis Failed</div>
-				<div style="font-size: 11px; color: #fca5a5;">${escapeHtml(record.error)}</div>
+				<div style="font-size: 11px; color: #fca5a5;">${d(a.error)}</div>
 			</div>
-		`);
-      return;
-    }
-    setHtml(detailsPane, `
+		`);return}k(o,`
 		<div style="padding: 12px; background: var(--bg-secondary); border: 1px solid var(--border-color); border-radius: 6px;">
 			<div style="display: flex; justify-content: space-between; align-items: center; gap: 8px; margin-bottom: 8px;">
-				<div style="font-size: 12px; color: var(--text-secondary);">Repository: <span style="color: var(--text-primary); font-weight: 600; font-family: 'Courier New', monospace;">${escapeHtml(workspaceName)}</span></div>
+				<div style="font-size: 12px; color: var(--text-secondary);">Repository: <span style="color: var(--text-primary); font-weight: 600; font-family: 'Courier New', monospace;">${d(i)}</span></div>
 				<vscode-button id="btn-switch-repository" style="min-width: 120px;">Switch Repository</vscode-button>
 			</div>
 			<div style="font-size: 11px; color: var(--text-muted);">No analysis data yet. Click Analyze in the list.</div>
 		</div>
-	`);
-  }
-  function displayRepoAnalysisResults(data, workspacePath) {
-    if (workspacePath) {
-      repoAnalysisInFlight.delete(workspacePath);
-      repoAnalysisState.set(workspacePath, { data, error: void 0 });
-      if (!isBatchAnalysisInProgress) {
-        selectedRepoPath = workspacePath;
-        isSwitchingRepository = false;
-      }
-      renderRepositoryHygienePanels();
-      return;
-    }
-    const btn = document.getElementById("btn-analyse-repo");
-    if (btn) {
-      isSingleRepoAnalysisInProgress = false;
-      btn.disabled = false;
-      btn.textContent = "Analyze Repo for Best Practices";
-      btn.removeAttribute("appearance");
-    }
-    const resultsHost = document.getElementById("repo-analysis-results");
-    if (resultsHost) {
-      resultsHost.replaceChildren();
-      const card = el("div", "repo-analysis-card");
-      card.setAttribute("style", "padding: 12px; background: var(--bg-secondary); border: 1px solid var(--border-color); border-radius: 6px; margin-bottom: 12px;");
-      card.appendChild(buildRepoAnalysisBodyElement(data, workspacePath));
-      resultsHost.appendChild(card);
-    }
-  }
-  function displayRepoAnalysisError(error, workspacePath) {
-    if (workspacePath) {
-      repoAnalysisInFlight.delete(workspacePath);
-      repoAnalysisState.set(workspacePath, { data: void 0, error });
-      if (!isBatchAnalysisInProgress) {
-        selectedRepoPath = workspacePath;
-        isSwitchingRepository = false;
-      }
-      renderRepositoryHygienePanels();
-      return;
-    }
-    const btn = document.getElementById("btn-analyse-repo");
-    if (btn) {
-      isSingleRepoAnalysisInProgress = false;
-      btn.disabled = false;
-      btn.textContent = "Analyze Repo for Best Practices";
-      btn.removeAttribute("appearance");
-    }
-    const resultsHost = document.getElementById("repo-analysis-results");
-    if (resultsHost) {
-      setHtml(resultsHost, `
+	`)}function Pd(e,t){if(t){$e.delete(t),ct.set(t,{data:e,error:void 0}),me||(B=t,ge=!1),X();return}let o=document.getElementById("btn-analyse-repo");o&&(st=!1,o.disabled=!1,o.textContent="Analyze Repo for Best Practices",o.removeAttribute("appearance"));let n=document.getElementById("repo-analysis-results");if(n){n.replaceChildren();let s=m("div","repo-analysis-card");s.setAttribute("style","padding: 12px; background: var(--bg-secondary); border: 1px solid var(--border-color); border-radius: 6px; margin-bottom: 12px;"),s.appendChild(tr(e,t)),n.appendChild(s)}}function Rs(e,t){if(t){$e.delete(t),ct.set(t,{data:void 0,error:e}),me||(B=t,ge=!1),X();return}let o=document.getElementById("btn-analyse-repo");o&&(st=!1,o.disabled=!1,o.textContent="Analyze Repo for Best Practices",o.removeAttribute("appearance"));let n=document.getElementById("repo-analysis-results");n&&k(n,`
 			<div style="padding: 12px; background: rgba(239, 68, 68, 0.1); border: 1px solid rgba(239, 68, 68, 0.3); border-radius: 6px; margin-bottom: 12px;">
 				<div style="font-size: 12px; font-weight: 600; color: #ef4444; margin-bottom: 4px;">\u274C Analysis Failed</div>
-				<div style="font-size: 11px; color: #fca5a5;">${escapeHtml(error)}</div>
+				<div style="font-size: 11px; color: #fca5a5;">${d(e)}</div>
 			</div>
-		`);
-    }
-  }
-  function handleBatchAnalysisComplete() {
-    isBatchAnalysisInProgress = false;
-    isSwitchingRepository = true;
-    selectedRepoPath = null;
-    repoAnalysisInFlight.clear();
-    renderRepositoryHygienePanels();
-    const btn = document.getElementById("btn-analyse-all");
-    if (btn) {
-      btn.disabled = false;
-      btn.removeAttribute("appearance");
-      const matrix = initialData?.customizationMatrix;
-      const count = matrix?.workspaces?.length || 0;
-      btn.textContent = `Analyze All Repositories (${count})`;
-    }
-  }
-  async function bootstrap() {
-    await Promise.resolve().then(() => (init_vscode_button2(), vscode_button_exports));
-    if (!initialData) {
-      renderUsageLoadingState("Loading usage analysis...");
-      loadingTimeoutId = setTimeout(() => {
-        const r6 = document.getElementById("root");
-        if (r6 && r6.querySelector("#usage-loading-card")) {
-          const hint = document.createElement("div");
-          hint.style.cssText = "padding: 32px; text-align: center; font-size: 14px;";
-          const msg = document.createElement("div");
-          msg.style.cssText = "color: var(--vscode-foreground); opacity: 0.7; margin-bottom: 12px;";
-          msg.textContent = "\u23F3 Taking longer than expected\u2026 Session files may be large or the scan is still in progress.";
-          hint.append(msg, createRefreshButton());
-          r6.textContent = "";
-          r6.append(hint);
-        }
-      }, 3e4);
-      return;
-    }
-    setFormatLocale(initialData.locale);
-    use24HourTime = initialData.use24HourTime !== false;
-    hideAutomaticToolCalls = initialData.hideAutomaticToolCalls !== false;
-    const savedColumns = initialData.sessionColumnSettings?.enabledColumns;
-    if (Array.isArray(savedColumns)) {
-      const valid = savedColumns.filter((c4) => ALL_SESSION_COLUMN_IDS.includes(c4));
-      enabledSessionColumns = new Set(valid);
-    }
-    renderLayout(initialData);
-    setupSessionsTableSort();
-    document.addEventListener("click", (event) => {
-      const target = event.target;
-      const toolName = target.getAttribute("data-suppress-tool");
-      if (toolName) {
-        handleToolSuppressed(toolName);
-        vscode.postMessage({ command: "suppressUnknownTool", toolName });
-      }
-    });
-  }
-  void bootstrap().catch((err) => {
-    console.error("[Usage Analysis] Bootstrap failed:", err);
-    const root = document.getElementById("root");
-    if (root) {
-      const container = document.createElement("div");
-      container.style.cssText = "padding: 32px; text-align: center; font-size: 14px;";
-      const msg = document.createElement("div");
-      msg.style.cssText = "color: var(--vscode-errorForeground, #f48771); margin-bottom: 16px;";
-      msg.textContent = "Failed to initialize usage analysis. Please try refreshing.";
-      container.append(msg, createRefreshButton());
-      root.textContent = "";
-      root.append(container);
-    }
-  });
-})();
+		`)}function Dd(){me=!1,ge=!0,B=null,$e.clear(),X();let e=document.getElementById("btn-analyse-all");if(e){e.disabled=!1,e.removeAttribute("appearance");let o=E?.customizationMatrix?.workspaces?.length||0;e.textContent=`Analyze All Repositories (${o})`}}async function Ld(){if(await Promise.resolve().then(()=>(fs(),ms)),!E){No("Loading usage analysis..."),Ut=setTimeout(()=>{let t=document.getElementById("root");if(t&&t.querySelector("#usage-loading-card")){let o=document.createElement("div");o.style.cssText="padding: 32px; text-align: center; font-size: 14px;";let n=document.createElement("div");n.style.cssText="color: var(--vscode-foreground); opacity: 0.7; margin-bottom: 12px;",n.textContent="\u23F3 Taking longer than expected\u2026 Session files may be large or the scan is still in progress.",o.append(n,Kt()),t.textContent="",t.append(o)}},3e4);return}Xt(E.locale),Ot=E.use24HourTime!==!1,at=E.hideAutomaticToolCalls!==!1,Is(E.recentSessions);let e=E.sessionColumnSettings?.enabledColumns;if(Array.isArray(e)){let t=e.filter(o=>Ds.includes(o));Me=new Set(t)}Zs(E),Ls(),document.addEventListener("click",t=>{let n=t.target.getAttribute("data-suppress-tool");n&&(Qs(n),f.postMessage({command:"suppressUnknownTool",toolName:n}))})}Ld().catch(e=>{console.error("[Usage Analysis] Bootstrap failed:",e);let t=document.getElementById("root");if(t){let o=document.createElement("div");o.style.cssText="padding: 32px; text-align: center; font-size: 14px;";let n=document.createElement("div");n.style.cssText="color: var(--vscode-errorForeground, #f48771); margin-bottom: 16px;",n.textContent="Failed to initialize usage analysis. Please try refreshing.",o.append(n,Kt()),t.textContent="",t.append(o)}});})();
 /*! Bundled license information:
 
 @lit/reactive-element/css-tag.js:
@@ -8912,4 +3138,3 @@ lit-html/directives/if-defined.js:
    * SPDX-License-Identifier: BSD-3-Clause
    *)
 */
-//# sourceMappingURL=usage.js.map

--- a/visualstudio-extension/src/AIEngineeringFluency/webview/usage.js
+++ b/visualstudio-extension/src/AIEngineeringFluency/webview/usage.js
@@ -1,9 +1,908 @@
-"use strict";(()=>{var sr=Object.defineProperty;var y=(e,t,o)=>()=>{if(o)throw o[0];try{return e&&(t=e(e=0)),t}catch(n){throw o=[n],n}};var rr=(e,t)=>{for(var o in t)sr(e,o,{get:t[o],enumerable:!0})};var xt,kt,ro,$n,Ue,wt,ae,An,io,ao=y(()=>{xt=globalThis,kt=xt.ShadowRoot&&(xt.ShadyCSS===void 0||xt.ShadyCSS.nativeShadow)&&"adoptedStyleSheets"in Document.prototype&&"replace"in CSSStyleSheet.prototype,ro=Symbol(),$n=new WeakMap,Ue=class{constructor(t,o,n){if(this._$cssResult$=!0,n!==ro)throw Error("CSSResult is not constructable. Use `unsafeCSS` or `css` instead.");this.cssText=t,this.t=o}get styleSheet(){let t=this.o,o=this.t;if(kt&&t===void 0){let n=o!==void 0&&o.length===1;n&&(t=$n.get(o)),t===void 0&&((this.o=t=new CSSStyleSheet).replaceSync(this.cssText),n&&$n.set(o,t))}return t}toString(){return this.cssText}},wt=e=>new Ue(typeof e=="string"?e:e+"",void 0,ro),ae=(e,...t)=>{let o=e.length===1?e[0]:t.reduce((n,s,r)=>n+(i=>{if(i._$cssResult$===!0)return i.cssText;if(typeof i=="number")return i;throw Error("Value passed to 'css' function must be a 'css' function result: "+i+". Use 'unsafeCSS' to pass non-literal values, but take care to ensure page security.")})(s)+e[r+1],e[0]);return new Ue(o,e,ro)},An=(e,t)=>{if(kt)e.adoptedStyleSheets=t.map(o=>o instanceof CSSStyleSheet?o:o.styleSheet);else for(let o of t){let n=document.createElement("style"),s=xt.litNonce;s!==void 0&&n.setAttribute("nonce",s),n.textContent=o.cssText,e.appendChild(n)}},io=kt?e=>e:e=>e instanceof CSSStyleSheet?(t=>{let o="";for(let n of t.cssRules)o+=n.cssText;return wt(o)})(e):e});var Ir,zr,Br,Or,Nr,Hr,te,Mn,jr,Fr,Ie,ze,Ct,En,K,Be=y(()=>{ao();ao();({is:Ir,defineProperty:zr,getOwnPropertyDescriptor:Br,getOwnPropertyNames:Or,getOwnPropertySymbols:Nr,getPrototypeOf:Hr}=Object),te=globalThis,Mn=te.trustedTypes,jr=Mn?Mn.emptyScript:"",Fr=te.reactiveElementPolyfillSupport,Ie=(e,t)=>e,ze={toAttribute(e,t){switch(t){case Boolean:e=e?jr:null;break;case Object:case Array:e=e==null?e:JSON.stringify(e)}return e},fromAttribute(e,t){let o=e;switch(t){case Boolean:o=e!==null;break;case Number:o=e===null?null:Number(e);break;case Object:case Array:try{o=JSON.parse(e)}catch{o=null}}return o}},Ct=(e,t)=>!Ir(e,t),En={attribute:!0,type:String,converter:ze,reflect:!1,useDefault:!1,hasChanged:Ct};Symbol.metadata??(Symbol.metadata=Symbol("metadata")),te.litPropertyMetadata??(te.litPropertyMetadata=new WeakMap);K=class extends HTMLElement{static addInitializer(t){this._$Ei(),(this.l??(this.l=[])).push(t)}static get observedAttributes(){return this.finalize(),this._$Eh&&[...this._$Eh.keys()]}static createProperty(t,o=En){if(o.state&&(o.attribute=!1),this._$Ei(),this.prototype.hasOwnProperty(t)&&((o=Object.create(o)).wrapped=!0),this.elementProperties.set(t,o),!o.noAccessor){let n=Symbol(),s=this.getPropertyDescriptor(t,n,o);s!==void 0&&zr(this.prototype,t,s)}}static getPropertyDescriptor(t,o,n){let{get:s,set:r}=Br(this.prototype,t)??{get(){return this[o]},set(i){this[o]=i}};return{get:s,set(i){let a=s?.call(this);r?.call(this,i),this.requestUpdate(t,a,n)},configurable:!0,enumerable:!0}}static getPropertyOptions(t){return this.elementProperties.get(t)??En}static _$Ei(){if(this.hasOwnProperty(Ie("elementProperties")))return;let t=Hr(this);t.finalize(),t.l!==void 0&&(this.l=[...t.l]),this.elementProperties=new Map(t.elementProperties)}static finalize(){if(this.hasOwnProperty(Ie("finalized")))return;if(this.finalized=!0,this._$Ei(),this.hasOwnProperty(Ie("properties"))){let o=this.properties,n=[...Or(o),...Nr(o)];for(let s of n)this.createProperty(s,o[s])}let t=this[Symbol.metadata];if(t!==null){let o=litPropertyMetadata.get(t);if(o!==void 0)for(let[n,s]of o)this.elementProperties.set(n,s)}this._$Eh=new Map;for(let[o,n]of this.elementProperties){let s=this._$Eu(o,n);s!==void 0&&this._$Eh.set(s,o)}this.elementStyles=this.finalizeStyles(this.styles)}static finalizeStyles(t){let o=[];if(Array.isArray(t)){let n=new Set(t.flat(1/0).reverse());for(let s of n)o.unshift(io(s))}else t!==void 0&&o.push(io(t));return o}static _$Eu(t,o){let n=o.attribute;return n===!1?void 0:typeof n=="string"?n:typeof t=="string"?t.toLowerCase():void 0}constructor(){super(),this._$Ep=void 0,this.isUpdatePending=!1,this.hasUpdated=!1,this._$Em=null,this._$Ev()}_$Ev(){this._$ES=new Promise(t=>this.enableUpdating=t),this._$AL=new Map,this._$E_(),this.requestUpdate(),this.constructor.l?.forEach(t=>t(this))}addController(t){(this._$EO??(this._$EO=new Set)).add(t),this.renderRoot!==void 0&&this.isConnected&&t.hostConnected?.()}removeController(t){this._$EO?.delete(t)}_$E_(){let t=new Map,o=this.constructor.elementProperties;for(let n of o.keys())this.hasOwnProperty(n)&&(t.set(n,this[n]),delete this[n]);t.size>0&&(this._$Ep=t)}createRenderRoot(){let t=this.shadowRoot??this.attachShadow(this.constructor.shadowRootOptions);return An(t,this.constructor.elementStyles),t}connectedCallback(){this.renderRoot??(this.renderRoot=this.createRenderRoot()),this.enableUpdating(!0),this._$EO?.forEach(t=>t.hostConnected?.())}enableUpdating(t){}disconnectedCallback(){this._$EO?.forEach(t=>t.hostDisconnected?.())}attributeChangedCallback(t,o,n){this._$AK(t,n)}_$ET(t,o){let n=this.constructor.elementProperties.get(t),s=this.constructor._$Eu(t,n);if(s!==void 0&&n.reflect===!0){let r=(n.converter?.toAttribute!==void 0?n.converter:ze).toAttribute(o,n.type);this._$Em=t,r==null?this.removeAttribute(s):this.setAttribute(s,r),this._$Em=null}}_$AK(t,o){let n=this.constructor,s=n._$Eh.get(t);if(s!==void 0&&this._$Em!==s){let r=n.getPropertyOptions(s),i=typeof r.converter=="function"?{fromAttribute:r.converter}:r.converter?.fromAttribute!==void 0?r.converter:ze;this._$Em=s;let a=i.fromAttribute(o,r.type);this[s]=a??this._$Ej?.get(s)??a,this._$Em=null}}requestUpdate(t,o,n,s=!1,r){if(t!==void 0){let i=this.constructor;if(s===!1&&(r=this[t]),n??(n=i.getPropertyOptions(t)),!((n.hasChanged??Ct)(r,o)||n.useDefault&&n.reflect&&r===this._$Ej?.get(t)&&!this.hasAttribute(i._$Eu(t,n))))return;this.C(t,o,n)}this.isUpdatePending===!1&&(this._$ES=this._$EP())}C(t,o,{useDefault:n,reflect:s,wrapped:r},i){n&&!(this._$Ej??(this._$Ej=new Map)).has(t)&&(this._$Ej.set(t,i??o??this[t]),r!==!0||i!==void 0)||(this._$AL.has(t)||(this.hasUpdated||n||(o=void 0),this._$AL.set(t,o)),s===!0&&this._$Em!==t&&(this._$Eq??(this._$Eq=new Set)).add(t))}async _$EP(){this.isUpdatePending=!0;try{await this._$ES}catch(o){Promise.reject(o)}let t=this.scheduleUpdate();return t!=null&&await t,!this.isUpdatePending}scheduleUpdate(){return this.performUpdate()}performUpdate(){if(!this.isUpdatePending)return;if(!this.hasUpdated){if(this.renderRoot??(this.renderRoot=this.createRenderRoot()),this._$Ep){for(let[s,r]of this._$Ep)this[s]=r;this._$Ep=void 0}let n=this.constructor.elementProperties;if(n.size>0)for(let[s,r]of n){let{wrapped:i}=r,a=this[s];i!==!0||this._$AL.has(s)||a===void 0||this.C(s,void 0,r,a)}}let t=!1,o=this._$AL;try{t=this.shouldUpdate(o),t?(this.willUpdate(o),this._$EO?.forEach(n=>n.hostUpdate?.()),this.update(o)):this._$EM()}catch(n){throw t=!1,this._$EM(),n}t&&this._$AE(o)}willUpdate(t){}_$AE(t){this._$EO?.forEach(o=>o.hostUpdated?.()),this.hasUpdated||(this.hasUpdated=!0,this.firstUpdated(t)),this.updated(t)}_$EM(){this._$AL=new Map,this.isUpdatePending=!1}get updateComplete(){return this.getUpdateComplete()}getUpdateComplete(){return this._$ES}shouldUpdate(t){return!0}update(t){this._$Eq&&(this._$Eq=this._$Eq.forEach(o=>this._$ET(o,this[o]))),this._$EM()}updated(t){}firstUpdated(t){}};K.elementStyles=[],K.shadowRootOptions={mode:"open"},K[Ie("elementProperties")]=new Map,K[Ie("finalized")]=new Map,Fr?.({ReactiveElement:K}),(te.reactiveElementVersions??(te.reactiveElementVersions=[])).push("2.1.2")});function Nn(e,t){if(!fo(e)||!e.hasOwnProperty("raw"))throw Error("invalid template strings array");return _n!==void 0?_n.createHTML(t):t}function ye(e,t,o=e,n){if(t===O)return t;let s=n!==void 0?o._$Co?.[n]:o._$Cl,r=je(t)?void 0:t._$litDirective$;return s?.constructor!==r&&(s?._$AO?.(!1),r===void 0?s=void 0:(s=new r(e),s._$AT(e,o,n)),n!==void 0?(o._$Co??(o._$Co=[]))[n]=s:o._$Cl=s),s!==void 0&&(t=ye(e,s._$AS(e,t.values),s,n)),t}var Ne,Rn,St,_n,zn,oe,Bn,Wr,ce,He,je,fo,qr,lo,Oe,Pn,Dn,le,Ln,Un,On,bo,G,Bc,Oc,O,T,In,de,Kr,Fe,co,We,he,uo,po,go,mo,Gr,Hn,ve=y(()=>{Ne=globalThis,Rn=e=>e,St=Ne.trustedTypes,_n=St?St.createPolicy("lit-html",{createHTML:e=>e}):void 0,zn="$lit$",oe=`lit$${Math.random().toFixed(9).slice(2)}$`,Bn="?"+oe,Wr=`<${Bn}>`,ce=document,He=()=>ce.createComment(""),je=e=>e===null||typeof e!="object"&&typeof e!="function",fo=Array.isArray,qr=e=>fo(e)||typeof e?.[Symbol.iterator]=="function",lo=`[ 	
-\f\r]`,Oe=/<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g,Pn=/-->/g,Dn=/>/g,le=RegExp(`>|${lo}(?:([^\\s"'>=/]+)(${lo}*=${lo}*(?:[^ 	
-\f\r"'\`<>=]|("|')|))|$)`,"g"),Ln=/'/g,Un=/"/g,On=/^(?:script|style|textarea|title)$/i,bo=e=>(t,...o)=>({_$litType$:e,strings:t,values:o}),G=bo(1),Bc=bo(2),Oc=bo(3),O=Symbol.for("lit-noChange"),T=Symbol.for("lit-nothing"),In=new WeakMap,de=ce.createTreeWalker(ce,129);Kr=(e,t)=>{let o=e.length-1,n=[],s,r=t===2?"<svg>":t===3?"<math>":"",i=Oe;for(let a=0;a<o;a++){let l=e[a],u,c,p=-1,b=0;for(;b<l.length&&(i.lastIndex=b,c=i.exec(l),c!==null);)b=i.lastIndex,i===Oe?c[1]==="!--"?i=Pn:c[1]!==void 0?i=Dn:c[2]!==void 0?(On.test(c[2])&&(s=RegExp("</"+c[2],"g")),i=le):c[3]!==void 0&&(i=le):i===le?c[0]===">"?(i=s??Oe,p=-1):c[1]===void 0?p=-2:(p=i.lastIndex-c[2].length,u=c[1],i=c[3]===void 0?le:c[3]==='"'?Un:Ln):i===Un||i===Ln?i=le:i===Pn||i===Dn?i=Oe:(i=le,s=void 0);let h=i===le&&e[a+1].startsWith("/>")?" ":"";r+=i===Oe?l+Wr:p>=0?(n.push(u),l.slice(0,p)+zn+l.slice(p)+oe+h):l+oe+(p===-2?a:h)}return[Nn(e,r+(e[o]||"<?>")+(t===2?"</svg>":t===3?"</math>":"")),n]},Fe=class e{constructor({strings:t,_$litType$:o},n){let s;this.parts=[];let r=0,i=0,a=t.length-1,l=this.parts,[u,c]=Kr(t,o);if(this.el=e.createElement(u,n),de.currentNode=this.el.content,o===2||o===3){let p=this.el.content.firstChild;p.replaceWith(...p.childNodes)}for(;(s=de.nextNode())!==null&&l.length<a;){if(s.nodeType===1){if(s.hasAttributes())for(let p of s.getAttributeNames())if(p.endsWith(zn)){let b=c[i++],h=s.getAttribute(p).split(oe),S=/([.?@])?(.*)/.exec(b);l.push({type:1,index:r,name:S[2],strings:h,ctor:S[1]==="."?uo:S[1]==="?"?po:S[1]==="@"?go:he}),s.removeAttribute(p)}else p.startsWith(oe)&&(l.push({type:6,index:r}),s.removeAttribute(p));if(On.test(s.tagName)){let p=s.textContent.split(oe),b=p.length-1;if(b>0){s.textContent=St?St.emptyScript:"";for(let h=0;h<b;h++)s.append(p[h],He()),de.nextNode(),l.push({type:2,index:++r});s.append(p[b],He())}}}else if(s.nodeType===8)if(s.data===Bn)l.push({type:2,index:r});else{let p=-1;for(;(p=s.data.indexOf(oe,p+1))!==-1;)l.push({type:7,index:r}),p+=oe.length-1}r++}}static createElement(t,o){let n=ce.createElement("template");return n.innerHTML=t,n}};co=class{constructor(t,o){this._$AV=[],this._$AN=void 0,this._$AD=t,this._$AM=o}get parentNode(){return this._$AM.parentNode}get _$AU(){return this._$AM._$AU}u(t){let{el:{content:o},parts:n}=this._$AD,s=(t?.creationScope??ce).importNode(o,!0);de.currentNode=s;let r=de.nextNode(),i=0,a=0,l=n[0];for(;l!==void 0;){if(i===l.index){let u;l.type===2?u=new We(r,r.nextSibling,this,t):l.type===1?u=new l.ctor(r,l.name,l.strings,this,t):l.type===6&&(u=new mo(r,this,t)),this._$AV.push(u),l=n[++a]}i!==l?.index&&(r=de.nextNode(),i++)}return de.currentNode=ce,s}p(t){let o=0;for(let n of this._$AV)n!==void 0&&(n.strings!==void 0?(n._$AI(t,n,o),o+=n.strings.length-2):n._$AI(t[o])),o++}},We=class e{get _$AU(){return this._$AM?._$AU??this._$Cv}constructor(t,o,n,s){this.type=2,this._$AH=T,this._$AN=void 0,this._$AA=t,this._$AB=o,this._$AM=n,this.options=s,this._$Cv=s?.isConnected??!0}get parentNode(){let t=this._$AA.parentNode,o=this._$AM;return o!==void 0&&t?.nodeType===11&&(t=o.parentNode),t}get startNode(){return this._$AA}get endNode(){return this._$AB}_$AI(t,o=this){t=ye(this,t,o),je(t)?t===T||t==null||t===""?(this._$AH!==T&&this._$AR(),this._$AH=T):t!==this._$AH&&t!==O&&this._(t):t._$litType$!==void 0?this.$(t):t.nodeType!==void 0?this.T(t):qr(t)?this.k(t):this._(t)}O(t){return this._$AA.parentNode.insertBefore(t,this._$AB)}T(t){this._$AH!==t&&(this._$AR(),this._$AH=this.O(t))}_(t){this._$AH!==T&&je(this._$AH)?this._$AA.nextSibling.data=t:this.T(ce.createTextNode(t)),this._$AH=t}$(t){let{values:o,_$litType$:n}=t,s=typeof n=="number"?this._$AC(t):(n.el===void 0&&(n.el=Fe.createElement(Nn(n.h,n.h[0]),this.options)),n);if(this._$AH?._$AD===s)this._$AH.p(o);else{let r=new co(s,this),i=r.u(this.options);r.p(o),this.T(i),this._$AH=r}}_$AC(t){let o=In.get(t.strings);return o===void 0&&In.set(t.strings,o=new Fe(t)),o}k(t){fo(this._$AH)||(this._$AH=[],this._$AR());let o=this._$AH,n,s=0;for(let r of t)s===o.length?o.push(n=new e(this.O(He()),this.O(He()),this,this.options)):n=o[s],n._$AI(r),s++;s<o.length&&(this._$AR(n&&n._$AB.nextSibling,s),o.length=s)}_$AR(t=this._$AA.nextSibling,o){for(this._$AP?.(!1,!0,o);t!==this._$AB;){let n=Rn(t).nextSibling;Rn(t).remove(),t=n}}setConnected(t){this._$AM===void 0&&(this._$Cv=t,this._$AP?.(t))}},he=class{get tagName(){return this.element.tagName}get _$AU(){return this._$AM._$AU}constructor(t,o,n,s,r){this.type=1,this._$AH=T,this._$AN=void 0,this.element=t,this.name=o,this._$AM=s,this.options=r,n.length>2||n[0]!==""||n[1]!==""?(this._$AH=Array(n.length-1).fill(new String),this.strings=n):this._$AH=T}_$AI(t,o=this,n,s){let r=this.strings,i=!1;if(r===void 0)t=ye(this,t,o,0),i=!je(t)||t!==this._$AH&&t!==O,i&&(this._$AH=t);else{let a=t,l,u;for(t=r[0],l=0;l<r.length-1;l++)u=ye(this,a[n+l],o,l),u===O&&(u=this._$AH[l]),i||(i=!je(u)||u!==this._$AH[l]),u===T?t=T:t!==T&&(t+=(u??"")+r[l+1]),this._$AH[l]=u}i&&!s&&this.j(t)}j(t){t===T?this.element.removeAttribute(this.name):this.element.setAttribute(this.name,t??"")}},uo=class extends he{constructor(){super(...arguments),this.type=3}j(t){this.element[this.name]=t===T?void 0:t}},po=class extends he{constructor(){super(...arguments),this.type=4}j(t){this.element.toggleAttribute(this.name,!!t&&t!==T)}},go=class extends he{constructor(t,o,n,s,r){super(t,o,n,s,r),this.type=5}_$AI(t,o=this){if((t=ye(this,t,o,0)??T)===O)return;let n=this._$AH,s=t===T&&n!==T||t.capture!==n.capture||t.once!==n.once||t.passive!==n.passive,r=t!==T&&(n===T||s);s&&this.element.removeEventListener(this.name,this,n),r&&this.element.addEventListener(this.name,this,t),this._$AH=t}handleEvent(t){typeof this._$AH=="function"?this._$AH.call(this.options?.host??this.element,t):this._$AH.handleEvent(t)}},mo=class{constructor(t,o,n){this.element=t,this.type=6,this._$AN=void 0,this._$AM=o,this.options=n}get _$AU(){return this._$AM._$AU}_$AI(t){ye(this,t)}},Gr=Ne.litHtmlPolyfillSupport;Gr?.(Fe,We),(Ne.litHtmlVersions??(Ne.litHtmlVersions=[])).push("3.3.3");Hn=(e,t,o)=>{let n=o?.renderBefore??t,s=n._$litPart$;if(s===void 0){let r=o?.renderBefore??null;n._$litPart$=s=new We(t.insertBefore(He(),r),r,void 0,o??{})}return s._$AI(e),s}});var qe,ne,Vr,jn=y(()=>{Be();Be();ve();ve();qe=globalThis,ne=class extends K{constructor(){super(...arguments),this.renderOptions={host:this},this._$Do=void 0}createRenderRoot(){var o;let t=super.createRenderRoot();return(o=this.renderOptions).renderBefore??(o.renderBefore=t.firstChild),t}update(t){let o=this.render();this.hasUpdated||(this.renderOptions.isConnected=this.isConnected),super.update(t),this._$Do=Hn(o,this.renderRoot,this.renderOptions)}connectedCallback(){super.connectedCallback(),this._$Do?.setConnected(!0)}disconnectedCallback(){super.disconnectedCallback(),this._$Do?.setConnected(!1)}render(){return O}};ne._$litElement$=!0,ne.finalized=!0,qe.litElementHydrateSupport?.({LitElement:ne});Vr=qe.litElementPolyfillSupport;Vr?.({LitElement:ne});(qe.litElementVersions??(qe.litElementVersions=[])).push("4.2.2")});var Fn=y(()=>{});var se=y(()=>{Be();ve();jn();Fn()});var Wn=y(()=>{});function v(e){return(t,o)=>typeof o=="object"?Jr(e,t,o):((n,s,r)=>{let i=s.hasOwnProperty(r);return s.constructor.createProperty(r,n),i?Object.getOwnPropertyDescriptor(s,r):void 0})(e,t,o)}var Yr,Jr,yo=y(()=>{Be();Yr={attribute:!0,type:String,converter:ze,reflect:!1,hasChanged:Ct},Jr=(e=Yr,t,o)=>{let{kind:n,metadata:s}=o,r=globalThis.litPropertyMetadata.get(s);if(r===void 0&&globalThis.litPropertyMetadata.set(s,r=new Map),n==="setter"&&((e=Object.create(e)).wrapped=!0),r.set(o.name,e),n==="accessor"){let{name:i}=o;return{set(a){let l=t.get.call(this);t.set.call(this,a),this.requestUpdate(i,l,e,!0,a)},init(a){return a!==void 0&&this.C(i,void 0,e,a),a}}}if(n==="setter"){let{name:i}=o;return function(a){let l=this[i];t.call(this,a),this.requestUpdate(i,l,e,!0,a)}}throw Error("Unsupported decorator location: "+n)}});function ho(e){return v({...e,state:!0,attribute:!1})}var qn=y(()=>{yo();});var Kn=y(()=>{});var xe=y(()=>{});var Gn=y(()=>{xe();});var Vn=y(()=>{xe();});var Yn=y(()=>{xe();});var Jn=y(()=>{xe();});var Xn=y(()=>{xe();});var vo=y(()=>{Wn();yo();qn();Kn();Gn();Vn();Yn();Jn();Xn()});var $t,At,ke,xo=y(()=>{$t={ATTRIBUTE:1,CHILD:2,PROPERTY:3,BOOLEAN_ATTRIBUTE:4,EVENT:5,ELEMENT:6},At=e=>(...t)=>({_$litDirective$:e,values:t}),ke=class{constructor(t){}get _$AU(){return this._$AM._$AU}_$AT(t,o,n){this._$Ct=t,this._$AM=o,this._$Ci=n}_$AS(t,o){return this.update(t,o)}update(t,o){return this.render(...o)}}});var Mt,Zn=y(()=>{ve();xo();Mt=At(class extends ke{constructor(e){if(super(e),e.type!==$t.ATTRIBUTE||e.name!=="class"||e.strings?.length>2)throw Error("`classMap()` can only be used in the `class` attribute and must be the only part in the attribute.")}render(e){return" "+Object.keys(e).filter(t=>e[t]).join(" ")+" "}update(e,[t]){if(this.st===void 0){this.st=new Set,e.strings!==void 0&&(this.nt=new Set(e.strings.join(" ").split(/\s/).filter(n=>n!=="")));for(let n in t)t[n]&&!this.nt?.has(n)&&this.st.add(n);return this.render(t)}let o=e.element.classList;for(let n of this.st)n in t||(o.remove(n),this.st.delete(n));for(let n in t){let s=!!t[n];s===this.st.has(n)||this.nt?.has(n)||(s?(o.add(n),this.st.add(n)):(o.remove(n),this.st.delete(n)))}return O}})});var ko=y(()=>{Zn()});var Et,Qn,es,we,Rt,wo=y(()=>{se();Et="2.5.1",Qn="__vscodeElements_disableRegistryWarning__",es=(e,t)=>{console.warn(t?`[VSCode Elements] ${e}
-%o`:`${e}
-%o`,t)},we=class extends ne{get version(){return Et}warn(t){es(t,this)}},Rt=e=>t=>{if(!customElements.get(e)){customElements.define(e,t);return}if(Qn in window)return;let s=document.createElement(e)?.version,r="";s?s!==Et?(r+="is already registered by a different version of VSCode Elements. ",r+=`This version is "${Et}", while the other one is "${s}".`):r+=`is already registered by the same version of VSCode Elements (${Et}).`:r+="is already registered by an unknown custom element handler class.",es(`The custom element "${e}" ${r}
-To suppress this warning, set window.${Qn} to true`)}});var Ce,ts=y(()=>{ve();Ce=e=>e??T});var Co=y(()=>{ts()});var os=y(()=>{xo()});var So,ns,ss=y(()=>{se();os();So=class extends ke{constructor(t){if(super(t),this._prevProperties={},t.type!==$t.PROPERTY||t.name!=="style")throw new Error("The `stylePropertyMap` directive must be used in the `style` property")}update(t,[o]){return Object.entries(o).forEach(([n,s])=>{this._prevProperties[n]!==s&&(n.startsWith("--")?t.element.style.setProperty(n,s):t.element.style[n]=s,this._prevProperties[n]=s)}),O}render(t){return O}},ns=At(So)});var _t,To=y(()=>{se();_t=ae`
+"use strict";
+(() => {
+  var __defProp = Object.defineProperty;
+  var __getOwnPropNames = Object.getOwnPropertyNames;
+  var __esm = (fn, res, err) => function __init() {
+    if (err) throw err[0];
+    try {
+      return fn && (res = (0, fn[__getOwnPropNames(fn)[0]])(fn = 0)), res;
+    } catch (e7) {
+      throw err = [e7], e7;
+    }
+  };
+  var __export = (target, all) => {
+    for (var name in all)
+      __defProp(target, name, { get: all[name], enumerable: true });
+  };
+
+  // node_modules/@lit/reactive-element/css-tag.js
+  var t, e, s, o, n, r, i, S, c;
+  var init_css_tag = __esm({
+    "node_modules/@lit/reactive-element/css-tag.js"() {
+      t = globalThis;
+      e = t.ShadowRoot && (void 0 === t.ShadyCSS || t.ShadyCSS.nativeShadow) && "adoptedStyleSheets" in Document.prototype && "replace" in CSSStyleSheet.prototype;
+      s = /* @__PURE__ */ Symbol();
+      o = /* @__PURE__ */ new WeakMap();
+      n = class {
+        constructor(t4, e7, o7) {
+          if (this._$cssResult$ = true, o7 !== s) throw Error("CSSResult is not constructable. Use `unsafeCSS` or `css` instead.");
+          this.cssText = t4, this.t = e7;
+        }
+        get styleSheet() {
+          let t4 = this.o;
+          const s4 = this.t;
+          if (e && void 0 === t4) {
+            const e7 = void 0 !== s4 && 1 === s4.length;
+            e7 && (t4 = o.get(s4)), void 0 === t4 && ((this.o = t4 = new CSSStyleSheet()).replaceSync(this.cssText), e7 && o.set(s4, t4));
+          }
+          return t4;
+        }
+        toString() {
+          return this.cssText;
+        }
+      };
+      r = (t4) => new n("string" == typeof t4 ? t4 : t4 + "", void 0, s);
+      i = (t4, ...e7) => {
+        const o7 = 1 === t4.length ? t4[0] : e7.reduce((e8, s4, o8) => e8 + ((t5) => {
+          if (true === t5._$cssResult$) return t5.cssText;
+          if ("number" == typeof t5) return t5;
+          throw Error("Value passed to 'css' function must be a 'css' function result: " + t5 + ". Use 'unsafeCSS' to pass non-literal values, but take care to ensure page security.");
+        })(s4) + t4[o8 + 1], t4[0]);
+        return new n(o7, t4, s);
+      };
+      S = (s4, o7) => {
+        if (e) s4.adoptedStyleSheets = o7.map((t4) => t4 instanceof CSSStyleSheet ? t4 : t4.styleSheet);
+        else for (const e7 of o7) {
+          const o8 = document.createElement("style"), n5 = t.litNonce;
+          void 0 !== n5 && o8.setAttribute("nonce", n5), o8.textContent = e7.cssText, s4.appendChild(o8);
+        }
+      };
+      c = e ? (t4) => t4 : (t4) => t4 instanceof CSSStyleSheet ? ((t5) => {
+        let e7 = "";
+        for (const s4 of t5.cssRules) e7 += s4.cssText;
+        return r(e7);
+      })(t4) : t4;
+    }
+  });
+
+  // node_modules/@lit/reactive-element/reactive-element.js
+  var i2, e2, h, r2, o2, n2, a, c2, l, p, d, u, f, b, y;
+  var init_reactive_element = __esm({
+    "node_modules/@lit/reactive-element/reactive-element.js"() {
+      init_css_tag();
+      init_css_tag();
+      ({ is: i2, defineProperty: e2, getOwnPropertyDescriptor: h, getOwnPropertyNames: r2, getOwnPropertySymbols: o2, getPrototypeOf: n2 } = Object);
+      a = globalThis;
+      c2 = a.trustedTypes;
+      l = c2 ? c2.emptyScript : "";
+      p = a.reactiveElementPolyfillSupport;
+      d = (t4, s4) => t4;
+      u = { toAttribute(t4, s4) {
+        switch (s4) {
+          case Boolean:
+            t4 = t4 ? l : null;
+            break;
+          case Object:
+          case Array:
+            t4 = null == t4 ? t4 : JSON.stringify(t4);
+        }
+        return t4;
+      }, fromAttribute(t4, s4) {
+        let i6 = t4;
+        switch (s4) {
+          case Boolean:
+            i6 = null !== t4;
+            break;
+          case Number:
+            i6 = null === t4 ? null : Number(t4);
+            break;
+          case Object:
+          case Array:
+            try {
+              i6 = JSON.parse(t4);
+            } catch (t5) {
+              i6 = null;
+            }
+        }
+        return i6;
+      } };
+      f = (t4, s4) => !i2(t4, s4);
+      b = { attribute: true, type: String, converter: u, reflect: false, useDefault: false, hasChanged: f };
+      Symbol.metadata ?? (Symbol.metadata = /* @__PURE__ */ Symbol("metadata")), a.litPropertyMetadata ?? (a.litPropertyMetadata = /* @__PURE__ */ new WeakMap());
+      y = class extends HTMLElement {
+        static addInitializer(t4) {
+          this._$Ei(), (this.l ?? (this.l = [])).push(t4);
+        }
+        static get observedAttributes() {
+          return this.finalize(), this._$Eh && [...this._$Eh.keys()];
+        }
+        static createProperty(t4, s4 = b) {
+          if (s4.state && (s4.attribute = false), this._$Ei(), this.prototype.hasOwnProperty(t4) && ((s4 = Object.create(s4)).wrapped = true), this.elementProperties.set(t4, s4), !s4.noAccessor) {
+            const i6 = /* @__PURE__ */ Symbol(), h3 = this.getPropertyDescriptor(t4, i6, s4);
+            void 0 !== h3 && e2(this.prototype, t4, h3);
+          }
+        }
+        static getPropertyDescriptor(t4, s4, i6) {
+          const { get: e7, set: r6 } = h(this.prototype, t4) ?? { get() {
+            return this[s4];
+          }, set(t5) {
+            this[s4] = t5;
+          } };
+          return { get: e7, set(s5) {
+            const h3 = e7?.call(this);
+            r6?.call(this, s5), this.requestUpdate(t4, h3, i6);
+          }, configurable: true, enumerable: true };
+        }
+        static getPropertyOptions(t4) {
+          return this.elementProperties.get(t4) ?? b;
+        }
+        static _$Ei() {
+          if (this.hasOwnProperty(d("elementProperties"))) return;
+          const t4 = n2(this);
+          t4.finalize(), void 0 !== t4.l && (this.l = [...t4.l]), this.elementProperties = new Map(t4.elementProperties);
+        }
+        static finalize() {
+          if (this.hasOwnProperty(d("finalized"))) return;
+          if (this.finalized = true, this._$Ei(), this.hasOwnProperty(d("properties"))) {
+            const t5 = this.properties, s4 = [...r2(t5), ...o2(t5)];
+            for (const i6 of s4) this.createProperty(i6, t5[i6]);
+          }
+          const t4 = this[Symbol.metadata];
+          if (null !== t4) {
+            const s4 = litPropertyMetadata.get(t4);
+            if (void 0 !== s4) for (const [t5, i6] of s4) this.elementProperties.set(t5, i6);
+          }
+          this._$Eh = /* @__PURE__ */ new Map();
+          for (const [t5, s4] of this.elementProperties) {
+            const i6 = this._$Eu(t5, s4);
+            void 0 !== i6 && this._$Eh.set(i6, t5);
+          }
+          this.elementStyles = this.finalizeStyles(this.styles);
+        }
+        static finalizeStyles(s4) {
+          const i6 = [];
+          if (Array.isArray(s4)) {
+            const e7 = new Set(s4.flat(1 / 0).reverse());
+            for (const s5 of e7) i6.unshift(c(s5));
+          } else void 0 !== s4 && i6.push(c(s4));
+          return i6;
+        }
+        static _$Eu(t4, s4) {
+          const i6 = s4.attribute;
+          return false === i6 ? void 0 : "string" == typeof i6 ? i6 : "string" == typeof t4 ? t4.toLowerCase() : void 0;
+        }
+        constructor() {
+          super(), this._$Ep = void 0, this.isUpdatePending = false, this.hasUpdated = false, this._$Em = null, this._$Ev();
+        }
+        _$Ev() {
+          this._$ES = new Promise((t4) => this.enableUpdating = t4), this._$AL = /* @__PURE__ */ new Map(), this._$E_(), this.requestUpdate(), this.constructor.l?.forEach((t4) => t4(this));
+        }
+        addController(t4) {
+          (this._$EO ?? (this._$EO = /* @__PURE__ */ new Set())).add(t4), void 0 !== this.renderRoot && this.isConnected && t4.hostConnected?.();
+        }
+        removeController(t4) {
+          this._$EO?.delete(t4);
+        }
+        _$E_() {
+          const t4 = /* @__PURE__ */ new Map(), s4 = this.constructor.elementProperties;
+          for (const i6 of s4.keys()) this.hasOwnProperty(i6) && (t4.set(i6, this[i6]), delete this[i6]);
+          t4.size > 0 && (this._$Ep = t4);
+        }
+        createRenderRoot() {
+          const t4 = this.shadowRoot ?? this.attachShadow(this.constructor.shadowRootOptions);
+          return S(t4, this.constructor.elementStyles), t4;
+        }
+        connectedCallback() {
+          this.renderRoot ?? (this.renderRoot = this.createRenderRoot()), this.enableUpdating(true), this._$EO?.forEach((t4) => t4.hostConnected?.());
+        }
+        enableUpdating(t4) {
+        }
+        disconnectedCallback() {
+          this._$EO?.forEach((t4) => t4.hostDisconnected?.());
+        }
+        attributeChangedCallback(t4, s4, i6) {
+          this._$AK(t4, i6);
+        }
+        _$ET(t4, s4) {
+          const i6 = this.constructor.elementProperties.get(t4), e7 = this.constructor._$Eu(t4, i6);
+          if (void 0 !== e7 && true === i6.reflect) {
+            const h3 = (void 0 !== i6.converter?.toAttribute ? i6.converter : u).toAttribute(s4, i6.type);
+            this._$Em = t4, null == h3 ? this.removeAttribute(e7) : this.setAttribute(e7, h3), this._$Em = null;
+          }
+        }
+        _$AK(t4, s4) {
+          const i6 = this.constructor, e7 = i6._$Eh.get(t4);
+          if (void 0 !== e7 && this._$Em !== e7) {
+            const t5 = i6.getPropertyOptions(e7), h3 = "function" == typeof t5.converter ? { fromAttribute: t5.converter } : void 0 !== t5.converter?.fromAttribute ? t5.converter : u;
+            this._$Em = e7;
+            const r6 = h3.fromAttribute(s4, t5.type);
+            this[e7] = r6 ?? this._$Ej?.get(e7) ?? r6, this._$Em = null;
+          }
+        }
+        requestUpdate(t4, s4, i6, e7 = false, h3) {
+          if (void 0 !== t4) {
+            const r6 = this.constructor;
+            if (false === e7 && (h3 = this[t4]), i6 ?? (i6 = r6.getPropertyOptions(t4)), !((i6.hasChanged ?? f)(h3, s4) || i6.useDefault && i6.reflect && h3 === this._$Ej?.get(t4) && !this.hasAttribute(r6._$Eu(t4, i6)))) return;
+            this.C(t4, s4, i6);
+          }
+          false === this.isUpdatePending && (this._$ES = this._$EP());
+        }
+        C(t4, s4, { useDefault: i6, reflect: e7, wrapped: h3 }, r6) {
+          i6 && !(this._$Ej ?? (this._$Ej = /* @__PURE__ */ new Map())).has(t4) && (this._$Ej.set(t4, r6 ?? s4 ?? this[t4]), true !== h3 || void 0 !== r6) || (this._$AL.has(t4) || (this.hasUpdated || i6 || (s4 = void 0), this._$AL.set(t4, s4)), true === e7 && this._$Em !== t4 && (this._$Eq ?? (this._$Eq = /* @__PURE__ */ new Set())).add(t4));
+        }
+        async _$EP() {
+          this.isUpdatePending = true;
+          try {
+            await this._$ES;
+          } catch (t5) {
+            Promise.reject(t5);
+          }
+          const t4 = this.scheduleUpdate();
+          return null != t4 && await t4, !this.isUpdatePending;
+        }
+        scheduleUpdate() {
+          return this.performUpdate();
+        }
+        performUpdate() {
+          if (!this.isUpdatePending) return;
+          if (!this.hasUpdated) {
+            if (this.renderRoot ?? (this.renderRoot = this.createRenderRoot()), this._$Ep) {
+              for (const [t6, s5] of this._$Ep) this[t6] = s5;
+              this._$Ep = void 0;
+            }
+            const t5 = this.constructor.elementProperties;
+            if (t5.size > 0) for (const [s5, i6] of t5) {
+              const { wrapped: t6 } = i6, e7 = this[s5];
+              true !== t6 || this._$AL.has(s5) || void 0 === e7 || this.C(s5, void 0, i6, e7);
+            }
+          }
+          let t4 = false;
+          const s4 = this._$AL;
+          try {
+            t4 = this.shouldUpdate(s4), t4 ? (this.willUpdate(s4), this._$EO?.forEach((t5) => t5.hostUpdate?.()), this.update(s4)) : this._$EM();
+          } catch (s5) {
+            throw t4 = false, this._$EM(), s5;
+          }
+          t4 && this._$AE(s4);
+        }
+        willUpdate(t4) {
+        }
+        _$AE(t4) {
+          this._$EO?.forEach((t5) => t5.hostUpdated?.()), this.hasUpdated || (this.hasUpdated = true, this.firstUpdated(t4)), this.updated(t4);
+        }
+        _$EM() {
+          this._$AL = /* @__PURE__ */ new Map(), this.isUpdatePending = false;
+        }
+        get updateComplete() {
+          return this.getUpdateComplete();
+        }
+        getUpdateComplete() {
+          return this._$ES;
+        }
+        shouldUpdate(t4) {
+          return true;
+        }
+        update(t4) {
+          this._$Eq && (this._$Eq = this._$Eq.forEach((t5) => this._$ET(t5, this[t5]))), this._$EM();
+        }
+        updated(t4) {
+        }
+        firstUpdated(t4) {
+        }
+      };
+      y.elementStyles = [], y.shadowRootOptions = { mode: "open" }, y[d("elementProperties")] = /* @__PURE__ */ new Map(), y[d("finalized")] = /* @__PURE__ */ new Map(), p?.({ ReactiveElement: y }), (a.reactiveElementVersions ?? (a.reactiveElementVersions = [])).push("2.1.2");
+    }
+  });
+
+  // node_modules/lit-html/lit-html.js
+  function V(t4, i6) {
+    if (!u2(t4) || !t4.hasOwnProperty("raw")) throw Error("invalid template strings array");
+    return void 0 !== e3 ? e3.createHTML(i6) : i6;
+  }
+  function M(t4, i6, s4 = t4, e7) {
+    if (i6 === E) return i6;
+    let h3 = void 0 !== e7 ? s4._$Co?.[e7] : s4._$Cl;
+    const o7 = a2(i6) ? void 0 : i6._$litDirective$;
+    return h3?.constructor !== o7 && (h3?._$AO?.(false), void 0 === o7 ? h3 = void 0 : (h3 = new o7(t4), h3._$AT(t4, s4, e7)), void 0 !== e7 ? (s4._$Co ?? (s4._$Co = []))[e7] = h3 : s4._$Cl = h3), void 0 !== h3 && (i6 = M(t4, h3._$AS(t4, i6.values), h3, e7)), i6;
+  }
+  var t2, i3, s2, e3, h2, o3, n3, r3, l2, c3, a2, u2, d2, f2, v, _, m, p2, g, $, y2, x, b2, w, T, E, A, C, P, N, S2, R, k, H, I, L, z, Z, B, D;
+  var init_lit_html = __esm({
+    "node_modules/lit-html/lit-html.js"() {
+      t2 = globalThis;
+      i3 = (t4) => t4;
+      s2 = t2.trustedTypes;
+      e3 = s2 ? s2.createPolicy("lit-html", { createHTML: (t4) => t4 }) : void 0;
+      h2 = "$lit$";
+      o3 = `lit$${Math.random().toFixed(9).slice(2)}$`;
+      n3 = "?" + o3;
+      r3 = `<${n3}>`;
+      l2 = document;
+      c3 = () => l2.createComment("");
+      a2 = (t4) => null === t4 || "object" != typeof t4 && "function" != typeof t4;
+      u2 = Array.isArray;
+      d2 = (t4) => u2(t4) || "function" == typeof t4?.[Symbol.iterator];
+      f2 = "[ 	\n\f\r]";
+      v = /<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g;
+      _ = /-->/g;
+      m = />/g;
+      p2 = RegExp(`>|${f2}(?:([^\\s"'>=/]+)(${f2}*=${f2}*(?:[^ 	
+\f\r"'\`<>=]|("|')|))|$)`, "g");
+      g = /'/g;
+      $ = /"/g;
+      y2 = /^(?:script|style|textarea|title)$/i;
+      x = (t4) => (i6, ...s4) => ({ _$litType$: t4, strings: i6, values: s4 });
+      b2 = x(1);
+      w = x(2);
+      T = x(3);
+      E = /* @__PURE__ */ Symbol.for("lit-noChange");
+      A = /* @__PURE__ */ Symbol.for("lit-nothing");
+      C = /* @__PURE__ */ new WeakMap();
+      P = l2.createTreeWalker(l2, 129);
+      N = (t4, i6) => {
+        const s4 = t4.length - 1, e7 = [];
+        let n5, l3 = 2 === i6 ? "<svg>" : 3 === i6 ? "<math>" : "", c4 = v;
+        for (let i7 = 0; i7 < s4; i7++) {
+          const s5 = t4[i7];
+          let a3, u3, d3 = -1, f3 = 0;
+          for (; f3 < s5.length && (c4.lastIndex = f3, u3 = c4.exec(s5), null !== u3); ) f3 = c4.lastIndex, c4 === v ? "!--" === u3[1] ? c4 = _ : void 0 !== u3[1] ? c4 = m : void 0 !== u3[2] ? (y2.test(u3[2]) && (n5 = RegExp("</" + u3[2], "g")), c4 = p2) : void 0 !== u3[3] && (c4 = p2) : c4 === p2 ? ">" === u3[0] ? (c4 = n5 ?? v, d3 = -1) : void 0 === u3[1] ? d3 = -2 : (d3 = c4.lastIndex - u3[2].length, a3 = u3[1], c4 = void 0 === u3[3] ? p2 : '"' === u3[3] ? $ : g) : c4 === $ || c4 === g ? c4 = p2 : c4 === _ || c4 === m ? c4 = v : (c4 = p2, n5 = void 0);
+          const x2 = c4 === p2 && t4[i7 + 1].startsWith("/>") ? " " : "";
+          l3 += c4 === v ? s5 + r3 : d3 >= 0 ? (e7.push(a3), s5.slice(0, d3) + h2 + s5.slice(d3) + o3 + x2) : s5 + o3 + (-2 === d3 ? i7 : x2);
+        }
+        return [V(t4, l3 + (t4[s4] || "<?>") + (2 === i6 ? "</svg>" : 3 === i6 ? "</math>" : "")), e7];
+      };
+      S2 = class _S {
+        constructor({ strings: t4, _$litType$: i6 }, e7) {
+          let r6;
+          this.parts = [];
+          let l3 = 0, a3 = 0;
+          const u3 = t4.length - 1, d3 = this.parts, [f3, v2] = N(t4, i6);
+          if (this.el = _S.createElement(f3, e7), P.currentNode = this.el.content, 2 === i6 || 3 === i6) {
+            const t5 = this.el.content.firstChild;
+            t5.replaceWith(...t5.childNodes);
+          }
+          for (; null !== (r6 = P.nextNode()) && d3.length < u3; ) {
+            if (1 === r6.nodeType) {
+              if (r6.hasAttributes()) for (const t5 of r6.getAttributeNames()) if (t5.endsWith(h2)) {
+                const i7 = v2[a3++], s4 = r6.getAttribute(t5).split(o3), e8 = /([.?@])?(.*)/.exec(i7);
+                d3.push({ type: 1, index: l3, name: e8[2], strings: s4, ctor: "." === e8[1] ? I : "?" === e8[1] ? L : "@" === e8[1] ? z : H }), r6.removeAttribute(t5);
+              } else t5.startsWith(o3) && (d3.push({ type: 6, index: l3 }), r6.removeAttribute(t5));
+              if (y2.test(r6.tagName)) {
+                const t5 = r6.textContent.split(o3), i7 = t5.length - 1;
+                if (i7 > 0) {
+                  r6.textContent = s2 ? s2.emptyScript : "";
+                  for (let s4 = 0; s4 < i7; s4++) r6.append(t5[s4], c3()), P.nextNode(), d3.push({ type: 2, index: ++l3 });
+                  r6.append(t5[i7], c3());
+                }
+              }
+            } else if (8 === r6.nodeType) if (r6.data === n3) d3.push({ type: 2, index: l3 });
+            else {
+              let t5 = -1;
+              for (; -1 !== (t5 = r6.data.indexOf(o3, t5 + 1)); ) d3.push({ type: 7, index: l3 }), t5 += o3.length - 1;
+            }
+            l3++;
+          }
+        }
+        static createElement(t4, i6) {
+          const s4 = l2.createElement("template");
+          return s4.innerHTML = t4, s4;
+        }
+      };
+      R = class {
+        constructor(t4, i6) {
+          this._$AV = [], this._$AN = void 0, this._$AD = t4, this._$AM = i6;
+        }
+        get parentNode() {
+          return this._$AM.parentNode;
+        }
+        get _$AU() {
+          return this._$AM._$AU;
+        }
+        u(t4) {
+          const { el: { content: i6 }, parts: s4 } = this._$AD, e7 = (t4?.creationScope ?? l2).importNode(i6, true);
+          P.currentNode = e7;
+          let h3 = P.nextNode(), o7 = 0, n5 = 0, r6 = s4[0];
+          for (; void 0 !== r6; ) {
+            if (o7 === r6.index) {
+              let i7;
+              2 === r6.type ? i7 = new k(h3, h3.nextSibling, this, t4) : 1 === r6.type ? i7 = new r6.ctor(h3, r6.name, r6.strings, this, t4) : 6 === r6.type && (i7 = new Z(h3, this, t4)), this._$AV.push(i7), r6 = s4[++n5];
+            }
+            o7 !== r6?.index && (h3 = P.nextNode(), o7++);
+          }
+          return P.currentNode = l2, e7;
+        }
+        p(t4) {
+          let i6 = 0;
+          for (const s4 of this._$AV) void 0 !== s4 && (void 0 !== s4.strings ? (s4._$AI(t4, s4, i6), i6 += s4.strings.length - 2) : s4._$AI(t4[i6])), i6++;
+        }
+      };
+      k = class _k {
+        get _$AU() {
+          return this._$AM?._$AU ?? this._$Cv;
+        }
+        constructor(t4, i6, s4, e7) {
+          this.type = 2, this._$AH = A, this._$AN = void 0, this._$AA = t4, this._$AB = i6, this._$AM = s4, this.options = e7, this._$Cv = e7?.isConnected ?? true;
+        }
+        get parentNode() {
+          let t4 = this._$AA.parentNode;
+          const i6 = this._$AM;
+          return void 0 !== i6 && 11 === t4?.nodeType && (t4 = i6.parentNode), t4;
+        }
+        get startNode() {
+          return this._$AA;
+        }
+        get endNode() {
+          return this._$AB;
+        }
+        _$AI(t4, i6 = this) {
+          t4 = M(this, t4, i6), a2(t4) ? t4 === A || null == t4 || "" === t4 ? (this._$AH !== A && this._$AR(), this._$AH = A) : t4 !== this._$AH && t4 !== E && this._(t4) : void 0 !== t4._$litType$ ? this.$(t4) : void 0 !== t4.nodeType ? this.T(t4) : d2(t4) ? this.k(t4) : this._(t4);
+        }
+        O(t4) {
+          return this._$AA.parentNode.insertBefore(t4, this._$AB);
+        }
+        T(t4) {
+          this._$AH !== t4 && (this._$AR(), this._$AH = this.O(t4));
+        }
+        _(t4) {
+          this._$AH !== A && a2(this._$AH) ? this._$AA.nextSibling.data = t4 : this.T(l2.createTextNode(t4)), this._$AH = t4;
+        }
+        $(t4) {
+          const { values: i6, _$litType$: s4 } = t4, e7 = "number" == typeof s4 ? this._$AC(t4) : (void 0 === s4.el && (s4.el = S2.createElement(V(s4.h, s4.h[0]), this.options)), s4);
+          if (this._$AH?._$AD === e7) this._$AH.p(i6);
+          else {
+            const t5 = new R(e7, this), s5 = t5.u(this.options);
+            t5.p(i6), this.T(s5), this._$AH = t5;
+          }
+        }
+        _$AC(t4) {
+          let i6 = C.get(t4.strings);
+          return void 0 === i6 && C.set(t4.strings, i6 = new S2(t4)), i6;
+        }
+        k(t4) {
+          u2(this._$AH) || (this._$AH = [], this._$AR());
+          const i6 = this._$AH;
+          let s4, e7 = 0;
+          for (const h3 of t4) e7 === i6.length ? i6.push(s4 = new _k(this.O(c3()), this.O(c3()), this, this.options)) : s4 = i6[e7], s4._$AI(h3), e7++;
+          e7 < i6.length && (this._$AR(s4 && s4._$AB.nextSibling, e7), i6.length = e7);
+        }
+        _$AR(t4 = this._$AA.nextSibling, s4) {
+          for (this._$AP?.(false, true, s4); t4 !== this._$AB; ) {
+            const s5 = i3(t4).nextSibling;
+            i3(t4).remove(), t4 = s5;
+          }
+        }
+        setConnected(t4) {
+          void 0 === this._$AM && (this._$Cv = t4, this._$AP?.(t4));
+        }
+      };
+      H = class {
+        get tagName() {
+          return this.element.tagName;
+        }
+        get _$AU() {
+          return this._$AM._$AU;
+        }
+        constructor(t4, i6, s4, e7, h3) {
+          this.type = 1, this._$AH = A, this._$AN = void 0, this.element = t4, this.name = i6, this._$AM = e7, this.options = h3, s4.length > 2 || "" !== s4[0] || "" !== s4[1] ? (this._$AH = Array(s4.length - 1).fill(new String()), this.strings = s4) : this._$AH = A;
+        }
+        _$AI(t4, i6 = this, s4, e7) {
+          const h3 = this.strings;
+          let o7 = false;
+          if (void 0 === h3) t4 = M(this, t4, i6, 0), o7 = !a2(t4) || t4 !== this._$AH && t4 !== E, o7 && (this._$AH = t4);
+          else {
+            const e8 = t4;
+            let n5, r6;
+            for (t4 = h3[0], n5 = 0; n5 < h3.length - 1; n5++) r6 = M(this, e8[s4 + n5], i6, n5), r6 === E && (r6 = this._$AH[n5]), o7 || (o7 = !a2(r6) || r6 !== this._$AH[n5]), r6 === A ? t4 = A : t4 !== A && (t4 += (r6 ?? "") + h3[n5 + 1]), this._$AH[n5] = r6;
+          }
+          o7 && !e7 && this.j(t4);
+        }
+        j(t4) {
+          t4 === A ? this.element.removeAttribute(this.name) : this.element.setAttribute(this.name, t4 ?? "");
+        }
+      };
+      I = class extends H {
+        constructor() {
+          super(...arguments), this.type = 3;
+        }
+        j(t4) {
+          this.element[this.name] = t4 === A ? void 0 : t4;
+        }
+      };
+      L = class extends H {
+        constructor() {
+          super(...arguments), this.type = 4;
+        }
+        j(t4) {
+          this.element.toggleAttribute(this.name, !!t4 && t4 !== A);
+        }
+      };
+      z = class extends H {
+        constructor(t4, i6, s4, e7, h3) {
+          super(t4, i6, s4, e7, h3), this.type = 5;
+        }
+        _$AI(t4, i6 = this) {
+          if ((t4 = M(this, t4, i6, 0) ?? A) === E) return;
+          const s4 = this._$AH, e7 = t4 === A && s4 !== A || t4.capture !== s4.capture || t4.once !== s4.once || t4.passive !== s4.passive, h3 = t4 !== A && (s4 === A || e7);
+          e7 && this.element.removeEventListener(this.name, this, s4), h3 && this.element.addEventListener(this.name, this, t4), this._$AH = t4;
+        }
+        handleEvent(t4) {
+          "function" == typeof this._$AH ? this._$AH.call(this.options?.host ?? this.element, t4) : this._$AH.handleEvent(t4);
+        }
+      };
+      Z = class {
+        constructor(t4, i6, s4) {
+          this.element = t4, this.type = 6, this._$AN = void 0, this._$AM = i6, this.options = s4;
+        }
+        get _$AU() {
+          return this._$AM._$AU;
+        }
+        _$AI(t4) {
+          M(this, t4);
+        }
+      };
+      B = t2.litHtmlPolyfillSupport;
+      B?.(S2, k), (t2.litHtmlVersions ?? (t2.litHtmlVersions = [])).push("3.3.3");
+      D = (t4, i6, s4) => {
+        const e7 = s4?.renderBefore ?? i6;
+        let h3 = e7._$litPart$;
+        if (void 0 === h3) {
+          const t5 = s4?.renderBefore ?? null;
+          e7._$litPart$ = h3 = new k(i6.insertBefore(c3(), t5), t5, void 0, s4 ?? {});
+        }
+        return h3._$AI(t4), h3;
+      };
+    }
+  });
+
+  // node_modules/lit-element/lit-element.js
+  var s3, i4, o4;
+  var init_lit_element = __esm({
+    "node_modules/lit-element/lit-element.js"() {
+      init_reactive_element();
+      init_reactive_element();
+      init_lit_html();
+      init_lit_html();
+      s3 = globalThis;
+      i4 = class extends y {
+        constructor() {
+          super(...arguments), this.renderOptions = { host: this }, this._$Do = void 0;
+        }
+        createRenderRoot() {
+          var _a;
+          const t4 = super.createRenderRoot();
+          return (_a = this.renderOptions).renderBefore ?? (_a.renderBefore = t4.firstChild), t4;
+        }
+        update(t4) {
+          const r6 = this.render();
+          this.hasUpdated || (this.renderOptions.isConnected = this.isConnected), super.update(t4), this._$Do = D(r6, this.renderRoot, this.renderOptions);
+        }
+        connectedCallback() {
+          super.connectedCallback(), this._$Do?.setConnected(true);
+        }
+        disconnectedCallback() {
+          super.disconnectedCallback(), this._$Do?.setConnected(false);
+        }
+        render() {
+          return E;
+        }
+      };
+      i4._$litElement$ = true, i4["finalized"] = true, s3.litElementHydrateSupport?.({ LitElement: i4 });
+      o4 = s3.litElementPolyfillSupport;
+      o4?.({ LitElement: i4 });
+      (s3.litElementVersions ?? (s3.litElementVersions = [])).push("4.2.2");
+    }
+  });
+
+  // node_modules/lit-html/is-server.js
+  var init_is_server = __esm({
+    "node_modules/lit-html/is-server.js"() {
+    }
+  });
+
+  // node_modules/lit/index.js
+  var init_lit = __esm({
+    "node_modules/lit/index.js"() {
+      init_reactive_element();
+      init_lit_html();
+      init_lit_element();
+      init_is_server();
+    }
+  });
+
+  // node_modules/@lit/reactive-element/decorators/custom-element.js
+  var init_custom_element = __esm({
+    "node_modules/@lit/reactive-element/decorators/custom-element.js"() {
+    }
+  });
+
+  // node_modules/@lit/reactive-element/decorators/property.js
+  function n4(t4) {
+    return (e7, o7) => "object" == typeof o7 ? r4(t4, e7, o7) : ((t5, e8, o8) => {
+      const r6 = e8.hasOwnProperty(o8);
+      return e8.constructor.createProperty(o8, t5), r6 ? Object.getOwnPropertyDescriptor(e8, o8) : void 0;
+    })(t4, e7, o7);
+  }
+  var o5, r4;
+  var init_property = __esm({
+    "node_modules/@lit/reactive-element/decorators/property.js"() {
+      init_reactive_element();
+      o5 = { attribute: true, type: String, converter: u, reflect: false, hasChanged: f };
+      r4 = (t4 = o5, e7, r6) => {
+        const { kind: n5, metadata: i6 } = r6;
+        let s4 = globalThis.litPropertyMetadata.get(i6);
+        if (void 0 === s4 && globalThis.litPropertyMetadata.set(i6, s4 = /* @__PURE__ */ new Map()), "setter" === n5 && ((t4 = Object.create(t4)).wrapped = true), s4.set(r6.name, t4), "accessor" === n5) {
+          const { name: o7 } = r6;
+          return { set(r7) {
+            const n6 = e7.get.call(this);
+            e7.set.call(this, r7), this.requestUpdate(o7, n6, t4, true, r7);
+          }, init(e8) {
+            return void 0 !== e8 && this.C(o7, void 0, t4, e8), e8;
+          } };
+        }
+        if ("setter" === n5) {
+          const { name: o7 } = r6;
+          return function(r7) {
+            const n6 = this[o7];
+            e7.call(this, r7), this.requestUpdate(o7, n6, t4, true, r7);
+          };
+        }
+        throw Error("Unsupported decorator location: " + n5);
+      };
+    }
+  });
+
+  // node_modules/@lit/reactive-element/decorators/state.js
+  function r5(r6) {
+    return n4({ ...r6, state: true, attribute: false });
+  }
+  var init_state = __esm({
+    "node_modules/@lit/reactive-element/decorators/state.js"() {
+      init_property();
+    }
+  });
+
+  // node_modules/@lit/reactive-element/decorators/event-options.js
+  var init_event_options = __esm({
+    "node_modules/@lit/reactive-element/decorators/event-options.js"() {
+    }
+  });
+
+  // node_modules/@lit/reactive-element/decorators/base.js
+  var init_base = __esm({
+    "node_modules/@lit/reactive-element/decorators/base.js"() {
+    }
+  });
+
+  // node_modules/@lit/reactive-element/decorators/query.js
+  var init_query = __esm({
+    "node_modules/@lit/reactive-element/decorators/query.js"() {
+      init_base();
+    }
+  });
+
+  // node_modules/@lit/reactive-element/decorators/query-all.js
+  var init_query_all = __esm({
+    "node_modules/@lit/reactive-element/decorators/query-all.js"() {
+      init_base();
+    }
+  });
+
+  // node_modules/@lit/reactive-element/decorators/query-async.js
+  var init_query_async = __esm({
+    "node_modules/@lit/reactive-element/decorators/query-async.js"() {
+      init_base();
+    }
+  });
+
+  // node_modules/@lit/reactive-element/decorators/query-assigned-elements.js
+  var init_query_assigned_elements = __esm({
+    "node_modules/@lit/reactive-element/decorators/query-assigned-elements.js"() {
+      init_base();
+    }
+  });
+
+  // node_modules/@lit/reactive-element/decorators/query-assigned-nodes.js
+  var init_query_assigned_nodes = __esm({
+    "node_modules/@lit/reactive-element/decorators/query-assigned-nodes.js"() {
+      init_base();
+    }
+  });
+
+  // node_modules/lit/decorators.js
+  var init_decorators = __esm({
+    "node_modules/lit/decorators.js"() {
+      init_custom_element();
+      init_property();
+      init_state();
+      init_event_options();
+      init_query();
+      init_query_all();
+      init_query_async();
+      init_query_assigned_elements();
+      init_query_assigned_nodes();
+    }
+  });
+
+  // node_modules/lit-html/directive.js
+  var t3, e5, i5;
+  var init_directive = __esm({
+    "node_modules/lit-html/directive.js"() {
+      t3 = { ATTRIBUTE: 1, CHILD: 2, PROPERTY: 3, BOOLEAN_ATTRIBUTE: 4, EVENT: 5, ELEMENT: 6 };
+      e5 = (t4) => (...e7) => ({ _$litDirective$: t4, values: e7 });
+      i5 = class {
+        constructor(t4) {
+        }
+        get _$AU() {
+          return this._$AM._$AU;
+        }
+        _$AT(t4, e7, i6) {
+          this._$Ct = t4, this._$AM = e7, this._$Ci = i6;
+        }
+        _$AS(t4, e7) {
+          return this.update(t4, e7);
+        }
+        update(t4, e7) {
+          return this.render(...e7);
+        }
+      };
+    }
+  });
+
+  // node_modules/lit-html/directives/class-map.js
+  var e6;
+  var init_class_map = __esm({
+    "node_modules/lit-html/directives/class-map.js"() {
+      init_lit_html();
+      init_directive();
+      e6 = e5(class extends i5 {
+        constructor(t4) {
+          if (super(t4), t4.type !== t3.ATTRIBUTE || "class" !== t4.name || t4.strings?.length > 2) throw Error("`classMap()` can only be used in the `class` attribute and must be the only part in the attribute.");
+        }
+        render(t4) {
+          return " " + Object.keys(t4).filter((s4) => t4[s4]).join(" ") + " ";
+        }
+        update(s4, [i6]) {
+          if (void 0 === this.st) {
+            this.st = /* @__PURE__ */ new Set(), void 0 !== s4.strings && (this.nt = new Set(s4.strings.join(" ").split(/\s/).filter((t4) => "" !== t4)));
+            for (const t4 in i6) i6[t4] && !this.nt?.has(t4) && this.st.add(t4);
+            return this.render(i6);
+          }
+          const r6 = s4.element.classList;
+          for (const t4 of this.st) t4 in i6 || (r6.remove(t4), this.st.delete(t4));
+          for (const t4 in i6) {
+            const s5 = !!i6[t4];
+            s5 === this.st.has(t4) || this.nt?.has(t4) || (s5 ? (r6.add(t4), this.st.add(t4)) : (r6.remove(t4), this.st.delete(t4)));
+          }
+          return E;
+        }
+      });
+    }
+  });
+
+  // node_modules/lit/directives/class-map.js
+  var init_class_map2 = __esm({
+    "node_modules/lit/directives/class-map.js"() {
+      init_class_map();
+    }
+  });
+
+  // node_modules/@vscode-elements/elements/dist/includes/VscElement.js
+  var VERSION, CONFIG_KEY, warn, VscElement, customElement;
+  var init_VscElement = __esm({
+    "node_modules/@vscode-elements/elements/dist/includes/VscElement.js"() {
+      init_lit();
+      VERSION = "2.5.1";
+      CONFIG_KEY = "__vscodeElements_disableRegistryWarning__";
+      warn = (message, componentInstance) => {
+        const prefix = "[VSCode Elements] ";
+        if (componentInstance) {
+          console.warn(`${prefix}${message}
+%o`, componentInstance);
+        } else {
+          console.warn(`${message}
+%o`, componentInstance);
+        }
+      };
+      VscElement = class extends i4 {
+        /** VSCode Elements version */
+        get version() {
+          return VERSION;
+        }
+        warn(message) {
+          warn(message, this);
+        }
+      };
+      customElement = (tagName) => {
+        return (classOrTarget) => {
+          const customElementClass = customElements.get(tagName);
+          if (!customElementClass) {
+            customElements.define(tagName, classOrTarget);
+            return;
+          }
+          if (CONFIG_KEY in window) {
+            return;
+          }
+          const el2 = document.createElement(tagName);
+          const anotherVersion = el2?.version;
+          let message = "";
+          if (!anotherVersion) {
+            message += "is already registered by an unknown custom element handler class.";
+          } else if (anotherVersion !== VERSION) {
+            message += "is already registered by a different version of VSCode Elements. ";
+            message += `This version is "${VERSION}", while the other one is "${anotherVersion}".`;
+          } else {
+            message += `is already registered by the same version of VSCode Elements (${VERSION}).`;
+          }
+          warn(`The custom element "${tagName}" ${message}
+To suppress this warning, set window.${CONFIG_KEY} to true`);
+        };
+      };
+    }
+  });
+
+  // node_modules/lit-html/directives/if-defined.js
+  var o6;
+  var init_if_defined = __esm({
+    "node_modules/lit-html/directives/if-defined.js"() {
+      init_lit_html();
+      o6 = (o7) => o7 ?? A;
+    }
+  });
+
+  // node_modules/lit/directives/if-defined.js
+  var init_if_defined2 = __esm({
+    "node_modules/lit/directives/if-defined.js"() {
+      init_if_defined();
+    }
+  });
+
+  // node_modules/lit/directive.js
+  var init_directive2 = __esm({
+    "node_modules/lit/directive.js"() {
+      init_directive();
+    }
+  });
+
+  // node_modules/@vscode-elements/elements/dist/includes/style-property-map.js
+  var StylePropertyMap, stylePropertyMap;
+  var init_style_property_map = __esm({
+    "node_modules/@vscode-elements/elements/dist/includes/style-property-map.js"() {
+      init_lit();
+      init_directive2();
+      StylePropertyMap = class extends i5 {
+        constructor(partInfo) {
+          super(partInfo);
+          this._prevProperties = {};
+          if (partInfo.type !== t3.PROPERTY || partInfo.name !== "style") {
+            throw new Error("The `stylePropertyMap` directive must be used in the `style` property");
+          }
+        }
+        update(part, [styleProps]) {
+          Object.entries(styleProps).forEach(([key, val]) => {
+            if (this._prevProperties[key] !== val) {
+              if (key.startsWith("--")) {
+                part.element.style.setProperty(key, val);
+              } else {
+                part.element.style[key] = val;
+              }
+              this._prevProperties[key] = val;
+            }
+          });
+          return E;
+        }
+        render(_styleProps) {
+          return E;
+        }
+      };
+      stylePropertyMap = e5(StylePropertyMap);
+    }
+  });
+
+  // node_modules/@vscode-elements/elements/dist/includes/default.styles.js
+  var default_styles_default;
+  var init_default_styles = __esm({
+    "node_modules/@vscode-elements/elements/dist/includes/default.styles.js"() {
+      init_lit();
+      default_styles_default = i`
   :host([hidden]) {
     display: none;
   }
@@ -14,7 +913,19 @@ To suppress this warning, set window.${Qn} to true`)}});var Ce,ts=y(()=>{ve();Ce
     opacity: 0.4;
     pointer-events: none;
   }
-`});var Xr,rs,is=y(()=>{se();To();Xr=[_t,ae`
+`;
+    }
+  });
+
+  // node_modules/@vscode-elements/elements/dist/vscode-icon/vscode-icon.styles.js
+  var styles, vscode_icon_styles_default;
+  var init_vscode_icon_styles = __esm({
+    "node_modules/@vscode-elements/elements/dist/vscode-icon/vscode-icon.styles.js"() {
+      init_lit();
+      init_default_styles();
+      styles = [
+        default_styles_default,
+        i`
     :host {
       color: var(--vscode-icon-foreground, #cccccc);
       display: inline-block;
@@ -74,25 +985,168 @@ To suppress this warning, set window.${Qn} to true`)}});var Ce,ts=y(()=>{ve();Ce
       animation-timing-function: linear;
       animation-iteration-count: infinite;
     }
-  `],rs=Xr});var ue,Ke,N,as=y(()=>{se();vo();ko();Co();wo();ss();is();ue=function(e,t,o,n){var s=arguments.length,r=s<3?t:n===null?n=Object.getOwnPropertyDescriptor(t,o):n,i;if(typeof Reflect=="object"&&typeof Reflect.decorate=="function")r=Reflect.decorate(e,t,o,n);else for(var a=e.length-1;a>=0;a--)(i=e[a])&&(r=(s<3?i(r):s>3?i(t,o,r):i(t,o))||r);return s>3&&r&&Object.defineProperty(t,o,r),r},N=Ke=class extends we{constructor(){super(...arguments),this.label="",this.name="",this.size=16,this.spin=!1,this.spinDuration=1.5,this.actionIcon=!1,this._onButtonClick=t=>{this.dispatchEvent(new CustomEvent("vsc-click",{detail:{originalEvent:t}}))}}connectedCallback(){super.connectedCallback();let{href:t,nonce:o}=this._getStylesheetConfig();Ke.stylesheetHref=t,Ke.nonce=o}_getStylesheetConfig(){if(typeof document>"u")return{nonce:void 0,href:void 0};let t=document.getElementById("vscode-codicon-stylesheet"),o=t?.getAttribute("href")||void 0,n=t?.nonce||void 0;if(!t){let s='To use the Icon component, the codicons.css file must be included in the page with the id "vscode-codicon-stylesheet"! ';s+="See https://vscode-elements.github.io/components/icon/ for more details.",this.warn(s)}return{nonce:n,href:o}}render(){let{stylesheetHref:t,nonce:o}=Ke,n=G`<span
-      class=${Mt({codicon:!0,["codicon-"+this.name]:!0,spin:this.spin})}
-      .style=${ns({animationDuration:String(this.spinDuration)+"s",fontSize:this.size+"px",height:this.size+"px",width:this.size+"px"})}
-    ></span>`,s=this.actionIcon?G` <button
+  `
+      ];
+      vscode_icon_styles_default = styles;
+    }
+  });
+
+  // node_modules/@vscode-elements/elements/dist/vscode-icon/vscode-icon.js
+  var __decorate, VscodeIcon_1, VscodeIcon;
+  var init_vscode_icon = __esm({
+    "node_modules/@vscode-elements/elements/dist/vscode-icon/vscode-icon.js"() {
+      init_lit();
+      init_decorators();
+      init_class_map2();
+      init_if_defined2();
+      init_VscElement();
+      init_style_property_map();
+      init_vscode_icon_styles();
+      __decorate = function(decorators, target, key, desc) {
+        var c4 = arguments.length, r6 = c4 < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d3;
+        if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r6 = Reflect.decorate(decorators, target, key, desc);
+        else for (var i6 = decorators.length - 1; i6 >= 0; i6--) if (d3 = decorators[i6]) r6 = (c4 < 3 ? d3(r6) : c4 > 3 ? d3(target, key, r6) : d3(target, key)) || r6;
+        return c4 > 3 && r6 && Object.defineProperty(target, key, r6), r6;
+      };
+      VscodeIcon = VscodeIcon_1 = class VscodeIcon2 extends VscElement {
+        constructor() {
+          super(...arguments);
+          this.label = "";
+          this.name = "";
+          this.size = 16;
+          this.spin = false;
+          this.spinDuration = 1.5;
+          this.actionIcon = false;
+          this._onButtonClick = (ev) => {
+            this.dispatchEvent(new CustomEvent("vsc-click", { detail: { originalEvent: ev } }));
+          };
+        }
+        connectedCallback() {
+          super.connectedCallback();
+          const { href, nonce } = this._getStylesheetConfig();
+          VscodeIcon_1.stylesheetHref = href;
+          VscodeIcon_1.nonce = nonce;
+        }
+        /**
+         * For using web fonts in web components, the font stylesheet must be included
+         * twice: on the page and in the web component. This function looks for the
+         * font stylesheet on the page and returns the stylesheet URL and the nonce
+         * id.
+         */
+        _getStylesheetConfig() {
+          if (typeof document === "undefined") {
+            return { nonce: void 0, href: void 0 };
+          }
+          const linkElement = document.getElementById("vscode-codicon-stylesheet");
+          const href = linkElement?.getAttribute("href") || void 0;
+          const nonce = linkElement?.nonce || void 0;
+          if (!linkElement) {
+            let msg = 'To use the Icon component, the codicons.css file must be included in the page with the id "vscode-codicon-stylesheet"! ';
+            msg += "See https://vscode-elements.github.io/components/icon/ for more details.";
+            this.warn(msg);
+          }
+          return { nonce, href };
+        }
+        render() {
+          const { stylesheetHref, nonce } = VscodeIcon_1;
+          const content = b2`<span
+      class=${e6({
+            codicon: true,
+            ["codicon-" + this.name]: true,
+            spin: this.spin
+          })}
+      .style=${stylePropertyMap({
+            animationDuration: String(this.spinDuration) + "s",
+            fontSize: this.size + "px",
+            height: this.size + "px",
+            width: this.size + "px"
+          })}
+    ></span>`;
+          const wrapped = this.actionIcon ? b2` <button
           class="button"
           @click=${this._onButtonClick}
           aria-label=${this.label}
         >
-          ${n}
-        </button>`:G` <span class="icon" aria-hidden="true" role="presentation"
-          >${n}</span
-        >`;return G`
+          ${content}
+        </button>` : b2` <span class="icon" aria-hidden="true" role="presentation"
+          >${content}</span
+        >`;
+          return b2`
       <link
         rel="stylesheet"
-        href=${Ce(t)}
-        nonce=${Ce(o)}
+        href=${o6(stylesheetHref)}
+        nonce=${o6(nonce)}
       />
-      ${s}
-    `}};N.styles=rs;N.stylesheetHref="";N.nonce="";ue([v()],N.prototype,"label",void 0);ue([v({type:String})],N.prototype,"name",void 0);ue([v({type:Number})],N.prototype,"size",void 0);ue([v({type:Boolean,reflect:!0})],N.prototype,"spin",void 0);ue([v({type:Number,attribute:"spin-duration"})],N.prototype,"spinDuration",void 0);ue([v({type:Boolean,reflect:!0,attribute:"action-icon"})],N.prototype,"actionIcon",void 0);N=Ke=ue([Rt("vscode-icon")],N)});var ls=y(()=>{as()});function ds(){return navigator.userAgent.indexOf("Linux")>-1?'system-ui, "Ubuntu", "Droid Sans", sans-serif':navigator.userAgent.indexOf("Mac")>-1?"-apple-system, BlinkMacSystemFont, sans-serif":navigator.userAgent.indexOf("Windows")>-1?'"Segoe WPC", "Segoe UI", sans-serif':"sans-serif"}var cs=y(()=>{});var Zr,Qr,us,ps=y(()=>{se();To();cs();Zr=wt(ds()),Qr=[_t,ae`
+      ${wrapped}
+    `;
+        }
+      };
+      VscodeIcon.styles = vscode_icon_styles_default;
+      VscodeIcon.stylesheetHref = "";
+      VscodeIcon.nonce = "";
+      __decorate([
+        n4()
+      ], VscodeIcon.prototype, "label", void 0);
+      __decorate([
+        n4({ type: String })
+      ], VscodeIcon.prototype, "name", void 0);
+      __decorate([
+        n4({ type: Number })
+      ], VscodeIcon.prototype, "size", void 0);
+      __decorate([
+        n4({ type: Boolean, reflect: true })
+      ], VscodeIcon.prototype, "spin", void 0);
+      __decorate([
+        n4({ type: Number, attribute: "spin-duration" })
+      ], VscodeIcon.prototype, "spinDuration", void 0);
+      __decorate([
+        n4({ type: Boolean, reflect: true, attribute: "action-icon" })
+      ], VscodeIcon.prototype, "actionIcon", void 0);
+      VscodeIcon = VscodeIcon_1 = __decorate([
+        customElement("vscode-icon")
+      ], VscodeIcon);
+    }
+  });
+
+  // node_modules/@vscode-elements/elements/dist/vscode-icon/index.js
+  var init_vscode_icon2 = __esm({
+    "node_modules/@vscode-elements/elements/dist/vscode-icon/index.js"() {
+      init_vscode_icon();
+    }
+  });
+
+  // node_modules/@vscode-elements/elements/dist/includes/helpers.js
+  function getDefaultFontStack() {
+    if (navigator.userAgent.indexOf("Linux") > -1) {
+      return 'system-ui, "Ubuntu", "Droid Sans", sans-serif';
+    } else if (navigator.userAgent.indexOf("Mac") > -1) {
+      return "-apple-system, BlinkMacSystemFont, sans-serif";
+    } else if (navigator.userAgent.indexOf("Windows") > -1) {
+      return '"Segoe WPC", "Segoe UI", sans-serif';
+    } else {
+      return "sans-serif";
+    }
+  }
+  var DEFAULT_LINE_HEIGHT, DEFAULT_FONT_SIZE, INPUT_LINE_HEIGHT_RATIO;
+  var init_helpers = __esm({
+    "node_modules/@vscode-elements/elements/dist/includes/helpers.js"() {
+      DEFAULT_LINE_HEIGHT = 16;
+      DEFAULT_FONT_SIZE = 13;
+      INPUT_LINE_HEIGHT_RATIO = DEFAULT_LINE_HEIGHT / DEFAULT_FONT_SIZE;
+    }
+  });
+
+  // node_modules/@vscode-elements/elements/dist/vscode-button/vscode-button.styles.js
+  var defaultFontStack, styles2, vscode_button_styles_default;
+  var init_vscode_button_styles = __esm({
+    "node_modules/@vscode-elements/elements/dist/vscode-button/vscode-button.styles.js"() {
+      init_lit();
+      init_default_styles();
+      init_helpers();
+      defaultFontStack = r(getDefaultFontStack());
+      styles2 = [
+        default_styles_default,
+        i`
     :host {
       cursor: pointer;
       display: inline-block;
@@ -120,7 +1174,7 @@ To suppress this warning, set window.${Qn} to true`)}});var Ce,ts=y(()=>{ve();Ce
       box-sizing: border-box;
       color: var(--vscode-button-foreground, #ffffff);
       display: flex;
-      font-family: var(--vscode-font-family, ${Zr});
+      font-family: var(--vscode-font-family, ${defaultFontStack});
       font-size: var(--vscode-font-size, 13px);
       font-weight: var(--vscode-font-weight, normal);
       height: 100%;
@@ -276,35 +1330,657 @@ To suppress this warning, set window.${Qn} to true`)}});var Ce,ts=y(()=>{ve();Ce
     :host([icon]) .icon-after {
       margin-left: 3px;
     }
-  `],us=Qr});var M,C,gs=y(()=>{se();vo();ko();wo();ls();ps();Co();M=function(e,t,o,n){var s=arguments.length,r=s<3?t:n===null?n=Object.getOwnPropertyDescriptor(t,o):n,i;if(typeof Reflect=="object"&&typeof Reflect.decorate=="function")r=Reflect.decorate(e,t,o,n);else for(var a=e.length-1;a>=0;a--)(i=e[a])&&(r=(s<3?i(r):s>3?i(t,o,r):i(t,o))||r);return s>3&&r&&Object.defineProperty(t,o,r),r},C=class extends we{get form(){return this._internals.form}constructor(){super(),this.autofocus=!1,this.tabIndex=0,this.secondary=!1,this.block=!1,this.role="button",this.disabled=!1,this.icon="",this.iconSpin=!1,this.iconAfter="",this.iconAfterSpin=!1,this.focused=!1,this.name=void 0,this.iconOnly=!1,this.type="button",this.value="",this._prevTabindex=0,this._hasContentBefore=!1,this._hasContentAfter=!1,this._handleFocus=()=>{this.focused=!0},this._handleBlur=()=>{this.focused=!1},this.addEventListener("keydown",this._handleKeyDown.bind(this)),this.addEventListener("click",this._handleClick.bind(this)),this._internals=this.attachInternals()}connectedCallback(){super.connectedCallback(),this.autofocus&&(this.tabIndex<0&&(this.tabIndex=0),this.updateComplete.then(()=>{this.focus(),this.requestUpdate()})),this.addEventListener("focus",this._handleFocus),this.addEventListener("blur",this._handleBlur)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener("focus",this._handleFocus),this.removeEventListener("blur",this._handleBlur)}update(t){super.update(t),t.has("value")&&this._internals.setFormValue(this.value),t.has("disabled")&&(this.disabled?(this._prevTabindex=this.tabIndex,this.tabIndex=-1):this.tabIndex=this._prevTabindex)}_executeAction(){this.type==="submit"&&this._internals.form&&this._internals.form.requestSubmit(),this.type==="reset"&&this._internals.form&&this._internals.form.reset()}_handleKeyDown(t){if((t.key==="Enter"||t.key===" ")&&!this.hasAttribute("disabled")){let o=new MouseEvent("click",{bubbles:!0,cancelable:!0});o.synthetic=!0,this.dispatchEvent(o),this._executeAction()}}_handleClick(t){t.synthetic||this.hasAttribute("disabled")||this._executeAction()}_handleSlotChange(t){let o=t.target;o.name==="content-before"&&(this._hasContentBefore=o.assignedElements().length>0),o.name==="content-after"&&(this._hasContentAfter=o.assignedElements().length>0)}render(){let t=this.icon!=="",o=this.iconAfter!=="",n={base:!0,"icon-only":this.iconOnly,"has-content-before":this._hasContentBefore,"has-content-after":this._hasContentAfter},s=t?G`<vscode-icon
+  `
+      ];
+      vscode_button_styles_default = styles2;
+    }
+  });
+
+  // node_modules/@vscode-elements/elements/dist/vscode-button/vscode-button.js
+  var __decorate2, VscodeButton;
+  var init_vscode_button = __esm({
+    "node_modules/@vscode-elements/elements/dist/vscode-button/vscode-button.js"() {
+      init_lit();
+      init_decorators();
+      init_class_map2();
+      init_VscElement();
+      init_vscode_icon2();
+      init_vscode_button_styles();
+      init_if_defined2();
+      __decorate2 = function(decorators, target, key, desc) {
+        var c4 = arguments.length, r6 = c4 < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d3;
+        if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r6 = Reflect.decorate(decorators, target, key, desc);
+        else for (var i6 = decorators.length - 1; i6 >= 0; i6--) if (d3 = decorators[i6]) r6 = (c4 < 3 ? d3(r6) : c4 > 3 ? d3(target, key, r6) : d3(target, key)) || r6;
+        return c4 > 3 && r6 && Object.defineProperty(target, key, r6), r6;
+      };
+      VscodeButton = class VscodeButton2 extends VscElement {
+        get form() {
+          return this._internals.form;
+        }
+        constructor() {
+          super();
+          this.autofocus = false;
+          this.tabIndex = 0;
+          this.secondary = false;
+          this.block = false;
+          this.role = "button";
+          this.disabled = false;
+          this.icon = "";
+          this.iconSpin = false;
+          this.iconAfter = "";
+          this.iconAfterSpin = false;
+          this.focused = false;
+          this.name = void 0;
+          this.iconOnly = false;
+          this.type = "button";
+          this.value = "";
+          this._prevTabindex = 0;
+          this._hasContentBefore = false;
+          this._hasContentAfter = false;
+          this._handleFocus = () => {
+            this.focused = true;
+          };
+          this._handleBlur = () => {
+            this.focused = false;
+          };
+          this.addEventListener("keydown", this._handleKeyDown.bind(this));
+          this.addEventListener("click", this._handleClick.bind(this));
+          this._internals = this.attachInternals();
+        }
+        connectedCallback() {
+          super.connectedCallback();
+          if (this.autofocus) {
+            if (this.tabIndex < 0) {
+              this.tabIndex = 0;
+            }
+            this.updateComplete.then(() => {
+              this.focus();
+              this.requestUpdate();
+            });
+          }
+          this.addEventListener("focus", this._handleFocus);
+          this.addEventListener("blur", this._handleBlur);
+        }
+        disconnectedCallback() {
+          super.disconnectedCallback();
+          this.removeEventListener("focus", this._handleFocus);
+          this.removeEventListener("blur", this._handleBlur);
+        }
+        update(changedProperties) {
+          super.update(changedProperties);
+          if (changedProperties.has("value")) {
+            this._internals.setFormValue(this.value);
+          }
+          if (changedProperties.has("disabled")) {
+            if (this.disabled) {
+              this._prevTabindex = this.tabIndex;
+              this.tabIndex = -1;
+            } else {
+              this.tabIndex = this._prevTabindex;
+            }
+          }
+        }
+        _executeAction() {
+          if (this.type === "submit" && this._internals.form) {
+            this._internals.form.requestSubmit();
+          }
+          if (this.type === "reset" && this._internals.form) {
+            this._internals.form.reset();
+          }
+        }
+        _handleKeyDown(event) {
+          if ((event.key === "Enter" || event.key === " ") && !this.hasAttribute("disabled")) {
+            const syntheticClick = new MouseEvent("click", {
+              bubbles: true,
+              cancelable: true
+            });
+            syntheticClick.synthetic = true;
+            this.dispatchEvent(syntheticClick);
+            this._executeAction();
+          }
+        }
+        _handleClick(event) {
+          if (event.synthetic) {
+            return;
+          }
+          if (!this.hasAttribute("disabled")) {
+            this._executeAction();
+          }
+        }
+        _handleSlotChange(ev) {
+          const slot = ev.target;
+          if (slot.name === "content-before") {
+            this._hasContentBefore = slot.assignedElements().length > 0;
+          }
+          if (slot.name === "content-after") {
+            this._hasContentAfter = slot.assignedElements().length > 0;
+          }
+        }
+        render() {
+          const hasIcon = this.icon !== "";
+          const hasIconAfter = this.iconAfter !== "";
+          const baseClasses = {
+            base: true,
+            "icon-only": this.iconOnly,
+            "has-content-before": this._hasContentBefore,
+            "has-content-after": this._hasContentAfter
+          };
+          const iconElem = hasIcon ? b2`<vscode-icon
           name=${this.icon}
           ?spin=${this.iconSpin}
-          spin-duration=${Ce(this.iconSpinDuration)}
+          spin-duration=${o6(this.iconSpinDuration)}
           class="icon"
-        ></vscode-icon>`:T,r=o?G`<vscode-icon
+        ></vscode-icon>` : A;
+          const iconAfterElem = hasIconAfter ? b2`<vscode-icon
           name=${this.iconAfter}
           ?spin=${this.iconAfterSpin}
-          spin-duration=${Ce(this.iconAfterSpinDuration)}
+          spin-duration=${o6(this.iconAfterSpinDuration)}
           class="icon-after"
-        ></vscode-icon>`:T;return G`
+        ></vscode-icon>` : A;
+          return b2`
       <div
-        class=${Mt(n)}
+        class=${e6(baseClasses)}
         part="base"
         @slotchange=${this._handleSlotChange}
       >
         <slot name="content-before"></slot>
-        ${s}
+        ${iconElem}
         <slot></slot>
-        ${r}
+        ${iconAfterElem}
         <slot name="content-after"></slot>
       </div>
-    `}};C.styles=us;C.formAssociated=!0;M([v({type:Boolean,reflect:!0})],C.prototype,"autofocus",void 0);M([v({type:Number,reflect:!0})],C.prototype,"tabIndex",void 0);M([v({type:Boolean,reflect:!0})],C.prototype,"secondary",void 0);M([v({type:Boolean,reflect:!0})],C.prototype,"block",void 0);M([v({reflect:!0})],C.prototype,"role",void 0);M([v({type:Boolean,reflect:!0})],C.prototype,"disabled",void 0);M([v()],C.prototype,"icon",void 0);M([v({type:Boolean,reflect:!0,attribute:"icon-spin"})],C.prototype,"iconSpin",void 0);M([v({type:Number,reflect:!0,attribute:"icon-spin-duration"})],C.prototype,"iconSpinDuration",void 0);M([v({attribute:"icon-after"})],C.prototype,"iconAfter",void 0);M([v({type:Boolean,reflect:!0,attribute:"icon-after-spin"})],C.prototype,"iconAfterSpin",void 0);M([v({type:Number,reflect:!0,attribute:"icon-after-spin-duration"})],C.prototype,"iconAfterSpinDuration",void 0);M([v({type:Boolean,reflect:!0})],C.prototype,"focused",void 0);M([v({type:String,reflect:!0})],C.prototype,"name",void 0);M([v({type:Boolean,reflect:!0,attribute:"icon-only"})],C.prototype,"iconOnly",void 0);M([v({reflect:!0})],C.prototype,"type",void 0);M([v()],C.prototype,"value",void 0);M([ho()],C.prototype,"_hasContentBefore",void 0);M([ho()],C.prototype,"_hasContentAfter",void 0);C=M([Rt("vscode-button")],C)});var ms={};rr(ms,{VscodeButton:()=>C});var fs=y(()=>{gs()});function k(e,t){e&&(e.innerHTML=t)}function m(e,t,o){let n=document.createElement(e);return t&&(n.className=t),o!==void 0&&(n.textContent=o),n}var pt={today:"Today",last7:"Last 7 days",last14:"Last 14 days",last30:"Last 30 days",last90:"Last 90 days",currentMonth:"Current month",lastMonth:"Previous month",thisWeek:"This week",allTime:"All time"},ir=["today","last7","last30","currentMonth","allTime"];function Xo(e,t,o){t===o&&(e.selected=!0)}function Yt(e){let t=m("div","period-selector");t.style.display="inline-flex",t.style.alignItems="center",t.style.gap="4px";let o=e.label??"Time window:";if(o){let i=m("span","period-selector-label",o);i.style.fontSize="11px",i.style.color="var(--vscode-descriptionForeground, var(--text-secondary, #9ca3af))",t.append(i)}let n=document.createElement("select");n.className="period-selector-select",e.id&&(n.id=e.id),n.style.background="var(--vscode-dropdown-background, var(--button-secondary-bg, #2d2d2d))",n.style.color="var(--vscode-dropdown-foreground, var(--text-primary, #cccccc))",n.style.border="1px solid var(--border-subtle, #555555)",n.style.borderRadius="4px",n.style.padding="4px 8px",n.style.fontSize="13px",n.style.cursor="pointer",n.style.minHeight="24px";let s=new Set(e.disabled??[]),r=e.periods??ir;for(let i of r){let a=document.createElement("option");a.value=i,a.textContent=pt[i],Xo(a,i,e.selected),s.has(i)&&(a.disabled=!0,e.disabledTitle&&(a.title=e.disabledTitle)),n.append(a)}for(let i of e.extraOptions??[]){let a=document.createElement("option");a.value=i.value,a.textContent=i.label,i.title&&(a.title=i.title),Xo(a,i.value,e.selected),i.disabled&&(a.disabled=!0),n.append(a)}return n.addEventListener("change",()=>{e.onChange(n.value)}),t.append(n),{wrapper:t,select:n}}var Jt={"nav.btnRefresh":"Refresh","nav.btnDetails":"Details","nav.btnChart":"Chart","nav.btnUsage":"Usage Analysis","nav.btnDiagnostics":"Diagnostics","nav.btnMaturity":"Fluency Score","nav.btnDashboard":"Team Dashboard","nav.btnLevelViewer":"Level Viewer","nav.btnEnvironmental":"Environmental Impact","nav.btnEfficiency":"Efficiency"},Zo={...Jt};function Qo(e){let t={};for(let[o,n]of Object.entries(e))typeof n=="string"&&n!==o&&(t[o]=n);Zo={...Jt,...t}}function en(e){return Zo[e]||Jt[e]||e}var ar="en";function tn(e){ar=e}var lr={"btn-refresh":{id:"btn-refresh",labelKey:"nav.btnRefresh",icon:"refresh",appearance:"primary"},"btn-details":{id:"btn-details",labelKey:"nav.btnDetails",icon:"robot",iconColor:"#c37bff",appearance:"secondary"},"btn-chart":{id:"btn-chart",labelKey:"nav.btnChart",icon:"graph-line",iconColor:"#60a5fa",appearance:"secondary"},"btn-usage":{id:"btn-usage",labelKey:"nav.btnUsage",icon:"graph",iconColor:"#22d3ee",appearance:"secondary"},"btn-diagnostics":{id:"btn-diagnostics",labelKey:"nav.btnDiagnostics",icon:"search",iconColor:"#fb7185",appearance:"secondary"},"btn-maturity":{id:"btn-maturity",labelKey:"nav.btnMaturity",icon:"target",iconColor:"#fbbf24",appearance:"secondary"},"btn-dashboard":{id:"btn-dashboard",labelKey:"nav.btnDashboard",icon:"organization",iconColor:"#818cf8",appearance:"secondary"},"btn-level-viewer":{id:"btn-level-viewer",labelKey:"nav.btnLevelViewer",icon:"list-tree",iconColor:"#94a3b8",appearance:"secondary"},"btn-environmental":{id:"btn-environmental",labelKey:"nav.btnEnvironmental",icon:"globe",iconColor:"#4ade80",appearance:"secondary"},"btn-efficiency":{id:"btn-efficiency",labelKey:"nav.btnEfficiency",icon:"dashboard",iconColor:"#f472b6",appearance:"secondary"}},on=new Proxy({},{get(e,t){let o=lr[t];if(!o)return;let{labelKey:n,...s}=o;return{...s,label:en(n)}}});var dr=["btn-refresh","btn-details","btn-chart","btn-usage","btn-maturity","btn-efficiency","btn-environmental","btn-diagnostics","btn-dashboard"];function cr(e,t){return dr.filter(o=>o!=="btn-dashboard"||t).map(o=>({...on[o],active:o===e}))}function ur(e){let t=typeof e=="string"?on[e]:e;if(t.hidden)return"";let o=t.appearance?` appearance="${t.appearance}"`:"",n=t.active?' class="nav-active" disabled aria-current="page"':"",s=t.iconColor?` style="--icon-accent:${t.iconColor}"`:"",r=t.icon?`<span class="codicon codicon-${t.icon} nav-icon"${s}></span>`:"";return`<vscode-button id="${t.id}"${o}${n}>${r}${t.label}</vscode-button>`}function nn(e,t){return cr(e,t).map(o=>ur(o)).join(`
-`)}function Re(e){return e.file+e.selection+e.implicitSelection+e.symbol+e.codebase+e.workspace+e.terminal+e.vscode+e.copilotInstructions+e.agentsMd+(e.terminalLastCommand||0)+(e.terminalSelection||0)+(e.clipboard||0)+(e.changes||0)+(e.outputPanel||0)+(e.problemsPanel||0)+(e.pullRequest||0)}function q(e){let t=globalThis.window;return t?t[e]:void 0}var pr=q("__TOKEN_ESTIMATORS__"),Yd=pr?.estimators??{},_e,gr=!0;function Xt(e){_e=e}function w(e,t){return new Intl.NumberFormat(_e,{minimumFractionDigits:t,maximumFractionDigits:t}).format(e)}function Q(e,t=1){return`${w(e,t)}%`}function g(e){return e.toLocaleString(_e)}function gt(e){return gr?new Intl.NumberFormat(_e,{notation:"compact",maximumFractionDigits:1}).format(e):g(e)}function sn(e){return new Intl.NumberFormat(_e,{style:"currency",currency:"USD",minimumFractionDigits:2,maximumFractionDigits:2}).format(e)}function d(e){return e.replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;").replace(/"/g,"&quot;").replace(/'/g,"&#039;")}function P(e,t,o=n=>console.error(n)){try{return t()}catch(n){let s=n instanceof Error?n.message:String(n);return o(`[usage-webview] Section "${e}" failed to render: ${s}`),`<div class="section" style="border-color: rgba(239, 68, 68, 0.3);">
-			<div class="section-title"><span>\u26A0\uFE0F</span><span>${d(e)}</span></div>
+    `;
+        }
+      };
+      VscodeButton.styles = vscode_button_styles_default;
+      VscodeButton.formAssociated = true;
+      __decorate2([
+        n4({ type: Boolean, reflect: true })
+      ], VscodeButton.prototype, "autofocus", void 0);
+      __decorate2([
+        n4({ type: Number, reflect: true })
+      ], VscodeButton.prototype, "tabIndex", void 0);
+      __decorate2([
+        n4({ type: Boolean, reflect: true })
+      ], VscodeButton.prototype, "secondary", void 0);
+      __decorate2([
+        n4({ type: Boolean, reflect: true })
+      ], VscodeButton.prototype, "block", void 0);
+      __decorate2([
+        n4({ reflect: true })
+      ], VscodeButton.prototype, "role", void 0);
+      __decorate2([
+        n4({ type: Boolean, reflect: true })
+      ], VscodeButton.prototype, "disabled", void 0);
+      __decorate2([
+        n4()
+      ], VscodeButton.prototype, "icon", void 0);
+      __decorate2([
+        n4({ type: Boolean, reflect: true, attribute: "icon-spin" })
+      ], VscodeButton.prototype, "iconSpin", void 0);
+      __decorate2([
+        n4({ type: Number, reflect: true, attribute: "icon-spin-duration" })
+      ], VscodeButton.prototype, "iconSpinDuration", void 0);
+      __decorate2([
+        n4({ attribute: "icon-after" })
+      ], VscodeButton.prototype, "iconAfter", void 0);
+      __decorate2([
+        n4({ type: Boolean, reflect: true, attribute: "icon-after-spin" })
+      ], VscodeButton.prototype, "iconAfterSpin", void 0);
+      __decorate2([
+        n4({
+          type: Number,
+          reflect: true,
+          attribute: "icon-after-spin-duration"
+        })
+      ], VscodeButton.prototype, "iconAfterSpinDuration", void 0);
+      __decorate2([
+        n4({ type: Boolean, reflect: true })
+      ], VscodeButton.prototype, "focused", void 0);
+      __decorate2([
+        n4({ type: String, reflect: true })
+      ], VscodeButton.prototype, "name", void 0);
+      __decorate2([
+        n4({ type: Boolean, reflect: true, attribute: "icon-only" })
+      ], VscodeButton.prototype, "iconOnly", void 0);
+      __decorate2([
+        n4({ reflect: true })
+      ], VscodeButton.prototype, "type", void 0);
+      __decorate2([
+        n4()
+      ], VscodeButton.prototype, "value", void 0);
+      __decorate2([
+        r5()
+      ], VscodeButton.prototype, "_hasContentBefore", void 0);
+      __decorate2([
+        r5()
+      ], VscodeButton.prototype, "_hasContentAfter", void 0);
+      VscodeButton = __decorate2([
+        customElement("vscode-button")
+      ], VscodeButton);
+    }
+  });
+
+  // node_modules/@vscode-elements/elements/dist/vscode-button/index.js
+  var vscode_button_exports = {};
+  __export(vscode_button_exports, {
+    VscodeButton: () => VscodeButton
+  });
+  var init_vscode_button2 = __esm({
+    "node_modules/@vscode-elements/elements/dist/vscode-button/index.js"() {
+      init_vscode_button();
+    }
+  });
+
+  // src/webview/shared/domUtils.ts
+  function setHtml(el2, html) {
+    if (!el2) {
+      return;
+    }
+    el2.innerHTML = html;
+  }
+  function el(tag, className, text) {
+    const node = document.createElement(tag);
+    if (className) {
+      node.className = className;
+    }
+    if (text !== void 0) {
+      node.textContent = text;
+    }
+    return node;
+  }
+
+  // src/webview/shared/periodSelector.ts
+  var PERIOD_LABELS = {
+    today: "Today",
+    last7: "Last 7 days",
+    last14: "Last 14 days",
+    last30: "Last 30 days",
+    last90: "Last 90 days",
+    currentMonth: "Current month",
+    lastMonth: "Previous month",
+    thisWeek: "This week",
+    allTime: "All time"
+  };
+  var CANONICAL_PERIODS = ["today", "last7", "last30", "currentMonth", "allTime"];
+  function setOptionSelected(option, value, selected) {
+    if (value === selected) {
+      option.selected = true;
+    }
+  }
+  function createPeriodSelector(options) {
+    const wrapper = el("div", "period-selector");
+    wrapper.style.display = "inline-flex";
+    wrapper.style.alignItems = "center";
+    wrapper.style.gap = "4px";
+    const labelText = options.label ?? "Time window:";
+    if (labelText) {
+      const label = el("span", "period-selector-label", labelText);
+      label.style.fontSize = "11px";
+      label.style.color = "var(--vscode-descriptionForeground, var(--text-secondary, #9ca3af))";
+      wrapper.append(label);
+    }
+    const select = document.createElement("select");
+    select.className = "period-selector-select";
+    if (options.id) {
+      select.id = options.id;
+    }
+    select.style.background = "var(--vscode-dropdown-background, var(--button-secondary-bg, #2d2d2d))";
+    select.style.color = "var(--vscode-dropdown-foreground, var(--text-primary, #cccccc))";
+    select.style.border = "1px solid var(--border-subtle, #555555)";
+    select.style.borderRadius = "4px";
+    select.style.padding = "4px 8px";
+    select.style.fontSize = "13px";
+    select.style.cursor = "pointer";
+    select.style.minHeight = "24px";
+    const disabledSet = new Set(options.disabled ?? []);
+    const periods = options.periods ?? CANONICAL_PERIODS;
+    for (const period of periods) {
+      const option = document.createElement("option");
+      option.value = period;
+      option.textContent = PERIOD_LABELS[period];
+      setOptionSelected(option, period, options.selected);
+      if (disabledSet.has(period)) {
+        option.disabled = true;
+        if (options.disabledTitle) {
+          option.title = options.disabledTitle;
+        }
+      }
+      select.append(option);
+    }
+    for (const extra of options.extraOptions ?? []) {
+      const option = document.createElement("option");
+      option.value = extra.value;
+      option.textContent = extra.label;
+      if (extra.title) {
+        option.title = extra.title;
+      }
+      setOptionSelected(option, extra.value, options.selected);
+      if (extra.disabled) {
+        option.disabled = true;
+      }
+      select.append(option);
+    }
+    select.addEventListener("change", () => {
+      options.onChange(select.value);
+    });
+    wrapper.append(select);
+    return { wrapper, select };
+  }
+
+  // src/webview/shared/localization.ts
+  var DEFAULT_LOCALIZATION = {
+    "nav.btnRefresh": "Refresh",
+    "nav.btnDetails": "Details",
+    "nav.btnChart": "Chart",
+    "nav.btnUsage": "Usage Analysis",
+    "nav.btnDiagnostics": "Diagnostics",
+    "nav.btnMaturity": "Fluency Score",
+    "nav.btnDashboard": "Team Dashboard",
+    "nav.btnLevelViewer": "Level Viewer",
+    "nav.btnEnvironmental": "Environmental Impact",
+    "nav.btnEfficiency": "Efficiency"
+  };
+  var currentLocalization = { ...DEFAULT_LOCALIZATION };
+  function initializeWebviewLocalization(localization) {
+    const resolved = {};
+    for (const [key, value] of Object.entries(localization)) {
+      if (typeof value === "string" && value !== key) {
+        resolved[key] = value;
+      }
+    }
+    currentLocalization = { ...DEFAULT_LOCALIZATION, ...resolved };
+  }
+  function localize(key) {
+    return currentLocalization[key] || DEFAULT_LOCALIZATION[key] || key;
+  }
+  var currentLanguage = "en";
+  function setCurrentLanguage(language) {
+    currentLanguage = language;
+  }
+
+  // src/webview/shared/buttonConfig.ts
+  var BUTTON_DEFS = {
+    "btn-refresh": {
+      id: "btn-refresh",
+      labelKey: "nav.btnRefresh",
+      icon: "refresh",
+      appearance: "primary"
+    },
+    "btn-details": {
+      id: "btn-details",
+      labelKey: "nav.btnDetails",
+      icon: "robot",
+      iconColor: "#c37bff",
+      appearance: "secondary"
+    },
+    "btn-chart": {
+      id: "btn-chart",
+      labelKey: "nav.btnChart",
+      icon: "graph-line",
+      iconColor: "#60a5fa",
+      appearance: "secondary"
+    },
+    "btn-usage": {
+      id: "btn-usage",
+      labelKey: "nav.btnUsage",
+      icon: "graph",
+      iconColor: "#22d3ee",
+      appearance: "secondary"
+    },
+    "btn-diagnostics": {
+      id: "btn-diagnostics",
+      labelKey: "nav.btnDiagnostics",
+      icon: "search",
+      iconColor: "#fb7185",
+      appearance: "secondary"
+    },
+    "btn-maturity": {
+      id: "btn-maturity",
+      labelKey: "nav.btnMaturity",
+      icon: "target",
+      iconColor: "#fbbf24",
+      appearance: "secondary"
+    },
+    "btn-dashboard": {
+      id: "btn-dashboard",
+      labelKey: "nav.btnDashboard",
+      icon: "organization",
+      iconColor: "#818cf8",
+      appearance: "secondary"
+    },
+    "btn-level-viewer": {
+      id: "btn-level-viewer",
+      labelKey: "nav.btnLevelViewer",
+      icon: "list-tree",
+      iconColor: "#94a3b8",
+      appearance: "secondary"
+    },
+    "btn-environmental": {
+      id: "btn-environmental",
+      labelKey: "nav.btnEnvironmental",
+      icon: "globe",
+      iconColor: "#4ade80",
+      appearance: "secondary"
+    },
+    "btn-efficiency": {
+      id: "btn-efficiency",
+      labelKey: "nav.btnEfficiency",
+      icon: "dashboard",
+      iconColor: "#f472b6",
+      appearance: "secondary"
+    }
+  };
+  var BUTTONS = new Proxy({}, {
+    get(_target, prop) {
+      const def = BUTTON_DEFS[prop];
+      if (!def) {
+        return void 0;
+      }
+      const { labelKey, ...rest } = def;
+      return { ...rest, label: localize(labelKey) };
+    }
+  });
+  var NAV_ORDER = [
+    "btn-refresh",
+    "btn-details",
+    "btn-chart",
+    "btn-usage",
+    "btn-maturity",
+    "btn-efficiency",
+    "btn-environmental",
+    "btn-diagnostics",
+    "btn-dashboard"
+  ];
+  function getNavButtons(activeView, backendConfigured) {
+    return NAV_ORDER.filter((id) => id !== "btn-dashboard" || backendConfigured).map((id) => ({ ...BUTTONS[id], active: id === activeView }));
+  }
+  function buttonHtml(idOrConfig) {
+    const config = typeof idOrConfig === "string" ? BUTTONS[idOrConfig] : idOrConfig;
+    if (config.hidden) {
+      return "";
+    }
+    const appearance = config.appearance ? ` appearance="${config.appearance}"` : "";
+    const active = config.active ? ' class="nav-active" disabled aria-current="page"' : "";
+    const iconStyle = config.iconColor ? ` style="--icon-accent:${config.iconColor}"` : "";
+    const icon = config.icon ? `<span class="codicon codicon-${config.icon} nav-icon"${iconStyle}></span>` : "";
+    return `<vscode-button id="${config.id}"${appearance}${active}>${icon}${config.label}</vscode-button>`;
+  }
+  function navButtonsHtml(activeView, backendConfigured) {
+    return getNavButtons(activeView, backendConfigured).map((config) => buttonHtml(config)).join("\n");
+  }
+
+  // src/webview/shared/contextRefUtils.ts
+  function getTotalContextRefs(refs) {
+    return refs.file + refs.selection + refs.implicitSelection + refs.symbol + refs.codebase + refs.workspace + refs.terminal + refs.vscode + refs.copilotInstructions + refs.agentsMd + (refs.terminalLastCommand || 0) + (refs.terminalSelection || 0) + (refs.clipboard || 0) + (refs.changes || 0) + (refs.outputPanel || 0) + (refs.problemsPanel || 0) + (refs.pullRequest || 0);
+  }
+
+  // ../src/webview/shared/dataLoader.ts
+  function getWindowData(key) {
+    const win = globalThis.window;
+    return win ? win[key] : void 0;
+  }
+
+  // src/webview/shared/formatUtils.ts
+  var _estimatorsData = getWindowData("__TOKEN_ESTIMATORS__");
+  var tokenEstimators = _estimatorsData?.estimators ?? {};
+  var currentLocale;
+  var compactNumbersEnabled = true;
+  function setFormatLocale(locale) {
+    currentLocale = locale;
+  }
+  function formatFixed(value, digits) {
+    return new Intl.NumberFormat(currentLocale, {
+      minimumFractionDigits: digits,
+      maximumFractionDigits: digits
+    }).format(value);
+  }
+  function formatPercent(value, digits = 1) {
+    return `${formatFixed(value, digits)}%`;
+  }
+  function formatNumber(value) {
+    return value.toLocaleString(currentLocale);
+  }
+  function formatCompact(value) {
+    if (!compactNumbersEnabled) {
+      return formatNumber(value);
+    }
+    return new Intl.NumberFormat(currentLocale, {
+      notation: "compact",
+      maximumFractionDigits: 1
+    }).format(value);
+  }
+  function formatCost(value) {
+    return new Intl.NumberFormat(currentLocale, {
+      style: "currency",
+      currency: "USD",
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2
+    }).format(value);
+  }
+  function escapeHtml(text) {
+    return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#039;");
+  }
+  function safeSectionHtml(label, builder, onError = (m2) => console.error(m2)) {
+    try {
+      return builder();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      onError(`[usage-webview] Section "${label}" failed to render: ${message}`);
+      return `<div class="section" style="border-color: rgba(239, 68, 68, 0.3);">
+			<div class="section-title"><span>\u26A0\uFE0F</span><span>${escapeHtml(label)}</span></div>
 			<div style="color: var(--text-secondary); font-size: 12px; padding: 8px 0;">
 				This section couldn't be displayed due to an unexpected error. Other sections are unaffected \u2014 try refreshing the dashboard.
 			</div>
-		</div>`}}function Pe(e){let t=Number(e);if(!Number.isFinite(t)||t<0)return"N/A";if(t<1024)return`${t} B`;let o=["KB","MB","GB","TB","PB"],n=t/1024,s=0;for(;n>=1024&&s<o.length-1;)n/=1024,s++;let r=s===0?1:2;return`${n.toFixed(r)} ${o[s]}`}function Zt(e){if(e===void 0||!Number.isFinite(e)||e<0)return"\u2014";let t=Math.round(e/6e4);if(t<1)return"<1m";if(t<60)return`${t}m`;let o=Math.floor(t/60),n=t%60;return`${o}h ${String(n).padStart(2,"0")}m`}function rn(e){try{let t=Date.now(),o=new Date(e).getTime();if(!Number.isFinite(o))return"Unknown";let n=t-o;if(n<0)return"Just now";let s=Math.floor(n/1e3),r=Math.floor(s/60),i=Math.floor(r/60),a=Math.floor(i/24);return a>0?`${a} day${a!==1?"s":""} ago`:i>0?`${i} hour${i!==1?"s":""} ago`:r>0?`${r} minute${r!==1?"s":""} ago`:`${s} second${s!==1?"s":""} ago`}catch{return"Unknown"}}function an(e){let t=window.__EXTENSION_POINT_BUTTONS__??[];if(t.length===0)return;let o=document.querySelector(".button-row");if(o)for(let n of t){let s=document.createElement("vscode-button");s.id=`ext-point-${n.id}`,s.textContent=n.label,s.addEventListener("click",()=>{e.postMessage({command:"extensionPointAction",buttonId:n.id})}),o.append(s)}}var mt=["last7","last30","currentMonth"];function Qt(e){if(!e||typeof e!="object")return;let t=e,o={};for(let n of mt){let s=t[n];if(!Array.isArray(s))return;o[n]=s.filter(r=>!!r&&typeof r=="object"&&typeof r.interactions=="number")}return o}var ln=`/**
+		</div>`;
+    }
+  }
+  function formatFileSize(bytes) {
+    const numericBytes = Number(bytes);
+    if (!Number.isFinite(numericBytes) || numericBytes < 0) {
+      return "N/A";
+    }
+    if (numericBytes < 1024) {
+      return `${numericBytes} B`;
+    }
+    const units = ["KB", "MB", "GB", "TB", "PB"];
+    let value = numericBytes / 1024;
+    let unitIndex = 0;
+    while (value >= 1024 && unitIndex < units.length - 1) {
+      value /= 1024;
+      unitIndex++;
+    }
+    const decimals = unitIndex === 0 ? 1 : 2;
+    return `${value.toFixed(decimals)} ${units[unitIndex]}`;
+  }
+  function formatDurationShort(durationMs) {
+    if (durationMs === void 0 || !Number.isFinite(durationMs) || durationMs < 0) {
+      return "\u2014";
+    }
+    const totalMinutes = Math.round(durationMs / 6e4);
+    if (totalMinutes < 1) {
+      return "<1m";
+    }
+    if (totalMinutes < 60) {
+      return `${totalMinutes}m`;
+    }
+    const hours = Math.floor(totalMinutes / 60);
+    const minutes = totalMinutes % 60;
+    return `${hours}h ${String(minutes).padStart(2, "0")}m`;
+  }
+  function getTimeSince(isoString) {
+    try {
+      const now = Date.now();
+      const then = new Date(isoString).getTime();
+      if (!Number.isFinite(then)) {
+        return "Unknown";
+      }
+      const diffMs = now - then;
+      if (diffMs < 0) {
+        return "Just now";
+      }
+      const seconds = Math.floor(diffMs / 1e3);
+      const minutes = Math.floor(seconds / 60);
+      const hours = Math.floor(minutes / 60);
+      const days = Math.floor(hours / 24);
+      if (days > 0) {
+        return `${days} day${days !== 1 ? "s" : ""} ago`;
+      }
+      if (hours > 0) {
+        return `${hours} hour${hours !== 1 ? "s" : ""} ago`;
+      }
+      if (minutes > 0) {
+        return `${minutes} minute${minutes !== 1 ? "s" : ""} ago`;
+      }
+      return `${seconds} second${seconds !== 1 ? "s" : ""} ago`;
+    } catch {
+      return "Unknown";
+    }
+  }
+
+  // src/webview/shared/extensionPoints.ts
+  function wireExtensionPointButtons(vscodeApi) {
+    const buttons = window.__EXTENSION_POINT_BUTTONS__ ?? [];
+    if (buttons.length === 0) {
+      return;
+    }
+    const buttonRow = document.querySelector(".button-row");
+    if (!buttonRow) {
+      return;
+    }
+    for (const btn of buttons) {
+      const el2 = document.createElement("vscode-button");
+      el2.id = `ext-point-${btn.id}`;
+      el2.textContent = btn.label;
+      el2.addEventListener("click", () => {
+        vscodeApi.postMessage({ command: "extensionPointAction", buttonId: btn.id });
+      });
+      buttonRow.append(el2);
+    }
+  }
+
+  // src/webview/usage/recentSessionsSanitizer.ts
+  var RECENT_SESSION_PERIODS = ["last7", "last30", "currentMonth"];
+  function sanitizeRecentSessionBuckets(raw) {
+    if (!raw || typeof raw !== "object") {
+      return void 0;
+    }
+    const source = raw;
+    const result = {};
+    for (const period of RECENT_SESSION_PERIODS) {
+      const sessions = source[period];
+      if (!Array.isArray(sessions)) {
+        return void 0;
+      }
+      result[period] = sessions.filter(
+        (session) => !!session && typeof session === "object" && typeof session.interactions === "number"
+      );
+    }
+    return result;
+  }
+
+  // src/webview/shared/theme.css
+  var theme_default = `/**
  * Shared theme variables for all webview panels
  * Uses VS Code theme tokens for automatic light/dark theme support.
  *
@@ -634,7 +2310,10 @@ body[data-vscode-theme-kind="vscode-high-contrast-light"] .title {
 	text-shadow: 2px 2px 0 var(--vscode-panel-border);
 	white-space: nowrap;
 }
-`;var dn=`* {
+`;
+
+  // src/webview/usage/styles.css
+  var styles_default = `* {
 	margin: 0;
 	padding: 0;
 	box-sizing: border-box;
@@ -1729,10 +3408,303 @@ background: var(--bg-tertiary);
 	color: var(--text-muted);
 	flex: 1;
 }
-`;function br(e,t){return e===null||e===t}function cn(e){window.addEventListener("message",t=>{br(t.source,window)&&e(t.data)})}var yr=q("__MODEL_PRICING__"),eo={};for(let[e,t]of Object.entries(yr?.pricing??{}))t.displayNames&&t.displayNames.length>0&&(eo[e]=t.displayNames[0]);var hr=" (Custom)";function ft(e){try{return decodeURIComponent(e)}catch{return e}}function to(e){let t=e.split("/");if(!(t.length!==3||t.some(o=>o.trim()==="")))return{source:ft(t[0]),providerName:ft(t[1]),modelId:ft(t[2])}}var bt=/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\//i;function De(e){let t=[],o=i=>{i&&!t.includes(i)&&t.push(i)},n=i=>{o(i),o(i.replace(/(\d+)-(\d+)(?=-|$)/,"$1.$2"))},s=e.replace(/^copilot\//,"");n(s);let r=to(s);return r&&n(r.modelId),bt.test(s)&&n(s.replace(bt,"")),t}function oo(e){let t=to(e);return t?`${t.providerName}${hr}`:void 0}function ee(e){for(let o of De(e))if(eo[o])return eo[o];let t=to(e);return t?t.modelId:bt.test(e)?e.replace(bt,""):ft(e)}var gc=1/1e11;function xr(e){if(!e)return null;let t=/([\d.]+)\s*([KkMm])?/.exec(e);if(!t)return null;let o=parseFloat(t[1]);if(!isFinite(o)||o<=0)return null;let n=(t[2]??"").toUpperCase();return Math.round(o*(n==="M"?1e6:n==="K"?1e3:1))}function un(e,t={}){let o=kr(e,t);if(!o){let r=e.toLowerCase();for(let[i,a]of Object.entries(t))if(r.includes(i.toLowerCase())||i.toLowerCase().includes(r)){o=a;break}}let n=o?.copilotPricing?.longContext;if(!n)return null;let s=xr(n.threshold);return s?{thresholdTokens:s,defaultInputCostPerMillion:o.copilotPricing.inputCostPerMillion,longContextInputCostPerMillion:n.inputCostPerMillion}:null}function kr(e,t){for(let o of De(e)){let n=t[o];if(n)return n}}function pn(e){return{oneShotRate:e.editTurns>0?e.oneShotEditTurns/e.editTurns:null,retryRate:e.editTurns>0?e.retries/e.editTurns:null,selfCorrectionRate:e.editTurns>0?e.selfCorrections/e.editTurns:null,costPerCall:e.calls>0?e.cost/e.calls:null,costPerEdit:e.editTurns>0?e.cost/e.editTurns:null,outputTokensPerCall:e.calls>0?e.outputTokens/e.calls:null,toolCallsPerCall:e.calls>0?(e.toolCalls??0)/e.calls:null,cacheHitRate:e.inputTokens>0?Math.min(1,e.cachedReadTokens/e.inputTokens):null}}function gn(e){let t=Object.values(e).map(o=>o.calls).sort((o,n)=>o-n);return t.length<4?null:t[Math.floor((t.length-1)*.25)]}var Cr=[["anthropic","Anthropic"],["claude","Anthropic"],["codestral","Mistral AI"],["devstral","Mistral AI"],["gemini","Google"],["goldeneye","xAI"],["google","Google"],["gpt","OpenAI"],["grok","xAI"],["magistral","Mistral AI"],["mai-","Microsoft"],["ministral","Mistral AI"],["mistral","Mistral AI"],["o1","OpenAI"],["o3","OpenAI"],["o4","OpenAI"],["pixtral","Mistral AI"],["qwen","Alibaba"],["raptor","xAI"]];function yt(e){let t=oo(e);if(t)return t;let o=De(e).flatMap(n=>Cr.filter(([s])=>n.toLowerCase().startsWith(s))).at(0);return o?o[1]:"Other"}var Sr=new Set(["\u2705","\u26A0\uFE0F","\u274C"]);function ht(e){let t=Number(e);return Number.isFinite(t)?t:0}function mn(e){if(!e||typeof e!="object")return;let t=e,o=Array.isArray(t.customizationTypes)?t.customizationTypes.filter(s=>!!s&&typeof s=="object").map(s=>({id:typeof s.id=="string"?s.id:"",icon:typeof s.icon=="string"?s.icon:"",label:typeof s.label=="string"?s.label:""})).filter(s=>s.id!==""):[],n=Array.isArray(t.workspaces)?t.workspaces.filter(s=>!!s&&typeof s=="object").map(s=>{let r=s.typeStatuses&&typeof s.typeStatuses=="object"?s.typeStatuses:{},i={};for(let[a,l]of Object.entries(r))i[a]=Sr.has(l)?l:"\u274C";return{workspacePath:typeof s.workspacePath=="string"?s.workspacePath:"",workspaceName:typeof s.workspaceName=="string"?s.workspaceName:"",sessionCount:ht(s.sessionCount),interactionCount:ht(s.interactionCount),typeStatuses:i}}):[];return{customizationTypes:o,workspaces:n,totalWorkspaces:ht(t.totalWorkspaces),workspacesWithIssues:ht(t.workspacesWithIssues)}}function Le(e){return typeof e=="number"&&Number.isFinite(e)?e:0}function Tr(e){if(!e||typeof e!="object")return null;let t=e;return{budgetUsd:Le(t.budgetUsd),budgetAiCredits:Le(t.budgetAiCredits),remainingAiCredits:Le(t.remainingAiCredits),usedAiCredits:Le(t.usedAiCredits),pctAvailable:Le(t.pctAvailable)}}function $r(e){if(!e||typeof e!="object")return null;let t={};for(let[o,n]of Object.entries(e))typeof n=="number"&&Number.isFinite(n)&&(t[o]=n);return t}function fn(e,t){if(!t||typeof t!="object")return;let o=t,n=Tr(o.copilotApiBalance);n&&(e.copilotApiBalance=n);let s=$r(o.monthBillingGroupCosts);s&&(e.monthBillingGroupCosts=s)}function Ar(e,t){if(!t)return 0;let o=e["GitHub Copilot"]??0;return Math.max(0,t.usedAiCredits*.01-o)}function bn(e,t){let o=Ar(e,t),n="GitHub Copilot"in e,s=Object.values(e).reduce((a,l)=>a+l,0)+o,r=o>.001?`<tr>
+`;
+
+  // src/webview/shared/messageHandler.ts
+  function isTrustedWebviewMessageSource(source, currentWindow) {
+    return source === null || source === currentWindow;
+  }
+  function registerMessageHandler(handler) {
+    window.addEventListener("message", (event) => {
+      if (!isTrustedWebviewMessageSource(event.source, window)) {
+        return;
+      }
+      handler(event.data);
+    });
+  }
+
+  // ../src/webview/shared/modelUtils.ts
+  var _pricingData = getWindowData("__MODEL_PRICING__");
+  var _modelNames = {};
+  for (const [modelId, pricing] of Object.entries(_pricingData?.pricing ?? {})) {
+    if (pricing.displayNames && pricing.displayNames.length > 0) {
+      _modelNames[modelId] = pricing.displayNames[0];
+    }
+  }
+  var CUSTOM_PROVIDER_SUFFIX = " (Custom)";
+  function decodeSegment(segment) {
+    try {
+      return decodeURIComponent(segment);
+    } catch {
+      return segment;
+    }
+  }
+  function parseCustomProviderModel(model) {
+    const parts = model.split("/");
+    if (parts.length !== 3 || parts.some((part) => part.trim() === "")) {
+      return void 0;
+    }
+    return {
+      source: decodeSegment(parts[0]),
+      providerName: decodeSegment(parts[1]),
+      modelId: decodeSegment(parts[2])
+    };
+  }
+  var UUID_PREFIX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\//i;
+  function getModelLookupCandidates(model) {
+    const candidates = [];
+    const add = (id) => {
+      if (id && !candidates.includes(id)) {
+        candidates.push(id);
+      }
+    };
+    const addWithVersionVariant = (id) => {
+      add(id);
+      add(id.replace(/(\d+)-(\d+)(?=-|$)/, "$1.$2"));
+    };
+    const base = model.replace(/^copilot\//, "");
+    addWithVersionVariant(base);
+    const custom = parseCustomProviderModel(base);
+    if (custom) {
+      addWithVersionVariant(custom.modelId);
+    }
+    if (UUID_PREFIX.test(base)) {
+      addWithVersionVariant(base.replace(UUID_PREFIX, ""));
+    }
+    return candidates;
+  }
+  function getCustomProviderGroup(model) {
+    const parsed = parseCustomProviderModel(model);
+    return parsed ? `${parsed.providerName}${CUSTOM_PROVIDER_SUFFIX}` : void 0;
+  }
+  function getModelDisplayName(model) {
+    for (const candidate of getModelLookupCandidates(model)) {
+      if (_modelNames[candidate]) {
+        return _modelNames[candidate];
+      }
+    }
+    const custom = parseCustomProviderModel(model);
+    if (custom) {
+      return custom.modelId;
+    }
+    if (UUID_PREFIX.test(model)) {
+      return model.replace(UUID_PREFIX, "");
+    }
+    return decodeSegment(model);
+  }
+
+  // ../src/tokenEstimation.ts
+  var NANO_AIU_TO_DOLLARS = 1 / 1e11;
+  function parseContextThreshold(threshold) {
+    if (!threshold) {
+      return null;
+    }
+    const m2 = /([\d.]+)\s*([KkMm])?/.exec(threshold);
+    if (!m2) {
+      return null;
+    }
+    const n5 = parseFloat(m2[1]);
+    if (!isFinite(n5) || n5 <= 0) {
+      return null;
+    }
+    const unit = (m2[2] ?? "").toUpperCase();
+    return Math.round(n5 * (unit === "M" ? 1e6 : unit === "K" ? 1e3 : 1));
+  }
+  function getLongContextInfo(modelId, modelPricing = {}) {
+    let pricing = _lookupModelPricing(modelId, modelPricing);
+    if (!pricing) {
+      const id = modelId.toLowerCase();
+      for (const [key, value] of Object.entries(modelPricing)) {
+        if (id.includes(key.toLowerCase()) || key.toLowerCase().includes(id)) {
+          pricing = value;
+          break;
+        }
+      }
+    }
+    const longContext = pricing?.copilotPricing?.longContext;
+    if (!longContext) {
+      return null;
+    }
+    const thresholdTokens = parseContextThreshold(longContext.threshold);
+    if (!thresholdTokens) {
+      return null;
+    }
+    return {
+      thresholdTokens,
+      defaultInputCostPerMillion: pricing.copilotPricing.inputCostPerMillion,
+      longContextInputCostPerMillion: longContext.inputCostPerMillion
+    };
+  }
+  function _lookupModelPricing(model, modelPricing) {
+    for (const candidate of getModelLookupCandidates(model)) {
+      const entry = modelPricing[candidate];
+      if (entry) {
+        return entry;
+      }
+    }
+    return void 0;
+  }
+
+  // ../src/modelEfficiency.ts
+  function deriveModelEfficiencyRates(c4) {
+    return {
+      oneShotRate: c4.editTurns > 0 ? c4.oneShotEditTurns / c4.editTurns : null,
+      retryRate: c4.editTurns > 0 ? c4.retries / c4.editTurns : null,
+      selfCorrectionRate: c4.editTurns > 0 ? c4.selfCorrections / c4.editTurns : null,
+      costPerCall: c4.calls > 0 ? c4.cost / c4.calls : null,
+      costPerEdit: c4.editTurns > 0 ? c4.cost / c4.editTurns : null,
+      outputTokensPerCall: c4.calls > 0 ? c4.outputTokens / c4.calls : null,
+      toolCallsPerCall: c4.calls > 0 ? (c4.toolCalls ?? 0) / c4.calls : null,
+      // Cap at 1.0: some providers report cachedReadTokens > inputTokens (e.g. DeepSeek).
+      cacheHitRate: c4.inputTokens > 0 ? Math.min(1, c4.cachedReadTokens / c4.inputTokens) : null
+    };
+  }
+  function computeEfficiencyLowUsageThreshold(usage) {
+    const calls = Object.values(usage).map((c4) => c4.calls).sort((a3, b3) => a3 - b3);
+    if (calls.length < 4) {
+      return null;
+    }
+    return calls[Math.floor((calls.length - 1) * 0.25)];
+  }
+
+  // ../src/chartDataBuilder.ts
+  var MODEL_PROVIDER_PREFIXES = [
+    ["anthropic", "Anthropic"],
+    ["claude", "Anthropic"],
+    ["codestral", "Mistral AI"],
+    ["devstral", "Mistral AI"],
+    ["gemini", "Google"],
+    ["goldeneye", "xAI"],
+    ["google", "Google"],
+    ["gpt", "OpenAI"],
+    ["grok", "xAI"],
+    ["magistral", "Mistral AI"],
+    ["mai-", "Microsoft"],
+    ["ministral", "Mistral AI"],
+    ["mistral", "Mistral AI"],
+    ["o1", "OpenAI"],
+    ["o3", "OpenAI"],
+    ["o4", "OpenAI"],
+    ["pixtral", "Mistral AI"],
+    ["qwen", "Alibaba"],
+    ["raptor", "xAI"]
+  ];
+  function getModelBillingProvider(modelId) {
+    const customGroup = getCustomProviderGroup(modelId);
+    if (customGroup) {
+      return customGroup;
+    }
+    const match = getModelLookupCandidates(modelId).flatMap((candidate) => MODEL_PROVIDER_PREFIXES.filter(([prefix]) => candidate.toLowerCase().startsWith(prefix))).at(0);
+    return match ? match[1] : "Other";
+  }
+
+  // src/webview/usage/customizationSanitizer.ts
+  var VALID_STATUSES = /* @__PURE__ */ new Set(["\u2705", "\u26A0\uFE0F", "\u274C"]);
+  function coerceNumber(value) {
+    const n5 = Number(value);
+    return Number.isFinite(n5) ? n5 : 0;
+  }
+  function sanitizeCustomizationMatrix(rawMatrix) {
+    if (!rawMatrix || typeof rawMatrix !== "object") {
+      return void 0;
+    }
+    const m2 = rawMatrix;
+    const customizationTypes = Array.isArray(m2.customizationTypes) ? m2.customizationTypes.filter((t4) => !!t4 && typeof t4 === "object").map((t4) => ({
+      id: typeof t4.id === "string" ? t4.id : "",
+      icon: typeof t4.icon === "string" ? t4.icon : "",
+      label: typeof t4.label === "string" ? t4.label : ""
+    })).filter((t4) => t4.id !== "") : [];
+    const workspaces = Array.isArray(m2.workspaces) ? m2.workspaces.filter((w2) => !!w2 && typeof w2 === "object").map((w2) => {
+      const rawStatuses = w2.typeStatuses && typeof w2.typeStatuses === "object" ? w2.typeStatuses : {};
+      const typeStatuses = {};
+      for (const [key, val] of Object.entries(rawStatuses)) {
+        typeStatuses[key] = VALID_STATUSES.has(val) ? val : "\u274C";
+      }
+      return {
+        workspacePath: typeof w2.workspacePath === "string" ? w2.workspacePath : "",
+        workspaceName: typeof w2.workspaceName === "string" ? w2.workspaceName : "",
+        sessionCount: coerceNumber(w2.sessionCount),
+        interactionCount: coerceNumber(w2.interactionCount),
+        typeStatuses
+      };
+    }) : [];
+    return {
+      customizationTypes,
+      workspaces,
+      totalWorkspaces: coerceNumber(m2.totalWorkspaces),
+      workspacesWithIssues: coerceNumber(m2.workspacesWithIssues)
+    };
+  }
+
+  // src/webview/usage/billingStatsSanitizer.ts
+  function finiteNumber(value) {
+    return typeof value === "number" && Number.isFinite(value) ? value : 0;
+  }
+  function sanitizeCopilotApiBalance(raw) {
+    if (!raw || typeof raw !== "object") {
+      return null;
+    }
+    const r6 = raw;
+    return {
+      budgetUsd: finiteNumber(r6.budgetUsd),
+      budgetAiCredits: finiteNumber(r6.budgetAiCredits),
+      remainingAiCredits: finiteNumber(r6.remainingAiCredits),
+      usedAiCredits: finiteNumber(r6.usedAiCredits),
+      pctAvailable: finiteNumber(r6.pctAvailable)
+    };
+  }
+  function sanitizeBillingGroupCosts(raw) {
+    if (!raw || typeof raw !== "object") {
+      return null;
+    }
+    const result = {};
+    for (const [key, value] of Object.entries(raw)) {
+      if (typeof value === "number" && Number.isFinite(value)) {
+        result[key] = value;
+      }
+    }
+    return result;
+  }
+  function applyBillingFields(target, raw) {
+    if (!raw || typeof raw !== "object") {
+      return;
+    }
+    const r6 = raw;
+    const apiBalance = sanitizeCopilotApiBalance(r6.copilotApiBalance);
+    if (apiBalance) {
+      target.copilotApiBalance = apiBalance;
+    }
+    const billingCosts = sanitizeBillingGroupCosts(r6.monthBillingGroupCosts);
+    if (billingCosts) {
+      target.monthBillingGroupCosts = billingCosts;
+    }
+  }
+
+  // src/webview/usage/billingCoverage.ts
+  function billingOtherSessionsCostUsd(groupCosts, api) {
+    if (!api) {
+      return 0;
+    }
+    const copilotCostUsd = groupCosts["GitHub Copilot"] ?? 0;
+    return Math.max(0, api.usedAiCredits * 0.01 - copilotCostUsd);
+  }
+  function billingExtGroupCostsHtml(groupCosts, api) {
+    const otherSessionsCostUsd = billingOtherSessionsCostUsd(groupCosts, api);
+    const hasLocalCopilotRow = "GitHub Copilot" in groupCosts;
+    const totalCostUsd = Object.values(groupCosts).reduce((s4, v2) => s4 + v2, 0) + otherSessionsCostUsd;
+    const otherSessionsRowHtml = otherSessionsCostUsd > 1e-3 ? `<tr>
 			<td style="padding:4px 8px; font-size:12px; color:var(--text-secondary);">GitHub Copilot - other sessions (remote or different environment)</td>
-			<td style="padding:4px 8px; font-size:12px; color:var(--text-secondary); text-align:right;">$${w(o,2)}</td>
-		</tr>`:"";return`
+			<td style="padding:4px 8px; font-size:12px; color:var(--text-secondary); text-align:right;">$${formatFixed(otherSessionsCostUsd, 2)}</td>
+		</tr>` : "";
+    const rows = Object.entries(groupCosts).sort(([, a3], [, b3]) => b3 - a3).map(([group, cost]) => {
+      const label = group === "GitHub Copilot" ? "GitHub Copilot - local sessions" : group;
+      return `
+				<tr>
+					<td style="padding:4px 8px; font-size:12px; color:var(--text-primary);">${escapeHtml(label)}</td>
+					<td style="padding:4px 8px; font-size:12px; color:var(--text-primary); text-align:right;">$${formatFixed(cost, 2)}</td>
+				</tr>${group === "GitHub Copilot" ? otherSessionsRowHtml : ""}`;
+    }).join("") + (hasLocalCopilotRow ? "" : otherSessionsRowHtml);
+    return `
 		<div style="margin-bottom:12px;">
 			<div style="font-size:12px; font-weight:600; color:var(--text-secondary); margin-bottom:6px;">Extension tracked (this calendar month, IDE sessions only)</div>
 			<table style="width:100%; border-collapse:collapse; border:1px solid var(--border-subtle); border-radius:6px; overflow:hidden;">
@@ -1742,19 +3714,375 @@ background: var(--bg-tertiary);
 						<th style="padding:6px 8px; text-align:right; font-size:11px; color:var(--text-secondary); font-weight:600;">Estimated cost</th>
 					</tr>
 				</thead>
-				<tbody>${Object.entries(e).sort(([,a],[,l])=>l-a).map(([a,l])=>`
-				<tr>
-					<td style="padding:4px 8px; font-size:12px; color:var(--text-primary);">${d(a==="GitHub Copilot"?"GitHub Copilot - local sessions":a)}</td>
-					<td style="padding:4px 8px; font-size:12px; color:var(--text-primary); text-align:right;">$${w(l,2)}</td>
-				</tr>${a==="GitHub Copilot"?r:""}`).join("")+(n?"":r)}</tbody>
+				<tbody>${rows}</tbody>
 				<tfoot>
 					<tr style="border-top:1px solid var(--border-color);">
 						<td style="padding:6px 8px; font-size:12px; font-weight:600; color:var(--text-primary);">Total</td>
-						<td style="padding:6px 8px; font-size:12px; font-weight:600; color:var(--text-primary); text-align:right;">$${w(s,2)}</td>
+						<td style="padding:6px 8px; font-size:12px; font-weight:600; color:var(--text-primary); text-align:right;">$${formatFixed(totalCostUsd, 2)}</td>
 					</tr>
 				</tfoot>
 			</table>
-		</div>`}var Mr=3600*1e3;function Er(e){return e==="account"||e==="both"?e:"workspace"}function _(e){let t=Number(e);return Number.isFinite(t)&&t>=0?t:0}function vt(e){let t=typeof e=="string"?e.trim():"";try{let o=new URL(t);if(o.protocol==="http:"||o.protocol==="https:")return o.toString()}catch{}return"#"}function yn(e){let t=e&&typeof e=="object"?e:{},o=Array.isArray(t.repos)?t.repos:[];return{authenticated:!!t.authenticated,since:typeof t.since=="string"?d(t.since):new Date(Date.now()-720*60*60*1e3).toISOString(),fetchedAt:typeof t.fetchedAt=="string"?t.fetchedAt:"",totalTasks:_(t.totalTasks),totalSessions:_(t.totalSessions),totalCredits:_(t.totalCredits),totalPremiumRequests:_(t.totalPremiumRequests),accountTasksAvailable:!!t.accountTasksAvailable,refreshIntervalMs:_(t.refreshIntervalMs)||Mr,accountTasksError:typeof t.accountTasksError=="string"?d(t.accountTasksError):void 0,partial:!!t.partial,repos:o.map(n=>{let s=n&&typeof n=="object"?n:{},r=d(typeof s.owner=="string"?s.owner:""),i=d(typeof s.repo=="string"?s.repo:""),a=!!s.unassigned||!r||!i;return{owner:r,repo:i,repoUrl:a?"#":vt(`https://github.com/${r}/${i}`),totalTasks:_(s.totalTasks),totalSessions:_(s.totalSessions),totalCredits:_(s.totalCredits),totalPremiumRequests:_(s.totalPremiumRequests),tasksScanned:_(s.tasksScanned),tasksTotal:_(s.tasksTotal),partial:!!s.partial,discovery:Er(s.discovery),unassigned:a,error:typeof s.error=="string"?d(s.error):void 0}})}}var Rr=new Set(["activity","sessions","tools","health","repos","agent","worktrees","insights","corrections"]);function hn(e){return Rr.has(String(e))}function no(e,t){if(!Number.isFinite(e)||e<=0||!Number.isFinite(t)||t<=0)return 5;let o=Math.min(e/t,1);return 5+Math.sqrt(o)*11}function be(e,t,o,n){let s=Math.max(18,Array.from(e.label).length*6),r=n==="start"?t:n==="end"?t-s:t-s/2;return{x:t,y:o,textAnchor:n,bounds:{left:r,right:r+s,top:o-10,bottom:o-10+12}}}function _r(e,t){let o=e.x+e.radius+4,n=e.x-e.radius-4,s=e.y-e.radius-6,r=e.y+e.radius+12,i=e.y<t.top+22?[e.y+18,e.y-10]:[e.y-10,e.y+18];return[be(e,o,i[0],"start"),be(e,o,i[1],"start"),be(e,n,i[0],"end"),be(e,n,i[1],"end"),be(e,e.x,s,"middle"),be(e,e.x,r,"middle")]}function Pr(e,t){return e.left<t.right+2&&e.right+2>t.left&&e.top<t.bottom+2&&e.bottom+2>t.top}function Dr(e,t){let o=Math.max(e.left,Math.min(t.x,e.right)),n=Math.max(e.top,Math.min(t.y,e.bottom)),s=t.x-o,r=t.y-n;return s*s+r*r<(t.radius+2)**2}function vn(e,t,o,n){let s=e.bounds,r=Math.max(0,n.left-s.left)+Math.max(0,s.right-n.right)+Math.max(0,n.top-s.top)+Math.max(0,s.bottom-n.bottom),i=t.filter(l=>Pr(s,l.bounds)).length,a=o.filter(l=>Dr(s,l)).length;return r*1e4+a*1e3+i*100}function xn(e,t){let o=[];for(let n of e){let r=_r(n,t).reduce((i,a)=>vn(a,o,e,t)<vn(i,o,e,t)?a:i);o.push(r)}return o}var kn=/^mcp__[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}__(.+)$/i;function wn(e){return e.replace(/_/g," ").replace(/\b\w/g,t=>t.toUpperCase())}function Cn(e){let t=kn.exec(e);if(t)return`Claude MCP: M365 Connector - ${wn(t[1])}`}function Sn(e){return kn.test(e)}var Lr=[{displayName:"GitHub MCP",keywords:["github"],actions:new Set(["actions_list","add_comment_to_pending_review","add_issue_comment","add_reply_to_pull_request_comment","assign_copilot_to_issue","create_or_update_file","create_pull_request","create_repository","get_commit","get_file_contents","get_job_logs","get_label","get_latest_release","get_me","get_release_by_tag","get_repository_tree","get_tag","issue_read","issue_write","label_write","list_branches","list_code_scanning_alerts","list_commits","list_issue_fields","list_issue_types","list_issues","list_label","list_pull_requests","list_tags","projects_list","pull_request_read","pull_request_review_write","request_copilot_review","search_code","search_issues","search_pull_requests","search_repositories","search_users","semantic_issue_similarity_search","semantic_issues_search","sub_issue_write","update_pull_request"])},{displayName:"Playwright MCP",keywords:["playwright"],actions:new Set(["browser_click","browser_close","browser_console_messages","browser_evaluate","browser_fill_form","browser_find","browser_hover","browser_install","browser_navigate","browser_network_request","browser_network_requests","browser_press_key","browser_resize","browser_run_code","browser_run_code_unsafe","browser_snapshot","browser_tabs","browser_take_screenshot","browser_type","browser_wait_for"])},{displayName:"Context7 MCP",keywords:["context7"],actions:new Set(["get_library_docs","query_docs","resolve_library_id"])},{displayName:"Tavily MCP",keywords:["tavily"],actions:new Set(["tavily_crawl","tavily_extract","tavily_research","tavily_search","crawl","extract","research","search"])},{displayName:"Microsoft Docs MCP",keywords:["microsoft_doc","microsoftdocs","microsoft_learn"],actions:new Set(["docs_fetch","docs_search","code_sample_search"])},{displayName:"Claude Browser MCP",keywords:["claude_browser","claude_in_chrome"],actions:new Set(["computer","find","get_page_text","javascript_tool","navigate","preview_list","preview_logs","preview_start","preview_stop","read_console_messages","read_network_requests","read_page","resize_window","tabs_close","tabs_context","tabs_create","tabs_select"])}];function Ur(e){return e.toLowerCase().replace(/[.-]/g,"_")}function so(e){let t=Ur(e);for(let o of Lr)if(o.keywords.some(n=>t.includes(n))){for(let n of o.actions)if(t===n||t.endsWith(`_${n}`))return`${o.displayName}: ${wn(n)}`}}function Tn(e){return so(e)!==void 0}function j(e,t){let o=t?` title="${d(t)}"`:"",n="display:inline-flex;align-items:center;justify-content:center;width:20px;height:20px;border-radius:4px;font-weight:700;flex-shrink:0;";return e==="\u2705"?`<span style="${n}background:rgba(34,197,94,0.2);border:1px solid rgba(34,197,94,0.5);color:#4ade80;font-size:12px;"${o} aria-label="${d(t??"Present and fresh")}">\u2713</span>`:e==="\u26A0\uFE0F"?`<span style="${n}background:rgba(251,191,36,0.2);border:1px solid rgba(251,191,36,0.5);color:#fbbf24;font-size:12px;"${o} aria-label="${d(t??"Present but stale")}">!</span>`:`<span style="${n}background:rgba(239,68,68,0.2);border:1px solid rgba(239,68,68,0.5);color:#f87171;font-size:12px;"${o} aria-label="${d(t??"Missing")}">\u2715</span>`}var f=acquireVsCodeApi(),bs=new Set,V=f.getState()?.aboutCollapsed??!1;function Z(e,t){try{f.postMessage({command:"traceUsageCuration",stage:e,details:t??{}})}catch{}}function pe(e,t,o){bs.has(e)||(bs.add(e),Z(t,o))}var E=q("__INITIAL_USAGE__");if(E?.localization){Qo(E.localization);let e=E.localization.__language__||"en";tn(e)}var H=null,ct=new Map,$e=new Set,B=null,ge=!1,me=!1,st=!1,_s=[],$="activity",Lt=null,Ut=null,Bo=[],It=null,U=E?.worktreeScanRoots?[...E.worktreeScanRoots]:[],L=E?.worktreeBackgroundScan?E.worktreeBackgroundScan.worktrees.map(qo):[],Ge=E?.worktreeBackgroundScan?{scannedAt:E.worktreeBackgroundScan.scannedAt,totalBytes:E.worktreeBackgroundScan.totalBytes}:null,R=!1,D={root:"",checked:0,total:0,foundCount:0,elapsedMs:0},rt=null,$o=!1,zt=new Set,Ve=!1,it="count",Ye="desc",W=!1,fe=!1,Oo={processed:0,total:0},re=[];function A(e){return Number(e??0)||0}var ei=`
+		</div>`;
+  }
+
+  // src/webview/usage/agentSessionsSanitizer.ts
+  var DEFAULT_SNAPSHOT_REFRESH_INTERVAL_MS = 60 * 60 * 1e3;
+  function toDiscovery(value) {
+    return value === "account" || value === "both" ? value : "workspace";
+  }
+  function toSafeNumber(value) {
+    const n5 = Number(value);
+    return Number.isFinite(n5) && n5 >= 0 ? n5 : 0;
+  }
+  function toSafeHttpUrl(value) {
+    const raw = typeof value === "string" ? value.trim() : "";
+    try {
+      const parsed = new URL(raw);
+      if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+        return parsed.toString();
+      }
+    } catch {
+    }
+    return "#";
+  }
+  function sanitizeAgentSessionsData(input) {
+    const src = input && typeof input === "object" ? input : {};
+    const repos = Array.isArray(src.repos) ? src.repos : [];
+    return {
+      authenticated: Boolean(src.authenticated),
+      since: typeof src.since === "string" ? escapeHtml(src.since) : new Date(Date.now() - 30 * 24 * 60 * 60 * 1e3).toISOString(),
+      fetchedAt: typeof src.fetchedAt === "string" ? src.fetchedAt : "",
+      totalTasks: toSafeNumber(src.totalTasks),
+      totalSessions: toSafeNumber(src.totalSessions),
+      totalCredits: toSafeNumber(src.totalCredits),
+      totalPremiumRequests: toSafeNumber(src.totalPremiumRequests),
+      accountTasksAvailable: Boolean(src.accountTasksAvailable),
+      refreshIntervalMs: toSafeNumber(src.refreshIntervalMs) || DEFAULT_SNAPSHOT_REFRESH_INTERVAL_MS,
+      accountTasksError: typeof src.accountTasksError === "string" ? escapeHtml(src.accountTasksError) : void 0,
+      partial: Boolean(src.partial),
+      repos: repos.map((repo) => {
+        const r6 = repo && typeof repo === "object" ? repo : {};
+        const owner = escapeHtml(typeof r6.owner === "string" ? r6.owner : "");
+        const repoName = escapeHtml(typeof r6.repo === "string" ? r6.repo : "");
+        const unassigned = Boolean(r6.unassigned) || !owner || !repoName;
+        return {
+          owner,
+          repo: repoName,
+          repoUrl: unassigned ? "#" : toSafeHttpUrl(`https://github.com/${owner}/${repoName}`),
+          totalTasks: toSafeNumber(r6.totalTasks),
+          totalSessions: toSafeNumber(r6.totalSessions),
+          totalCredits: toSafeNumber(r6.totalCredits),
+          totalPremiumRequests: toSafeNumber(r6.totalPremiumRequests),
+          tasksScanned: toSafeNumber(r6.tasksScanned),
+          tasksTotal: toSafeNumber(r6.tasksTotal),
+          partial: Boolean(r6.partial),
+          discovery: toDiscovery(r6.discovery),
+          unassigned,
+          error: typeof r6.error === "string" ? escapeHtml(r6.error) : void 0
+        };
+      })
+    };
+  }
+
+  // src/webview/usage/switchableTabs.ts
+  var SWITCHABLE_TABS = /* @__PURE__ */ new Set([
+    "activity",
+    "sessions",
+    "tools",
+    "health",
+    "repos",
+    "agent",
+    "worktrees",
+    "insights",
+    "corrections"
+  ]);
+  function isSwitchableTab(value) {
+    return SWITCHABLE_TABS.has(String(value));
+  }
+
+  // src/webview/usage/modelLeaderboard.ts
+  var MIN_BUBBLE_RADIUS = 5;
+  var MAX_BUBBLE_RADIUS = 16;
+  var LABEL_HEIGHT = 12;
+  var LABEL_CHARACTER_WIDTH = 6;
+  var LABEL_GAP = 4;
+  function scaleBubbleRadius(value, maxValue) {
+    if (!Number.isFinite(value) || value <= 0 || !Number.isFinite(maxValue) || maxValue <= 0) {
+      return MIN_BUBBLE_RADIUS;
+    }
+    const normalized = Math.min(value / maxValue, 1);
+    return MIN_BUBBLE_RADIUS + Math.sqrt(normalized) * (MAX_BUBBLE_RADIUS - MIN_BUBBLE_RADIUS);
+  }
+  function createLabelPlacement(input, x2, y3, textAnchor) {
+    const width = Math.max(18, Array.from(input.label).length * LABEL_CHARACTER_WIDTH);
+    const left = textAnchor === "start" ? x2 : textAnchor === "end" ? x2 - width : x2 - width / 2;
+    return {
+      x: x2,
+      y: y3,
+      textAnchor,
+      bounds: { left, right: left + width, top: y3 - 10, bottom: y3 - 10 + LABEL_HEIGHT }
+    };
+  }
+  function getLabelCandidates(input, bounds) {
+    const right = input.x + input.radius + LABEL_GAP;
+    const left = input.x - input.radius - LABEL_GAP;
+    const above = input.y - input.radius - 6;
+    const below = input.y + input.radius + LABEL_HEIGHT;
+    const sideY = input.y < bounds.top + 22 ? [input.y + 18, input.y - 10] : [input.y - 10, input.y + 18];
+    return [
+      createLabelPlacement(input, right, sideY[0], "start"),
+      createLabelPlacement(input, right, sideY[1], "start"),
+      createLabelPlacement(input, left, sideY[0], "end"),
+      createLabelPlacement(input, left, sideY[1], "end"),
+      createLabelPlacement(input, input.x, above, "middle"),
+      createLabelPlacement(input, input.x, below, "middle")
+    ];
+  }
+  function rectanglesOverlap(a3, b3) {
+    return a3.left < b3.right + 2 && a3.right + 2 > b3.left && a3.top < b3.bottom + 2 && a3.bottom + 2 > b3.top;
+  }
+  function intersectsBubble(rect, bubble) {
+    const nearestX = Math.max(rect.left, Math.min(bubble.x, rect.right));
+    const nearestY = Math.max(rect.top, Math.min(bubble.y, rect.bottom));
+    const dx = bubble.x - nearestX;
+    const dy = bubble.y - nearestY;
+    return dx * dx + dy * dy < (bubble.radius + 2) ** 2;
+  }
+  function getPlacementPenalty(placement, placed, bubbles, bounds) {
+    const rect = placement.bounds;
+    const overflow = Math.max(0, bounds.left - rect.left) + Math.max(0, rect.right - bounds.right) + Math.max(0, bounds.top - rect.top) + Math.max(0, rect.bottom - bounds.bottom);
+    const labelCollisions = placed.filter((other) => rectanglesOverlap(rect, other.bounds)).length;
+    const bubbleCollisions = bubbles.filter((bubble) => intersectsBubble(rect, bubble)).length;
+    return overflow * 1e4 + bubbleCollisions * 1e3 + labelCollisions * 100;
+  }
+  function placeBubbleLabels(inputs, bounds) {
+    const placed = [];
+    for (const input of inputs) {
+      const candidates = getLabelCandidates(input, bounds);
+      const best = candidates.reduce(
+        (current, candidate) => getPlacementPenalty(candidate, placed, inputs, bounds) < getPlacementPenalty(current, placed, inputs, bounds) ? candidate : current
+      );
+      placed.push(best);
+    }
+    return placed;
+  }
+
+  // ../src/utils/toolUtils.ts
+  var GUID_MCP_PATTERN = /^mcp__[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}__(.+)$/i;
+  function toTitleCase(s4) {
+    return s4.replace(/_/g, " ").replace(/\b\w/g, (c4) => c4.toUpperCase());
+  }
+  function resolveGuidMcpToolName(id) {
+    const match = GUID_MCP_PATTERN.exec(id);
+    if (!match) {
+      return void 0;
+    }
+    return `Claude MCP: M365 Connector - ${toTitleCase(match[1])}`;
+  }
+  function isGuidMcpTool(id) {
+    return GUID_MCP_PATTERN.test(id);
+  }
+  var MCP_TOOL_FAMILIES = [
+    {
+      displayName: "GitHub MCP",
+      keywords: ["github"],
+      actions: /* @__PURE__ */ new Set([
+        "actions_list",
+        "add_comment_to_pending_review",
+        "add_issue_comment",
+        "add_reply_to_pull_request_comment",
+        "assign_copilot_to_issue",
+        "create_or_update_file",
+        "create_pull_request",
+        "create_repository",
+        "get_commit",
+        "get_file_contents",
+        "get_job_logs",
+        "get_label",
+        "get_latest_release",
+        "get_me",
+        "get_release_by_tag",
+        "get_repository_tree",
+        "get_tag",
+        "issue_read",
+        "issue_write",
+        "label_write",
+        "list_branches",
+        "list_code_scanning_alerts",
+        "list_commits",
+        "list_issue_fields",
+        "list_issue_types",
+        "list_issues",
+        "list_label",
+        "list_pull_requests",
+        "list_tags",
+        "projects_list",
+        "pull_request_read",
+        "pull_request_review_write",
+        "request_copilot_review",
+        "search_code",
+        "search_issues",
+        "search_pull_requests",
+        "search_repositories",
+        "search_users",
+        "semantic_issue_similarity_search",
+        "semantic_issues_search",
+        "sub_issue_write",
+        "update_pull_request"
+      ])
+    },
+    {
+      displayName: "Playwright MCP",
+      keywords: ["playwright"],
+      actions: /* @__PURE__ */ new Set([
+        "browser_click",
+        "browser_close",
+        "browser_console_messages",
+        "browser_evaluate",
+        "browser_fill_form",
+        "browser_find",
+        "browser_hover",
+        "browser_install",
+        "browser_navigate",
+        "browser_network_request",
+        "browser_network_requests",
+        "browser_press_key",
+        "browser_resize",
+        "browser_run_code",
+        "browser_run_code_unsafe",
+        "browser_snapshot",
+        "browser_tabs",
+        "browser_take_screenshot",
+        "browser_type",
+        "browser_wait_for"
+      ])
+    },
+    {
+      displayName: "Context7 MCP",
+      keywords: ["context7"],
+      actions: /* @__PURE__ */ new Set(["get_library_docs", "query_docs", "resolve_library_id"])
+    },
+    {
+      displayName: "Tavily MCP",
+      keywords: ["tavily"],
+      actions: /* @__PURE__ */ new Set(["tavily_crawl", "tavily_extract", "tavily_research", "tavily_search", "crawl", "extract", "research", "search"])
+    },
+    {
+      displayName: "Microsoft Docs MCP",
+      keywords: ["microsoft_doc", "microsoftdocs", "microsoft_learn"],
+      actions: /* @__PURE__ */ new Set(["docs_fetch", "docs_search", "code_sample_search"])
+    },
+    {
+      displayName: "Claude Browser MCP",
+      keywords: ["claude_browser", "claude_in_chrome"],
+      actions: /* @__PURE__ */ new Set([
+        "computer",
+        "find",
+        "get_page_text",
+        "javascript_tool",
+        "navigate",
+        "preview_list",
+        "preview_logs",
+        "preview_start",
+        "preview_stop",
+        "read_console_messages",
+        "read_network_requests",
+        "read_page",
+        "resize_window",
+        "tabs_close",
+        "tabs_context",
+        "tabs_create",
+        "tabs_select"
+      ])
+    }
+  ];
+  function normalizeMcpId(id) {
+    return id.toLowerCase().replace(/[.-]/g, "_");
+  }
+  function resolveMcpFamilyToolName(id) {
+    const normalized = normalizeMcpId(id);
+    for (const family of MCP_TOOL_FAMILIES) {
+      if (!family.keywords.some((keyword) => normalized.includes(keyword))) {
+        continue;
+      }
+      for (const action of family.actions) {
+        if (normalized === action || normalized.endsWith(`_${action}`)) {
+          return `${family.displayName}: ${toTitleCase(action)}`;
+        }
+      }
+    }
+    return void 0;
+  }
+  function isMcpFamilyResolvedTool(id) {
+    return resolveMcpFamilyToolName(id) !== void 0;
+  }
+
+  // src/webview/usage/main.ts
+  function statusBadgeHtml(status, label) {
+    const titleAttr = label ? ` title="${escapeHtml(label)}"` : "";
+    const base = "display:inline-flex;align-items:center;justify-content:center;width:20px;height:20px;border-radius:4px;font-weight:700;flex-shrink:0;";
+    if (status === "\u2705") {
+      return `<span style="${base}background:rgba(34,197,94,0.2);border:1px solid rgba(34,197,94,0.5);color:#4ade80;font-size:12px;"${titleAttr} aria-label="${escapeHtml(label ?? "Present and fresh")}">\u2713</span>`;
+    } else if (status === "\u26A0\uFE0F") {
+      return `<span style="${base}background:rgba(251,191,36,0.2);border:1px solid rgba(251,191,36,0.5);color:#fbbf24;font-size:12px;"${titleAttr} aria-label="${escapeHtml(label ?? "Present but stale")}">!</span>`;
+    } else {
+      return `<span style="${base}background:rgba(239,68,68,0.2);border:1px solid rgba(239,68,68,0.5);color:#f87171;font-size:12px;"${titleAttr} aria-label="${escapeHtml(label ?? "Missing")}">\u2715</span>`;
+    }
+  }
+  var vscode = acquireVsCodeApi();
+  var curationTraceOnceKeys = /* @__PURE__ */ new Set();
+  var aboutCollapsed = vscode.getState()?.aboutCollapsed ?? false;
+  function traceCuration(stage, details) {
+    try {
+      vscode.postMessage({ command: "traceUsageCuration", stage, details: details ?? {} });
+    } catch {
+    }
+  }
+  function traceCurationOnce(key, stage, details) {
+    if (curationTraceOnceKeys.has(key)) {
+      return;
+    }
+    curationTraceOnceKeys.add(key);
+    traceCuration(stage, details);
+  }
+  var initialData = getWindowData("__INITIAL_USAGE__");
+  if (initialData?.localization) {
+    initializeWebviewLocalization(initialData.localization);
+    const language = initialData.localization["__language__"] || "en";
+    setCurrentLanguage(language);
+  }
+  var hygieneMatrixState = null;
+  var repoAnalysisState = /* @__PURE__ */ new Map();
+  var repoAnalysisInFlight = /* @__PURE__ */ new Set();
+  var selectedRepoPath = null;
+  var isSwitchingRepository = false;
+  var isBatchAnalysisInProgress = false;
+  var isSingleRepoAnalysisInProgress = false;
+  var currentWorkspacePaths = [];
+  var activeTab = "activity";
+  var pendingTabAnchor = null;
+  var loadingTimeoutId = null;
+  var currentInsights = [];
+  var currentCurationAnalysis = null;
+  var worktreeRoots = initialData?.worktreeScanRoots ? [...initialData.worktreeScanRoots] : [];
+  var worktreeResults = initialData?.worktreeBackgroundScan ? initialData.worktreeBackgroundScan.worktrees.map(sanitizeWorktreeResult) : [];
+  var worktreeBackgroundScanMeta = initialData?.worktreeBackgroundScan ? { scannedAt: initialData.worktreeBackgroundScan.scannedAt, totalBytes: initialData.worktreeBackgroundScan.totalBytes } : null;
+  var worktreeScanInProgress = false;
+  var worktreeScanStatus = { root: "", checked: 0, total: 0, foundCount: 0, elapsedMs: 0 };
+  var worktreeScanError = null;
+  var worktreeRenderPending = false;
+  var worktreeExpandedRepos = /* @__PURE__ */ new Set();
+  var worktreeRootsExpanded = false;
+  var worktreeSortColumn = "count";
+  var worktreeSortDir = "desc";
+  var worktreeCleanupInProgress = false;
+  var worktreeCleanupConfirmPending = false;
+  var worktreeCleanupStatus = { processed: 0, total: 0 };
+  var worktreeCleanupLog = [];
+  function numField(v2) {
+    return Number(v2 ?? 0) || 0;
+  }
+  var USAGE_LOADING_CSS = `
 <style id="usage-loading-css">
 :root {
   --ul-bg: var(--vscode-sideBar-background, #181825);
@@ -1798,13 +4126,48 @@ background: var(--bg-tertiary);
 .ul-cnt { font-size: 11px; opacity: 0.75; font-variant-numeric: tabular-nums; }
 @keyframes ul-pop { 0% { transform: scale(0.4); opacity: 0; } 60% { transform: scale(1.3); } 100% { transform: scale(1); opacity: 1; } }
 .ul-pop { animation: ul-pop 0.3s ease both; }
-</style>`,Je=[{id:"ul-s-start",label:"Starting usage analysis"},{id:"ul-s-tools",label:"Collecting runtime tools"},{id:"ul-s-mcp",label:"Discovering MCP servers"},{id:"ul-s-skills",label:"Scanning skill directories"},{id:"ul-s-crunch",label:"Computing curation analysis"},{id:"ul-s-ready",label:"Ready!"}],ti={start:{pct:5,stepId:"ul-s-start",subtitle:"Starting usage analysis\u2026"},"curation:start":{pct:20,stepId:"ul-s-tools",subtitle:"Collecting tools and skills\u2026"},"curation:runtimeTools":{pct:32,stepId:"ul-s-tools",subtitle:"Collected runtime tools"},"curation:mcpJson":{pct:44,stepId:"ul-s-mcp",subtitle:"Scanning MCP config files\u2026"},"curation:mcpSources":{pct:55,stepId:"ul-s-mcp",subtitle:"Collected MCP servers"},"curation:skillsScanStart":{pct:63,stepId:"ul-s-skills",subtitle:"Scanning skill directories\u2026"},"curation:skillsScanDone":{pct:75,stepId:"ul-s-skills",subtitle:"Skill discovery complete"},"curation:analyzing":{pct:85,stepId:"ul-s-crunch",subtitle:"Analyzing tool usage patterns\u2026"},"curation:done":{pct:96,stepId:"ul-s-crunch",subtitle:"Curation analysis complete"},ready:{pct:100,stepId:"ul-s-ready",subtitle:"Usage analysis ready"},error:{pct:100,stepId:"ul-s-ready",subtitle:"Analysis completed with errors"},"curation:error":{pct:85,stepId:"ul-s-crunch",subtitle:"Curation analysis skipped"}};function No(e="Loading usage analysis..."){let t=document.getElementById("root");if(!t)return;Ho=!0;let o=Je.map((n,s)=>{let r=s===0,i=r?"ul-step ul-active":"ul-step",a=r?'<span class="ul-spin">\u21BB</span>':"\u25CB";return`<div class="${i}" id="${n.id}"><span class="ul-ico">${a}</span><span class="ul-lbl">${d(n.label)}</span><span class="ul-cnt" id="${n.id}-cnt"></span></div>`}).join("");k(t,`${ei}
+</style>`;
+  var USAGE_LOADING_STEPS = [
+    { id: "ul-s-start", label: "Starting usage analysis" },
+    { id: "ul-s-tools", label: "Collecting runtime tools" },
+    { id: "ul-s-mcp", label: "Discovering MCP servers" },
+    { id: "ul-s-skills", label: "Scanning skill directories" },
+    { id: "ul-s-crunch", label: "Computing curation analysis" },
+    { id: "ul-s-ready", label: "Ready!" }
+  ];
+  var USAGE_STAGE_MAP = {
+    start: { pct: 5, stepId: "ul-s-start", subtitle: "Starting usage analysis\u2026" },
+    "curation:start": { pct: 20, stepId: "ul-s-tools", subtitle: "Collecting tools and skills\u2026" },
+    "curation:runtimeTools": { pct: 32, stepId: "ul-s-tools", subtitle: "Collected runtime tools" },
+    "curation:mcpJson": { pct: 44, stepId: "ul-s-mcp", subtitle: "Scanning MCP config files\u2026" },
+    "curation:mcpSources": { pct: 55, stepId: "ul-s-mcp", subtitle: "Collected MCP servers" },
+    "curation:skillsScanStart": { pct: 63, stepId: "ul-s-skills", subtitle: "Scanning skill directories\u2026" },
+    "curation:skillsScanDone": { pct: 75, stepId: "ul-s-skills", subtitle: "Skill discovery complete" },
+    "curation:analyzing": { pct: 85, stepId: "ul-s-crunch", subtitle: "Analyzing tool usage patterns\u2026" },
+    "curation:done": { pct: 96, stepId: "ul-s-crunch", subtitle: "Curation analysis complete" },
+    ready: { pct: 100, stepId: "ul-s-ready", subtitle: "Usage analysis ready" },
+    error: { pct: 100, stepId: "ul-s-ready", subtitle: "Analysis completed with errors" },
+    "curation:error": { pct: 85, stepId: "ul-s-crunch", subtitle: "Curation analysis skipped" }
+  };
+  function renderUsageLoadingState(initialMessage = "Loading usage analysis...") {
+    const root = document.getElementById("root");
+    if (!root) {
+      return;
+    }
+    _ulLoadingActive = true;
+    const stepsHtml = USAGE_LOADING_STEPS.map((s4, i6) => {
+      const isFirst = i6 === 0;
+      const cls = isFirst ? "ul-step ul-active" : "ul-step";
+      const ico = isFirst ? '<span class="ul-spin">\u21BB</span>' : "\u25CB";
+      return `<div class="${cls}" id="${s4.id}"><span class="ul-ico">${ico}</span><span class="ul-lbl">${escapeHtml(s4.label)}</span><span class="ul-cnt" id="${s4.id}-cnt"></span></div>`;
+    }).join("");
+    setHtml(root, `${USAGE_LOADING_CSS}
 <div id="usage-loading-wrap">
   <div id="usage-loading-card">
     <div id="ul-header">
       <div>
         <div id="ul-badge">\u{1F4CA} Analyzing Usage Data</div>
-        <div id="ul-title">${d(e)}</div>
+        <div id="ul-title">${escapeHtml(initialMessage)}</div>
         <div id="ul-subtitle">Initializing\u2026</div>
       </div>
       <div id="ul-right">
@@ -1813,109 +4176,362 @@ background: var(--bg-tertiary);
       </div>
     </div>
     <div id="ul-track"><div id="ul-fill" class="ul-indeterminate"></div></div>
-    <div id="ul-steps">${o}</div>
+    <div id="ul-steps">${stepsHtml}</div>
   </div>
-</div>`)}function ys(e){let t=document.getElementById(e);if(!t)return;t.className="ul-step ul-done";let o=t.querySelector(".ul-ico");o&&k(o,'<span class="ul-pop">\u2713</span>')}function oi(e){let t=document.getElementById(e);if(!t)return;t.className="ul-step ul-active";let o=t.querySelector(".ul-ico");o&&k(o,'<span class="ul-spin">\u21BB</span>')}function ni(e,t){let o=document.getElementById(`${e}-cnt`);o&&(o.textContent=t)}var Xe=0,Ho=!1;function si(e,t){for(let o=Xe;o<e;o++)ys(Je[o].id);e>Xe&&(Xe=e),t<100?oi(Je[e].id):ys(Je[e].id)}function ri(e){return typeof e.count=="number"?`${e.count}`:typeof e.skills=="number"?`${e.skills} skills`:typeof e.availableTools=="number"?`${e.availableTools} tools`:""}function ii(){let e=document.getElementById("root");return e?e.querySelector("#usage-loading-card")?!0:Ho?(No("Building Usage Analysis"),Xe=0,!0):!1:!1}function ai(e){if(!ii())return;let t=typeof e?.stage=="string"?e.stage:"",o=ti[t];if(!o)return;let n=o.pct,s=document.getElementById("ul-fill");s&&(s.classList.remove("ul-indeterminate"),s.style.width=`${Math.max(n,3)}%`);let r=document.getElementById("ul-pct");r&&(r.textContent=n===100?"100%":`${n}%`);let i=document.getElementById("ul-subtitle");i&&(i.textContent=o.subtitle);let a=Je.findIndex(u=>u.id===o.stepId);a>=0&&si(a,n);let l=e?.details;if(l&&typeof l=="object"){let u=ri(l);u&&ni(o.stepId,`(${u})`)}}function Po(){Ut!==null&&(clearTimeout(Ut),Ut=null)}function Kt(){let e=document.createElement("button");return e.textContent="\u{1F504} Refresh",e.style.cssText="padding: 6px 16px; cursor: pointer; border: 1px solid var(--vscode-button-border, transparent); background: var(--vscode-button-background, #0e639c); color: var(--vscode-button-foreground, #fff); border-radius: 2px; font-size: 13px;",e.addEventListener("click",()=>f.postMessage({command:"refresh"})),e}function Ps(e){let t=document.getElementById("root");if(!t)return;let o=document.createElement("div");o.style.cssText="padding: 32px; text-align: center; font-size: 14px;";let n=document.createElement("div");n.style.cssText="font-size: 24px; margin-bottom: 12px;",k(n,j("\u274C","Error"));let s=document.createElement("div");s.style.cssText="color: var(--vscode-errorForeground, #f48771); margin-bottom: 16px;",s.textContent=e,o.append(n,s,Kt()),t.textContent="",t.append(o)}var Do=!1,Ze=null,Lo=!1,Qe=null,li={xhigh:"Extra High"};function di(e){return li[e]??e}var et=q("__TOOL_NAMES__")??null,ci=q("__AUTOMATIC_TOOLS__")??[],hs=new Set(ci.map(e=>e.toLowerCase()));function tt(e){return et?et[e]??et[e.toLowerCase()]??Cn(e)??so(e)??e:e}function Ao(e){let t=tt(e),o=t.indexOf(":");return o!==-1?t.substring(o+1).trim():t}function ui(e){let t=new Set;Object.entries(e.today.mcpTools.byTool).forEach(([n])=>t.add(n)),Object.entries(e.last30Days.mcpTools.byTool).forEach(([n])=>t.add(n)),Object.entries(e.month.mcpTools.byTool).forEach(([n])=>t.add(n)),Object.keys(e.today.mcpTools.byServer).forEach(n=>t.add(n)),Object.keys(e.last30Days.mcpTools.byServer).forEach(n=>t.add(n)),Object.keys(e.month.mcpTools.byServer).forEach(n=>t.add(n)),Object.entries(e.today.toolCalls.byTool).forEach(([n])=>t.add(n)),Object.entries(e.last30Days.toolCalls.byTool).forEach(([n])=>t.add(n)),Object.entries(e.month.toolCalls.byTool).forEach(([n])=>t.add(n));let o=new Set(e.suppressedUnknownTools??[]);return Array.from(t).filter(n=>!et?.[n]&&!et?.[n.toLowerCase()]&&!Sn(n)&&!Tn(n)&&!o.has(n)).sort()}function pi(e){let t="https://github.com/rajbos/ai-engineering-fluency",o=encodeURIComponent("Add missing friendly names for tools"),n=e.map(i=>`- \`${i}\``).join(`
-`),s=encodeURIComponent(`## Unknown Tools Found
+</div>`);
+  }
+  function _ulSetDone(id) {
+    const el2 = document.getElementById(id);
+    if (!el2) {
+      return;
+    }
+    el2.className = "ul-step ul-done";
+    const ico = el2.querySelector(".ul-ico");
+    if (ico) {
+      setHtml(ico, '<span class="ul-pop">\u2713</span>');
+    }
+  }
+  function _ulSetActive(id) {
+    const el2 = document.getElementById(id);
+    if (!el2) {
+      return;
+    }
+    el2.className = "ul-step ul-active";
+    const ico = el2.querySelector(".ul-ico");
+    if (ico) {
+      setHtml(ico, '<span class="ul-spin">\u21BB</span>');
+    }
+  }
+  function _ulSetCnt(id, text) {
+    const el2 = document.getElementById(`${id}-cnt`);
+    if (el2) {
+      el2.textContent = text;
+    }
+  }
+  var _ulLastStepIdx = 0;
+  var _ulLoadingActive = false;
+  function _ulAdvanceSteps(targetIdx, pct) {
+    for (let i6 = _ulLastStepIdx; i6 < targetIdx; i6++) {
+      _ulSetDone(USAGE_LOADING_STEPS[i6].id);
+    }
+    if (targetIdx > _ulLastStepIdx) {
+      _ulLastStepIdx = targetIdx;
+    }
+    if (pct < 100) {
+      _ulSetActive(USAGE_LOADING_STEPS[targetIdx].id);
+    } else {
+      _ulSetDone(USAGE_LOADING_STEPS[targetIdx].id);
+    }
+  }
+  function _ulDetailCnt(details) {
+    if (typeof details.count === "number") {
+      return `${details.count}`;
+    }
+    if (typeof details.skills === "number") {
+      return `${details.skills} skills`;
+    }
+    if (typeof details.availableTools === "number") {
+      return `${details.availableTools} tools`;
+    }
+    return "";
+  }
+  function _ulEnsureCard() {
+    const root = document.getElementById("root");
+    if (!root) {
+      return false;
+    }
+    if (root.querySelector("#usage-loading-card")) {
+      return true;
+    }
+    if (!_ulLoadingActive) {
+      return false;
+    }
+    renderUsageLoadingState("Building Usage Analysis");
+    _ulLastStepIdx = 0;
+    return true;
+  }
+  function updateUsageLoadingProgress(message) {
+    if (!_ulEnsureCard()) {
+      return;
+    }
+    const stage = typeof message?.stage === "string" ? message.stage : "";
+    const mapped = USAGE_STAGE_MAP[stage];
+    if (!mapped) {
+      return;
+    }
+    const pct = mapped.pct;
+    const fill = document.getElementById("ul-fill");
+    if (fill) {
+      fill.classList.remove("ul-indeterminate");
+      fill.style.width = `${Math.max(pct, 3)}%`;
+    }
+    const pctEl = document.getElementById("ul-pct");
+    if (pctEl) {
+      pctEl.textContent = pct === 100 ? "100%" : `${pct}%`;
+    }
+    const subtitleEl = document.getElementById("ul-subtitle");
+    if (subtitleEl) {
+      subtitleEl.textContent = mapped.subtitle;
+    }
+    const targetIdx = USAGE_LOADING_STEPS.findIndex((s4) => s4.id === mapped.stepId);
+    if (targetIdx >= 0) {
+      _ulAdvanceSteps(targetIdx, pct);
+    }
+    const details = message?.details;
+    if (details && typeof details === "object") {
+      const cnt = _ulDetailCnt(details);
+      if (cnt) {
+        _ulSetCnt(mapped.stepId, `(${cnt})`);
+      }
+    }
+  }
+  function clearLoadingTimeout() {
+    if (loadingTimeoutId !== null) {
+      clearTimeout(loadingTimeoutId);
+      loadingTimeoutId = null;
+    }
+  }
+  function createRefreshButton() {
+    const btn = document.createElement("button");
+    btn.textContent = "\u{1F504} Refresh";
+    btn.style.cssText = "padding: 6px 16px; cursor: pointer; border: 1px solid var(--vscode-button-border, transparent); background: var(--vscode-button-background, #0e639c); color: var(--vscode-button-foreground, #fff); border-radius: 2px; font-size: 13px;";
+    btn.addEventListener("click", () => vscode.postMessage({ command: "refresh" }));
+    return btn;
+  }
+  function showLoadError(message) {
+    const root = document.getElementById("root");
+    if (!root) {
+      return;
+    }
+    const container = document.createElement("div");
+    container.style.cssText = "padding: 32px; text-align: center; font-size: 14px;";
+    const icon = document.createElement("div");
+    icon.style.cssText = "font-size: 24px; margin-bottom: 12px;";
+    setHtml(icon, statusBadgeHtml("\u274C", "Error"));
+    const msg = document.createElement("div");
+    msg.style.cssText = "color: var(--vscode-errorForeground, #f48771); margin-bottom: 16px;";
+    msg.textContent = message;
+    container.append(icon, msg, createRefreshButton());
+    root.textContent = "";
+    root.append(container);
+  }
+  var repoPrStatsLoaded = false;
+  var repoPrStatsData = null;
+  var agentSessionsLoaded = false;
+  var agentSessionsData = null;
+  var EFFORT_DISPLAY_NAMES = {
+    xhigh: "Extra High"
+  };
+  function getEffortDisplayName(level) {
+    return EFFORT_DISPLAY_NAMES[level] ?? level;
+  }
+  var TOOL_NAME_MAP = getWindowData("__TOOL_NAMES__") ?? null;
+  var _automaticToolIds = getWindowData("__AUTOMATIC_TOOLS__") ?? [];
+  var AUTOMATIC_TOOL_SET_WV = new Set(_automaticToolIds.map((id) => id.toLowerCase()));
+  function lookupToolName(id) {
+    if (!TOOL_NAME_MAP) {
+      return id;
+    }
+    return TOOL_NAME_MAP[id] ?? TOOL_NAME_MAP[id.toLowerCase()] ?? resolveGuidMcpToolName(id) ?? resolveMcpFamilyToolName(id) ?? id;
+  }
+  function lookupMcpToolName(id) {
+    const full = lookupToolName(id);
+    const colonIdx = full.indexOf(":");
+    if (colonIdx !== -1) {
+      return full.substring(colonIdx + 1).trim();
+    }
+    return full;
+  }
+  function getUnknownMcpTools(stats) {
+    const allTools = /* @__PURE__ */ new Set();
+    Object.entries(stats.today.mcpTools.byTool).forEach(([tool]) => allTools.add(tool));
+    Object.entries(stats.last30Days.mcpTools.byTool).forEach(([tool]) => allTools.add(tool));
+    Object.entries(stats.month.mcpTools.byTool).forEach(([tool]) => allTools.add(tool));
+    Object.keys(stats.today.mcpTools.byServer).forEach((server) => allTools.add(server));
+    Object.keys(stats.last30Days.mcpTools.byServer).forEach((server) => allTools.add(server));
+    Object.keys(stats.month.mcpTools.byServer).forEach((server) => allTools.add(server));
+    Object.entries(stats.today.toolCalls.byTool).forEach(([tool]) => allTools.add(tool));
+    Object.entries(stats.last30Days.toolCalls.byTool).forEach(([tool]) => allTools.add(tool));
+    Object.entries(stats.month.toolCalls.byTool).forEach(([tool]) => allTools.add(tool));
+    const suppressed = new Set(stats.suppressedUnknownTools ?? []);
+    return Array.from(allTools).filter((tool) => !TOOL_NAME_MAP?.[tool] && !TOOL_NAME_MAP?.[tool.toLowerCase()] && !isGuidMcpTool(tool) && !isMcpFamilyResolvedTool(tool) && !suppressed.has(tool)).sort();
+  }
+  function createMcpToolIssueUrl(unknownTools) {
+    const repoUrl = "https://github.com/rajbos/ai-engineering-fluency";
+    const title = encodeURIComponent("Add missing friendly names for tools");
+    const toolList = unknownTools.map((tool) => `- \`${tool}\``).join("\n");
+    const body = encodeURIComponent(
+      `## Unknown Tools Found
 
 The following tools were detected but don't have friendly display names:
 
-${n}
+${toolList}
 
-Please add friendly names for these tools to improve the user experience.`),r=encodeURIComponent("MCP Toolnames");return`${t}/issues/new?title=${o}&body=${s}&labels=${r}`}var gi=[{label:"\u{1F4AC} Ask Mode",key:"ask",gradient:"linear-gradient(90deg, #3b82f6, #60a5fa)"},{label:"\u270F\uFE0F Edit Mode",key:"edit",gradient:"linear-gradient(90deg, #10b981, #34d399)"},{label:"\u{1F916} Agent Mode",key:"agent",gradient:"linear-gradient(90deg, #7c3aed, #a855f7)"},{label:"\u{1F4CB} Plan Mode",key:"plan",gradient:"linear-gradient(90deg, #f59e0b, #fbbf24)"},{label:"\u26A1 Custom Agent",key:"customAgent",gradient:"linear-gradient(90deg, #ec4899, #f472b6)"},{label:"\u{1F5A5}\uFE0F CLI",key:"cli",gradient:"linear-gradient(90deg, #06b6d4, #22d3ee)"},{label:"\u2728 Copilot App",key:"cliApp",gradient:"linear-gradient(90deg, #6366f1, #818cf8)"}];function mi(e,t,o,n){let s=o>0?t/o*100:0;return`
+Please add friendly names for these tools to improve the user experience.`
+    );
+    const labels = encodeURIComponent("MCP Toolnames");
+    return `${repoUrl}/issues/new?title=${title}&body=${body}&labels=${labels}`;
+  }
+  var MODE_BAR_CONFIGS = [
+    { label: "\u{1F4AC} Ask Mode", key: "ask", gradient: "linear-gradient(90deg, #3b82f6, #60a5fa)" },
+    { label: "\u270F\uFE0F Edit Mode", key: "edit", gradient: "linear-gradient(90deg, #10b981, #34d399)" },
+    { label: "\u{1F916} Agent Mode", key: "agent", gradient: "linear-gradient(90deg, #7c3aed, #a855f7)" },
+    { label: "\u{1F4CB} Plan Mode", key: "plan", gradient: "linear-gradient(90deg, #f59e0b, #fbbf24)" },
+    { label: "\u26A1 Custom Agent", key: "customAgent", gradient: "linear-gradient(90deg, #ec4899, #f472b6)" },
+    { label: "\u{1F5A5}\uFE0F CLI", key: "cli", gradient: "linear-gradient(90deg, #06b6d4, #22d3ee)" },
+    { label: "\u2728 Copilot App", key: "cliApp", gradient: "linear-gradient(90deg, #6366f1, #818cf8)" }
+  ];
+  function renderModeBarItem(label, count, total, gradient) {
+    const pct = total > 0 ? count / total * 100 : 0;
+    return `
 <div class="bar-item">
-<div class="bar-label"><span>${e}</span><span><strong>${g(t)}</strong> (${Q(s,0)})</span></div>
-<div class="bar-track"><div class="bar-fill" style="width: ${s.toFixed(1)}%; background: ${n};"></div></div>
-</div>`}function vs(e,t){let o=e.ask+e.edit+e.agent+e.plan+e.customAgent+e.cli+(e.cliApp??0),n=gi.map(({label:s,key:r,gradient:i})=>mi(s,e[r]??0,o,i)).join("");return`
+<div class="bar-label"><span>${label}</span><span><strong>${formatNumber(count)}</strong> (${formatPercent(pct, 0)})</span></div>
+<div class="bar-track"><div class="bar-fill" style="width: ${pct.toFixed(1)}%; background: ${gradient};"></div></div>
+</div>`;
+  }
+  function renderModeBarChart(modeUsage, title) {
+    const total = modeUsage.ask + modeUsage.edit + modeUsage.agent + modeUsage.plan + modeUsage.customAgent + modeUsage.cli + (modeUsage.cliApp ?? 0);
+    const bars = MODE_BAR_CONFIGS.map(({ label, key, gradient }) => renderModeBarItem(label, modeUsage[key] ?? 0, total, gradient)).join("");
+    return `
 <div>
-<h4 style="color: var(--text-primary); font-size: 13px; margin-bottom: 8px;">${t}</h4>
-<div class="bar-chart">${n}
+<h4 style="color: var(--text-primary); font-size: 13px; margin-bottom: 8px;">${title}</h4>
+<div class="bar-chart">${bars}
 </div>
-</div>`}function fi(e){return`
+</div>`;
+  }
+  function _renderMultiModelStatCards(switching) {
+    return `
 <div class="stats-grid" style="grid-template-columns: 1fr;">
 <div class="stat-card">
 <div class="stat-label">\u{1F4CA} Avg Models per Conversation</div>
-<div class="stat-value">${w(e.averageModelsPerSession,1)}</div>
+<div class="stat-value">${formatFixed(switching.averageModelsPerSession, 1)}</div>
 </div>
 <div class="stat-card">
 <div class="stat-label">\u{1F504} Switching Frequency</div>
-<div class="stat-value">${Q(e.switchingFrequency,0)}</div>
+<div class="stat-value">${formatPercent(switching.switchingFrequency, 0)}</div>
 <div style="font-size: 10px; color: var(--text-muted); margin-top: 4px;">Sessions with &gt;1 model</div>
 </div>
 <div class="stat-card">
 <div class="stat-label">\u{1F4C8} Max Models in Session</div>
-<div class="stat-value">${g(e.maxModelsPerSession||0)}</div>
+<div class="stat-value">${formatNumber(switching.maxModelsPerSession || 0)}</div>
 </div>
-</div>`}function bi(e,t,o,n){return`
+</div>`;
+  }
+  function _renderMultiModelCostLevelBreakdown(allLowCostModels, allMediumCostModels, allHighCostModels, allUnknownModels) {
+    return `
 <div style="min-height: 110px;">
-${e.length>0?`
+${allLowCostModels.length > 0 ? `
 <div style="margin-bottom: 6px;">
 <span style="color: #4ade80;">\u{1F49A} Low cost:</span>
-<span style="font-size: 11px; color: var(--text-primary);">${e.map(d).join(", ")}</span>
+<span style="font-size: 11px; color: var(--text-primary);">${allLowCostModels.map(escapeHtml).join(", ")}</span>
 </div>
-`:'<div style="margin-bottom: 6px; height: 21px;"></div>'}
-${t.length>0?`
+` : '<div style="margin-bottom: 6px; height: 21px;"></div>'}
+${allMediumCostModels.length > 0 ? `
 <div style="margin-bottom: 6px;">
 <span style="color: var(--link-color);">\u{1F7E1} Medium cost:</span>
-<span style="font-size: 11px; color: var(--text-primary);">${t.map(d).join(", ")}</span>
+<span style="font-size: 11px; color: var(--text-primary);">${allMediumCostModels.map(escapeHtml).join(", ")}</span>
 </div>
-`:'<div style="margin-bottom: 6px; height: 21px;"></div>'}
-${o.length>0?`
+` : '<div style="margin-bottom: 6px; height: 21px;"></div>'}
+${allHighCostModels.length > 0 ? `
 <div style="margin-bottom: 6px;">
 <span style="color: var(--warning-fg);">\u{1F4B8} High cost:</span>
-<span style="font-size: 11px; color: var(--text-primary);">${o.map(d).join(", ")}</span>
+<span style="font-size: 11px; color: var(--text-primary);">${allHighCostModels.map(escapeHtml).join(", ")}</span>
 </div>
-`:'<div style="margin-bottom: 6px; height: 21px;"></div>'}
-${n.length>0?`
+` : '<div style="margin-bottom: 6px; height: 21px;"></div>'}
+${allUnknownModels.length > 0 ? `
 <div style="margin-bottom: 6px;">
 <span style="color: var(--text-muted);">\u2753 Unknown:</span>
-<span style="font-size: 11px; color: var(--text-primary);">${n.map(d).join(", ")}</span>
+<span style="font-size: 11px; color: var(--text-primary);">${allUnknownModels.map(escapeHtml).join(", ")}</span>
 </div>
-`:""}
-</div>`}function yi(e){return e.totalRequests<=0?"":`
+` : ""}
+</div>`;
+  }
+  function _renderMultiModelRequestCountBreakdown(switching) {
+    if (switching.totalRequests <= 0) {
+      return "";
+    }
+    return `
 <div style="padding-top: 8px; border-top: 1px solid var(--border-subtle); min-height: 85px;">
 <div style="font-size: 11px; font-weight: 600; color: var(--text-primary); margin-bottom: 4px;">Request Count:</div>
-${e.lowCostRequests>0?`
+${switching.lowCostRequests > 0 ? `
 <div style="margin-bottom: 4px; font-size: 11px;">
 <span style="color: #4ade80;">\u{1F49A} Low cost: </span>
-<span style="color: var(--text-primary);">${g(e.lowCostRequests)} (${Q(e.lowCostRequests/e.totalRequests*100)})</span>
+<span style="color: var(--text-primary);">${formatNumber(switching.lowCostRequests)} (${formatPercent(switching.lowCostRequests / switching.totalRequests * 100)})</span>
 </div>
-`:""}
-${e.mediumCostRequests>0?`
+` : ""}
+${switching.mediumCostRequests > 0 ? `
 <div style="margin-bottom: 4px; font-size: 11px;">
 <span style="color: var(--link-color);">\u{1F7E1} Medium cost: </span>
-<span style="color: var(--text-primary);">${g(e.mediumCostRequests)} (${Q(e.mediumCostRequests/e.totalRequests*100)})</span>
+<span style="color: var(--text-primary);">${formatNumber(switching.mediumCostRequests)} (${formatPercent(switching.mediumCostRequests / switching.totalRequests * 100)})</span>
 </div>
-`:""}
-${e.highCostRequests>0?`
+` : ""}
+${switching.highCostRequests > 0 ? `
 <div style="margin-bottom: 4px; font-size: 11px;">
 <span style="color: var(--warning-fg);">\u{1F4B8} High cost: </span>
-<span style="color: var(--text-primary);">${g(e.highCostRequests)} (${Q(e.highCostRequests/e.totalRequests*100)})</span>
+<span style="color: var(--text-primary);">${formatNumber(switching.highCostRequests)} (${formatPercent(switching.highCostRequests / switching.totalRequests * 100)})</span>
 </div>
-`:""}
-${e.unknownRequests>0?`
+` : ""}
+${switching.unknownRequests > 0 ? `
 <div style="margin-bottom: 4px; font-size: 11px;">
 <span style="color: var(--text-muted);">\u2753 Unknown: </span>
-<span style="color: var(--text-primary);">${g(e.unknownRequests)} (${Q(e.unknownRequests/e.totalRequests*100)})</span>
+<span style="color: var(--text-primary);">${formatNumber(switching.unknownRequests)} (${formatPercent(switching.unknownRequests / switching.totalRequests * 100)})</span>
 </div>
-`:""}
-</div>`}function hi(e){return e.mixedCostSessions<=0?"":`
+` : ""}
+</div>`;
+  }
+  function _renderMultiModelMixedCostSessions(switching) {
+    if (switching.mixedCostSessions <= 0) {
+      return "";
+    }
+    return `
 <div style="margin-top: 8px; padding-top: 8px; border-top: 1px solid var(--border-subtle);">
-<span style="font-size: 11px; color: var(--link-color);">\u{1F500} Mixed cost sessions: ${g(e.mixedCostSessions)}</span>
-</div>`}function Mo(e,t,o,n,s,r){return`
+<span style="font-size: 11px; color: var(--link-color);">\u{1F500} Mixed cost sessions: ${formatNumber(switching.mixedCostSessions)}</span>
+</div>`;
+  }
+  function renderMultiModelPeriod(title, switching, allLowCostModels, allMediumCostModels, allHighCostModels, allUnknownModels) {
+    return `
 <div>
-<h4 style="color: var(--text-primary); font-size: 13px; margin-bottom: 8px;">${e}</h4>
-${fi(t)}
+<h4 style="color: var(--text-primary); font-size: 13px; margin-bottom: 8px;">${title}</h4>
+${_renderMultiModelStatCards(switching)}
 <div style="margin-top: 12px; padding: 12px; background: var(--bg-tertiary); border: 1px solid var(--border-subtle); border-radius: 6px;">
 <div style="font-size: 12px; font-weight: 600; color: var(--text-primary); margin-bottom: 8px;">Models by Cost Level:</div>
-${bi(o,n,s,r)}
-${yi(t)}
-${hi(t)}
+${_renderMultiModelCostLevelBreakdown(allLowCostModels, allMediumCostModels, allHighCostModels, allUnknownModels)}
+${_renderMultiModelRequestCountBreakdown(switching)}
+${_renderMultiModelMixedCostSessions(switching)}
 </div>
-</div>`}function xs(e,t,o,n,s){let r=document.querySelector(e);if(!r)return;let i=s>0?Math.round(n/s*100):0,a=`${o} ${n}/${s} repos (${i}%)`,l=r.querySelector(`.${t}`);if(l)l.textContent=a;else{Array.from(r.children).forEach(c=>{let p=c;!p.classList.contains("section-title")&&!p.classList.contains("section-subtitle")&&p.remove()});let u=document.createElement("div");u.className=t,u.style.cssText="margin-top:8px; font-size:12px; color:var(--text-secondary);",u.textContent=a,r.appendChild(u)}}function vi(e){let t=e.missedPotential||E?.missedPotential||[];return t.length===0?`
+</div>`;
+  }
+  function updateProgressPanel(selector, progressClass, messagePrefix, done, total) {
+    const container = document.querySelector(selector);
+    if (!container) {
+      return;
+    }
+    const pct = total > 0 ? Math.round(done / total * 100) : 0;
+    const message = `${messagePrefix} ${done}/${total} repos (${pct}%)`;
+    const existing = container.querySelector(`.${progressClass}`);
+    if (existing) {
+      existing.textContent = message;
+    } else {
+      Array.from(container.children).forEach((child) => {
+        const htmlEl = child;
+        if (!htmlEl.classList.contains("section-title") && !htmlEl.classList.contains("section-subtitle")) {
+          htmlEl.remove();
+        }
+      });
+      const div = document.createElement("div");
+      div.className = progressClass;
+      div.style.cssText = "margin-top:8px; font-size:12px; color:var(--text-secondary);";
+      div.textContent = message;
+      container.appendChild(div);
+    }
+  }
+  function renderMissedPotential(stats) {
+    const missed = stats.missedPotential || initialData?.missedPotential || [];
+    if (missed.length === 0) {
+      return `
 			<div style="margin-top: 16px; margin-bottom: 16px; padding: 12px; background: rgba(34, 197, 94, 0.1); border: 1px solid rgba(34, 197, 94, 0.3); border-radius: 6px;">
 				<div style="font-size: 13px; font-weight: 600; color: var(--success-fg); margin-bottom: 8px; display: flex; align-items: center; gap: 6px;">
-					${j("\u2705")} No other AI tool configs missing a Copilot counterpart
+					${statusBadgeHtml("\u2705")} No other AI tool configs missing a Copilot counterpart
 				</div>
 				<div style="font-size: 11px; color: var(--text-secondary); margin-bottom: 8px;">
 					All active workspaces that contain instruction files for other AI tools (e.g. .cursorrules, CLAUDE.md, AGENTS.md) also have Copilot customization files configured.
@@ -1924,10 +4540,12 @@ ${hi(t)}
 					A workspace appears here when it has instruction files for other AI tools but no Copilot customization files \u2014 indicating Copilot may be under-configured compared to other tools. <a href="https://code.visualstudio.com/docs/copilot/customization/custom-instructions" style="color: var(--link-color);" target="_blank">Learn how to add Copilot instructions</a>.
 				</div>
 			</div>
-		`:`
+		`;
+    }
+    return `
         <div style="margin-top: 16px; margin-bottom: 16px; padding: 12px; background: rgba(251, 191, 36, 0.1); border: 1px solid rgba(251, 191, 36, 0.3); border-radius: 6px;">
             <div style="font-size: 13px; font-weight: 600; color: var(--warning-fg); margin-bottom: 8px; display: flex; align-items: center; gap: 6px;">
-                ${j("\u26A0\uFE0F")} Missed Potential: Non-Copilot Instruction Files
+                ${statusBadgeHtml("\u26A0\uFE0F")} Missed Potential: Non-Copilot Instruction Files
             </div>
             <div style="font-size: 11px; color: var(--text-secondary); margin-bottom: 12px;">
                 These active workspaces use other AI tools but lack Copilot customizations. <a href="https://code.visualstudio.com/docs/copilot/customization/custom-instructions" style="color: var(--link-color);" target="_blank">Learn how to add Copilot instructions</a>.
@@ -1943,24 +4561,24 @@ ${hi(t)}
                         </tr>
                     </thead>
                     <tbody>
-                        ${t.map(o=>`
+                        ${missed.map((ws) => `
                             <tr style="background: rgba(251, 191, 36, 0.05);">
                                 <td style="padding: 6px 8px; border-bottom: 1px solid rgba(251, 191, 36, 0.2); font-family: 'Courier New', monospace; font-size: 12px;">
-                                    ${d(o.workspaceName)}
+                                    ${escapeHtml(ws.workspaceName)}
                                 </td>
                                 <td style="padding: 6px 8px; border-bottom: 1px solid rgba(251, 191, 36, 0.2); text-align: center; color: var(--text-primary);">
-                                    ${g(o.sessionCount)}
+                                    ${formatNumber(ws.sessionCount)}
                                 </td>
                                 <td style="padding: 6px 8px; border-bottom: 1px solid rgba(251, 191, 36, 0.2); text-align: center; color: var(--text-primary);">
-                                    ${g(o.interactionCount)}
+                                    ${formatNumber(ws.interactionCount)}
                                 </td>
                                 <td style="padding: 6px 8px; border-bottom: 1px solid rgba(251, 191, 36, 0.2);">
                                     <div style="display: flex; flex-direction: column; gap: 4px;">
-                                        ${o.nonCopilotFiles.map(n=>`
+                                        ${ws.nonCopilotFiles.map((f3) => `
                                             <div style="font-size: 11px; display: flex; align-items: center; gap: 6px;">
-                                                <span>${d(n.icon||"\u{1F4C4}")}</span>
-                                                <span style="font-weight: 500;">${d(n.label||"")}:</span>
-                                                <span style="font-family: monospace; color: var(--text-muted);">${d(n.relativePath)}</span>
+                                                <span>${escapeHtml(f3.icon || "\u{1F4C4}")}</span>
+                                                <span style="font-weight: 500;">${escapeHtml(f3.label || "")}:</span>
+                                                <span style="font-family: monospace; color: var(--text-muted);">${escapeHtml(f3.relativePath)}</span>
                                             </div>
                                         `).join("")}
                                     </div>
@@ -1971,7 +4589,26 @@ ${hi(t)}
                 </table>
             </div>
         </div>
-    `}function Y(e,t=10,o=tt,n=!1){let r=(n&&at?Object.entries(e).filter(([a])=>!hs.has(a.toLowerCase())):Object.entries(e)).sort(([,a],[,l])=>l-a).slice(0,t);return r.length===0?n&&at?'<div style="color: var(--text-muted);">No purposeful tools used yet (automatic tool calls are hidden)</div>':'<div style="color: var(--text-muted);">No tools used yet</div>':`
+    `;
+  }
+  function renderToolsTable(byTool, limit = 10, nameResolver = lookupToolName, applyAutoFilter = false) {
+    const entries = applyAutoFilter && hideAutomaticToolCalls ? Object.entries(byTool).filter(([tool]) => !AUTOMATIC_TOOL_SET_WV.has(tool.toLowerCase())) : Object.entries(byTool);
+    const sortedTools = entries.sort(([, a3], [, b3]) => b3 - a3).slice(0, limit);
+    if (sortedTools.length === 0) {
+      return applyAutoFilter && hideAutomaticToolCalls ? '<div style="color: var(--text-muted);">No purposeful tools used yet (automatic tool calls are hidden)</div>' : '<div style="color: var(--text-muted);">No tools used yet</div>';
+    }
+    const rows = sortedTools.map(([tool, count], idx) => {
+      const friendly = escapeHtml(nameResolver(tool));
+      const idEscaped = escapeHtml(tool);
+      const autoBadge = AUTOMATIC_TOOL_SET_WV.has(tool.toLowerCase()) ? `<span class="auto-badge" title="Automatic tool \u2014 Copilot uses this internally and it does not count toward fluency scoring">auto</span>` : "";
+      return `
+		    <tr>
+			    <td style="padding:8px 12px; border-bottom:1px solid var(--border-subtle); width:40px; max-width:40px; text-align:center;">${idx + 1}</td>
+			    <td style="padding:8px 12px; border-bottom:1px solid var(--border-subtle); word-break:break-word; overflow-wrap:break-word; max-width:0;"> <strong title="${idEscaped}">${friendly}</strong>${autoBadge}</td>
+			    <td style="padding:8px 12px; border-bottom:1px solid var(--border-subtle); text-align:right; width:90px; white-space:nowrap;">${formatNumber(count)}</td>
+		    </tr>`;
+    }).join("");
+    return `
 		<table style="width:100%; border-collapse:collapse; table-layout:fixed;">
 			<thead>
 				<tr style="color:var(--text-secondary); font-size:12px; text-align:left;">
@@ -1981,69 +4618,1141 @@ ${hi(t)}
 				</tr>
 			</thead>
 			<tbody>
-				${r.map(([a,l],u)=>{let c=d(o(a)),p=d(a),b=hs.has(a.toLowerCase())?'<span class="auto-badge" title="Automatic tool \u2014 Copilot uses this internally and it does not count toward fluency scoring">auto</span>':"";return`
-		    <tr>
-			    <td style="padding:8px 12px; border-bottom:1px solid var(--border-subtle); width:40px; max-width:40px; text-align:center;">${u+1}</td>
-			    <td style="padding:8px 12px; border-bottom:1px solid var(--border-subtle); word-break:break-word; overflow-wrap:break-word; max-width:0;"> <strong title="${p}">${c}</strong>${b}</td>
-			    <td style="padding:8px 12px; border-bottom:1px solid var(--border-subtle); text-align:right; width:90px; white-space:nowrap;">${g(l)}</td>
-		    </tr>`}).join("")}
+				${rows}
 			</tbody>
-		</table>`}var jo=[{id:"interactions",label:"Turns",sortKey:"interactions",align:"right",render:e=>({html:g(e.interactions)})},{id:"toolCalls",label:"Tools",sortKey:"toolCalls",align:"right",render:e=>({html:g(e.toolCalls)})},{id:"subAgentCalls",label:"Sub-Agents",sortKey:"subAgentCalls",align:"right",render:e=>e.subAgentCalls?{html:g(e.subAgentCalls),title:`${e.subAgentCalls} sub-agent tool call${e.subAgentCalls===1?"":"s"} detected in this session`}:{html:"\u2014",title:"No sub-agent calls detected in this session"}},{id:"inputTokens",label:"Input",sortKey:"inputTokens",align:"right",render:e=>({html:g(e.inputTokens)})},{id:"outputTokens",label:"Output",sortKey:"outputTokens",align:"right",render:e=>({html:g(e.outputTokens)})},{id:"thinkingTokens",label:"Thinking",sortKey:"thinkingTokens",align:"right",render:e=>({html:g(e.thinkingTokens)})},{id:"cachedTokens",label:"Cached",sortKey:"cachedTokens",align:"right",render:e=>({html:g(e.cachedTokens)})},{id:"totalTokens",label:"Total",sortKey:"totalTokens",align:"right",render:e=>({html:g(e.totalTokens)})},{id:"estimatedCost",label:"Cost",sortKey:"estimatedCost",align:"right",render:e=>({html:e.estimatedCost>0?`$${e.estimatedCost.toFixed(4)}`:"\u2014"})},{id:"editor",label:"Editor",sortKey:"editor",align:"left",render:e=>({html:d(e.editor||"unknown")})},{id:"workspace",label:"Workspace",sortKey:"workspace",align:"left",cellStyle:"max-width:140px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;",render:e=>{let t=d(e.workspace||"\u2014");return{html:t,title:t}}},{id:"models",label:"Models",align:"left",cellStyle:"font-size:11px; max-width:180px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;",render:e=>{let t=e.models.map(o=>d(ee(o))).join(", ")||"\u2014";return{html:t,title:t}}},{id:"durationMs",label:"Duration",sortKey:"durationMs",align:"right",cellStyle:"white-space:nowrap;",render:e=>{let t=e.activeDurationMs??e.durationMs,o=e.durationMs!==void 0?`Wall time: ${Zt(e.durationMs)}`:void 0;return{html:Zt(t),...o?{title:o}:{}}}},{id:"lastActivity",label:"Last Active",sortKey:"lastActivity",align:"right",cellStyle:"white-space:nowrap;",render:e=>({html:e.lastActivity?I==="today"?new Date(e.lastActivity).toLocaleTimeString([],{hour:"2-digit",minute:"2-digit",hour12:!Ot}):new Date(e.lastActivity).toLocaleString([],{month:"short",day:"numeric",hour:"2-digit",minute:"2-digit",hour12:!Ot}):"\u2014"})}],Ds=jo.map(e=>e.id),Te="interactions",ot="desc",Fo=[],Ot=!0,at=!0,I="today",Uo=[],Ae={},Me=new Set(Ds);function xi(){f.postMessage({command:"saveSessionColumnSettings",settings:{enabledColumns:Array.from(Me)}})}function ks(e){return Te!==e?"":ot==="desc"?" \u25BC":" \u25B2"}var ki={title:(e,t)=>(e.title||"").localeCompare(t.title||""),editor:(e,t)=>(e.editor||"").localeCompare(t.editor||""),workspace:(e,t)=>(e.workspace||"").localeCompare(t.workspace||""),durationMs:(e,t)=>(e.activeDurationMs??e.durationMs??-1)-(t.activeDurationMs??t.durationMs??-1),subAgentCalls:(e,t)=>(e.subAgentCalls??0)-(t.subAgentCalls??0),lastActivity:(e,t)=>(e.lastActivity||"").localeCompare(t.lastActivity||"")};function wi(e,t){let o=ki[Te];return o?o(e,t):e[Te]-t[Te]}function Ci(e){return[...e].sort((t,o)=>{let n=wi(t,o);return ot==="desc"?-n:n})}function Io(e){return Fo=e,!e||e.length===0?`<div style="color: var(--text-secondary); font-size: 13px; padding: 16px;">${I==="today"?"No sessions recorded today yet.":"No sessions recorded in this period."}</div>`:`<div id="sessions-table-container">${Wo(e)}</div>`}function Wo(e){let t=Ci(e),o=jo.filter(r=>Me.has(r.id)),n=t.map((r,i)=>{let a=d(r.title||"Untitled session"),l=d(r.filePath||""),u=o.map(c=>{let{html:p,title:b}=c.render(r),h=c.align==="right"?"text-align:right;":"",S=b!==void 0?` title="${b}"`:"";return`<td style="padding:6px 8px; border-bottom:1px solid var(--border-subtle); font-size:12px; ${h}${c.cellStyle||""}"${S}>${p}</td>`}).join("");return`<tr>
-			<td style="padding:6px 8px; border-bottom:1px solid var(--border-subtle); font-size:12px; color:var(--text-secondary);">${i+1}</td>
-			<td style="padding:6px 8px; border-bottom:1px solid var(--border-subtle); font-size:12px; max-width:200px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;" title="Open viewer for session &quot;${a}&quot;"><a href="#" class="session-title-link" data-file="${l}" style="color:var(--link-color, #4fc1ff); text-decoration:none; cursor:pointer;">${a}</a></td>
-			${u}
-		</tr>`}).join(""),s=o.map(r=>{let i=r.align==="right"?" text-align:right;":"";return r.sortKey?`<th class="sortable" data-sort="${r.sortKey}" style="padding:6px 8px;${i}">${r.label}${ks(r.sortKey)}</th>`:`<th style="padding:6px 8px;${i}">${r.label}</th>`}).join("");return`
+		</table>`;
+  }
+  var SESSION_COLUMN_DEFS = [
+    { id: "interactions", label: "Turns", sortKey: "interactions", align: "right", render: (s4) => ({ html: formatNumber(s4.interactions) }) },
+    { id: "toolCalls", label: "Tools", sortKey: "toolCalls", align: "right", render: (s4) => ({ html: formatNumber(s4.toolCalls) }) },
+    { id: "subAgentCalls", label: "Sub-Agents", sortKey: "subAgentCalls", align: "right", render: (s4) => s4.subAgentCalls ? { html: formatNumber(s4.subAgentCalls), title: `${s4.subAgentCalls} sub-agent tool call${s4.subAgentCalls === 1 ? "" : "s"} detected in this session` } : { html: "\u2014", title: "No sub-agent calls detected in this session" } },
+    { id: "inputTokens", label: "Input", sortKey: "inputTokens", align: "right", render: (s4) => ({ html: formatNumber(s4.inputTokens) }) },
+    { id: "outputTokens", label: "Output", sortKey: "outputTokens", align: "right", render: (s4) => ({ html: formatNumber(s4.outputTokens) }) },
+    { id: "thinkingTokens", label: "Thinking", sortKey: "thinkingTokens", align: "right", render: (s4) => ({ html: formatNumber(s4.thinkingTokens) }) },
+    { id: "cachedTokens", label: "Cached", sortKey: "cachedTokens", align: "right", render: (s4) => ({ html: formatNumber(s4.cachedTokens) }) },
+    { id: "totalTokens", label: "Total", sortKey: "totalTokens", align: "right", render: (s4) => ({ html: formatNumber(s4.totalTokens) }) },
+    { id: "estimatedCost", label: "Cost", sortKey: "estimatedCost", align: "right", render: (s4) => ({ html: s4.estimatedCost > 0 ? `$${s4.estimatedCost.toFixed(4)}` : "\u2014" }) },
+    { id: "editor", label: "Editor", sortKey: "editor", align: "left", render: (s4) => ({ html: escapeHtml(s4.editor || "unknown") }) },
+    { id: "workspace", label: "Workspace", sortKey: "workspace", align: "left", cellStyle: "max-width:140px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;", render: (s4) => {
+      const workspace = escapeHtml(s4.workspace || "\u2014");
+      return { html: workspace, title: workspace };
+    } },
+    { id: "models", label: "Models", align: "left", cellStyle: "font-size:11px; max-width:180px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;", render: (s4) => {
+      const models = s4.models.map((m2) => escapeHtml(getModelDisplayName(m2))).join(", ") || "\u2014";
+      return { html: models, title: models };
+    } },
+    { id: "durationMs", label: "Duration", sortKey: "durationMs", align: "right", cellStyle: "white-space:nowrap;", render: (s4) => {
+      const net = s4.activeDurationMs ?? s4.durationMs;
+      const wallLabel = s4.durationMs !== void 0 ? `Wall time: ${formatDurationShort(s4.durationMs)}` : void 0;
+      return { html: formatDurationShort(net), ...wallLabel ? { title: wallLabel } : {} };
+    } },
+    {
+      id: "lastActivity",
+      label: "Last Active",
+      sortKey: "lastActivity",
+      align: "right",
+      cellStyle: "white-space:nowrap;",
+      render: (s4) => ({
+        html: s4.lastActivity ? sessionsLookback === "today" ? new Date(s4.lastActivity).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: !use24HourTime }) : new Date(s4.lastActivity).toLocaleString([], { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit", hour12: !use24HourTime }) : "\u2014"
+      })
+    }
+  ];
+  var ALL_SESSION_COLUMN_IDS = SESSION_COLUMN_DEFS.map((c4) => c4.id);
+  var sessionSortColumn = "interactions";
+  var sessionSortDirection = "desc";
+  var cachedTodaySessions = [];
+  var use24HourTime = true;
+  var hideAutomaticToolCalls = true;
+  var sessionsLookback = "today";
+  var latestTodaySessions = [];
+  var recentSessionsCache = {};
+  var enabledSessionColumns = new Set(ALL_SESSION_COLUMN_IDS);
+  function saveSessionColumnSettings() {
+    vscode.postMessage({ command: "saveSessionColumnSettings", settings: { enabledColumns: Array.from(enabledSessionColumns) } });
+  }
+  function getSessionSortIndicator(column) {
+    if (sessionSortColumn !== column) {
+      return "";
+    }
+    return sessionSortDirection === "desc" ? " \u25BC" : " \u25B2";
+  }
+  var _todaySessionColumnComparators = {
+    title: (a3, b3) => (a3.title || "").localeCompare(b3.title || ""),
+    editor: (a3, b3) => (a3.editor || "").localeCompare(b3.editor || ""),
+    workspace: (a3, b3) => (a3.workspace || "").localeCompare(b3.workspace || ""),
+    durationMs: (a3, b3) => (a3.activeDurationMs ?? a3.durationMs ?? -1) - (b3.activeDurationMs ?? b3.durationMs ?? -1),
+    subAgentCalls: (a3, b3) => (a3.subAgentCalls ?? 0) - (b3.subAgentCalls ?? 0),
+    lastActivity: (a3, b3) => (a3.lastActivity || "").localeCompare(b3.lastActivity || "")
+  };
+  function _compareTodaySessionsByColumn(a3, b3) {
+    const comparator = _todaySessionColumnComparators[sessionSortColumn];
+    if (comparator) {
+      return comparator(a3, b3);
+    }
+    return a3[sessionSortColumn] - b3[sessionSortColumn];
+  }
+  function sortTodaySessions(sessions) {
+    return [...sessions].sort((a3, b3) => {
+      const cmp = _compareTodaySessionsByColumn(a3, b3);
+      return sessionSortDirection === "desc" ? -cmp : cmp;
+    });
+  }
+  function renderTodaySessionsTable(sessions) {
+    cachedTodaySessions = sessions;
+    if (!sessions || sessions.length === 0) {
+      const emptyMessage = sessionsLookback === "today" ? "No sessions recorded today yet." : "No sessions recorded in this period.";
+      return `<div style="color: var(--text-secondary); font-size: 13px; padding: 16px;">${emptyMessage}</div>`;
+    }
+    return `<div id="sessions-table-container">${buildSessionsTableHtml(sessions)}</div>`;
+  }
+  function buildSessionsTableHtml(sessions) {
+    const sorted = sortTodaySessions(sessions);
+    const visibleColumns = SESSION_COLUMN_DEFS.filter((c4) => enabledSessionColumns.has(c4.id));
+    const rows = sorted.map((s4, idx) => {
+      const title = escapeHtml(s4.title || "Untitled session");
+      const filePath = escapeHtml(s4.filePath || "");
+      const optionalCells = visibleColumns.map((col) => {
+        const { html, title: cellTitle } = col.render(s4);
+        const alignStyle = col.align === "right" ? "text-align:right;" : "";
+        const titleAttr = cellTitle !== void 0 ? ` title="${cellTitle}"` : "";
+        return `<td style="padding:6px 8px; border-bottom:1px solid var(--border-subtle); font-size:12px; ${alignStyle}${col.cellStyle || ""}"${titleAttr}>${html}</td>`;
+      }).join("");
+      return `<tr>
+			<td style="padding:6px 8px; border-bottom:1px solid var(--border-subtle); font-size:12px; color:var(--text-secondary);">${idx + 1}</td>
+			<td style="padding:6px 8px; border-bottom:1px solid var(--border-subtle); font-size:12px; max-width:200px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;" title="Open viewer for session &quot;${title}&quot;"><a href="#" class="session-title-link" data-file="${filePath}" style="color:var(--link-color, #4fc1ff); text-decoration:none; cursor:pointer;">${title}</a></td>
+			${optionalCells}
+		</tr>`;
+    }).join("");
+    const headerCells = visibleColumns.map((col) => {
+      const alignStyle = col.align === "right" ? " text-align:right;" : "";
+      if (!col.sortKey) {
+        return `<th style="padding:6px 8px;${alignStyle}">${col.label}</th>`;
+      }
+      return `<th class="sortable" data-sort="${col.sortKey}" style="padding:6px 8px;${alignStyle}">${col.label}${getSessionSortIndicator(col.sortKey)}</th>`;
+    }).join("");
+    return `
 		<div style="overflow-x:auto;">
 		<table class="sessions-table" style="width:100%; border-collapse:collapse; min-width:1050px;">
 			<thead>
 				<tr style="color:var(--text-secondary); font-size:11px; text-align:left;">
 					<th style="padding:6px 8px;">#</th>
-					<th class="sortable" data-sort="title" style="padding:6px 8px;">Title${ks("title")}</th>
-					${s}
+					<th class="sortable" data-sort="title" style="padding:6px 8px;">Title${getSessionSortIndicator("title")}</th>
+					${headerCells}
 				</tr>
 			</thead>
 			<tbody>
-				${n}
+				${rows}
 			</tbody>
 		</table>
-		</div>`}function Si(){return`
+		</div>`;
+  }
+  function buildSessionColumnsMenuHtml() {
+    const items = SESSION_COLUMN_DEFS.map((col) => `
+		<label style="display:flex; align-items:center; gap:6px; padding:4px 8px; font-size:12px; white-space:nowrap; cursor:pointer;">
+			<input type="checkbox" data-column="${col.id}"${enabledSessionColumns.has(col.id) ? " checked" : ""} />
+			<span>${col.label}</span>
+		</label>`).join("");
+    return `
 		<div class="columns-menu-wrap" style="position:relative;">
 			<button id="sessions-columns-toggle" type="button" style="font-size:12px; padding:2px 8px; background:var(--vscode-dropdown-background, var(--bg-secondary)); color:var(--vscode-dropdown-foreground, var(--text-primary)); border:1px solid var(--border-subtle); border-radius:4px; cursor:pointer;">\u2699 Columns</button>
 			<div id="sessions-columns-menu" style="display:none; position:absolute; right:0; top:100%; margin-top:4px; z-index:20; background:var(--bg-secondary); border:1px solid var(--border-color); border-radius:6px; box-shadow:0 4px 10px var(--shadow-color); padding:4px 0; min-width:160px;">
-				${jo.map(t=>`
-		<label style="display:flex; align-items:center; gap:6px; padding:4px 8px; font-size:12px; white-space:nowrap; cursor:pointer;">
-			<input type="checkbox" data-column="${t.id}"${Me.has(t.id)?" checked":""} />
-			<span>${t.label}</span>
-		</label>`).join("")}
+				${items}
 			</div>
-		</div>`}function Ls(){let e=document.getElementById("sessions-panel-body");e&&(e.addEventListener("click",t=>{let o=t.target.closest("a.session-title-link");if(o){t.preventDefault();let i=o.getAttribute("data-file");i&&f.postMessage({command:"openSessionFile",file:i});return}let n=t.target.closest("th.sortable");if(!n)return;let s=n.getAttribute("data-sort");if(!s)return;Te===s?ot=ot==="desc"?"asc":"desc":(Te=s,ot="desc");let r=document.getElementById("sessions-table-container");r&&k(r,Wo(Fo))}),Us(),Ti())}var ws=!1;function Ti(){let e=document.getElementById("sessions-columns-toggle"),t=document.getElementById("sessions-columns-menu");!e||!t||(e.addEventListener("click",o=>{o.stopPropagation(),t.style.display=t.style.display==="none"?"block":"none"}),t.addEventListener("click",o=>o.stopPropagation()),t.addEventListener("change",o=>{let n=o.target,s=n.getAttribute("data-column");if(!s)return;n.checked?Me.add(s):Me.delete(s);let r=document.getElementById("sessions-table-container");r&&k(r,Wo(Fo)),xi()}),ws||(ws=!0,document.addEventListener("click",()=>{let o=document.getElementById("sessions-columns-menu");o&&(o.style.display="none")})))}function Us(){let e=document.getElementById("sessions-lookback-wrapper");if(!e)return;e.replaceChildren();let{wrapper:t}=Yt({id:"sessions-lookback",selected:I,disabled:["allTime"],disabledTitle:"All-time sessions are not loaded yet",label:"",onChange:o=>{I=o,zo()}});e.append(t),I!=="today"&&!Ae[I]&&zo()}function zo(){let e=document.getElementById("sessions-panel-body");if(!e)return;if(I==="today"){k(e,Io(Uo));return}let t=Ae[I];if(t){k(e,Io(t));return}k(e,`<div style="color: var(--text-secondary); font-size: 13px; padding: 16px;">Loading sessions for ${pt[I]}\u2026</div>`),f.postMessage({command:"loadRecentSessions",period:I})}function $i(e){let t=e.period;if(!t)return;let o=Array.isArray(e.sessions)?e.sessions.filter(n=>n&&typeof n=="object"&&typeof n.interactions=="number"):[];Ae[t]=o,I===t&&zo()}function Is(e){for(let o of mt)delete Ae[o];let t=Qt(e);if(t)for(let o of mt)Ae[o]=t[o]}function J(e,t){let o={...e};for(let n of t)n in o||(o[n]=0);return o}function x(e){let t=Number(e);return Number.isFinite(t)?t:0}function Ai(e){let t=e&&typeof e=="object"?e:{};return{ask:x(t.ask),edit:x(t.edit),agent:x(t.agent),plan:x(t.plan),customAgent:x(t.customAgent),cli:x(t.cli),cliApp:x(t.cliApp)}}function Mi(e){let t=e&&typeof e=="object"?e:{};return{file:x(t.file),selection:x(t.selection),implicitSelection:x(t.implicitSelection),symbol:x(t.symbol),codebase:x(t.codebase),workspace:x(t.workspace),terminal:x(t.terminal),vscode:x(t.vscode),terminalLastCommand:x(t.terminalLastCommand),terminalSelection:x(t.terminalSelection),clipboard:x(t.clipboard),changes:x(t.changes),outputPanel:x(t.outputPanel),problemsPanel:x(t.problemsPanel),pullRequest:x(t.pullRequest),byKind:t.byKind??{},copilotInstructions:x(t.copilotInstructions),agentsMd:x(t.agentsMd),byPath:t.byPath??{}}}function Pt(e){let t=e&&typeof e=="object"?e:{},o=t.toolCalls&&typeof t.toolCalls=="object"?t.toolCalls:{},n=t.mcpTools&&typeof t.mcpTools=="object"?t.mcpTools:{};return{sessions:x(t.sessions),modeUsage:Ai(t.modeUsage),contextReferences:Mi(t.contextReferences),toolCalls:{total:x(o.total),byTool:o.byTool??{}},mcpTools:{total:x(n.total),byServer:n.byServer??{},byTool:n.byTool??{}},modelSwitching:{modelsPerSession:[],totalSessions:0,averageModelsPerSession:0,maxModelsPerSession:0,minModelsPerSession:0,switchingFrequency:0,standardModels:[],premiumModels:[],unknownModels:[],mixedTierSessions:0,lowCostModels:[],mediumCostModels:[],highCostModels:[],mixedCostSessions:0,standardRequests:0,premiumRequests:0,lowCostRequests:0,mediumCostRequests:0,highCostRequests:0,unknownRequests:0,totalRequests:0,...t.modelSwitching??{}},thinkingEffortUsage:t.thinkingEffortUsage,modelEfficiency:t.modelEfficiency}}function zs(e){return e.filter(t=>t&&typeof t=="object"&&typeof t.id=="string").map(t=>({id:String(t.id),category:typeof t.category=="string"?t.category:"general",severity:["tip","opportunity","celebration"].includes(t.severity)?t.severity:"tip",title:typeof t.title=="string"?t.title:"",body:typeof t.body=="string"?t.body:"",actionLabel:typeof t.actionLabel=="string"?t.actionLabel:void 0,actionCommand:typeof t.actionCommand=="string"?t.actionCommand:void 0,status:["new","seen","dismissed","snoozed","done"].includes(t.status)?t.status:"new",allowToast:!!t.allowToast}))}var Ei=["user-correction","edit-retry","edit-self-correction","tool-error","agent-self-correction"];function Ri(e){return!e||typeof e!="object"||!Ei.includes(e.type)||typeof e.snippet!="string"?null:{type:e.type,turnNumber:typeof e.turnNumber=="number"?e.turnNumber:0,timestamp:typeof e.timestamp=="string"?e.timestamp:null,snippet:e.snippet,tool:typeof e.tool=="string"?e.tool:void 0,file:typeof e.file=="string"?e.file:void 0,retried:e.retried===!0?!0:void 0,matchedPattern:typeof e.matchedPattern=="string"?e.matchedPattern:void 0}}function Bs(e){let t=o=>typeof o=="number"&&isFinite(o)&&o>=0?o:0;return{userCorrections:t(e?.userCorrections),editRetries:t(e?.editRetries),editSelfCorrections:t(e?.editSelfCorrections),toolErrors:t(e?.toolErrors),toolErrorsRetried:t(e?.toolErrorsRetried),agentSelfCorrections:t(e?.agentSelfCorrections)}}function _i(e){if(!e||typeof e!="object"||typeof e.file!="string"||!Array.isArray(e.moments))return null;let t=e.moments.map(Ri).filter(o=>o!==null);return t.length===0?null:{file:e.file,title:typeof e.title=="string"?e.title:null,lastInteraction:typeof e.lastInteraction=="string"?e.lastInteraction:null,moments:t,totalMoments:typeof e.totalMoments=="number"&&isFinite(e.totalMoments)?Math.max(t.length,e.totalMoments):t.length}}function Pi(e){if(!e||typeof e!="object"||typeof e.repository!="string"||!Array.isArray(e.sessions))return null;let t=e.sessions.map(_i).filter(o=>o!==null);return t.length===0?null:{repository:e.repository,sessions:t,counts:Bs(e.counts),sessionsWithMoments:typeof e.sessionsWithMoments=="number"?e.sessionsWithMoments:t.length}}function Di(e){if(!e||typeof e!="object"||!Array.isArray(e.repos))return null;let t=e.repos.map(Pi).filter(o=>o!==null);return t.length===0?null:{sessionsPerRepo:typeof e.sessionsPerRepo=="number"?e.sessionsPerRepo:25,repos:t,counts:Bs(e.counts),sessionsWithMoments:typeof e.sessionsWithMoments=="number"?e.sessionsWithMoments:t.reduce((o,n)=>o+n.sessionsWithMoments,0)}}function Li(e){if(!e||typeof e!="object"||typeof e.representativePrompt!="string"||typeof e.sessionCount!="number"||!Array.isArray(e.sessions))return null;let t=e.sessions.filter(o=>o&&typeof o=="object"&&typeof o.file=="string").map(o=>({file:o.file,title:typeof o.title=="string"?o.title:null,lastInteraction:typeof o.lastInteraction=="string"?o.lastInteraction:null,repository:typeof o.repository=="string"?o.repository:void 0}));return t.length===0?null:{representativePrompt:e.representativePrompt,sessionCount:t.length,repositories:Array.isArray(e.repositories)?e.repositories.filter(o=>typeof o=="string"):[],sessions:t,sharedKeywords:Array.isArray(e.sharedKeywords)?e.sharedKeywords.filter(o=>typeof o=="string"):[]}}function Ui(e){if(!e||typeof e!="object"||!Array.isArray(e.clusters))return null;let t=e.clusters.map(Li).filter(o=>o!==null);return t.length===0?null:{minClusterSize:typeof e.minClusterSize=="number"?e.minClusterSize:2,sessionsScanned:typeof e.sessionsScanned=="number"?e.sessionsScanned:0,clusters:t}}function Ii(e){if(!e||typeof e!="object")return null;let t=e;return{windowDays:typeof t.windowDays=="number"?t.windowDays:30,availableTools:Array.isArray(t.availableTools)?t.availableTools:[],usedTools:Array.isArray(t.usedTools)?t.usedTools:[],unusedTools:Array.isArray(t.unusedTools)?t.unusedTools:[],underusedMcpServers:Array.isArray(t.underusedMcpServers)?t.underusedMcpServers:[],underusedAgentPlugins:Array.isArray(t.underusedAgentPlugins)?t.underusedAgentPlugins:[],estimatedPromptBloat:t.estimatedPromptBloat&&typeof t.estimatedPromptBloat=="object"?t.estimatedPromptBloat:{totalTokens:0,byServer:{}},recommendations:Array.isArray(t.recommendations)?t.recommendations:[]}}function zi(e,t){e.correctionReport=Di(t.correctionReport),e.repeatedTasks=Ui(t.repeatedTasks)}function Bi(e,t){Array.isArray(t.todaySessions)&&(e.todaySessions=t.todaySessions.filter(n=>n&&typeof n=="object"&&typeof n.interactions=="number"));let o=Qt(t.recentSessions);o&&(e.recentSessions=o)}function Oi(e){if(!e||typeof e!="object")return pe("sanitize-invalid-root","sanitizeStats.invalidRoot"),null;try{let t={today:Pt(e.today),last30Days:Pt(e.last30Days),month:Pt(e.month),lastMonth:Pt(e.lastMonth),lastUpdated:typeof e.lastUpdated=="string"?e.lastUpdated:"",backendConfigured:!!e.backendConfigured,locale:typeof e.locale=="string"?e.locale:void 0,currentWorkspacePaths:Array.isArray(e.currentWorkspacePaths)?e.currentWorkspacePaths.filter(s=>typeof s=="string"):void 0,suppressedUnknownTools:Array.isArray(e.suppressedUnknownTools)?e.suppressedUnknownTools.filter(s=>typeof s=="string"):void 0},o=mn(e.customizationMatrix);o&&(t.customizationMatrix=o),Array.isArray(e.missedPotential)&&(t.missedPotential=e.missedPotential.filter(s=>s&&typeof s=="object"&&typeof s.workspacePath=="string")),Bi(t,e),Array.isArray(e.insights)&&(t.insights=zs(e.insights)),zi(t,e);let n=Ii(e.curationAnalysis);return n?(t.curationAnalysis=n,Z("sanitizeStats.curation.present",{availableTools:n.availableTools.length,unusedTools:n.unusedTools.length,unusedServers:n.underusedMcpServers.filter(s=>s&&s.usedToolCount===0).length})):pe("sanitize-no-curation","sanitizeStats.curation.missing"),fn(t,e),t}catch(t){return pe("sanitize-error","sanitizeStats.error",{error:t instanceof Error?t.message:String(t)}),null}}function F(){let e=document.getElementById("worktree-controls");e&&k(e,qs())}function z(){let e=document.getElementById("worktree-results");e&&k(e,Gs())}function Ee(){let e=document.getElementById("worktree-progress-area");e&&k(e,Ws())}function Os(){$o||($o=!0,requestAnimationFrame(()=>{$o=!1,z()}))}function Ns(){let e=document.getElementById("worktree-root-input"),t=e?.value.trim();t&&(U.some(o=>o.toLowerCase()===t.toLowerCase())||U.push(t),e&&(e.value=""),F())}function Ni(){U.length===0||R||W||(R=!0,L=[],Ge=null,rt=null,D={root:"",checked:0,total:0,foundCount:0,elapsedMs:0},re=[],F(),z(),f.postMessage({command:"scanWorktrees",rootPaths:U}))}function Hi(){if(W||fe||R)return;let e=Ks();e.length!==0&&(fe=!0,z(),f.postMessage({command:"cleanupPushedWorktrees",worktrees:e.map(t=>({path:t.path,branch:t.branch,repoLabel:t.repoLabel}))}))}function ji(e){return e.id==="btn-browse-worktree-root"?(f.postMessage({command:"pickWorktreeRoot"}),!0):e.id==="btn-add-worktree-root"?(Ns(),!0):e.id==="btn-scan-worktrees"?(Ni(),!0):e.id==="btn-cancel-worktree-scan"?(f.postMessage({command:"cancelWorktreeScan"}),!0):e.id==="btn-cleanup-pushed-worktrees"?(Hi(),!0):e.id==="btn-cancel-cleanup"?(f.postMessage({command:"cancelCleanupPushedWorktrees"}),!0):!1}function Fi(e){if(e.closest("#btn-toggle-worktree-roots"))return Ve=!Ve,F(),!0;if(e.classList.contains("worktree-remove-root")){let t=Number(e.getAttribute("data-index"));return isNaN(t)||(U.splice(t,1),F()),!0}return!1}function Wi(e,t){let o=t.closest(".worktree-reveal-link");if(o){e.preventDefault();let s=decodeURIComponent(o.getAttribute("data-path")||"");return s&&f.postMessage({command:"revealPath",path:s}),!0}let n=t.closest(".worktree-delete-link");if(n){e.preventDefault();let s=decodeURIComponent(n.getAttribute("data-path")||""),r=decodeURIComponent(n.getAttribute("data-branch")||""),i=decodeURIComponent(n.getAttribute("data-repo")||""),a=n.getAttribute("data-pushed")||"?";return s&&f.postMessage({command:"deleteWorktree",path:s,branch:r,repoLabel:i,pushed:a}),!0}return!1}function qi(e){let t=e.closest("[data-wt-sort]");if(!t)return!1;let o=t.getAttribute("data-wt-sort");return o&&(it===o?Ye=Ye==="desc"?"asc":"desc":(it=o,Ye=o==="repo"?"asc":"desc"),z()),!0}function Ki(e){let t=e.closest(".worktree-repo-row");if(!t)return!1;let o=t.getAttribute("data-repo")??"";return zt.has(o)?zt.delete(o):zt.add(o),z(),!0}function Gi(e){return qi(e)?!0:Ki(e)}function Vi(e){let t=e.target;t&&(ji(t)||Fi(t)||Wi(e,t)||Gi(t))}function Yi(){let e=document.getElementById("tab-panel-worktrees");e&&(e.addEventListener("click",Vi),e.addEventListener("keydown",t=>{t.target?.id==="worktree-root-input"&&t.key==="Enter"&&(t.preventDefault(),Ns())}))}function qo(e){let t=e??{},o=String(t.pushed??"?"),n=o==="yes"||o==="no"?o:"?";return{path:String(t.path??""),repoLabel:String(t.repoLabel??"Unknown"),branch:String(t.branch??"?"),lastCommit:String(t.lastCommit??"?"),lastCommitDate:t.lastCommitDate?String(t.lastCommitDate):null,pushed:n,files:A(t.files),folders:A(t.folders),bytes:A(t.bytes)}}function Ji(e){if(!e.folderPath)return;let t=String(e.folderPath);U.some(o=>o.toLowerCase()===t.toLowerCase())||U.push(t),F()}function Xi(e){if(R||!Array.isArray(e.roots))return;let t=!1;for(let o of e.roots){if(typeof o!="string")continue;let n=o.trim();n&&(U.some(s=>s.toLowerCase()===n.toLowerCase())||(U.push(n),t=!0))}t&&F()}function Zi(){R=!0,L=[],rt=null,D={root:"",checked:0,total:0,foundCount:0,elapsedMs:0},F(),z()}function Qi(e){D={...D,root:String(e.root||""),checked:0,total:0,phase:"walking",dirsScanned:0},Ee()}function ea(e){D={...D,root:String(e.root??D.root),phase:"walking",dirsScanned:A(e.dirsScanned),elapsedMs:A(e.elapsedMs)},Ee()}function ta(e){D={...D,total:A(e.count),phase:"checking"},Ee()}function oa(e){rt=`Skipped "${e.root}": ${e.reason||"not accessible"}`,F()}function na(e){D={root:String(e.root??D.root),checked:A(e.checked),total:e.total!==void 0?A(e.total):D.total,foundCount:A(e.foundCount),elapsedMs:A(e.elapsedMs)},Ee()}function sa(e){e.worktree&&(L.push(qo(e.worktree)),Os())}function ra(e){let t=String(e.path??"");if(!t)return;let o=L.findIndex(n=>n.path===t);o!==-1&&(L.splice(o,1),z())}function ia(){fe=!1,z()}function aa(e){fe=!1,W=!0,Oo={processed:0,total:A(e.total)},re=[],z()}function la(e){Oo={processed:A(e.processed),total:A(e.total)};let t=e.status,o=t==="deleted"||t==="skipped"?t:"error";re.push({path:String(e.path??""),branch:String(e.branch??"?"),repoLabel:String(e.repoLabel??""),status:o,reason:typeof e.reason=="string"?e.reason:void 0}),z()}function da(){W=!1,z()}function ca(){W=!1,fe=!1,z()}function ua(e){D={...D,phase:"enriching",enriched:0,enrichTotal:A(e.total),elapsedMs:A(e.elapsedMs)},Ee()}function pa(e){D={...D,phase:"enriching",enriched:A(e.enriched),enrichTotal:A(e.total),elapsedMs:A(e.elapsedMs)},Ee()}function ga(e){let t=String(e.path??"");if(!t)return;let o=L.find(s=>s.path===t);if(!o)return;o.files=A(e.files),o.folders=A(e.folders),o.bytes=A(e.bytes);let n=String(e.pushed??"?");o.pushed=n==="yes"||n==="no"?n:"?",Os()}function ma(){R=!1,F(),z()}function fa(){R=!1,F()}function ba(e){if(R||W)return;L=(Array.isArray(e.worktrees)?e.worktrees:[]).map(qo),Ge={scannedAt:String(e.scannedAt??""),totalBytes:A(e.totalBytes)},F(),z()}var ya={worktreeRootPicked:Ji,worktreeRootsDiscovered:Xi,worktreeScanStarted:()=>Zi(),worktreeScanRootStarted:Qi,worktreeScanWalkProgress:ea,worktreeScanRootMarkersFound:ta,worktreeScanRootSkipped:oa,worktreeScanProgress:na,worktreeFound:sa,worktreeEnrichStarted:ua,worktreeEnrichProgress:pa,worktreeEnriched:ga,worktreeDeleted:ra,worktreeScanComplete:()=>ma(),worktreeScanCancelled:()=>fa(),worktreeBackgroundResults:ba,cleanupDeclined:()=>ia(),cleanupStarted:aa,cleanupWorktreeResult:la,cleanupComplete:()=>da(),cleanupCancelled:()=>ca()};function ha(e){let t=ya[e.command];t&&t(e)}function va(){let e=document.querySelectorAll(".tab-button");e.forEach(t=>{t.addEventListener("click",()=>{let o=t.getAttribute("data-tab");if(!o)return;$=o,e.forEach(s=>s.classList.toggle("active",s.getAttribute("data-tab")===o)),document.querySelectorAll(".tab-panel").forEach(s=>{s.style.display="none"});let n=document.getElementById(`tab-panel-${o}`);n&&(n.style.display="block"),o==="repos"&&!Do&&(Do=!0,f.postMessage({command:"loadRepoPrStats"})),o==="agent"&&!Lo&&(Lo=!0,f.postMessage({command:"loadAgentSessions"})),o==="insights"&&Bo.filter(s=>s.status==="new").forEach(s=>f.postMessage({command:"insightAction",id:s.id,action:"seen"}))})})}function xa(e){let t=e&&typeof e=="object"?e:{},o=Array.isArray(t.repos)?t.repos:[];return{authenticated:!!t.authenticated,since:typeof t.since=="string"||typeof t.since=="number"?t.since:Date.now(),error:typeof t.error=="string"?d(t.error):void 0,repos:o.map(n=>{let s=n&&typeof n=="object"?n:{},r=Array.isArray(s.aiDetails)?s.aiDetails:[];return{repoUrl:vt(s.repoUrl),owner:d(typeof s.owner=="string"?s.owner:""),repo:d(typeof s.repo=="string"?s.repo:""),error:typeof s.error=="string"?d(s.error):"",totalPrs:_(s.totalPrs),aiAuthoredPrs:_(s.aiAuthoredPrs),aiReviewRequestedPrs:_(s.aiReviewRequestedPrs),userAuthoredPrs:_(s.userAuthoredPrs),userMergedPrs:_(s.userMergedPrs),aiDetails:r.map(i=>{let a=i&&typeof i=="object"?i:{},l=["copilot","claude","openai","other-ai"],u=["author","reviewer-requested"],c=l.includes(a.aiType)?a.aiType:"other-ai",p=u.includes(a.role)?a.role:"author";return{number:_(a.number),title:d(typeof a.title=="string"?a.title:""),url:vt(a.url),aiType:c,role:p}})}})}}var ka={copilot:"\u{1F916} Copilot",claude:"\u{1F9E0} Claude",openai:"\u2728 Codex","other-ai":"\u{1F916} AI"};function wa(e,t,o){let n=`<a href="${d(e.repoUrl)}" target="_blank" rel="noopener noreferrer" style="color:var(--link-color); font-family:'Courier New',monospace; font-size:12px;">${d(e.owner)}/${d(e.repo)}</a>`;if(e.error)return`<tr>
-			<td style="${t} font-family:'Courier New',monospace; font-size:12px;">${n}</td>
-			<td colspan="4" style="${t} color:var(--text-secondary); font-style:italic; font-size:12px;">${d(e.error)}</td>
-		</tr>`;let s="";if(e.aiDetails.length>0){let i=e.aiDetails.map(a=>`<li><a href="${d(a.url)}" target="_blank" rel="noopener noreferrer" style="color:var(--link-color);">#${a.number} ${d(a.title)}</a> \u2014 ${ka[a.aiType]??d(String(a.aiType))} (${a.role==="author"?"authored":"review requested"})</li>`).join("");s=`
+		</div>`;
+  }
+  function setupSessionsTableSort() {
+    const body = document.getElementById("sessions-panel-body");
+    if (!body) {
+      return;
+    }
+    body.addEventListener("click", (e7) => {
+      const link = e7.target.closest("a.session-title-link");
+      if (link) {
+        e7.preventDefault();
+        const file = link.getAttribute("data-file");
+        if (file) {
+          vscode.postMessage({ command: "openSessionFile", file });
+        }
+        return;
+      }
+      const th = e7.target.closest("th.sortable");
+      if (!th) {
+        return;
+      }
+      const col = th.getAttribute("data-sort");
+      if (!col) {
+        return;
+      }
+      if (sessionSortColumn === col) {
+        sessionSortDirection = sessionSortDirection === "desc" ? "asc" : "desc";
+      } else {
+        sessionSortColumn = col;
+        sessionSortDirection = "desc";
+      }
+      const container = document.getElementById("sessions-table-container");
+      if (container) {
+        setHtml(container, buildSessionsTableHtml(cachedTodaySessions));
+      }
+    });
+    renderSessionsLookbackSelector();
+    setupSessionColumnsMenu();
+  }
+  var _documentClickClosesColumnsMenu = false;
+  function setupSessionColumnsMenu() {
+    const toggle = document.getElementById("sessions-columns-toggle");
+    const menu = document.getElementById("sessions-columns-menu");
+    if (!toggle || !menu) {
+      return;
+    }
+    toggle.addEventListener("click", (e7) => {
+      e7.stopPropagation();
+      menu.style.display = menu.style.display === "none" ? "block" : "none";
+    });
+    menu.addEventListener("click", (e7) => e7.stopPropagation());
+    menu.addEventListener("change", (e7) => {
+      const checkbox = e7.target;
+      const columnId = checkbox.getAttribute("data-column");
+      if (!columnId) {
+        return;
+      }
+      if (checkbox.checked) {
+        enabledSessionColumns.add(columnId);
+      } else {
+        enabledSessionColumns.delete(columnId);
+      }
+      const container = document.getElementById("sessions-table-container");
+      if (container) {
+        setHtml(container, buildSessionsTableHtml(cachedTodaySessions));
+      }
+      saveSessionColumnSettings();
+    });
+    if (!_documentClickClosesColumnsMenu) {
+      _documentClickClosesColumnsMenu = true;
+      document.addEventListener("click", () => {
+        const liveMenu = document.getElementById("sessions-columns-menu");
+        if (liveMenu) {
+          liveMenu.style.display = "none";
+        }
+      });
+    }
+  }
+  function renderSessionsLookbackSelector() {
+    const wrapper = document.getElementById("sessions-lookback-wrapper");
+    if (!wrapper) {
+      return;
+    }
+    wrapper.replaceChildren();
+    const { wrapper: selectorWrapper } = createPeriodSelector({
+      id: "sessions-lookback",
+      selected: sessionsLookback,
+      disabled: ["allTime"],
+      disabledTitle: "All-time sessions are not loaded yet",
+      label: "",
+      onChange: (value) => {
+        sessionsLookback = value;
+        refreshSessionsPanelBody();
+      }
+    });
+    wrapper.append(selectorWrapper);
+    if (sessionsLookback !== "today" && !recentSessionsCache[sessionsLookback]) {
+      refreshSessionsPanelBody();
+    }
+  }
+  function refreshSessionsPanelBody() {
+    const body = document.getElementById("sessions-panel-body");
+    if (!body) {
+      return;
+    }
+    if (sessionsLookback === "today") {
+      setHtml(body, renderTodaySessionsTable(latestTodaySessions));
+      return;
+    }
+    const cached = recentSessionsCache[sessionsLookback];
+    if (cached) {
+      setHtml(body, renderTodaySessionsTable(cached));
+      return;
+    }
+    setHtml(body, `<div style="color: var(--text-secondary); font-size: 13px; padding: 16px;">Loading sessions for ${PERIOD_LABELS[sessionsLookback]}\u2026</div>`);
+    vscode.postMessage({ command: "loadRecentSessions", period: sessionsLookback });
+  }
+  function handleRecentSessionsLoaded(message) {
+    const period = message.period;
+    if (!period) {
+      return;
+    }
+    const sessions = Array.isArray(message.sessions) ? message.sessions.filter((s4) => s4 && typeof s4 === "object" && typeof s4.interactions === "number") : [];
+    recentSessionsCache[period] = sessions;
+    if (sessionsLookback === period) {
+      refreshSessionsPanelBody();
+    }
+  }
+  function replaceRecentSessionsCache(raw) {
+    for (const period of RECENT_SESSION_PERIODS) {
+      delete recentSessionsCache[period];
+    }
+    const buckets = sanitizeRecentSessionBuckets(raw);
+    if (!buckets) {
+      return;
+    }
+    for (const period of RECENT_SESSION_PERIODS) {
+      recentSessionsCache[period] = buckets[period];
+    }
+  }
+  function unionFill(map, keys) {
+    const result = { ...map };
+    for (const k2 of keys) {
+      if (!(k2 in result)) {
+        result[k2] = 0;
+      }
+    }
+    return result;
+  }
+  function coerceNumber2(value) {
+    const n5 = Number(value);
+    return Number.isFinite(n5) ? n5 : 0;
+  }
+  function sanitizeModeUsage(mode) {
+    const m2 = mode && typeof mode === "object" ? mode : {};
+    return {
+      ask: coerceNumber2(m2.ask),
+      edit: coerceNumber2(m2.edit),
+      agent: coerceNumber2(m2.agent),
+      plan: coerceNumber2(m2.plan),
+      customAgent: coerceNumber2(m2.customAgent),
+      cli: coerceNumber2(m2.cli),
+      cliApp: coerceNumber2(m2.cliApp)
+    };
+  }
+  function sanitizeContextRefs(refs) {
+    const r6 = refs && typeof refs === "object" ? refs : {};
+    return {
+      file: coerceNumber2(r6.file),
+      selection: coerceNumber2(r6.selection),
+      implicitSelection: coerceNumber2(r6.implicitSelection),
+      symbol: coerceNumber2(r6.symbol),
+      codebase: coerceNumber2(r6.codebase),
+      workspace: coerceNumber2(r6.workspace),
+      terminal: coerceNumber2(r6.terminal),
+      vscode: coerceNumber2(r6.vscode),
+      terminalLastCommand: coerceNumber2(r6.terminalLastCommand),
+      terminalSelection: coerceNumber2(r6.terminalSelection),
+      clipboard: coerceNumber2(r6.clipboard),
+      changes: coerceNumber2(r6.changes),
+      outputPanel: coerceNumber2(r6.outputPanel),
+      problemsPanel: coerceNumber2(r6.problemsPanel),
+      pullRequest: coerceNumber2(r6.pullRequest),
+      byKind: r6.byKind ?? {},
+      copilotInstructions: coerceNumber2(r6.copilotInstructions),
+      agentsMd: coerceNumber2(r6.agentsMd),
+      byPath: r6.byPath ?? {}
+    };
+  }
+  function sanitizePeriod(period) {
+    const p3 = period && typeof period === "object" ? period : {};
+    const toolCalls = p3.toolCalls && typeof p3.toolCalls === "object" ? p3.toolCalls : {};
+    const mcpTools = p3.mcpTools && typeof p3.mcpTools === "object" ? p3.mcpTools : {};
+    return {
+      sessions: coerceNumber2(p3.sessions),
+      modeUsage: sanitizeModeUsage(p3.modeUsage),
+      contextReferences: sanitizeContextRefs(p3.contextReferences),
+      toolCalls: {
+        total: coerceNumber2(toolCalls.total),
+        byTool: toolCalls.byTool ?? {}
+      },
+      mcpTools: {
+        total: coerceNumber2(mcpTools.total),
+        byServer: mcpTools.byServer ?? {},
+        byTool: mcpTools.byTool ?? {}
+      },
+      modelSwitching: {
+        modelsPerSession: [],
+        totalSessions: 0,
+        averageModelsPerSession: 0,
+        maxModelsPerSession: 0,
+        minModelsPerSession: 0,
+        switchingFrequency: 0,
+        standardModels: [],
+        premiumModels: [],
+        unknownModels: [],
+        mixedTierSessions: 0,
+        lowCostModels: [],
+        mediumCostModels: [],
+        highCostModels: [],
+        mixedCostSessions: 0,
+        standardRequests: 0,
+        premiumRequests: 0,
+        lowCostRequests: 0,
+        mediumCostRequests: 0,
+        highCostRequests: 0,
+        unknownRequests: 0,
+        totalRequests: 0,
+        ...p3.modelSwitching ?? {}
+      },
+      thinkingEffortUsage: p3.thinkingEffortUsage,
+      modelEfficiency: p3.modelEfficiency
+    };
+  }
+  function sanitizeInsights(rawInsights) {
+    return rawInsights.filter((i6) => i6 && typeof i6 === "object" && typeof i6.id === "string").map((i6) => ({
+      id: String(i6.id),
+      category: typeof i6.category === "string" ? i6.category : "general",
+      severity: ["tip", "opportunity", "celebration"].includes(i6.severity) ? i6.severity : "tip",
+      title: typeof i6.title === "string" ? i6.title : "",
+      body: typeof i6.body === "string" ? i6.body : "",
+      actionLabel: typeof i6.actionLabel === "string" ? i6.actionLabel : void 0,
+      actionCommand: typeof i6.actionCommand === "string" ? i6.actionCommand : void 0,
+      status: ["new", "seen", "dismissed", "snoozed", "done"].includes(i6.status) ? i6.status : "new",
+      allowToast: !!i6.allowToast
+    }));
+  }
+  var CORRECTION_MOMENT_TYPES = ["user-correction", "edit-retry", "edit-self-correction", "tool-error", "agent-self-correction"];
+  function sanitizeCorrectionMoment(raw) {
+    if (!raw || typeof raw !== "object") {
+      return null;
+    }
+    if (!CORRECTION_MOMENT_TYPES.includes(raw.type) || typeof raw.snippet !== "string") {
+      return null;
+    }
+    return {
+      type: raw.type,
+      turnNumber: typeof raw.turnNumber === "number" ? raw.turnNumber : 0,
+      timestamp: typeof raw.timestamp === "string" ? raw.timestamp : null,
+      snippet: raw.snippet,
+      tool: typeof raw.tool === "string" ? raw.tool : void 0,
+      file: typeof raw.file === "string" ? raw.file : void 0,
+      retried: raw.retried === true ? true : void 0,
+      matchedPattern: typeof raw.matchedPattern === "string" ? raw.matchedPattern : void 0
+    };
+  }
+  function sanitizeCorrectionCounts(raw) {
+    const num = (v2) => typeof v2 === "number" && isFinite(v2) && v2 >= 0 ? v2 : 0;
+    return {
+      userCorrections: num(raw?.userCorrections),
+      editRetries: num(raw?.editRetries),
+      editSelfCorrections: num(raw?.editSelfCorrections),
+      toolErrors: num(raw?.toolErrors),
+      toolErrorsRetried: num(raw?.toolErrorsRetried),
+      agentSelfCorrections: num(raw?.agentSelfCorrections)
+    };
+  }
+  function sanitizeCorrectionSession(raw) {
+    if (!raw || typeof raw !== "object" || typeof raw.file !== "string" || !Array.isArray(raw.moments)) {
+      return null;
+    }
+    const moments = raw.moments.map(sanitizeCorrectionMoment).filter((m2) => m2 !== null);
+    if (moments.length === 0) {
+      return null;
+    }
+    return {
+      file: raw.file,
+      title: typeof raw.title === "string" ? raw.title : null,
+      lastInteraction: typeof raw.lastInteraction === "string" ? raw.lastInteraction : null,
+      moments,
+      totalMoments: typeof raw.totalMoments === "number" && isFinite(raw.totalMoments) ? Math.max(moments.length, raw.totalMoments) : moments.length
+    };
+  }
+  function sanitizeCorrectionRepoGroup(raw) {
+    if (!raw || typeof raw !== "object" || typeof raw.repository !== "string" || !Array.isArray(raw.sessions)) {
+      return null;
+    }
+    const sessions = raw.sessions.map(sanitizeCorrectionSession).filter((s4) => s4 !== null);
+    if (sessions.length === 0) {
+      return null;
+    }
+    return {
+      repository: raw.repository,
+      sessions,
+      counts: sanitizeCorrectionCounts(raw.counts),
+      sessionsWithMoments: typeof raw.sessionsWithMoments === "number" ? raw.sessionsWithMoments : sessions.length
+    };
+  }
+  function sanitizeCorrectionReport(raw) {
+    if (!raw || typeof raw !== "object" || !Array.isArray(raw.repos)) {
+      return null;
+    }
+    const repos = raw.repos.map(sanitizeCorrectionRepoGroup).filter((r6) => r6 !== null);
+    if (repos.length === 0) {
+      return null;
+    }
+    return {
+      sessionsPerRepo: typeof raw.sessionsPerRepo === "number" ? raw.sessionsPerRepo : 25,
+      repos,
+      counts: sanitizeCorrectionCounts(raw.counts),
+      sessionsWithMoments: typeof raw.sessionsWithMoments === "number" ? raw.sessionsWithMoments : repos.reduce((n5, g2) => n5 + g2.sessionsWithMoments, 0)
+    };
+  }
+  function sanitizeRepeatedTaskCluster(raw) {
+    if (!raw || typeof raw !== "object") {
+      return null;
+    }
+    if (typeof raw.representativePrompt !== "string" || typeof raw.sessionCount !== "number" || !Array.isArray(raw.sessions)) {
+      return null;
+    }
+    const sessions = raw.sessions.filter((s4) => s4 && typeof s4 === "object" && typeof s4.file === "string").map((s4) => ({
+      file: s4.file,
+      title: typeof s4.title === "string" ? s4.title : null,
+      lastInteraction: typeof s4.lastInteraction === "string" ? s4.lastInteraction : null,
+      repository: typeof s4.repository === "string" ? s4.repository : void 0
+    }));
+    if (sessions.length === 0) {
+      return null;
+    }
+    return {
+      representativePrompt: raw.representativePrompt,
+      // Derive from the sanitized session list so the UI count can never
+      // disagree with it (and NaN/float counts are impossible).
+      sessionCount: sessions.length,
+      repositories: Array.isArray(raw.repositories) ? raw.repositories.filter((r6) => typeof r6 === "string") : [],
+      sessions,
+      sharedKeywords: Array.isArray(raw.sharedKeywords) ? raw.sharedKeywords.filter((k2) => typeof k2 === "string") : []
+    };
+  }
+  function sanitizeRepeatedTaskReport(raw) {
+    if (!raw || typeof raw !== "object" || !Array.isArray(raw.clusters)) {
+      return null;
+    }
+    const clusters = raw.clusters.map(sanitizeRepeatedTaskCluster).filter((c4) => c4 !== null);
+    if (clusters.length === 0) {
+      return null;
+    }
+    return {
+      minClusterSize: typeof raw.minClusterSize === "number" ? raw.minClusterSize : 2,
+      sessionsScanned: typeof raw.sessionsScanned === "number" ? raw.sessionsScanned : 0,
+      clusters
+    };
+  }
+  function _sanitizeCurationAnalysis(rawCa) {
+    if (!rawCa || typeof rawCa !== "object") {
+      return null;
+    }
+    const ca = rawCa;
+    return {
+      windowDays: typeof ca.windowDays === "number" ? ca.windowDays : 30,
+      availableTools: Array.isArray(ca.availableTools) ? ca.availableTools : [],
+      usedTools: Array.isArray(ca.usedTools) ? ca.usedTools : [],
+      unusedTools: Array.isArray(ca.unusedTools) ? ca.unusedTools : [],
+      underusedMcpServers: Array.isArray(ca.underusedMcpServers) ? ca.underusedMcpServers : [],
+      underusedAgentPlugins: Array.isArray(ca.underusedAgentPlugins) ? ca.underusedAgentPlugins : [],
+      estimatedPromptBloat: ca.estimatedPromptBloat && typeof ca.estimatedPromptBloat === "object" ? ca.estimatedPromptBloat : { totalTokens: 0, byServer: {} },
+      recommendations: Array.isArray(ca.recommendations) ? ca.recommendations : []
+    };
+  }
+  function sanitizeOptionalReports(sanitized, raw) {
+    sanitized.correctionReport = sanitizeCorrectionReport(raw.correctionReport);
+    sanitized.repeatedTasks = sanitizeRepeatedTaskReport(raw.repeatedTasks);
+  }
+  function applySessionSummaries(sanitized, raw) {
+    if (Array.isArray(raw.todaySessions)) {
+      sanitized.todaySessions = raw.todaySessions.filter(
+        (session) => session && typeof session === "object" && typeof session.interactions === "number"
+      );
+    }
+    const recentSessions = sanitizeRecentSessionBuckets(raw.recentSessions);
+    if (recentSessions) {
+      sanitized.recentSessions = recentSessions;
+    }
+  }
+  function sanitizeStats(raw) {
+    if (!raw || typeof raw !== "object") {
+      traceCurationOnce("sanitize-invalid-root", "sanitizeStats.invalidRoot");
+      return null;
+    }
+    try {
+      const sanitized = {
+        today: sanitizePeriod(raw.today),
+        last30Days: sanitizePeriod(raw.last30Days),
+        month: sanitizePeriod(raw.month),
+        lastMonth: sanitizePeriod(raw.lastMonth),
+        lastUpdated: typeof raw.lastUpdated === "string" ? raw.lastUpdated : "",
+        backendConfigured: !!raw.backendConfigured,
+        locale: typeof raw.locale === "string" ? raw.locale : void 0,
+        currentWorkspacePaths: Array.isArray(raw.currentWorkspacePaths) ? raw.currentWorkspacePaths.filter((p3) => typeof p3 === "string") : void 0,
+        suppressedUnknownTools: Array.isArray(raw.suppressedUnknownTools) ? raw.suppressedUnknownTools.filter((t4) => typeof t4 === "string") : void 0
+      };
+      const safeMatrix = sanitizeCustomizationMatrix(raw.customizationMatrix);
+      if (safeMatrix) {
+        sanitized.customizationMatrix = safeMatrix;
+      }
+      if (Array.isArray(raw.missedPotential)) {
+        sanitized.missedPotential = raw.missedPotential.filter(
+          (w2) => w2 && typeof w2 === "object" && typeof w2.workspacePath === "string"
+        );
+      }
+      applySessionSummaries(sanitized, raw);
+      if (Array.isArray(raw.insights)) {
+        sanitized.insights = sanitizeInsights(raw.insights);
+      }
+      sanitizeOptionalReports(sanitized, raw);
+      const curationAnalysis = _sanitizeCurationAnalysis(raw.curationAnalysis);
+      if (curationAnalysis) {
+        sanitized.curationAnalysis = curationAnalysis;
+        traceCuration("sanitizeStats.curation.present", {
+          availableTools: curationAnalysis.availableTools.length,
+          unusedTools: curationAnalysis.unusedTools.length,
+          unusedServers: curationAnalysis.underusedMcpServers.filter((s4) => s4 && s4.usedToolCount === 0).length
+        });
+      } else {
+        traceCurationOnce("sanitize-no-curation", "sanitizeStats.curation.missing");
+      }
+      applyBillingFields(sanitized, raw);
+      return sanitized;
+    } catch (error) {
+      traceCurationOnce("sanitize-error", "sanitizeStats.error", {
+        error: error instanceof Error ? error.message : String(error)
+      });
+      return null;
+    }
+  }
+  function updateWorktreeControls() {
+    const controlsEl = document.getElementById("worktree-controls");
+    if (controlsEl) {
+      setHtml(controlsEl, renderWorktreeControls());
+    }
+  }
+  function updateWorktreeResults() {
+    const resultsEl = document.getElementById("worktree-results");
+    if (resultsEl) {
+      setHtml(resultsEl, renderWorktreeResults());
+    }
+  }
+  function updateWorktreeProgressArea() {
+    const el2 = document.getElementById("worktree-progress-area");
+    if (el2) {
+      setHtml(el2, renderWorktreeProgress());
+    }
+  }
+  function scheduleWorktreeResultsRender() {
+    if (worktreeRenderPending) {
+      return;
+    }
+    worktreeRenderPending = true;
+    requestAnimationFrame(() => {
+      worktreeRenderPending = false;
+      updateWorktreeResults();
+    });
+  }
+  function addWorktreeRootFromInput() {
+    const input = document.getElementById("worktree-root-input");
+    const value = input?.value.trim();
+    if (!value) {
+      return;
+    }
+    if (!worktreeRoots.some((r6) => r6.toLowerCase() === value.toLowerCase())) {
+      worktreeRoots.push(value);
+    }
+    if (input) {
+      input.value = "";
+    }
+    updateWorktreeControls();
+  }
+  function startWorktreeScan() {
+    if (worktreeRoots.length === 0 || worktreeScanInProgress || worktreeCleanupInProgress) {
+      return;
+    }
+    worktreeScanInProgress = true;
+    worktreeResults = [];
+    worktreeBackgroundScanMeta = null;
+    worktreeScanError = null;
+    worktreeScanStatus = { root: "", checked: 0, total: 0, foundCount: 0, elapsedMs: 0 };
+    worktreeCleanupLog = [];
+    updateWorktreeControls();
+    updateWorktreeResults();
+    vscode.postMessage({ command: "scanWorktrees", rootPaths: worktreeRoots });
+  }
+  function startWorktreeCleanup() {
+    if (worktreeCleanupInProgress || worktreeCleanupConfirmPending || worktreeScanInProgress) {
+      return;
+    }
+    const targets = getCleanupCandidates();
+    if (targets.length === 0) {
+      return;
+    }
+    worktreeCleanupConfirmPending = true;
+    updateWorktreeResults();
+    vscode.postMessage({
+      command: "cleanupPushedWorktrees",
+      worktrees: targets.map((w2) => ({ path: w2.path, branch: w2.branch, repoLabel: w2.repoLabel }))
+    });
+  }
+  function _handleWorktreeActionButtonClick(target) {
+    if (target.id === "btn-browse-worktree-root") {
+      vscode.postMessage({ command: "pickWorktreeRoot" });
+      return true;
+    }
+    if (target.id === "btn-add-worktree-root") {
+      addWorktreeRootFromInput();
+      return true;
+    }
+    if (target.id === "btn-scan-worktrees") {
+      startWorktreeScan();
+      return true;
+    }
+    if (target.id === "btn-cancel-worktree-scan") {
+      vscode.postMessage({ command: "cancelWorktreeScan" });
+      return true;
+    }
+    if (target.id === "btn-cleanup-pushed-worktrees") {
+      startWorktreeCleanup();
+      return true;
+    }
+    if (target.id === "btn-cancel-cleanup") {
+      vscode.postMessage({ command: "cancelCleanupPushedWorktrees" });
+      return true;
+    }
+    return false;
+  }
+  function _handleWorktreeRootsListClick(target) {
+    if (target.closest("#btn-toggle-worktree-roots")) {
+      worktreeRootsExpanded = !worktreeRootsExpanded;
+      updateWorktreeControls();
+      return true;
+    }
+    if (target.classList.contains("worktree-remove-root")) {
+      const idx = Number(target.getAttribute("data-index"));
+      if (!isNaN(idx)) {
+        worktreeRoots.splice(idx, 1);
+        updateWorktreeControls();
+      }
+      return true;
+    }
+    return false;
+  }
+  function _handleWorktreeRowLinkClick(event, target) {
+    const revealLink = target.closest(".worktree-reveal-link");
+    if (revealLink) {
+      event.preventDefault();
+      const p3 = decodeURIComponent(revealLink.getAttribute("data-path") || "");
+      if (p3) {
+        vscode.postMessage({ command: "revealPath", path: p3 });
+      }
+      return true;
+    }
+    const deleteLink = target.closest(".worktree-delete-link");
+    if (deleteLink) {
+      event.preventDefault();
+      const p3 = decodeURIComponent(deleteLink.getAttribute("data-path") || "");
+      const branch = decodeURIComponent(deleteLink.getAttribute("data-branch") || "");
+      const repoLabel = decodeURIComponent(deleteLink.getAttribute("data-repo") || "");
+      const pushed = deleteLink.getAttribute("data-pushed") || "?";
+      if (p3) {
+        vscode.postMessage({ command: "deleteWorktree", path: p3, branch, repoLabel, pushed });
+      }
+      return true;
+    }
+    return false;
+  }
+  function _handleWorktreeSortHeaderClick(target) {
+    const sortHeader = target.closest("[data-wt-sort]");
+    if (!sortHeader) {
+      return false;
+    }
+    const col = sortHeader.getAttribute("data-wt-sort");
+    if (!col) {
+      return true;
+    }
+    if (worktreeSortColumn === col) {
+      worktreeSortDir = worktreeSortDir === "desc" ? "asc" : "desc";
+    } else {
+      worktreeSortColumn = col;
+      worktreeSortDir = col === "repo" ? "asc" : "desc";
+    }
+    updateWorktreeResults();
+    return true;
+  }
+  function _handleWorktreeRepoRowClick(target) {
+    const repoRow = target.closest(".worktree-repo-row");
+    if (!repoRow) {
+      return false;
+    }
+    const repo = repoRow.getAttribute("data-repo") ?? "";
+    if (worktreeExpandedRepos.has(repo)) {
+      worktreeExpandedRepos.delete(repo);
+    } else {
+      worktreeExpandedRepos.add(repo);
+    }
+    updateWorktreeResults();
+    return true;
+  }
+  function _handleWorktreeTableInteractionClick(target) {
+    if (_handleWorktreeSortHeaderClick(target)) {
+      return true;
+    }
+    return _handleWorktreeRepoRowClick(target);
+  }
+  function handleWorktreeTabClick(event) {
+    const target = event.target;
+    if (!target) {
+      return;
+    }
+    if (_handleWorktreeActionButtonClick(target)) {
+      return;
+    }
+    if (_handleWorktreeRootsListClick(target)) {
+      return;
+    }
+    if (_handleWorktreeRowLinkClick(event, target)) {
+      return;
+    }
+    _handleWorktreeTableInteractionClick(target);
+  }
+  function setupWorktreesHandlers() {
+    const tabEl = document.getElementById("tab-panel-worktrees");
+    if (!tabEl) {
+      return;
+    }
+    tabEl.addEventListener("click", handleWorktreeTabClick);
+    tabEl.addEventListener("keydown", (event) => {
+      const target = event.target;
+      if (target?.id === "worktree-root-input" && event.key === "Enter") {
+        event.preventDefault();
+        addWorktreeRootFromInput();
+      }
+    });
+  }
+  function sanitizeWorktreeResult(item) {
+    const w2 = item ?? {};
+    const pushedRaw = String(w2.pushed ?? "?");
+    const pushed = pushedRaw === "yes" || pushedRaw === "no" ? pushedRaw : "?";
+    return {
+      path: String(w2.path ?? ""),
+      repoLabel: String(w2.repoLabel ?? "Unknown"),
+      branch: String(w2.branch ?? "?"),
+      lastCommit: String(w2.lastCommit ?? "?"),
+      lastCommitDate: w2.lastCommitDate ? String(w2.lastCommitDate) : null,
+      pushed,
+      files: numField(w2.files),
+      folders: numField(w2.folders),
+      bytes: numField(w2.bytes)
+    };
+  }
+  function handleWorktreeRootPicked(message) {
+    if (!message.folderPath) {
+      return;
+    }
+    const folderPath = String(message.folderPath);
+    if (!worktreeRoots.some((r6) => r6.toLowerCase() === folderPath.toLowerCase())) {
+      worktreeRoots.push(folderPath);
+    }
+    updateWorktreeControls();
+  }
+  function handleWorktreeRootsDiscovered(message) {
+    if (worktreeScanInProgress || !Array.isArray(message.roots)) {
+      return;
+    }
+    let added = false;
+    for (const raw of message.roots) {
+      if (typeof raw !== "string") {
+        continue;
+      }
+      const root = raw.trim();
+      if (!root) {
+        continue;
+      }
+      if (!worktreeRoots.some((r6) => r6.toLowerCase() === root.toLowerCase())) {
+        worktreeRoots.push(root);
+        added = true;
+      }
+    }
+    if (added) {
+      updateWorktreeControls();
+    }
+  }
+  function handleWorktreeScanStarted() {
+    worktreeScanInProgress = true;
+    worktreeResults = [];
+    worktreeScanError = null;
+    worktreeScanStatus = { root: "", checked: 0, total: 0, foundCount: 0, elapsedMs: 0 };
+    updateWorktreeControls();
+    updateWorktreeResults();
+  }
+  function handleWorktreeScanRootStarted(message) {
+    worktreeScanStatus = { ...worktreeScanStatus, root: String(message.root || ""), checked: 0, total: 0, phase: "walking", dirsScanned: 0 };
+    updateWorktreeProgressArea();
+  }
+  function handleWorktreeScanWalkProgress(message) {
+    worktreeScanStatus = {
+      ...worktreeScanStatus,
+      root: String(message.root ?? worktreeScanStatus.root),
+      phase: "walking",
+      dirsScanned: numField(message.dirsScanned),
+      elapsedMs: numField(message.elapsedMs)
+    };
+    updateWorktreeProgressArea();
+  }
+  function handleWorktreeScanRootMarkersFound(message) {
+    worktreeScanStatus = { ...worktreeScanStatus, total: numField(message.count), phase: "checking" };
+    updateWorktreeProgressArea();
+  }
+  function handleWorktreeScanRootSkipped(message) {
+    worktreeScanError = `Skipped "${message.root}": ${message.reason || "not accessible"}`;
+    updateWorktreeControls();
+  }
+  function handleWorktreeScanProgress(message) {
+    worktreeScanStatus = {
+      root: String(message.root ?? worktreeScanStatus.root),
+      checked: numField(message.checked),
+      total: message.total !== void 0 ? numField(message.total) : worktreeScanStatus.total,
+      foundCount: numField(message.foundCount),
+      elapsedMs: numField(message.elapsedMs)
+    };
+    updateWorktreeProgressArea();
+  }
+  function handleWorktreeFound(message) {
+    if (!message.worktree) {
+      return;
+    }
+    worktreeResults.push(sanitizeWorktreeResult(message.worktree));
+    scheduleWorktreeResultsRender();
+  }
+  function handleWorktreeDeleted(message) {
+    const targetPath = String(message.path ?? "");
+    if (!targetPath) {
+      return;
+    }
+    const idx = worktreeResults.findIndex((w2) => w2.path === targetPath);
+    if (idx === -1) {
+      return;
+    }
+    worktreeResults.splice(idx, 1);
+    updateWorktreeResults();
+  }
+  function handleCleanupDeclined() {
+    worktreeCleanupConfirmPending = false;
+    updateWorktreeResults();
+  }
+  function handleCleanupStarted(message) {
+    worktreeCleanupConfirmPending = false;
+    worktreeCleanupInProgress = true;
+    worktreeCleanupStatus = { processed: 0, total: numField(message.total) };
+    worktreeCleanupLog = [];
+    updateWorktreeResults();
+  }
+  function handleCleanupWorktreeResult(message) {
+    worktreeCleanupStatus = { processed: numField(message.processed), total: numField(message.total) };
+    const rawStatus = message.status;
+    const status = rawStatus === "deleted" || rawStatus === "skipped" ? rawStatus : "error";
+    worktreeCleanupLog.push({
+      path: String(message.path ?? ""),
+      branch: String(message.branch ?? "?"),
+      repoLabel: String(message.repoLabel ?? ""),
+      status,
+      reason: typeof message.reason === "string" ? message.reason : void 0
+    });
+    updateWorktreeResults();
+  }
+  function handleCleanupComplete() {
+    worktreeCleanupInProgress = false;
+    updateWorktreeResults();
+  }
+  function handleCleanupCancelled() {
+    worktreeCleanupInProgress = false;
+    worktreeCleanupConfirmPending = false;
+    updateWorktreeResults();
+  }
+  function handleWorktreeEnrichStarted(message) {
+    worktreeScanStatus = { ...worktreeScanStatus, phase: "enriching", enriched: 0, enrichTotal: numField(message.total), elapsedMs: numField(message.elapsedMs) };
+    updateWorktreeProgressArea();
+  }
+  function handleWorktreeEnrichProgress(message) {
+    worktreeScanStatus = { ...worktreeScanStatus, phase: "enriching", enriched: numField(message.enriched), enrichTotal: numField(message.total), elapsedMs: numField(message.elapsedMs) };
+    updateWorktreeProgressArea();
+  }
+  function handleWorktreeEnriched(message) {
+    const targetPath = String(message.path ?? "");
+    if (!targetPath) {
+      return;
+    }
+    const wt = worktreeResults.find((w2) => w2.path === targetPath);
+    if (!wt) {
+      return;
+    }
+    wt.files = numField(message.files);
+    wt.folders = numField(message.folders);
+    wt.bytes = numField(message.bytes);
+    const pushedRaw = String(message.pushed ?? "?");
+    wt.pushed = pushedRaw === "yes" || pushedRaw === "no" ? pushedRaw : "?";
+    scheduleWorktreeResultsRender();
+  }
+  function handleWorktreeScanComplete() {
+    worktreeScanInProgress = false;
+    updateWorktreeControls();
+    updateWorktreeResults();
+  }
+  function handleWorktreeScanCancelled() {
+    worktreeScanInProgress = false;
+    updateWorktreeControls();
+  }
+  function handleWorktreeBackgroundResults(message) {
+    if (worktreeScanInProgress || worktreeCleanupInProgress) {
+      return;
+    }
+    const worktrees = Array.isArray(message.worktrees) ? message.worktrees : [];
+    worktreeResults = worktrees.map(sanitizeWorktreeResult);
+    worktreeBackgroundScanMeta = { scannedAt: String(message.scannedAt ?? ""), totalBytes: numField(message.totalBytes) };
+    updateWorktreeControls();
+    updateWorktreeResults();
+  }
+  var _worktreeMessageHandlers = {
+    worktreeRootPicked: handleWorktreeRootPicked,
+    worktreeRootsDiscovered: handleWorktreeRootsDiscovered,
+    worktreeScanStarted: () => handleWorktreeScanStarted(),
+    worktreeScanRootStarted: handleWorktreeScanRootStarted,
+    worktreeScanWalkProgress: handleWorktreeScanWalkProgress,
+    worktreeScanRootMarkersFound: handleWorktreeScanRootMarkersFound,
+    worktreeScanRootSkipped: handleWorktreeScanRootSkipped,
+    worktreeScanProgress: handleWorktreeScanProgress,
+    worktreeFound: handleWorktreeFound,
+    worktreeEnrichStarted: handleWorktreeEnrichStarted,
+    worktreeEnrichProgress: handleWorktreeEnrichProgress,
+    worktreeEnriched: handleWorktreeEnriched,
+    worktreeDeleted: handleWorktreeDeleted,
+    worktreeScanComplete: () => handleWorktreeScanComplete(),
+    worktreeScanCancelled: () => handleWorktreeScanCancelled(),
+    worktreeBackgroundResults: handleWorktreeBackgroundResults,
+    cleanupDeclined: () => handleCleanupDeclined(),
+    cleanupStarted: handleCleanupStarted,
+    cleanupWorktreeResult: handleCleanupWorktreeResult,
+    cleanupComplete: () => handleCleanupComplete(),
+    cleanupCancelled: () => handleCleanupCancelled()
+  };
+  function handleWorktreeMessage(message) {
+    const handler = _worktreeMessageHandlers[message.command];
+    if (handler) {
+      handler(message);
+    }
+  }
+  function setupTabs() {
+    const tabButtons = document.querySelectorAll(".tab-button");
+    tabButtons.forEach((button) => {
+      button.addEventListener("click", () => {
+        const tab = button.getAttribute("data-tab");
+        if (!tab) {
+          return;
+        }
+        activeTab = tab;
+        tabButtons.forEach((btn) => btn.classList.toggle("active", btn.getAttribute("data-tab") === tab));
+        document.querySelectorAll(".tab-panel").forEach((panel) => {
+          panel.style.display = "none";
+        });
+        const activePanel = document.getElementById(`tab-panel-${tab}`);
+        if (activePanel) {
+          activePanel.style.display = "block";
+        }
+        if (tab === "repos" && !repoPrStatsLoaded) {
+          repoPrStatsLoaded = true;
+          vscode.postMessage({ command: "loadRepoPrStats" });
+        }
+        if (tab === "agent" && !agentSessionsLoaded) {
+          agentSessionsLoaded = true;
+          vscode.postMessage({ command: "loadAgentSessions" });
+        }
+        if (tab === "insights") {
+          currentInsights.filter((i6) => i6.status === "new").forEach((i6) => vscode.postMessage({ command: "insightAction", id: i6.id, action: "seen" }));
+        }
+      });
+    });
+  }
+  function sanitizeRepoPrStatsData(input) {
+    const src = input && typeof input === "object" ? input : {};
+    const repos = Array.isArray(src.repos) ? src.repos : [];
+    return {
+      authenticated: Boolean(src.authenticated),
+      since: typeof src.since === "string" || typeof src.since === "number" ? src.since : Date.now(),
+      error: typeof src.error === "string" ? escapeHtml(src.error) : void 0,
+      repos: repos.map((repo) => {
+        const r6 = repo && typeof repo === "object" ? repo : {};
+        const aiDetails = Array.isArray(r6.aiDetails) ? r6.aiDetails : [];
+        return {
+          repoUrl: toSafeHttpUrl(r6.repoUrl),
+          owner: escapeHtml(typeof r6.owner === "string" ? r6.owner : ""),
+          repo: escapeHtml(typeof r6.repo === "string" ? r6.repo : ""),
+          error: typeof r6.error === "string" ? escapeHtml(r6.error) : "",
+          totalPrs: toSafeNumber(r6.totalPrs),
+          aiAuthoredPrs: toSafeNumber(r6.aiAuthoredPrs),
+          aiReviewRequestedPrs: toSafeNumber(r6.aiReviewRequestedPrs),
+          userAuthoredPrs: toSafeNumber(r6.userAuthoredPrs),
+          userMergedPrs: toSafeNumber(r6.userMergedPrs),
+          aiDetails: aiDetails.map((d3) => {
+            const detail = d3 && typeof d3 === "object" ? d3 : {};
+            const validAiTypes = ["copilot", "claude", "openai", "other-ai"];
+            const validRoles = ["author", "reviewer-requested"];
+            const aiType = validAiTypes.includes(detail.aiType) ? detail.aiType : "other-ai";
+            const role = validRoles.includes(detail.role) ? detail.role : "author";
+            return {
+              number: toSafeNumber(detail.number),
+              title: escapeHtml(typeof detail.title === "string" ? detail.title : ""),
+              url: toSafeHttpUrl(detail.url),
+              aiType,
+              role
+            };
+          })
+        };
+      })
+    };
+  }
+  var AI_PR_LABEL = {
+    copilot: "\u{1F916} Copilot",
+    claude: "\u{1F9E0} Claude",
+    openai: "\u2728 Codex",
+    "other-ai": "\u{1F916} AI"
+  };
+  function renderRepoPrRow(r6, cell, cellCenter) {
+    const repoLink = `<a href="${escapeHtml(r6.repoUrl)}" target="_blank" rel="noopener noreferrer" style="color:var(--link-color); font-family:'Courier New',monospace; font-size:12px;">${escapeHtml(r6.owner)}/${escapeHtml(r6.repo)}</a>`;
+    if (r6.error) {
+      return `<tr>
+			<td style="${cell} font-family:'Courier New',monospace; font-size:12px;">${repoLink}</td>
+			<td colspan="4" style="${cell} color:var(--text-secondary); font-style:italic; font-size:12px;">${escapeHtml(r6.error)}</td>
+		</tr>`;
+    }
+    let detailsHtml = "";
+    if (r6.aiDetails.length > 0) {
+      const items = r6.aiDetails.map(
+        (d3) => `<li><a href="${escapeHtml(d3.url)}" target="_blank" rel="noopener noreferrer" style="color:var(--link-color);">#${d3.number} ${escapeHtml(d3.title)}</a> \u2014 ${AI_PR_LABEL[d3.aiType] ?? escapeHtml(String(d3.aiType))} (${d3.role === "author" ? "authored" : "review requested"})</li>`
+      ).join("");
+      detailsHtml = `
 			<details style="margin-top:4px; font-size:11px;">
-				<summary style="cursor:pointer; color:var(--text-secondary);">Show ${e.aiDetails.length} detail(s)</summary>
-				<ul style="margin:4px 0 0 16px; padding:0; list-style:disc;">${i}</ul>
-			</details>`}let r=(e.userAuthoredPrs??0)>0?`<span style="font-weight:600;">${e.userMergedPrs??0} / ${e.userAuthoredPrs}</span>`:"0";return`<tr>
-		<td style="${t} font-family:'Courier New',monospace; font-size:12px;">${n}${s}</td>
-		<td style="${o} font-weight:600;">${e.totalPrs}</td>
-		<td style="${o}">${r}</td>
-		<td style="${o}">${e.aiAuthoredPrs>0?`<span style="font-weight:600;">${e.aiAuthoredPrs}</span>`:"0"}</td>
-		<td style="${o}">${e.aiReviewRequestedPrs>0?`<span style="font-weight:600;">${e.aiReviewRequestedPrs}</span>`:"0"}</td>
-	</tr>`}function Ca(e){let t=d(new Date(e.since).toLocaleDateString());if(e.error)return`
+				<summary style="cursor:pointer; color:var(--text-secondary);">Show ${r6.aiDetails.length} detail(s)</summary>
+				<ul style="margin:4px 0 0 16px; padding:0; list-style:disc;">${items}</ul>
+			</details>`;
+    }
+    const yours = (r6.userAuthoredPrs ?? 0) > 0 ? `<span style="font-weight:600;">${r6.userMergedPrs ?? 0} / ${r6.userAuthoredPrs}</span>` : "0";
+    return `<tr>
+		<td style="${cell} font-family:'Courier New',monospace; font-size:12px;">${repoLink}${detailsHtml}</td>
+		<td style="${cellCenter} font-weight:600;">${r6.totalPrs}</td>
+		<td style="${cellCenter}">${yours}</td>
+		<td style="${cellCenter}">${r6.aiAuthoredPrs > 0 ? `<span style="font-weight:600;">${r6.aiAuthoredPrs}</span>` : "0"}</td>
+		<td style="${cellCenter}">${r6.aiReviewRequestedPrs > 0 ? `<span style="font-weight:600;">${r6.aiReviewRequestedPrs}</span>` : "0"}</td>
+	</tr>`;
+  }
+  function renderReposPrContent(data) {
+    const sinceDate = escapeHtml(new Date(data.since).toLocaleDateString());
+    if (data.error) {
+      return `
 			<div style="margin-top:12px; padding:12px; background:var(--bg-tertiary); border:1px solid var(--border-color); border-radius:6px; font-size:12px; color:var(--text-secondary);">
 				<strong>\u26A0\uFE0F Failed to load repository PR activity</strong><br/>
-				${e.error}<br/>
+				${data.error}<br/>
 				Switch to another tab and back to retry \u2014 details are in the extension Output channel.
-			</div>`;if(!e.authenticated)return`
+			</div>`;
+    }
+    if (!data.authenticated) {
+      return `
 			<div style="margin-top:12px; padding:12px; background:var(--bg-tertiary); border:1px solid var(--border-color); border-radius:6px; font-size:12px; color:var(--text-secondary);">
 				<strong>\u{1F512} GitHub authentication required</strong><br/>
 				Sign in with GitHub (via the Diagnostics tab) to see AI PR activity across your repositories.
-			</div>`;if(e.repos.length===0)return`
+			</div>`;
+    }
+    if (data.repos.length === 0) {
+      return `
 			<div style="margin-top:12px; font-size:12px; color:var(--text-secondary);">
 				No GitHub repositories detected in your workspace folders.
-			</div>`;let o="padding: 6px 8px; border-bottom: 1px solid var(--border-subtle);",n=`${o} text-align: center;`,s=e.repos.map(r=>wa(r,o,n)).join("");return`
+			</div>`;
+    }
+    const cell = "padding: 6px 8px; border-bottom: 1px solid var(--border-subtle);";
+    const cellCenter = `${cell} text-align: center;`;
+    const rows = data.repos.map((r6) => renderRepoPrRow(r6, cell, cellCenter)).join("");
+    return `
 		<div style="font-size:11px; color:var(--text-secondary); margin-bottom:12px;">
-			Showing PRs created since ${t}.
+			Showing PRs created since ${sinceDate}.
 			Reviewer requests are only visible for <strong>open</strong> PRs \u2014 the GitHub API clears this field after a PR is merged or closed.
 		</div>
 		<div class="customization-matrix-container">
@@ -2058,64 +5767,124 @@ ${hi(t)}
 					</tr>
 				</thead>
 				<tbody>
-					${s}
+					${rows}
 				</tbody>
 			</table>
 		</div>
 		<div style="margin-top:8px; font-size:10px; color:var(--text-muted); border-top:1px solid var(--border-subtle); padding-top:8px;">
 			\u2020 Copilot Review Agent requested counts are for open PRs only. GitHub removes reviewer data after a PR is merged or closed.<br/>
 			\u{1F916} Cloud Agent Authored = PR author's GitHub login matches a known cloud agent (e.g. <code>copilot-swe-agent</code>, <code>claude-code-action</code>, <code>openai-code-agent</code>).
-		</div>`}function Hs(e){let t=document.querySelector("#repos-pr-content");t&&k(t,`
+		</div>`;
+  }
+  function updateReposPrPanel(data) {
+    const container = document.querySelector("#repos-pr-content");
+    if (!container) {
+      return;
+    }
+    setHtml(container, `
 		<div class="section-title"><span>\u{1F916}</span><span>AI Activity in Repository PRs</span></div>
 		<div class="section-subtitle">
 			PRs from the last 30 days across your known repositories, showing how many were <strong>authored by cloud agents</strong>
 			(i.e. opened by a bot account like <code>copilot-swe-agent</code>, <code>claude-code-action</code>, or <code>openai-code-agent</code>)
 			or had an AI agent requested as a reviewer.
 		</div>
-		${Ca(e)}
-	`)}function Sa(e){let t="font-family:'Courier New',monospace; font-size:12px;";if(e.unassigned)return`<span style="${t} color:var(--text-secondary);" title="Tasks the agents API reported without a repository \u2014 typically ad-hoc sessions started from cloud chat">no repository (cloud chat)</span>`;let o=`<a href="${e.repoUrl}" target="_blank" rel="noopener noreferrer" style="color:var(--link-color); ${t}">${e.owner}/${e.repo}</a>`,n=e.discovery==="account"?' <span title="Found through your account-wide agent tasks \u2014 this repo is not open in any workspace folder" style="color:var(--text-muted); font-size:10px;">(not in workspace)</span>':"";return`${o}${n}`}function Ta(e,t,o){return e.repos.map(n=>{let s=Sa(n);if(n.error)return`<tr>
-        <td style="${t}">${s}</td>
-        <td colspan="3" style="${t} color:var(--text-secondary); font-style:italic; font-size:12px;">${n.error}</td>
-      </tr>`;let r=n.partial?` <span title="Showing ${n.tasksScanned} of ${n.tasksTotal} tasks \u2014 capped to limit API usage" style="color:var(--text-muted); font-size:10px;">(${n.tasksScanned}/${n.tasksTotal} tasks scanned)</span>`:"",i=n.totalCredits>0?n.totalCredits.toFixed(1):n.totalPremiumRequests>0?`${n.totalPremiumRequests.toFixed(1)} PR`:"\u2014";return`<tr>
-      <td style="${t}">${s}${r}</td>
-      <td style="${o} font-weight:600;">${n.totalTasks}</td>
-      <td style="${o} font-weight:600;">${n.totalSessions}</td>
-      <td style="${o}">${i}</td>
-    </tr>`}).join("")}function Cs(e){let t="margin-bottom:12px; padding:8px 10px; background:var(--bg-tertiary); border:1px solid var(--border-color); border-radius:6px; font-size:11px; color:var(--text-secondary);";if(!e.fetchedAt)return`<div style="${t}">\u{1F552} <strong>Not fetched yet.</strong> The snapshot is refreshed hourly by the main VS Code window \u2014 it will appear here once that first refresh completes.</div>`;let o=Date.parse(e.fetchedAt),n=Number.isFinite(o)?new Date(o+e.refreshIntervalMs).toLocaleTimeString([],{hour:"2-digit",minute:"2-digit"}):"unknown";return`<div style="${t}">
-    \u{1F552} Updated <strong>${d(rn(e.fetchedAt))}</strong> \xB7 next refresh after ${d(n)}.
+		${renderReposPrContent(data)}
+	`);
+  }
+  function agentRepoLabelHtml(r6) {
+    const mono = "font-family:'Courier New',monospace; font-size:12px;";
+    if (r6.unassigned) {
+      return `<span style="${mono} color:var(--text-secondary);" title="Tasks the agents API reported without a repository \u2014 typically ad-hoc sessions started from cloud chat">no repository (cloud chat)</span>`;
+    }
+    const link = `<a href="${r6.repoUrl}" target="_blank" rel="noopener noreferrer" style="color:var(--link-color); ${mono}">${r6.owner}/${r6.repo}</a>`;
+    const accountOnly = r6.discovery === "account" ? ` <span title="Found through your account-wide agent tasks \u2014 this repo is not open in any workspace folder" style="color:var(--text-muted); font-size:10px;">(not in workspace)</span>` : "";
+    return `${link}${accountOnly}`;
+  }
+  function buildAgentSessionRows(data, cell, cellCenter) {
+    return data.repos.map((r6) => {
+      const label = agentRepoLabelHtml(r6);
+      if (r6.error) {
+        return `<tr>
+        <td style="${cell}">${label}</td>
+        <td colspan="3" style="${cell} color:var(--text-secondary); font-style:italic; font-size:12px;">${r6.error}</td>
+      </tr>`;
+      }
+      const partialNote = r6.partial ? ` <span title="Showing ${r6.tasksScanned} of ${r6.tasksTotal} tasks \u2014 capped to limit API usage" style="color:var(--text-muted); font-size:10px;">(${r6.tasksScanned}/${r6.tasksTotal} tasks scanned)</span>` : "";
+      const credits = r6.totalCredits > 0 ? r6.totalCredits.toFixed(1) : r6.totalPremiumRequests > 0 ? `${r6.totalPremiumRequests.toFixed(1)} PR` : "\u2014";
+      return `<tr>
+      <td style="${cell}">${label}${partialNote}</td>
+      <td style="${cellCenter} font-weight:600;">${r6.totalTasks}</td>
+      <td style="${cellCenter} font-weight:600;">${r6.totalSessions}</td>
+      <td style="${cellCenter}">${credits}</td>
+    </tr>`;
+    }).join("");
+  }
+  function agentSnapshotFreshnessHtml(data) {
+    const box = "margin-bottom:12px; padding:8px 10px; background:var(--bg-tertiary); border:1px solid var(--border-color); border-radius:6px; font-size:11px; color:var(--text-secondary);";
+    if (!data.fetchedAt) {
+      return `<div style="${box}">\u{1F552} <strong>Not fetched yet.</strong> The snapshot is refreshed hourly by the main VS Code window \u2014 it will appear here once that first refresh completes.</div>`;
+    }
+    const fetchedMs = Date.parse(data.fetchedAt);
+    const nextRefresh = Number.isFinite(fetchedMs) ? new Date(fetchedMs + data.refreshIntervalMs).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }) : "unknown";
+    return `<div style="${box}">
+    \u{1F552} Updated <strong>${escapeHtml(getTimeSince(data.fetchedAt))}</strong> \xB7 next refresh after ${escapeHtml(nextRefresh)}.
     Cached and refreshed at most once an hour, by a single VS Code window, to keep GitHub API usage low.
-  </div>`}function $a(e){if(!e.authenticated)return`
+  </div>`;
+  }
+  function renderAgentSessionsContent(data) {
+    if (!data.authenticated) {
+      return `
 			<div style="margin-top:12px; padding:12px; background:var(--bg-tertiary); border:1px solid var(--border-color); border-radius:6px; font-size:12px; color:var(--text-secondary);">
 				<strong>\u{1F512} GitHub authentication required</strong><br/>
 				Sign in with GitHub (via the Diagnostics tab) to see Copilot cloud agent session data.
-			</div>`;if(e.repos.length===0)return`${Cs(e)}
+			</div>`;
+    }
+    if (data.repos.length === 0) {
+      return `${agentSnapshotFreshnessHtml(data)}
 			<div style="margin-top:12px; font-size:12px; color:var(--text-secondary);">
 				No cloud agent tasks found \u2014 neither in your workspace repositories nor anywhere else in your account.
-			</div>`;let t=new Date(e.since).toLocaleDateString(),o="padding: 6px 8px; border-bottom: 1px solid var(--border-subtle);",n=`${o} text-align: center;`,s=e.repos.reduce((l,u)=>(u.error||(l.tasks+=u.totalTasks,l.sessions+=u.totalSessions,l.credits+=u.totalCredits,l.premiumRequests+=u.totalPremiumRequests),l),{tasks:0,sessions:0,credits:0,premiumRequests:0}),r=e.repos.some(l=>l.partial&&!l.error),i=Ta(e,o,n),a="background:var(--bg-tertiary); border:1px solid var(--border-color); border-radius:6px; padding:12px 20px; text-align:center; min-width:80px;";return`
-		${Cs(e)}
+			</div>`;
+    }
+    const sinceDate = new Date(data.since).toLocaleDateString();
+    const cell = "padding: 6px 8px; border-bottom: 1px solid var(--border-subtle);";
+    const cellCenter = `${cell} text-align: center;`;
+    const summaryTotals = data.repos.reduce((acc, r6) => {
+      if (!r6.error) {
+        acc.tasks += r6.totalTasks;
+        acc.sessions += r6.totalSessions;
+        acc.credits += r6.totalCredits;
+        acc.premiumRequests += r6.totalPremiumRequests;
+      }
+      return acc;
+    }, { tasks: 0, sessions: 0, credits: 0, premiumRequests: 0 });
+    const hasPartial = data.repos.some((r6) => r6.partial && !r6.error);
+    const rows = buildAgentSessionRows(data, cell, cellCenter);
+    const tile = "background:var(--bg-tertiary); border:1px solid var(--border-color); border-radius:6px; padding:12px 20px; text-align:center; min-width:80px;";
+    return `
+		${agentSnapshotFreshnessHtml(data)}
 		<div style="margin-bottom:12px; display:flex; gap:24px; flex-wrap:wrap;">
-			<div style="${a}">
-				<div style="font-size:22px; font-weight:700; color:var(--text-primary);">${s.tasks}</div>
+			<div style="${tile}">
+				<div style="font-size:22px; font-weight:700; color:var(--text-primary);">${summaryTotals.tasks}</div>
 				<div style="font-size:11px; color:var(--text-secondary); margin-top:2px;">Tasks</div>
 			</div>
-			<div style="${a}">
-				<div style="font-size:22px; font-weight:700; color:var(--text-primary);">${s.sessions}</div>
+			<div style="${tile}">
+				<div style="font-size:22px; font-weight:700; color:var(--text-primary);">${summaryTotals.sessions}</div>
 				<div style="font-size:11px; color:var(--text-secondary); margin-top:2px;">Sessions</div>
 			</div>
-			<div style="${a}">
-				<div style="font-size:22px; font-weight:700; color:var(--text-primary);">${s.credits>0?s.credits.toFixed(1):"\u2014"}</div>
+			<div style="${tile}">
+				<div style="font-size:22px; font-weight:700; color:var(--text-primary);">${summaryTotals.credits > 0 ? summaryTotals.credits.toFixed(1) : "\u2014"}</div>
 				<div style="font-size:11px; color:var(--text-secondary); margin-top:2px;">AI Credits</div>
 			</div>
-			${s.premiumRequests>0?`
-			<div style="${a}">
-				<div style="font-size:22px; font-weight:700; color:var(--text-primary);">${s.premiumRequests.toFixed(1)}</div>
+			${summaryTotals.premiumRequests > 0 ? `
+			<div style="${tile}">
+				<div style="font-size:22px; font-weight:700; color:var(--text-primary);">${summaryTotals.premiumRequests.toFixed(1)}</div>
 				<div style="font-size:11px; color:var(--text-secondary); margin-top:2px;" title="Sessions that ran before the June 2026 switch to AI credits are billed in premium requests">Premium Requests</div>
-			</div>`:""}
+			</div>` : ""}
 		</div>
 		<div style="font-size:11px; color:var(--text-secondary); margin-bottom:12px;">
-			Showing cloud-agent sessions from ${t} to now.
-			${r?"<strong>Note:</strong> Some repos were capped \u2014 totals are lower bounds. ":""}
-			${e.accountTasksAvailable?"":`<strong>Account-wide tasks unavailable:</strong> ${e.accountTasksError??"the /agents/tasks endpoint could not be read"} \u2014 only workspace repositories are shown.`}
+			Showing cloud-agent sessions from ${sinceDate} to now.
+			${hasPartial ? "<strong>Note:</strong> Some repos were capped \u2014 totals are lower bounds. " : ""}
+			${data.accountTasksAvailable ? "" : `<strong>Account-wide tasks unavailable:</strong> ${data.accountTasksError ?? "the /agents/tasks endpoint could not be read"} \u2014 only workspace repositories are shown.`}
 		</div>
 		<div class="customization-matrix-container">
 			<table class="customization-matrix" style="width:100%; border-collapse:collapse;">
@@ -2127,46 +5896,69 @@ ${hi(t)}
 						<th style="text-align:center; padding:8px; border-bottom:2px solid var(--border-color); font-size:12px; color:var(--text-secondary); opacity:0.9;" title="AI credits consumed (1 credit = $0.01). Only available when the API reports usage data.">AI Credits</th>
 					</tr>
 				</thead>
-				<tbody>${i}</tbody>
+				<tbody>${rows}</tbody>
 			</table>
 		</div>
 		<div style="margin-top:8px; font-size:10px; color:var(--text-muted); border-top:1px solid var(--border-subtle); padding-top:8px;">
 			\u2139\uFE0F <strong>No double-counting:</strong> These are cloud agent sessions only. CLI/remote sessions and local IDE chat sessions (shown in "My Activity") are excluded.<br/>
 			\u2139\uFE0F <strong>Two sources:</strong> your workspace repositories (which also surface tasks other people started there) plus your account-wide agent tasks, which cover repos you don't have open and ad-hoc cloud chat sessions. Tasks seen in both are counted once.<br/>
 			\u2139\uFE0F <strong>Action minutes</strong> (GitHub Actions compute used by the agent) are not shown here \u2014 they require additional per-branch API calls.
-		</div>`}function js(e){let t=document.querySelector("#agent-sessions-content");t&&k(t,`
+		</div>`;
+  }
+  function updateAgentSessionsPanel(data) {
+    const container = document.querySelector("#agent-sessions-content");
+    if (!container) {
+      return;
+    }
+    setHtml(container, `
 		<div class="section-title"><span>\u{1F916}</span><span>Copilot Cloud Agent Sessions</span></div>
 		<div class="section-subtitle">
 			Cloud agent tasks and sessions from the last 30 days. Each <strong>task</strong> is a user request to the agent;
 			each <strong>session</strong> is an autonomous coding run within that task.
 			<strong>CLI/remote sessions are excluded</strong> \u2014 they are separate from these cloud agent sessions.
 		</div>
-		${$a(e)}
-	`)}function Aa(e){if(!e||!e.workspaces||e.workspaces.length===0)return`
+		${renderAgentSessionsContent(data)}
+	`);
+  }
+  function buildCustomizationSectionHtml(matrix) {
+    if (!matrix || !matrix.workspaces || matrix.workspaces.length === 0) {
+      return `
 			<div class="section">
 				<div class="section-title"><span>\u{1F6E0}\uFE0F</span><span>Copilot Customization Files</span></div>
 				<div class="section-subtitle">Showing workspace customization status for active workspaces</div>
 				<div style="color: var(--text-muted); padding:12px;">No workspaces with customization files detected in the last 30 days.</div>
-			</div>`;let t=e.workspaces.map(o=>{let n=o.typeStatuses??{},s=Object.values(n).every(i=>i==="\u274C"),r=(e.customizationTypes??[]).map(i=>{let a=n[i.id]||"\u2753";return`
+			</div>`;
+    }
+    const workspaceRows = matrix.workspaces.map((ws) => {
+      const statuses = ws.typeStatuses ?? {};
+      const hasNoCustomization = Object.values(statuses).every((s4) => s4 === "\u274C");
+      const typeCells = (matrix.customizationTypes ?? []).map((type) => {
+        const status = statuses[type.id] || "\u2753";
+        const statusLabel = status === "\u2705" ? "Present and fresh" : status === "\u26A0\uFE0F" ? "Present but stale" : status === "\u274C" ? "Missing" : "Status unknown";
+        return `
 				<td style="position: relative; padding: 6px 8px; border-bottom: 1px solid var(--border-subtle); text-align: center;">
-					${j(a,a==="\u2705"?"Present and fresh":a==="\u26A0\uFE0F"?"Present but stale":a==="\u274C"?"Missing":"Status unknown")}
-				</td>`}).join("");return`
+					${statusBadgeHtml(status, statusLabel)}
+				</td>`;
+      }).join("");
+      return `
 			<tr>
 				<td style="padding: 6px 8px; border-bottom: 1px solid var(--border-subtle); font-family: 'Courier New', monospace; font-size: 12px;">
-					${d(o.workspaceName)}${s?` <span style="font-family: sans-serif; vertical-align: middle;">${j("\u26A0\uFE0F","No customization files")}</span>`:""}
+					${escapeHtml(ws.workspaceName)}${hasNoCustomization ? ` <span style="font-family: sans-serif; vertical-align: middle;">${statusBadgeHtml("\u26A0\uFE0F", "No customization files")}</span>` : ""}
 				</td>
 				<td style="padding: 6px 8px; border-bottom: 1px solid var(--border-subtle); text-align: center; color: var(--link-color); font-weight: 600;">
-					${o.sessionCount}
+					${ws.sessionCount}
 				</td>
-				${r}
-			</tr>`}).join("");return`
+				${typeCells}
+			</tr>`;
+    }).join("");
+    return `
 		<div style="margin-top: 16px; margin-bottom: 16px; padding: 12px; background: var(--bg-tertiary); border: 1px solid var(--border-color); border-radius: 6px;">
 			<div style="font-size: 13px; font-weight: 600; color: var(--text-primary); margin-bottom: 8px;">
 				\u{1F6E0}\uFE0F Copilot Customization Files
 			</div>
 			<div style="font-size: 11px; color: var(--text-secondary); margin-bottom: 12px; display: flex; align-items: center; gap: 6px; flex-wrap: wrap;">
-				Showing ${e.totalWorkspaces} workspace(s) with Copilot activity in the last 30 days.
-				${e.workspacesWithIssues>0?`<span class="stale-warning" style="display:inline-flex;align-items:center;gap:4px;">${j("\u26A0\uFE0F")} ${e.workspacesWithIssues} workspace(s) have no customization files.</span>`:`<span style="display:inline-flex;align-items:center;gap:4px;">${j("\u2705")} All workspaces have up-to-date customizations.</span>`}
+				Showing ${matrix.totalWorkspaces} workspace(s) with Copilot activity in the last 30 days.
+				${matrix.workspacesWithIssues > 0 ? `<span class="stale-warning" style="display:inline-flex;align-items:center;gap:4px;">${statusBadgeHtml("\u26A0\uFE0F")} ${matrix.workspacesWithIssues} workspace(s) have no customization files.</span>` : `<span style="display:inline-flex;align-items:center;gap:4px;">${statusBadgeHtml("\u2705")} All workspaces have up-to-date customizations.</span>`}
 			</div>
 			<div class="customization-matrix-container">
 				<table class="customization-matrix">
@@ -2174,39 +5966,65 @@ ${hi(t)}
 						<tr>
 							<th style="text-align: left; padding: 8px; border-bottom: 2px solid var(--border-color);">\u{1F4C2} Workspace</th>
 							<th style="text-align: center; padding: 8px; border-bottom: 2px solid var(--border-color);">Sessions</th>
-							${(e.customizationTypes??[]).map(o=>`
-								<th style="text-align: center; padding: 8px; border-bottom: 2px solid var(--border-color);" title="${d(o.label)}">
-									${d(o.icon)}
+							${(matrix.customizationTypes ?? []).map((type) => `
+								<th style="text-align: center; padding: 8px; border-bottom: 2px solid var(--border-color);" title="${escapeHtml(type.label)}">
+									${escapeHtml(type.icon)}
 								</th>
 							`).join("")}
 						</tr>
 					</thead>
 					<tbody>
-						${t}
+						${workspaceRows}
 					</tbody>
 				</table>
 			</div>
 			<div style="margin-top: 12px; font-size: 10px; color: var(--text-muted); border-top: 1px solid var(--border-subtle); padding-top: 8px;">
 				<div style="display: flex; gap: 16px; flex-wrap: wrap;">
-					${(e.customizationTypes??[]).map(o=>`
-						<span>${d(o.icon)} ${d(o.label)}</span>
+					${(matrix.customizationTypes ?? []).map((type) => `
+						<span>${escapeHtml(type.icon)} ${escapeHtml(type.label)}</span>
 					`).join("")}
 				</div>
 				<div style="margin-top: 8px; display: flex; align-items: center; gap: 8px; flex-wrap: wrap;">
-					<span style="display:inline-flex;align-items:center;gap:4px;">${j("\u2705")} = Present &amp; Fresh</span>
+					<span style="display:inline-flex;align-items:center;gap:4px;">${statusBadgeHtml("\u2705")} = Present &amp; Fresh</span>
 					<span style="color: var(--text-muted);">\u2022</span>
-					<span style="display:inline-flex;align-items:center;gap:4px;">${j("\u26A0\uFE0F")} = Present but Stale</span>
+					<span style="display:inline-flex;align-items:center;gap:4px;">${statusBadgeHtml("\u26A0\uFE0F")} = Present but Stale</span>
 					<span style="color: var(--text-muted);">\u2022</span>
-					<span style="display:inline-flex;align-items:center;gap:4px;">${j("\u274C")} = Missing</span>
+					<span style="display:inline-flex;align-items:center;gap:4px;">${statusBadgeHtml("\u274C")} = Missing</span>
 				</div>
 			</div>
-		</div>`}function Ma(e){let t=e.last30Days.modelSwitching,o=e.today.modelSwitching;if((t.totalRequests??0)===0&&(o.totalRequests??0)===0)return"";function n(s){let r=s.totalRequests??0;if(r===0)return'<div style="color: var(--text-muted); font-size: 11px;">No data</div>';let a=[{label:"\u{1F49A} Low cost",count:s.lowCostRequests??0,color:"#4ade80"},{label:"\u{1F535} Medium cost",count:s.mediumCostRequests??0,color:"var(--link-color)"},{label:"\u{1F4B8} High cost",count:s.highCostRequests??0,color:"var(--warning-fg)"},{label:"\u2753 Unknown",count:s.unknownRequests??0,color:"var(--text-muted)"}].filter(u=>u.count>0).map(u=>{let c=r>0?Math.round(u.count/r*100):0;return`<div style="display: flex; align-items: center; gap: 8px; margin-bottom: 8px;">
-				<span style="width: 90px; font-size: 12px; font-weight: 600; color: ${u.color};">${u.label}</span>
+		</div>`;
+  }
+  function buildModelCostSectionHtml(stats) {
+    const p30 = stats.last30Days.modelSwitching;
+    const today = stats.today.modelSwitching;
+    if ((p30.totalRequests ?? 0) === 0 && (today.totalRequests ?? 0) === 0) {
+      return "";
+    }
+    function renderCostPeriod(ms) {
+      const total = ms.totalRequests ?? 0;
+      if (total === 0) {
+        return '<div style="color: var(--text-muted); font-size: 11px;">No data</div>';
+      }
+      const buckets = [
+        { label: "\u{1F49A} Low cost", count: ms.lowCostRequests ?? 0, color: "#4ade80" },
+        { label: "\u{1F535} Medium cost", count: ms.mediumCostRequests ?? 0, color: "var(--link-color)" },
+        { label: "\u{1F4B8} High cost", count: ms.highCostRequests ?? 0, color: "var(--warning-fg)" },
+        { label: "\u2753 Unknown", count: ms.unknownRequests ?? 0, color: "var(--text-muted)" }
+      ].filter((b3) => b3.count > 0);
+      const rows = buckets.map((b3) => {
+        const pct = total > 0 ? Math.round(b3.count / total * 100) : 0;
+        return `<div style="display: flex; align-items: center; gap: 8px; margin-bottom: 8px;">
+				<span style="width: 90px; font-size: 12px; font-weight: 600; color: ${b3.color};">${b3.label}</span>
 				<div style="flex: 1; background: var(--bg-secondary); border-radius: 4px; height: 12px; overflow: hidden;">
-					<div style="width: ${c}%; background: ${u.color}; height: 100%; border-radius: 4px;"></div>
+					<div style="width: ${pct}%; background: ${b3.color}; height: 100%; border-radius: 4px;"></div>
 				</div>
-				<span style="font-size: 12px; font-weight: 600; color: var(--text-primary); min-width: 70px; text-align: right;">${g(u.count)} <span style="color: var(--text-secondary); font-weight: 400;">(${c}%)</span></span>
-			</div>`}).join(""),l=(s.mixedCostSessions??0)>0?`<div style="font-size: 11px; color: var(--link-color); margin-top: 6px;">\u{1F500} ${g(s.mixedCostSessions)} mixed-cost session${s.mixedCostSessions!==1?"s":""}</div>`:"";return`${a}<div style="font-size: 11px; color: var(--text-muted); margin-top: 6px;">${g(r)} total requests</div>${l}`}return`
+				<span style="font-size: 12px; font-weight: 600; color: var(--text-primary); min-width: 70px; text-align: right;">${formatNumber(b3.count)} <span style="color: var(--text-secondary); font-weight: 400;">(${pct}%)</span></span>
+			</div>`;
+      }).join("");
+      const mixedNote = (ms.mixedCostSessions ?? 0) > 0 ? `<div style="font-size: 11px; color: var(--link-color); margin-top: 6px;">\u{1F500} ${formatNumber(ms.mixedCostSessions)} mixed-cost session${ms.mixedCostSessions !== 1 ? "s" : ""}</div>` : "";
+      return `${rows}<div style="font-size: 11px; color: var(--text-muted); margin-top: 6px;">${formatNumber(total)} total requests</div>${mixedNote}`;
+    }
+    return `
 		<!-- Model Cost Section -->
 		<div class="section">
 			<div class="section-title"><span>\u{1F4B0}</span><span>Model Cost Usage</span></div>
@@ -2214,18 +6032,25 @@ ${hi(t)}
 			<div class="three-column">
 				<div>
 					<h4 style="color: var(--text-primary); font-size: 13px; margin-bottom: 8px;">\u{1F4C5} Today</h4>
-					${n(o)}
+					${renderCostPeriod(today)}
 				</div>
 				<div>
 					<h4 style="color: var(--text-primary); font-size: 13px; margin-bottom: 8px;">\u{1F4C6} Last 30 Days</h4>
-					${n(t)}
+					${renderCostPeriod(p30)}
 				</div>
 				<div>
 					<h4 style="color: var(--text-primary); font-size: 13px; margin-bottom: 8px;">\u{1F4C5} Previous Month</h4>
-					${n(e.month.modelSwitching)}
+					${renderCostPeriod(stats.month.modelSwitching)}
 				</div>
 			</div>
-		</div>`}function Ea(e){return e.last30Days.thinkingEffortUsage||e.today.thinkingEffortUsage||e.month.thinkingEffortUsage?`
+		</div>`;
+  }
+  function buildThinkingEffortSectionHtml(stats) {
+    const effortData = stats.last30Days.thinkingEffortUsage || stats.today.thinkingEffortUsage || stats.month.thinkingEffortUsage;
+    if (!effortData) {
+      return "";
+    }
+    return `
 		<!-- Thinking Effort Section -->
 		<div class="section">
 			<div class="section-title"><span>\u{1F4A1}</span><span>Thinking Effort (Reasoning)</span></div>
@@ -2233,30 +6058,58 @@ ${hi(t)}
 			<div class="three-column">
 				<div>
 					<h4 style="color: var(--text-primary); font-size: 13px; margin-bottom: 8px;">\u{1F4C5} Today</h4>
-					${Eo(e.today.thinkingEffortUsage)}
+					${renderEffortPeriodHtml(stats.today.thinkingEffortUsage)}
 				</div>
 				<div>
 					<h4 style="color: var(--text-primary); font-size: 13px; margin-bottom: 8px;">\u{1F4C6} Last 30 Days</h4>
-					${Eo(e.last30Days.thinkingEffortUsage)}
+					${renderEffortPeriodHtml(stats.last30Days.thinkingEffortUsage)}
 				</div>
 				<div>
 					<h4 style="color: var(--text-primary); font-size: 13px; margin-bottom: 8px;">\u{1F4C5} Previous Month</h4>
-					${Eo(e.month.thinkingEffortUsage)}
+					${renderEffortPeriodHtml(stats.month.thinkingEffortUsage)}
 				</div>
 			</div>
-		</div>`:""}function Eo(e){let t=["minimal","low","medium","high","max","xhigh"];if(!e||e.sessionCount===0)return'<div style="color: var(--text-muted); font-size: 11px;">No data</div>';let o=Object.values(e.byEffort).reduce((s,r)=>s+r,0);return`
-		${t.filter(s=>e.byEffort[s]>0).concat(Object.keys(e.byEffort).filter(s=>!t.includes(s)&&e.byEffort[s]>0)).map(s=>{let r=e.byEffort[s]||0,i=o>0?Math.round(r/o*100):0;return`<div style="display: flex; align-items: center; gap: 8px; margin-bottom: 8px;">
-				<span style="width: 56px; font-size: 12px; font-weight: 600; color: var(--text-primary); text-transform: capitalize;">${d(di(s))}</span>
+		</div>`;
+  }
+  function renderEffortPeriodHtml(teu) {
+    const EFFORT_ORDER = ["minimal", "low", "medium", "high", "max", "xhigh"];
+    if (!teu || teu.sessionCount === 0) {
+      return '<div style="color: var(--text-muted); font-size: 11px;">No data</div>';
+    }
+    const total = Object.values(teu.byEffort).reduce((s4, v2) => s4 + v2, 0);
+    const sorted = EFFORT_ORDER.filter((k2) => teu.byEffort[k2] > 0).concat(Object.keys(teu.byEffort).filter((k2) => !EFFORT_ORDER.includes(k2) && teu.byEffort[k2] > 0));
+    return `
+		${sorted.map((level) => {
+      const count = teu.byEffort[level] || 0;
+      const pct = total > 0 ? Math.round(count / total * 100) : 0;
+      return `<div style="display: flex; align-items: center; gap: 8px; margin-bottom: 8px;">
+				<span style="width: 56px; font-size: 12px; font-weight: 600; color: var(--text-primary); text-transform: capitalize;">${escapeHtml(getEffortDisplayName(level))}</span>
 				<div style="flex: 1; background: var(--bg-secondary); border-radius: 4px; height: 12px; overflow: hidden;">
-					<div style="width: ${i}%; background: var(--link-color); height: 100%; border-radius: 4px;"></div>
+					<div style="width: ${pct}%; background: var(--link-color); height: 100%; border-radius: 4px;"></div>
 				</div>
-				<span style="font-size: 12px; font-weight: 600; color: var(--text-primary); min-width: 70px; text-align: right;">${r} <span style="color: var(--text-secondary); font-weight: 400;">(${i}%)</span></span>
-			</div>`}).join("")}
-		<div style="font-size: 11px; color: var(--text-muted); margin-top: 6px;">${e.sessionCount} session${e.sessionCount!==1?"s":""} \xB7 ${e.switchCount} effort switch${e.switchCount!==1?"es":""}</div>
-	`}function Ra(e){return{allToolKeys:[...new Set([...Object.keys(e.today.toolCalls.byTool),...Object.keys(e.last30Days.toolCalls.byTool),...Object.keys(e.month.toolCalls.byTool)])].sort(),allMcpToolKeys:[...new Set([...Object.keys(e.today.mcpTools.byTool),...Object.keys(e.last30Days.mcpTools.byTool),...Object.keys(e.month.mcpTools.byTool)])].sort(),allMcpServerKeys:[...new Set([...Object.keys(e.today.mcpTools.byServer),...Object.keys(e.last30Days.mcpTools.byServer),...Object.keys(e.month.mcpTools.byServer)])].sort(),allStandardModels:[...new Set([...e.today.modelSwitching.standardModels,...e.last30Days.modelSwitching.standardModels,...e.month.modelSwitching.standardModels])].sort(),allHighCostModels:[...new Set([...e.today.modelSwitching.highCostModels,...e.last30Days.modelSwitching.highCostModels,...e.month.modelSwitching.highCostModels])].sort(),allLowCostModels:[...new Set([...e.today.modelSwitching.lowCostModels,...e.last30Days.modelSwitching.lowCostModels,...e.month.modelSwitching.lowCostModels])].sort(),allMediumCostModels:[...new Set([...e.today.modelSwitching.mediumCostModels,...e.last30Days.modelSwitching.mediumCostModels,...e.month.modelSwitching.mediumCostModels])].sort(),allUnknownModels:[...new Set([...e.today.modelSwitching.unknownModels,...e.last30Days.modelSwitching.unknownModels,...e.month.modelSwitching.unknownModels])].sort()}}function _a(e,t){return`
-		<div id="tab-panel-health" class="tab-panel"${$!=="health"?' style="display:none"':""}>
-			${e}
-			${vi(t)}
+				<span style="font-size: 12px; font-weight: 600; color: var(--text-primary); min-width: 70px; text-align: right;">${count} <span style="color: var(--text-secondary); font-weight: 400;">(${pct}%)</span></span>
+			</div>`;
+    }).join("")}
+		<div style="font-size: 11px; color: var(--text-muted); margin-top: 6px;">${teu.sessionCount} session${teu.sessionCount !== 1 ? "s" : ""} \xB7 ${teu.switchCount} effort switch${teu.switchCount !== 1 ? "es" : ""}</div>
+	`;
+  }
+  function buildUsageAllKeysSets(stats) {
+    return {
+      allToolKeys: [.../* @__PURE__ */ new Set([...Object.keys(stats.today.toolCalls.byTool), ...Object.keys(stats.last30Days.toolCalls.byTool), ...Object.keys(stats.month.toolCalls.byTool)])].sort(),
+      allMcpToolKeys: [.../* @__PURE__ */ new Set([...Object.keys(stats.today.mcpTools.byTool), ...Object.keys(stats.last30Days.mcpTools.byTool), ...Object.keys(stats.month.mcpTools.byTool)])].sort(),
+      allMcpServerKeys: [.../* @__PURE__ */ new Set([...Object.keys(stats.today.mcpTools.byServer), ...Object.keys(stats.last30Days.mcpTools.byServer), ...Object.keys(stats.month.mcpTools.byServer)])].sort(),
+      allStandardModels: [.../* @__PURE__ */ new Set([...stats.today.modelSwitching.standardModels, ...stats.last30Days.modelSwitching.standardModels, ...stats.month.modelSwitching.standardModels])].sort(),
+      allHighCostModels: [.../* @__PURE__ */ new Set([...stats.today.modelSwitching.highCostModels, ...stats.last30Days.modelSwitching.highCostModels, ...stats.month.modelSwitching.highCostModels])].sort(),
+      allLowCostModels: [.../* @__PURE__ */ new Set([...stats.today.modelSwitching.lowCostModels, ...stats.last30Days.modelSwitching.lowCostModels, ...stats.month.modelSwitching.lowCostModels])].sort(),
+      allMediumCostModels: [.../* @__PURE__ */ new Set([...stats.today.modelSwitching.mediumCostModels, ...stats.last30Days.modelSwitching.mediumCostModels, ...stats.month.modelSwitching.mediumCostModels])].sort(),
+      allUnknownModels: [.../* @__PURE__ */ new Set([...stats.today.modelSwitching.unknownModels, ...stats.last30Days.modelSwitching.unknownModels, ...stats.month.modelSwitching.unknownModels])].sort()
+    };
+  }
+  function buildHealthTabPanelHtml(customizationHtml, stats) {
+    return `
+		<div id="tab-panel-health" class="tab-panel"${activeTab !== "health" ? ' style="display:none"' : ""}>
+			${customizationHtml}
+			${renderMissedPotential(stats)}
 
 			<!-- Repository Setup Section -->
 			<div class="repo-hygiene-section" style="margin-top: 16px; margin-bottom: 16px; padding: 12px; background: var(--bg-tertiary); border: 1px solid var(--border-color); border-radius: 6px;">
@@ -2266,9 +6119,9 @@ ${hi(t)}
 				<div style="font-size: 11px; color: var(--text-secondary); margin-bottom: 12px;">
 					Analyze repository hygiene and structure to identify missing configuration files and best practices.
 				</div>
-				${H&&H.workspaces&&H.workspaces.length>0?`
+				${hygieneMatrixState && hygieneMatrixState.workspaces && hygieneMatrixState.workspaces.length > 0 ? `
 					<div style="margin-bottom: 12px;">
-						<vscode-button id="btn-analyse-all" style="margin-bottom: 8px;" ${me?'disabled="true" appearance="secondary"':""}>${me?"Analyzing All...":`Analyze All Repositories (${H.workspaces.length})`}</vscode-button>
+						<vscode-button id="btn-analyse-all" style="margin-bottom: 8px;" ${isBatchAnalysisInProgress ? 'disabled="true" appearance="secondary"' : ""}>${isBatchAnalysisInProgress ? "Analyzing All..." : `Analyze All Repositories (${hygieneMatrixState.workspaces.length})`}</vscode-button>
 					</div>
 					<div id="repo-list-pane-container" class="repo-hygiene-pane">
 						<div class="repo-hygiene-pane-header">\u{1F4C1} Repository List</div>
@@ -2278,109 +6131,214 @@ ${hi(t)}
 						<div class="repo-hygiene-pane-header">\u{1F4CA} Repository Details</div>
 						<div id="repo-details-pane" class="repo-hygiene-pane-body"></div>
 					</div>
-				`:`
-					<vscode-button id="btn-analyse-repo" ${st?'disabled="true" appearance="secondary"':""}>${st?"Analyzing...":"Analyze Repo for Best Practices"}</vscode-button>
+				` : `
+					<vscode-button id="btn-analyse-repo" ${isSingleRepoAnalysisInProgress ? 'disabled="true" appearance="secondary"' : ""}>${isSingleRepoAnalysisInProgress ? "Analyzing..." : "Analyze Repo for Best Practices"}</vscode-button>
 					<div id="repo-analysis-results" class="repo-hygiene-results" style="margin-top: 12px;"></div>
 				`}
 			</div>
-		</div>`}function Pa(e,t,o){return`
+		</div>`;
+  }
+  function buildMcpToolsSectionHtml(stats, allMcpToolKeys, allMcpServerKeys) {
+    return `
 		<!-- MCP Tools Section -->
 		<div class="section">
 			<div class="section-title"><span>\u{1F50C}</span><span>MCP Tools</span></div>
 			<div class="section-subtitle">Model Context Protocol (MCP) server and tool usage</div>
-			${zl(e)}
+			${buildUnknownMcpToolsBannerHtml(stats)}
 			<div class="three-column">
 				<div>
 					<h4 style="color: var(--text-primary); font-size: 13px; margin-bottom: 8px;">\u{1F4C5} Today</h4>
 					<div class="list">
-						<div style="font-size: 14px; font-weight: 600; color: var(--text-primary); margin-bottom: 8px;">Total MCP Calls: ${g(e.today.mcpTools.total)}</div>
-						${o.length>0?`
-							<div style="margin-top: 12px;"><strong>By Server:</strong><div style="margin-top: 8px;">${Y(J(e.today.mcpTools.byServer,o),200)}</div></div>
-						`:'<div style="color: var(--text-muted); margin-top: 8px;">No MCP tools used yet</div>'}
+						<div style="font-size: 14px; font-weight: 600; color: var(--text-primary); margin-bottom: 8px;">Total MCP Calls: ${formatNumber(stats.today.mcpTools.total)}</div>
+						${allMcpServerKeys.length > 0 ? `
+							<div style="margin-top: 12px;"><strong>By Server:</strong><div style="margin-top: 8px;">${renderToolsTable(unionFill(stats.today.mcpTools.byServer, allMcpServerKeys), 200)}</div></div>
+						` : '<div style="color: var(--text-muted); margin-top: 8px;">No MCP tools used yet</div>'}
 					</div>
 				</div>
 				<div>
 					<h4 style="color: var(--text-primary); font-size: 13px; margin-bottom: 8px;">\u{1F4C6} Last 30 Days</h4>
 					<div class="list">
-						<div style="font-size: 14px; font-weight: 600; color: var(--text-primary); margin-bottom: 8px;">Total MCP Calls: ${g(e.last30Days.mcpTools.total)}</div>
-						${o.length>0?`
-							<div style="margin-top: 12px;"><strong>By Server:</strong><div style="margin-top: 8px;">${Y(J(e.last30Days.mcpTools.byServer,o),200)}</div></div>
-						`:'<div style="color: var(--text-muted); margin-top: 8px;">No MCP tools used yet</div>'}
+						<div style="font-size: 14px; font-weight: 600; color: var(--text-primary); margin-bottom: 8px;">Total MCP Calls: ${formatNumber(stats.last30Days.mcpTools.total)}</div>
+						${allMcpServerKeys.length > 0 ? `
+							<div style="margin-top: 12px;"><strong>By Server:</strong><div style="margin-top: 8px;">${renderToolsTable(unionFill(stats.last30Days.mcpTools.byServer, allMcpServerKeys), 200)}</div></div>
+						` : '<div style="color: var(--text-muted); margin-top: 8px;">No MCP tools used yet</div>'}
 					</div>
 				</div>
 				<div>
 					<h4 style="color: var(--text-primary); font-size: 13px; margin-bottom: 8px;">\u{1F4C5} Previous Month</h4>
 					<div class="list">
-						<div style="font-size: 14px; font-weight: 600; color: var(--text-primary); margin-bottom: 8px;">Total MCP Calls: ${g(e.month.mcpTools.total)}</div>
-						${o.length>0?`
-							<div style="margin-top: 12px;"><strong>By Server:</strong><div style="margin-top: 8px;">${Y(J(e.month.mcpTools.byServer,o),200)}</div></div>
-						`:'<div style="color: var(--text-muted); margin-top: 8px;">No MCP tools used yet</div>'}
+						<div style="font-size: 14px; font-weight: 600; color: var(--text-primary); margin-bottom: 8px;">Total MCP Calls: ${formatNumber(stats.month.mcpTools.total)}</div>
+						${allMcpServerKeys.length > 0 ? `
+							<div style="margin-top: 12px;"><strong>By Server:</strong><div style="margin-top: 8px;">${renderToolsTable(unionFill(stats.month.mcpTools.byServer, allMcpServerKeys), 200)}</div></div>
+						` : '<div style="color: var(--text-muted); margin-top: 8px;">No MCP tools used yet</div>'}
 					</div>
 				</div>
 			</div>
 			<div class="three-column" style="margin-top: 12px;">
 				<div>
-					${t.length>0?`
+					${allMcpToolKeys.length > 0 ? `
 						<div class="list">
-							<div style="margin-top: 4px;"><strong>By Tool:</strong><div style="margin-top: 8px;">${Y(J(e.today.mcpTools.byTool,t),10,Ao)}</div></div>
+							<div style="margin-top: 4px;"><strong>By Tool:</strong><div style="margin-top: 8px;">${renderToolsTable(unionFill(stats.today.mcpTools.byTool, allMcpToolKeys), 10, lookupMcpToolName)}</div></div>
 						</div>
-					`:""}
+					` : ""}
 				</div>
 				<div>
-					${t.length>0?`
+					${allMcpToolKeys.length > 0 ? `
 						<div class="list">
-							<div style="margin-top: 4px;"><strong>By Tool:</strong><div style="margin-top: 8px;">${Y(J(e.last30Days.mcpTools.byTool,t),10,Ao)}</div></div>
+							<div style="margin-top: 4px;"><strong>By Tool:</strong><div style="margin-top: 8px;">${renderToolsTable(unionFill(stats.last30Days.mcpTools.byTool, allMcpToolKeys), 10, lookupMcpToolName)}</div></div>
 						</div>
-					`:""}
+					` : ""}
 				</div>
 				<div>
-					${t.length>0?`
+					${allMcpToolKeys.length > 0 ? `
 						<div class="list">
-							<div style="margin-top: 4px;"><strong>By Tool:</strong><div style="margin-top: 8px;">${Y(J(e.month.mcpTools.byTool,t),10,Ao)}</div></div>
+							<div style="margin-top: 4px;"><strong>By Tool:</strong><div style="margin-top: 8px;">${renderToolsTable(unionFill(stats.month.mcpTools.byTool, allMcpToolKeys), 10, lookupMcpToolName)}</div></div>
 						</div>
-					`:""}
+					` : ""}
 				</div>
 			</div>
-		</div>`}function Da(e,t,o){let n=e.length-t.length,s=t.length>0?"rgba(251,191,36,0.12)":"rgba(74,222,128,0.12)",r=t.length>0?"rgba(251,191,36,0.4)":"rgba(74,222,128,0.4)",i=t.length>0?"#fbbf24":"#4ade80",a=o.totalTokens,l=o.byServer.skill??0,u=o.byServer.builtin??0,c=a-l-u,p=S=>S>=1e3?`~${Math.round(S/1e3)}K`:`~${S}`,b=c+l,h=[];return c>0&&h.push(`${p(c)} MCP`),l>0&&h.push(`${p(l)} skills`),`<div style="display:flex; gap:16px; flex-wrap:wrap; margin:12px 0;">
+		</div>`;
+  }
+  function buildCurationSummaryHtml(availableTools, unusedTools, bloat) {
+    const usedCount = availableTools.length - unusedTools.length;
+    const severityColor = unusedTools.length > 0 ? "rgba(251,191,36,0.12)" : "rgba(74,222,128,0.12)";
+    const severityBorder = unusedTools.length > 0 ? "rgba(251,191,36,0.4)" : "rgba(74,222,128,0.4)";
+    const unusedColor = unusedTools.length > 0 ? "#fbbf24" : "#4ade80";
+    const totalBloat = bloat.totalTokens;
+    const skillBloat = bloat.byServer["skill"] ?? 0;
+    const builtinBloat = bloat.byServer["builtin"] ?? 0;
+    const mcpBloat = totalBloat - skillBloat - builtinBloat;
+    const fmt = (n5) => n5 >= 1e3 ? `~${Math.round(n5 / 1e3)}K` : `~${n5}`;
+    const actionableBloat = mcpBloat + skillBloat;
+    const actionableParts = [];
+    if (mcpBloat > 0) {
+      actionableParts.push(`${fmt(mcpBloat)} MCP`);
+    }
+    if (skillBloat > 0) {
+      actionableParts.push(`${fmt(skillBloat)} skills`);
+    }
+    return `<div style="display:flex; gap:16px; flex-wrap:wrap; margin:12px 0;">
 		<div style="background:var(--bg-tertiary); border:1px solid var(--border-color); border-radius:6px; padding:10px 16px; min-width:120px; text-align:center;">
-			<div style="font-size:20px; font-weight:700; color:var(--text-primary);">${g(e.length)}</div>
+			<div style="font-size:20px; font-weight:700; color:var(--text-primary);">${formatNumber(availableTools.length)}</div>
 			<div style="font-size:11px; color:var(--text-primary); opacity:0.75;">Available</div>
 		</div>
 		<div style="background:var(--bg-tertiary); border:1px solid var(--border-color); border-radius:6px; padding:10px 16px; min-width:120px; text-align:center;">
-			<div style="font-size:20px; font-weight:700; color:#4ade80;">${g(n)}</div>
+			<div style="font-size:20px; font-weight:700; color:#4ade80;">${formatNumber(usedCount)}</div>
 			<div style="font-size:11px; color:var(--text-primary); opacity:0.75;">Used</div>
 		</div>
-		<div style="background:${s}; border:1px solid ${r}; border-radius:6px; padding:10px 16px; min-width:120px; text-align:center;">
-			<div style="font-size:20px; font-weight:700; color:${i};">${g(t.length)}</div>
+		<div style="background:${severityColor}; border:1px solid ${severityBorder}; border-radius:6px; padding:10px 16px; min-width:120px; text-align:center;">
+			<div style="font-size:20px; font-weight:700; color:${unusedColor};">${formatNumber(unusedTools.length)}</div>
 			<div style="font-size:11px; color:var(--text-primary); opacity:0.75;">Unused</div>
 		</div>
-		${b>0?`<div style="background:rgba(239,68,68,0.1); border:1px solid rgba(239,68,68,0.3); border-radius:6px; padding:10px 16px; min-width:140px; text-align:center;" title="Overhead you can reduce by disabling unused MCP servers or removing unused skills">
-			<div style="font-size:20px; font-weight:700; color:#f87171;">${p(b)}</div>
+		${actionableBloat > 0 ? `<div style="background:rgba(239,68,68,0.1); border:1px solid rgba(239,68,68,0.3); border-radius:6px; padding:10px 16px; min-width:140px; text-align:center;" title="Overhead you can reduce by disabling unused MCP servers or removing unused skills">
+			<div style="font-size:20px; font-weight:700; color:#f87171;">${fmt(actionableBloat)}</div>
 			<div style="font-size:11px; color:var(--text-primary); opacity:0.75;">Actionable overhead</div>
-			${h.length>0?`<div style="font-size:10px; color:var(--text-secondary); margin-top:2px;">${d(h.join(" + "))}</div>`:""}
-		</div>`:""}
-		${u>0?`<div style="background:var(--bg-tertiary); border:1px solid var(--border-color); border-radius:6px; padding:10px 16px; min-width:140px; text-align:center; opacity:0.7;" title="Overhead from VS Code built-in tools \u2014 cannot be disabled">
-			<div style="font-size:20px; font-weight:700; color:var(--text-secondary);">${p(u)}</div>
+			${actionableParts.length > 0 ? `<div style="font-size:10px; color:var(--text-secondary); margin-top:2px;">${escapeHtml(actionableParts.join(" + "))}</div>` : ""}
+		</div>` : ""}
+		${builtinBloat > 0 ? `<div style="background:var(--bg-tertiary); border:1px solid var(--border-color); border-radius:6px; padding:10px 16px; min-width:140px; text-align:center; opacity:0.7;" title="Overhead from VS Code built-in tools \u2014 cannot be disabled">
+			<div style="font-size:20px; font-weight:700; color:var(--text-secondary);">${fmt(builtinBloat)}</div>
 			<div style="font-size:11px; color:var(--text-primary); opacity:0.75;">Built-in overhead</div>
 			<div style="font-size:10px; color:var(--text-secondary); margin-top:2px;">not actionable</div>
-		</div>`:""}
-	</div>`}function La(e){if(e.extensionId)return"Extension";if(!e.configFiles||e.configFiles.length===0)return"Settings";let t=new Set;for(let o of e.configFiles){let n=o.replace(/\\/g,"/");n.includes("/.vscode/")?t.add("Workspace"):n.includes("/.vs/")?t.add("Workspace (VS)"):n.includes("/.cursor/")?t.add("Workspace (Cursor)"):n.endsWith("/.mcp.json")?t.add(n.split("/").slice(-2).join("/")):t.add("Config file")}return[...t].join(", ")}function Ua(e,t){return e.configFiles&&e.configFiles.length===1?` <button class="curation-file-btn" data-command="openFile" data-path="${d(e.configFiles[0])}" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:11px;text-decoration:underline;" title="Open ${d(e.configFiles[0])}">open</button>`:e.configFiles&&e.configFiles.length>1?` <button class="curation-file-btn" data-command="openFileFromList" data-paths="${d(JSON.stringify(e.configFiles))}" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:11px;text-decoration:underline;" title="${d(t)}">open</button>`:e.extensionId?` <button class="curation-file-btn" data-command="manageExtension" data-extension-id="${d(e.extensionId)}" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:11px;text-decoration:underline;" title="Open Extensions view for ${d(e.extensionId)}">open</button>`:' <button class="curation-file-btn" data-command="searchMcpExtensions" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:11px;text-decoration:underline;" title="Browse MCP extensions in the marketplace">open</button>'}function Ia(e){return e.extensionId?`<button class="curation-file-btn" data-command="manageExtension" data-extension-id="${d(e.extensionId)}" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:11px;text-decoration:underline;" title="Open the Extensions view for ${d(e.extensionId)} (disable or uninstall to reclaim prompt budget)">Manage Extension</button>`:!e.configFiles||e.configFiles.length===0?'<button class="curation-file-btn" data-command="openToolPicker" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:11px;text-decoration:underline;" title="Open VS Code tool selection menu">Change Tools</button>':e.configFiles.length===1?`<button class="curation-file-btn" data-command="openFile" data-path="${d(e.configFiles[0])}" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:11px;text-decoration:underline;" title="Open ${d(e.configFiles[0])}">Change Tools</button>`:`<button class="curation-file-btn" data-command="openFileFromList" data-paths="${d(JSON.stringify(e.configFiles))}" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:11px;text-decoration:underline;" title="Defined in ${e.configFiles.length} config files">Change Tools</button>`}function za(e,t){let o=t.byServer[e.server]??0,n=La(e),s=e.configFiles?.join(`
-`)??e.extensionId??"",r=Ua(e,s),i=Ia(e),a=e.availableToolCount===0;return`<tr class="${e.usedToolCount>0?"mcp-has-usage":""}">
-		<td style="padding:5px 8px; color:var(--text-primary); font-size:12px; white-space:nowrap;">${d(e.server)}</td>
-		<td style="padding:5px 8px; color:var(--text-primary); font-size:12px; white-space:nowrap;" title="${d(s)}">${d(n)}${r}</td>
-		<td style="padding:5px 8px; color:var(--text-primary); font-size:12px;">${a?'<em style="color:var(--text-secondary)">not connected</em>':e.availableToolCount}</td>
-		<td style="padding:5px 8px; color:var(--text-primary); font-size:12px;">${a?"\u2014":e.usedToolCount}</td>
-		<td style="padding:5px 8px; color:var(--text-primary); font-size:12px;">${o>0?`~${o.toLocaleString()} tokens`:"\u2014"}</td>
-		<td style="padding:5px 8px; font-size:12px;">${i}</td>
-	</tr>`}function Ba(e){let t=[...new Set(e.filter(s=>!s.extensionId).flatMap(s=>s.configFiles??[]))],o=t.find(s=>s.replace(/\\/g,"/").endsWith(".vscode/mcp.json"))??t[0];if(!o)return"<code>.vscode/mcp.json</code>";let n=o.replace(/\\/g,"/").split("/").slice(-3).join("/");return`<button class="curation-file-btn" data-command="openFile" data-path="${d(o)}" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:11px;text-decoration:underline;" title="${d(o)}">${d(n)}</button>`}function Oa(e,t,o){let n=[...e].sort((l,u)=>{let c=l.usedToolCount===0?0:l.usedToolCount<l.availableToolCount?1:2,p=u.usedToolCount===0?0:u.usedToolCount<u.availableToolCount?1:2;return c!==p?c-p:l.usedToolCount-u.usedToolCount});if(n.length===0)return"";let s=n.map(l=>za(l,t)).join(""),r=Ba(n),i=n.filter(l=>l.usedToolCount>0).length,a=n.length-i;return`<details style="margin-top:12px;" open>
+		</div>` : ""}
+	</div>`;
+  }
+  function _mcpSourceLabel(s4) {
+    if (s4.extensionId) {
+      return "Extension";
+    }
+    if (!s4.configFiles || s4.configFiles.length === 0) {
+      return "Settings";
+    }
+    const labels = /* @__PURE__ */ new Set();
+    for (const f3 of s4.configFiles) {
+      const p3 = f3.replace(/\\/g, "/");
+      if (p3.includes("/.vscode/")) {
+        labels.add("Workspace");
+      } else if (p3.includes("/.vs/")) {
+        labels.add("Workspace (VS)");
+      } else if (p3.includes("/.cursor/")) {
+        labels.add("Workspace (Cursor)");
+      } else if (p3.endsWith("/.mcp.json")) {
+        labels.add(p3.split("/").slice(-2).join("/"));
+      } else {
+        labels.add("Config file");
+      }
+    }
+    return [...labels].join(", ");
+  }
+  function _buildMcpSourceOpenBtn(s4, sourceTip) {
+    if (s4.configFiles && s4.configFiles.length === 1) {
+      return ` <button class="curation-file-btn" data-command="openFile" data-path="${escapeHtml(s4.configFiles[0])}" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:11px;text-decoration:underline;" title="Open ${escapeHtml(s4.configFiles[0])}">open</button>`;
+    }
+    if (s4.configFiles && s4.configFiles.length > 1) {
+      return ` <button class="curation-file-btn" data-command="openFileFromList" data-paths="${escapeHtml(JSON.stringify(s4.configFiles))}" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:11px;text-decoration:underline;" title="${escapeHtml(sourceTip)}">open</button>`;
+    }
+    if (s4.extensionId) {
+      return ` <button class="curation-file-btn" data-command="manageExtension" data-extension-id="${escapeHtml(s4.extensionId)}" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:11px;text-decoration:underline;" title="Open Extensions view for ${escapeHtml(s4.extensionId)}">open</button>`;
+    }
+    return ` <button class="curation-file-btn" data-command="searchMcpExtensions" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:11px;text-decoration:underline;" title="Browse MCP extensions in the marketplace">open</button>`;
+  }
+  function _buildMcpActionCell(s4) {
+    if (s4.extensionId) {
+      return `<button class="curation-file-btn" data-command="manageExtension" data-extension-id="${escapeHtml(s4.extensionId)}" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:11px;text-decoration:underline;" title="Open the Extensions view for ${escapeHtml(s4.extensionId)} (disable or uninstall to reclaim prompt budget)">Manage Extension</button>`;
+    }
+    if (!s4.configFiles || s4.configFiles.length === 0) {
+      return `<button class="curation-file-btn" data-command="openToolPicker" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:11px;text-decoration:underline;" title="Open VS Code tool selection menu">Change Tools</button>`;
+    }
+    if (s4.configFiles.length === 1) {
+      return `<button class="curation-file-btn" data-command="openFile" data-path="${escapeHtml(s4.configFiles[0])}" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:11px;text-decoration:underline;" title="Open ${escapeHtml(s4.configFiles[0])}">Change Tools</button>`;
+    }
+    return `<button class="curation-file-btn" data-command="openFileFromList" data-paths="${escapeHtml(JSON.stringify(s4.configFiles))}" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:11px;text-decoration:underline;" title="Defined in ${s4.configFiles.length} config files">Change Tools</button>`;
+  }
+  function _buildMcpServerRowHtml(s4, bloat) {
+    const b3 = bloat.byServer[s4.server] ?? 0;
+    const sourceLabel = _mcpSourceLabel(s4);
+    const sourceTip = s4.configFiles?.join("\n") ?? s4.extensionId ?? "";
+    const sourceOpenBtn = _buildMcpSourceOpenBtn(s4, sourceTip);
+    const actionCell = _buildMcpActionCell(s4);
+    const notConnected = s4.availableToolCount === 0;
+    return `<tr class="${s4.usedToolCount > 0 ? "mcp-has-usage" : ""}">
+		<td style="padding:5px 8px; color:var(--text-primary); font-size:12px; white-space:nowrap;">${escapeHtml(s4.server)}</td>
+		<td style="padding:5px 8px; color:var(--text-primary); font-size:12px; white-space:nowrap;" title="${escapeHtml(sourceTip)}">${escapeHtml(sourceLabel)}${sourceOpenBtn}</td>
+		<td style="padding:5px 8px; color:var(--text-primary); font-size:12px;">${notConnected ? '<em style="color:var(--text-secondary)">not connected</em>' : s4.availableToolCount}</td>
+		<td style="padding:5px 8px; color:var(--text-primary); font-size:12px;">${notConnected ? "\u2014" : s4.usedToolCount}</td>
+		<td style="padding:5px 8px; color:var(--text-primary); font-size:12px;">${b3 > 0 ? `~${b3.toLocaleString()} tokens` : "\u2014"}</td>
+		<td style="padding:5px 8px; font-size:12px;">${actionCell}</td>
+	</tr>`;
+  }
+  function _buildMcpJsonLink(allServers) {
+    const allConfigFiles = [...new Set(
+      allServers.filter((s4) => !s4.extensionId).flatMap((s4) => s4.configFiles ?? [])
+    )];
+    const preferredFile = allConfigFiles.find((f3) => f3.replace(/\\/g, "/").endsWith(".vscode/mcp.json")) ?? allConfigFiles[0];
+    if (!preferredFile) {
+      return `<code>.vscode/mcp.json</code>`;
+    }
+    const displayName = preferredFile.replace(/\\/g, "/").split("/").slice(-3).join("/");
+    return `<button class="curation-file-btn" data-command="openFile" data-path="${escapeHtml(preferredFile)}" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:11px;text-decoration:underline;" title="${escapeHtml(preferredFile)}">${escapeHtml(displayName)}</button>`;
+  }
+  function buildUnusedMcpHtml(underusedMcpServers, bloat, windowDays) {
+    const allServers = [...underusedMcpServers].sort((a3, b3) => {
+      const aKey = a3.usedToolCount === 0 ? 0 : a3.usedToolCount < a3.availableToolCount ? 1 : 2;
+      const bKey = b3.usedToolCount === 0 ? 0 : b3.usedToolCount < b3.availableToolCount ? 1 : 2;
+      return aKey !== bKey ? aKey - bKey : a3.usedToolCount - b3.usedToolCount;
+    });
+    if (allServers.length === 0) {
+      return "";
+    }
+    const rows = allServers.map((s4) => _buildMcpServerRowHtml(s4, bloat)).join("");
+    const mcpJsonLink = _buildMcpJsonLink(allServers);
+    const usedCount = allServers.filter((s4) => s4.usedToolCount > 0).length;
+    const unusedCount = allServers.length - usedCount;
+    return `<details style="margin-top:12px;" open>
 		<summary style="cursor:pointer; font-size:13px; font-weight:600; color:var(--text-primary); padding:6px 0;">
-			\u{1F50C} MCP Servers in Last ${o} Days (${n.length})
+			\u{1F50C} MCP Servers in Last ${windowDays} Days (${allServers.length})
 		</summary>
 		<style>#mcp-hide-toggle:checked ~ .mcp-table-wrap .mcp-has-usage { display: none; }</style>
 		<div style="display:flex; align-items:center; gap:6px; margin:6px 0;">
 			<input type="checkbox" id="mcp-hide-toggle" checked style="margin:0; cursor:pointer; flex-shrink:0;">
 			<label for="mcp-hide-toggle" style="font-size:12px; color:var(--text-primary); cursor:pointer; user-select:none;">Hide servers with usage</label>
-			<span style="font-size:11px; color:var(--text-secondary);">${a} with no usage \xB7 ${i} with usage</span>
+			<span style="font-size:11px; color:var(--text-secondary);">${unusedCount} with no usage \xB7 ${usedCount} with usage</span>
 		</div>
 		<div class="mcp-table-wrap" style="margin-top:8px; overflow-x:auto;">
 			<table style="width:100%; border-collapse:collapse; font-size:12px;">
@@ -2392,19 +6350,47 @@ ${hi(t)}
 					<th style="padding:5px 8px; text-align:left; color:var(--text-primary); font-weight:600; font-size:12px;">Est. Overhead</th>
 					<th style="padding:5px 8px; text-align:left; color:var(--text-primary); font-weight:600; font-size:12px;">Action</th>
 				</tr></thead>
-				<tbody>${s}</tbody>
+				<tbody>${rows}</tbody>
 			</table>
-			<div style="margin-top:8px; font-size:11px; color:var(--text-secondary);">\u{1F4A1} Open ${r} to disable file-configured servers, or use <em>Manage Extension</em> to disable or uninstall an MCP-providing extension. (VS Code does not expose per-server picker state to extensions, so servers you disabled in the chat tool picker may still appear here.)</div>
+			<div style="margin-top:8px; font-size:11px; color:var(--text-secondary);">\u{1F4A1} Open ${mcpJsonLink} to disable file-configured servers, or use <em>Manage Extension</em> to disable or uninstall an MCP-providing extension. (VS Code does not expose per-server picker state to extensions, so servers you disabled in the chat tool picker may still appear here.)</div>
 		</div>
-	</details>`}function Na(e){if(e.length===0)return"";let t=e.map(o=>{let n=o.configFiles?.[0],s=n?`<button class="curation-file-btn" data-command="openFile" data-path="${d(n)}" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:12px;text-decoration:underline;" title="Open ${d(n)}">View skill</button>`:"\u2014",r="\u2014",i="";o.pluginName?(r=`Plugin: ${o.pluginName}`,i=` <button class="curation-file-btn" data-command="openAgentPlugins" data-plugin-name="${d(o.pluginName)}" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:11px;text-decoration:underline;" title="Open Extensions view filtered to agent plugins">manage</button>`):o.skillPath&&(o.skillPath.startsWith(".github/skills")?r="Workspace (.github)":o.skillPath.startsWith(".claude/skills")?r="Workspace (.claude)":o.skillPath.startsWith(".agents/skills")?r="Workspace (.agents)":r="User (~)");let a=Math.round((o.name.length+o.description.length+10)/4);return`<tr>
-		<td style="padding:5px 8px; color:var(--text-primary); font-size:12px; white-space:nowrap;">${d(o.name)}</td>
-		<td style="padding:5px 8px; color:var(--text-primary); font-size:12px; white-space:nowrap;">${d(r)}${i}</td>
-		<td style="padding:5px 8px; color:var(--text-primary); font-size:12px; max-width:320px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;" title="${d(o.description)}">${d(o.description)}</td>
-		<td style="padding:5px 8px; color:var(--text-primary); font-size:12px; white-space:nowrap;">~${a.toLocaleString()} tokens</td>
-		<td style="padding:5px 8px; font-size:12px; white-space:nowrap;">${s}</td>
-	</tr>`}).join("");return`<details style="margin-top:8px;" open>
+	</details>`;
+  }
+  function buildUnusedSkillsHtml(unusedSkills) {
+    if (unusedSkills.length === 0) {
+      return "";
+    }
+    const rows = unusedSkills.map((s4) => {
+      const skillFile = s4.configFiles?.[0];
+      const viewLink = skillFile ? `<button class="curation-file-btn" data-command="openFile" data-path="${escapeHtml(skillFile)}" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:12px;text-decoration:underline;" title="Open ${escapeHtml(skillFile)}">View skill</button>` : "\u2014";
+      let sourceLabel = "\u2014";
+      let manageBtn = "";
+      if (s4.pluginName) {
+        sourceLabel = `Plugin: ${s4.pluginName}`;
+        manageBtn = ` <button class="curation-file-btn" data-command="openAgentPlugins" data-plugin-name="${escapeHtml(s4.pluginName)}" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:11px;text-decoration:underline;" title="Open Extensions view filtered to agent plugins">manage</button>`;
+      } else if (s4.skillPath) {
+        if (s4.skillPath.startsWith(".github/skills")) {
+          sourceLabel = "Workspace (.github)";
+        } else if (s4.skillPath.startsWith(".claude/skills")) {
+          sourceLabel = "Workspace (.claude)";
+        } else if (s4.skillPath.startsWith(".agents/skills")) {
+          sourceLabel = "Workspace (.agents)";
+        } else {
+          sourceLabel = "User (~)";
+        }
+      }
+      const estTokens = Math.round((s4.name.length + s4.description.length + 10) / 4);
+      return `<tr>
+		<td style="padding:5px 8px; color:var(--text-primary); font-size:12px; white-space:nowrap;">${escapeHtml(s4.name)}</td>
+		<td style="padding:5px 8px; color:var(--text-primary); font-size:12px; white-space:nowrap;">${escapeHtml(sourceLabel)}${manageBtn}</td>
+		<td style="padding:5px 8px; color:var(--text-primary); font-size:12px; max-width:320px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;" title="${escapeHtml(s4.description)}">${escapeHtml(s4.description)}</td>
+		<td style="padding:5px 8px; color:var(--text-primary); font-size:12px; white-space:nowrap;">~${estTokens.toLocaleString()} tokens</td>
+		<td style="padding:5px 8px; font-size:12px; white-space:nowrap;">${viewLink}</td>
+	</tr>`;
+    }).join("");
+    return `<details style="margin-top:8px;" open>
 		<summary style="cursor:pointer; font-size:13px; font-weight:600; color:var(--text-primary); padding:6px 0;">
-			\u{1F4DA} Unused Skills (${e.length})
+			\u{1F4DA} Unused Skills (${unusedSkills.length})
 		</summary>
 		<div style="margin-top:8px; overflow-x:auto;">
 			<table style="width:100%; border-collapse:collapse; font-size:12px;">
@@ -2415,24 +6401,37 @@ ${hi(t)}
 					<th style="padding:5px 8px; text-align:left; color:var(--text-primary); font-weight:600; font-size:12px;">Est. Overhead</th>
 					<th style="padding:5px 8px; text-align:left; color:var(--text-primary); font-weight:600; font-size:12px;">View</th>
 				</tr></thead>
-				<tbody>${t}</tbody>
+				<tbody>${rows}</tbody>
 			</table>
 			<div style="margin-top:8px; font-size:11px; color:var(--text-secondary);">\u{1F4A1} Est. overhead is per agent interaction. For plugin skills, click <em>manage</em> to open the agent plugins view where you can uninstall the plugin. For workspace skills, update the description or remove the SKILL.md.</div>
 		</div>
-	</details>`}function Ha(e,t){if(e.length===0)return"";let o=e.map(r=>{let i=`<button class="curation-file-btn" data-command="openAgentPlugins" data-plugin-name="${d(r.pluginName)}" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:11px;text-decoration:underline;" title="Open Extensions view filtered to @agentPlugins ${d(r.pluginName)}">Manage Plugin</button>`;return`<tr class="${r.usedSkillCount===0?"":"plugin-has-usage"}">
-			<td style="padding:5px 8px; color:var(--text-primary); font-size:12px; white-space:nowrap;">${d(r.pluginName)}</td>
-			<td style="padding:5px 8px; color:var(--text-primary); font-size:12px;">${r.availableSkillCount}</td>
-			<td style="padding:5px 8px; color:var(--text-primary); font-size:12px;">${r.usedSkillCount}</td>
-			<td style="padding:5px 8px; font-size:12px;">${i}</td>
-		</tr>`}).join(""),n=e.filter(r=>r.usedSkillCount===0).length,s=e.length-n;return`<details style="margin-top:8px;" open>
+	</details>`;
+  }
+  function buildUnderusedAgentPluginsHtml(underusedAgentPlugins, windowDays) {
+    if (underusedAgentPlugins.length === 0) {
+      return "";
+    }
+    const rows = underusedAgentPlugins.map((p3) => {
+      const manageBtn = `<button class="curation-file-btn" data-command="openAgentPlugins" data-plugin-name="${escapeHtml(p3.pluginName)}" style="background:none;border:none;padding:0;cursor:pointer;color:var(--link-color);font-size:11px;text-decoration:underline;" title="Open Extensions view filtered to @agentPlugins ${escapeHtml(p3.pluginName)}">Manage Plugin</button>`;
+      const usageClass = p3.usedSkillCount === 0 ? "" : "plugin-has-usage";
+      return `<tr class="${usageClass}">
+			<td style="padding:5px 8px; color:var(--text-primary); font-size:12px; white-space:nowrap;">${escapeHtml(p3.pluginName)}</td>
+			<td style="padding:5px 8px; color:var(--text-primary); font-size:12px;">${p3.availableSkillCount}</td>
+			<td style="padding:5px 8px; color:var(--text-primary); font-size:12px;">${p3.usedSkillCount}</td>
+			<td style="padding:5px 8px; font-size:12px;">${manageBtn}</td>
+		</tr>`;
+    }).join("");
+    const unusedCount = underusedAgentPlugins.filter((p3) => p3.usedSkillCount === 0).length;
+    const usedCount = underusedAgentPlugins.length - unusedCount;
+    return `<details style="margin-top:8px;" open>
 		<summary style="cursor:pointer; font-size:13px; font-weight:600; color:var(--text-primary); padding:6px 0;">
-			\u{1F9E9} Agent Plugins in Last ${t} Days (${e.length})
+			\u{1F9E9} Agent Plugins in Last ${windowDays} Days (${underusedAgentPlugins.length})
 		</summary>
 		<style>#plugin-hide-toggle:checked ~ .plugin-table-wrap .plugin-has-usage { display: none; }</style>
 		<div style="display:flex; align-items:center; gap:6px; margin:6px 0;">
 			<input type="checkbox" id="plugin-hide-toggle" checked style="margin:0; cursor:pointer; flex-shrink:0;">
 			<label for="plugin-hide-toggle" style="font-size:12px; color:var(--text-primary); cursor:pointer; user-select:none;">Hide plugins with usage</label>
-			<span style="font-size:11px; color:var(--text-secondary);">${n} with no usage \xB7 ${s} with usage</span>
+			<span style="font-size:11px; color:var(--text-secondary);">${unusedCount} with no usage \xB7 ${usedCount} with usage</span>
 		</div>
 		<div class="plugin-table-wrap" style="margin-top:8px; overflow-x:auto;">
 			<table style="width:100%; border-collapse:collapse; font-size:12px;">
@@ -2442,17 +6441,29 @@ ${hi(t)}
 					<th style="padding:5px 8px; text-align:left; color:var(--text-primary); font-weight:600; font-size:12px;">Skills Used</th>
 					<th style="padding:5px 8px; text-align:left; color:var(--text-primary); font-weight:600; font-size:12px;">Action</th>
 				</tr></thead>
-				<tbody>${o}</tbody>
+				<tbody>${rows}</tbody>
 			</table>
 			<div style="margin-top:8px; font-size:11px; color:var(--text-secondary);">\u{1F4A1} Click <em>Manage Plugin</em> to open the Extensions view filtered to <code>@agentPlugins</code> where you can uninstall unused plugins to reclaim prompt budget.</div>
 		</div>
-	</details>`}function ja(e,t){if(e.length===0)return"";let o=t.byServer.builtin??0,n=e.map(r=>{let i=Math.round((r.name.length+(r.description?.length??0)+10)/4);return`<tr>
-			<td style="padding:5px 8px; color:var(--text-primary); font-size:12px; white-space:nowrap;">${d(r.name)}</td>
-			<td style="padding:5px 8px; color:var(--text-primary); font-size:12px; max-width:400px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;" title="${d(r.description??"")}">${d(r.description??"\u2014")}</td>
-			<td style="padding:5px 8px; color:var(--text-primary); font-size:12px; white-space:nowrap;">~${i} tokens</td>
-		</tr>`}).join(""),s=r=>r>=1e3?`~${Math.round(r/1e3)}K`:`~${r}`;return`<details style="margin-top:12px;">
+	</details>`;
+  }
+  function buildBuiltinToolsHtml(builtinTools, bloat) {
+    if (builtinTools.length === 0) {
+      return "";
+    }
+    const builtinBloat = bloat.byServer["builtin"] ?? 0;
+    const rows = builtinTools.map((t4) => {
+      const overhead = Math.round((t4.name.length + (t4.description?.length ?? 0) + 10) / 4);
+      return `<tr>
+			<td style="padding:5px 8px; color:var(--text-primary); font-size:12px; white-space:nowrap;">${escapeHtml(t4.name)}</td>
+			<td style="padding:5px 8px; color:var(--text-primary); font-size:12px; max-width:400px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;" title="${escapeHtml(t4.description ?? "")}">${escapeHtml(t4.description ?? "\u2014")}</td>
+			<td style="padding:5px 8px; color:var(--text-primary); font-size:12px; white-space:nowrap;">~${overhead} tokens</td>
+		</tr>`;
+    }).join("");
+    const fmt = (n5) => n5 >= 1e3 ? `~${Math.round(n5 / 1e3)}K` : `~${n5}`;
+    return `<details style="margin-top:12px;">
 		<summary style="cursor:pointer; font-size:13px; font-weight:600; color:var(--text-primary); padding:6px 0;">
-			\u{1F527} Built-in VS Code Tools (${e.length}) \u2014 ${s(o)} tokens overhead, not actionable
+			\u{1F527} Built-in VS Code Tools (${builtinTools.length}) \u2014 ${fmt(builtinBloat)} tokens overhead, not actionable
 		</summary>
 		<div style="margin-top:8px; overflow-x:auto;">
 			<table style="width:100%; border-collapse:collapse; font-size:12px;">
@@ -2461,131 +6472,247 @@ ${hi(t)}
 					<th style="padding:5px 8px; text-align:left; color:var(--text-primary); font-weight:600; font-size:12px;">Description</th>
 					<th style="padding:5px 8px; text-align:left; color:var(--text-primary); font-weight:600; font-size:12px;">Est. Overhead</th>
 				</tr></thead>
-				<tbody>${n}</tbody>
+				<tbody>${rows}</tbody>
 			</table>
 			<div style="margin-top:8px; font-size:11px; color:var(--text-secondary);">\u{1F4A1} These tools are provided by VS Code itself and cannot be disabled. They are excluded from the actionable overhead total above.</div>
 		</div>
-	</details>`}function Fa(e){try{if(!e||e.availableTools.length===0)return pe("render-hidden-empty","buildCurationSectionHtml.hidden",{hasCurationObject:!!e,availableTools:e?.availableTools?.length??0}),"";let{availableTools:t,unusedTools:o,underusedMcpServers:n,underusedAgentPlugins:s,estimatedPromptBloat:r,windowDays:i}=e,a=o.filter(u=>u.source==="skill"),l=t.filter(u=>u.source==="builtin");return Z("buildCurationSectionHtml.render",{availableTools:t.length,unusedTools:o.length,unusedSkills:a.length,mcpServers:n.length}),`
+	</details>`;
+  }
+  function buildCurationSectionHtml(curation) {
+    try {
+      if (!curation || curation.availableTools.length === 0) {
+        traceCurationOnce("render-hidden-empty", "buildCurationSectionHtml.hidden", {
+          hasCurationObject: !!curation,
+          availableTools: curation?.availableTools?.length ?? 0
+        });
+        return "";
+      }
+      const { availableTools, unusedTools, underusedMcpServers, underusedAgentPlugins, estimatedPromptBloat, windowDays } = curation;
+      const unusedSkills = unusedTools.filter((t4) => t4.source === "skill");
+      const builtinTools = availableTools.filter((t4) => t4.source === "builtin");
+      traceCuration("buildCurationSectionHtml.render", {
+        availableTools: availableTools.length,
+        unusedTools: unusedTools.length,
+        unusedSkills: unusedSkills.length,
+        mcpServers: underusedMcpServers.length
+      });
+      return `
 			<!-- Tool Curation Section -->
 			<div id="section-tool-curation" class="section">
 				<div class="section-title"><span>\u2702\uFE0F</span><span>Tool Curation</span></div>
-				<div class="section-subtitle" style="color:var(--text-primary); opacity:0.75;">Compare available tools against actual usage to reduce prompt overhead (last ${i} days)</div>
-				${Da(t,o,r)}
-				${Oa(n,r,i)}
-				${Ha(s,i)}
-				${ja(l,r)}
-				${Na(a)}
-			</div>`}catch(t){return Z("buildCurationSectionHtml.error",{error:t instanceof Error?t.message:String(t)}),`
+				<div class="section-subtitle" style="color:var(--text-primary); opacity:0.75;">Compare available tools against actual usage to reduce prompt overhead (last ${windowDays} days)</div>
+				${buildCurationSummaryHtml(availableTools, unusedTools, estimatedPromptBloat)}
+				${buildUnusedMcpHtml(underusedMcpServers, estimatedPromptBloat, windowDays)}
+				${buildUnderusedAgentPluginsHtml(underusedAgentPlugins, windowDays)}
+				${buildBuiltinToolsHtml(builtinTools, estimatedPromptBloat)}
+				${buildUnusedSkillsHtml(unusedSkills)}
+			</div>`;
+    } catch (error) {
+      traceCuration("buildCurationSectionHtml.error", {
+        error: error instanceof Error ? error.message : String(error)
+      });
+      return `
 			<div id="section-tool-curation" class="section">
 				<div class="section-title"><span>\u2702\uFE0F</span><span>Tool Curation</span></div>
 				<div class="section-subtitle" style="color:var(--text-primary); opacity:0.75;">Tool curation is temporarily unavailable due to a rendering error. Try Refresh.</div>
-			</div>`}}function Wa(){return`
-		<div id="tab-panel-repos" class="tab-panel"${$!=="repos"?' style="display:none"':""}>
+			</div>`;
+    }
+  }
+  function buildReposAndAgentTabPanelsHtml() {
+    return `
+		<div id="tab-panel-repos" class="tab-panel"${activeTab !== "repos" ? ' style="display:none"' : ""}>
 			<div class="section" id="repos-pr-content">
 				<div class="section-title"><span>\u{1F916}</span><span>AI Activity in Repository PRs</span></div>
 				<div class="section-subtitle">PRs from the last 30 days across your known repositories \u2014 authored or reviewed by AI agents.</div>
 				<div style="margin-top:12px; color: var(--text-secondary); font-size:12px;">Loading\u2026 (sign in with GitHub to see data)</div>
 			</div>
 		</div>
-		<div id="tab-panel-agent" class="tab-panel"${$!=="agent"?' style="display:none"':""}>
+		<div id="tab-panel-agent" class="tab-panel"${activeTab !== "agent" ? ' style="display:none"' : ""}>
 			<div class="section" id="agent-sessions-content">
 				<div class="section-title"><span>\u{1F916}</span><span>Copilot Cloud Agent Sessions</span></div>
 				<div class="section-subtitle">Cloud agent tasks and sessions from the last 30 days, fetched from the GitHub API.</div>
 				<div style="margin-top:12px; color: var(--text-secondary); font-size:12px;">Loading\u2026 (sign in with GitHub to see data)</div>
 			</div>
-		</div>`}function Nt(e){let t={tip:"rgba(96,165,250,0.12)",opportunity:"rgba(251,191,36,0.12)",celebration:"rgba(74,222,128,0.12)"},o={tip:"rgba(96,165,250,0.5)",opportunity:"rgba(251,191,36,0.5)",celebration:"rgba(74,222,128,0.5)"},n={tip:"rgba(96,165,250,0.85)",opportunity:"rgba(251,191,36,0.85)",celebration:"rgba(74,222,128,0.85)"},s=t[e.severity]??t.tip,r=o[e.severity]??o.tip,i=n[e.severity]??n.tip,a=e.status==="new",l=e.status==="done",u=e.actionLabel?`<button class="insight-action-btn" data-insight-id="${d(e.id)}" data-action="execute" data-command="${d(e.actionCommand??"")}"
+		</div>`;
+  }
+  function buildInsightCardHtml(insight) {
+    const severityColors = {
+      tip: "rgba(96,165,250,0.12)",
+      opportunity: "rgba(251,191,36,0.12)",
+      celebration: "rgba(74,222,128,0.12)"
+    };
+    const severityBorder = {
+      tip: "rgba(96,165,250,0.5)",
+      opportunity: "rgba(251,191,36,0.5)",
+      celebration: "rgba(74,222,128,0.5)"
+    };
+    const severityAccent = {
+      tip: "rgba(96,165,250,0.85)",
+      opportunity: "rgba(251,191,36,0.85)",
+      celebration: "rgba(74,222,128,0.85)"
+    };
+    const bg = severityColors[insight.severity] ?? severityColors.tip;
+    const border = severityBorder[insight.severity] ?? severityBorder.tip;
+    const accent = severityAccent[insight.severity] ?? severityAccent.tip;
+    const isNew = insight.status === "new";
+    const isDone = insight.status === "done";
+    const actionBtn = insight.actionLabel ? `<button class="insight-action-btn" data-insight-id="${escapeHtml(insight.id)}" data-action="execute" data-command="${escapeHtml(insight.actionCommand ?? "")}"
 				style="padding:5px 14px; font-size:12px; font-weight:600; cursor:pointer;
-				border:1px solid ${r}; border-radius:5px;
-				background:${s}; color:var(--text-primary);">${d(e.actionLabel)}</button>`:"",c=l?'<span style="font-size:12px; color:var(--text-secondary); opacity:0.5; padding:5px 6px;">\u2713 Done</span>':`<button class="insight-action-btn" data-insight-id="${d(e.id)}" data-action="done"
+				border:1px solid ${border}; border-radius:5px;
+				background:${bg}; color:var(--text-primary);">${escapeHtml(insight.actionLabel)}</button>` : "";
+    const doneBtn = !isDone ? `<button class="insight-action-btn" data-insight-id="${escapeHtml(insight.id)}" data-action="done"
 				title="Mark as done"
 				style="padding:5px 14px; font-size:12px; font-weight:600; cursor:pointer;
-				border:1px solid ${r}; border-radius:5px;
-				background:${i}; color:#0d1117;">\u2713 Done</button>`,p=l?"":`<button class="insight-action-btn" data-insight-id="${d(e.id)}" data-action="snooze"
+				border:1px solid ${border}; border-radius:5px;
+				background:${accent}; color:#0d1117;">\u2713 Done</button>` : `<span style="font-size:12px; color:var(--text-secondary); opacity:0.5; padding:5px 6px;">\u2713 Done</span>`;
+    const snoozeBtn = !isDone ? `<button class="insight-action-btn" data-insight-id="${escapeHtml(insight.id)}" data-action="snooze"
 				title="Snooze for 7 days"
 				style="padding:5px 14px; font-size:12px; font-weight:500; cursor:pointer;
-				border:1px solid ${r}; border-radius:5px;
-				background:transparent; color:var(--text-primary);">\u23F8 Snooze</button>`,b=l?"":`<button class="insight-action-btn" data-insight-id="${d(e.id)}" data-action="dismiss"
+				border:1px solid ${border}; border-radius:5px;
+				background:transparent; color:var(--text-primary);">\u23F8 Snooze</button>` : "";
+    const dismissBtn = !isDone ? `<button class="insight-action-btn" data-insight-id="${escapeHtml(insight.id)}" data-action="dismiss"
 				title="Dismiss permanently"
 				style="padding:4px 8px; font-size:14px; line-height:1; cursor:pointer; border:none; border-radius:4px;
-				background:transparent; color:var(--text-primary); opacity:0.5;">\u2715</button>`;return`
-		<div class="insight-card" data-insight-id="${d(e.id)}"
+				background:transparent; color:var(--text-primary); opacity:0.5;">\u2715</button>` : "";
+    return `
+		<div class="insight-card" data-insight-id="${escapeHtml(insight.id)}"
 			style="margin-bottom:12px; padding:16px 18px; border-radius:8px;
-			background:${s}; border:1px solid ${r};
-			${a?"box-shadow:0 2px 8px "+s+";":""}
-			${l?"opacity:0.45;":""}">
+			background:${bg}; border:1px solid ${border};
+			${isNew ? "box-shadow:0 2px 8px " + bg + ";" : ""}
+			${isDone ? "opacity:0.45;" : ""}">
 			<div style="display:flex; align-items:flex-start; gap:10px;">
 				<div style="flex:1;">
 					<div style="font-size:13px; font-weight:700; color:var(--text-primary); margin-bottom:8px; display:flex; align-items:center; gap:8px;">
-						${a?`<span style="font-size:10px; padding:2px 7px; border-radius:10px; background:${i}; color:#0d1117; font-weight:700; letter-spacing:0.04em;">NEW</span>`:""}
-						${d(e.title)}
+						${isNew ? `<span style="font-size:10px; padding:2px 7px; border-radius:10px; background:${accent}; color:#0d1117; font-weight:700; letter-spacing:0.04em;">NEW</span>` : ""}
+						${escapeHtml(insight.title)}
 					</div>
-					<div style="font-size:12px; color:var(--text-primary); line-height:1.5; opacity:0.85; white-space:pre-wrap;">${d(e.body)}</div>
-					${u?`<div style="margin-top:12px;">${u}</div>`:""}
+					<div style="font-size:12px; color:var(--text-primary); line-height:1.5; opacity:0.85; white-space:pre-wrap;">${escapeHtml(insight.body)}</div>
+					${actionBtn ? `<div style="margin-top:12px;">${actionBtn}</div>` : ""}
 				</div>
 				<div style="flex-shrink:0; margin-top:-4px;">
-					${b}
+					${dismissBtn}
 				</div>
 			</div>
-			<div style="display:flex; gap:8px; margin-top:14px; justify-content:flex-end; border-top:1px solid ${r}; padding-top:10px;">
-				${c}
-				${p}
+			<div style="display:flex; gap:8px; margin-top:14px; justify-content:flex-end; border-top:1px solid ${border}; padding-top:10px;">
+				${doneBtn}
+				${snoozeBtn}
 			</div>
-		</div>`}function qa(e){let t=e.filter(i=>i.status!=="dismissed"),o=t.filter(i=>i.status==="new"),n=t.filter(i=>i.status!=="new"&&i.status!=="done"),s=o.length>0?`<div style="margin-bottom:20px;">
+		</div>`;
+  }
+  function buildInsightsTabPanelHtml(insights) {
+    const applicable = insights.filter((i6) => i6.status !== "dismissed");
+    const newInsights = applicable.filter((i6) => i6.status === "new");
+    const otherInsights = applicable.filter((i6) => i6.status !== "new" && i6.status !== "done");
+    const forYouSection = newInsights.length > 0 ? `<div style="margin-bottom:20px;">
 			<div style="font-size:12px; font-weight:600; text-transform:uppercase; color:var(--text-secondary); letter-spacing:0.05em; margin-bottom:10px;">\u2728 For You</div>
-			${o.map(Nt).join("")}
-		</div>`:`<div style="margin-bottom:20px; padding:16px; background:var(--bg-tertiary); border-radius:8px; font-size:12px; color:var(--text-secondary); text-align:center;">
+			${newInsights.map(buildInsightCardHtml).join("")}
+		</div>` : `<div style="margin-bottom:20px; padding:16px; background:var(--bg-tertiary); border-radius:8px; font-size:12px; color:var(--text-secondary); text-align:center;">
 			\u{1F389} No new insights right now \u2014 keep using Copilot and check back later!
-		</div>`,r=n.length>0?`<div>
+		</div>`;
+    const allSection = otherInsights.length > 0 ? `<div>
 			<div style="font-size:12px; font-weight:600; text-transform:uppercase; color:var(--text-secondary); letter-spacing:0.05em; margin-bottom:10px;">All Tips</div>
-			${n.map(Nt).join("")}
-		</div>`:"";return`
-		<div id="tab-panel-insights" class="tab-panel"${$!=="insights"?' style="display:none"':""}>
+			${otherInsights.map(buildInsightCardHtml).join("")}
+		</div>` : "";
+    return `
+		<div id="tab-panel-insights" class="tab-panel"${activeTab !== "insights" ? ' style="display:none"' : ""}>
 			<div class="section">
 				<div class="section-title"><span>\u{1F4A1}</span><span>Insights</span></div>
 				<div class="section-subtitle">
 					Personalized tips based on your usage patterns. Tips are data-driven \u2014 they only appear when relevant to how you code with AI.
 				</div>
 				<div id="insights-container" style="margin-top:16px;">
-					${s}
-					${r}
+					${forYouSection}
+					${allSection}
 				</div>
 			</div>
-		</div>`}function Ka(e){return!e||e.sessionsWithMoments===0?"":` <span style="background:rgba(251,191,36,0.4);border-radius:10px;padding:1px 6px;font-size:11px;">${e.sessionsWithMoments}</span>`}function Ga(e){return`<button class="tab-button ${$==="corrections"?"active":""}" data-tab="corrections"><span class="codicon codicon-debug-restart"></span> Corrections${Ka(e)}</button>`}function Va(e){let t=e.title||e.file.split(/[\\/]/).pop()||e.file,o=e.lastInteraction?new Date(e.lastInteraction):null,n=o&&!isNaN(o.getTime())?o.toLocaleDateString():"",s=e.repository?` \xB7 ${e.repository}`:"";return`<div style="font-size:11px; color:var(--text-secondary); padding:2px 0; overflow-wrap:anywhere;">${d(t)}${d(n?` \xB7 ${n}`:"")}${d(s)}</div>`}function Ya(e){let t=e.sharedKeywords.length>0?`<div style="margin-top:6px; display:flex; flex-wrap:wrap; gap:4px;">${e.sharedKeywords.map(o=>`<span style="font-size:10px; padding:1px 7px; border-radius:8px; background:var(--bg-tertiary); color:var(--text-secondary);">${d(o)}</span>`).join("")}</div>`:"";return`
+		</div>`;
+  }
+  function correctionsCountBadgeHtml(report) {
+    if (!report || report.sessionsWithMoments === 0) {
+      return "";
+    }
+    return ` <span style="background:rgba(251,191,36,0.4);border-radius:10px;padding:1px 6px;font-size:11px;">${report.sessionsWithMoments}</span>`;
+  }
+  function correctionsTabButtonHtml(report) {
+    return `<button class="tab-button ${activeTab === "corrections" ? "active" : ""}" data-tab="corrections"><span class="codicon codicon-debug-restart"></span> Corrections${correctionsCountBadgeHtml(report)}</button>`;
+  }
+  function buildRepeatedTaskSessionLinkHtml(session) {
+    const title = session.title || session.file.split(/[\\/]/).pop() || session.file;
+    const date = session.lastInteraction ? new Date(session.lastInteraction) : null;
+    const dateLabel = date && !isNaN(date.getTime()) ? date.toLocaleDateString() : "";
+    const repo = session.repository ? ` \xB7 ${session.repository}` : "";
+    return `<div style="font-size:11px; color:var(--text-secondary); padding:2px 0; overflow-wrap:anywhere;">${escapeHtml(title)}${escapeHtml(dateLabel ? ` \xB7 ${dateLabel}` : "")}${escapeHtml(repo)}</div>`;
+  }
+  function buildRepeatedTaskClusterHtml(cluster) {
+    const keywords = cluster.sharedKeywords.length > 0 ? `<div style="margin-top:6px; display:flex; flex-wrap:wrap; gap:4px;">${cluster.sharedKeywords.map((k2) => `<span style="font-size:10px; padding:1px 7px; border-radius:8px; background:var(--bg-tertiary); color:var(--text-secondary);">${escapeHtml(k2)}</span>`).join("")}</div>` : "";
+    return `
 		<div style="margin-top:10px; padding:12px 14px; border-radius:8px; background:var(--bg-tertiary); border:1px solid var(--border-color, transparent);">
 			<div style="display:flex; align-items:flex-start; gap:10px;">
-				<span style="flex-shrink:0; font-size:11px; font-weight:700; padding:2px 8px; border-radius:10px; background:rgba(74,222,128,0.15); border:1px solid rgba(74,222,128,0.5); color:var(--text-primary); white-space:nowrap;">${e.sessionCount}\xD7 repeated</span>
-				<div style="flex:1; min-width:0; font-size:12px; color:var(--text-primary); font-style:italic; overflow-wrap:anywhere;">&ldquo;${d(e.representativePrompt)}&rdquo;</div>
+				<span style="flex-shrink:0; font-size:11px; font-weight:700; padding:2px 8px; border-radius:10px; background:rgba(74,222,128,0.15); border:1px solid rgba(74,222,128,0.5); color:var(--text-primary); white-space:nowrap;">${cluster.sessionCount}\xD7 repeated</span>
+				<div style="flex:1; min-width:0; font-size:12px; color:var(--text-primary); font-style:italic; overflow-wrap:anywhere;">&ldquo;${escapeHtml(cluster.representativePrompt)}&rdquo;</div>
 			</div>
-			${t}
+			${keywords}
 			<details style="margin-top:8px;">
-				<summary style="font-size:11px; color:var(--text-secondary); cursor:pointer;">Sessions (${e.sessions.length})</summary>
-				<div style="margin-top:4px;">${e.sessions.map(Va).join("")}</div>
+				<summary style="font-size:11px; color:var(--text-secondary); cursor:pointer;">Sessions (${cluster.sessions.length})</summary>
+				<div style="margin-top:4px;">${cluster.sessions.map(buildRepeatedTaskSessionLinkHtml).join("")}</div>
 			</details>
-		</div>`}function Ja(e){return!e||e.clusters.length===0?"":`
+		</div>`;
+  }
+  function buildSkillSuggestionsSectionHtml(report) {
+    if (!report || report.clusters.length === 0) {
+      return "";
+    }
+    return `
 		<div class="section">
 			<div class="section-title"><span>\u{1F9E9}</span><span>Skill Suggestions</span></div>
 			<div class="section-subtitle">
-				Tasks you keep prompting for across sessions (first prompt per session, ${e.sessionsScanned} sessions scanned).
+				Tasks you keep prompting for across sessions (first prompt per session, ${report.sessionsScanned} sessions scanned).
 				A repeated task is a good candidate for a reusable skill, prompt file, or custom agent.
 			</div>
-			${e.clusters.map(Ya).join("")}
-		</div>`}var Xa={"user-correction":{label:"You corrected the agent",color:"rgba(251,191,36,0.85)"},"tool-error":{label:"Tool failed",color:"rgba(248,113,113,0.85)"},"edit-retry":{label:"Edit retry",color:"rgba(251,146,60,0.85)"},"edit-self-correction":{label:"Edit self-correction",color:"rgba(251,146,60,0.85)"},"agent-self-correction":{label:"Agent caught itself",color:"rgba(96,165,250,0.85)"}};function Za(e){let t=Xa[e.type]??{label:e.type,color:"rgba(148,163,184,0.85)"},o=e.timestamp?new Date(e.timestamp):null,n=o&&!isNaN(o.getTime())?o.toLocaleString():"",s=e.type==="tool-error"?`tool \`${e.tool??"?"}\`${e.retried?" \u2014 retried shortly after":""}`:e.matchedPattern?`matched ${e.matchedPattern}`:"";return`
+			${report.clusters.map(buildRepeatedTaskClusterHtml).join("")}
+		</div>`;
+  }
+  var CORRECTION_TYPE_META = {
+    "user-correction": { label: "You corrected the agent", color: "rgba(251,191,36,0.85)" },
+    "tool-error": { label: "Tool failed", color: "rgba(248,113,113,0.85)" },
+    "edit-retry": { label: "Edit retry", color: "rgba(251,146,60,0.85)" },
+    "edit-self-correction": { label: "Edit self-correction", color: "rgba(251,146,60,0.85)" },
+    "agent-self-correction": { label: "Agent caught itself", color: "rgba(96,165,250,0.85)" }
+  };
+  function buildCorrectionMomentHtml(moment) {
+    const meta = CORRECTION_TYPE_META[moment.type] ?? { label: moment.type, color: "rgba(148,163,184,0.85)" };
+    const time = moment.timestamp ? new Date(moment.timestamp) : null;
+    const timeLabel = time && !isNaN(time.getTime()) ? time.toLocaleString() : "";
+    const detail = moment.type === "tool-error" ? `tool \`${moment.tool ?? "?"}\`${moment.retried ? " \u2014 retried shortly after" : ""}` : moment.matchedPattern ? `matched ${moment.matchedPattern}` : "";
+    return `
 		<div style="display:flex; gap:10px; align-items:flex-start; padding:8px 0; border-bottom:1px solid var(--bg-tertiary);">
-			<span style="flex-shrink:0; font-size:10px; font-weight:700; letter-spacing:0.03em; padding:2px 8px; border-radius:10px; border:1px solid ${t.color}; color:var(--text-primary); background:${t.color.replace("0.85","0.12")}; white-space:nowrap;">${d(t.label)}</span>
+			<span style="flex-shrink:0; font-size:10px; font-weight:700; letter-spacing:0.03em; padding:2px 8px; border-radius:10px; border:1px solid ${meta.color}; color:var(--text-primary); background:${meta.color.replace("0.85", "0.12")}; white-space:nowrap;">${escapeHtml(meta.label)}</span>
 			<div style="flex:1; min-width:0;">
-				<div style="font-size:12px; color:var(--text-primary); opacity:0.9; overflow-wrap:anywhere;">${d(e.snippet)}</div>
+				<div style="font-size:12px; color:var(--text-primary); opacity:0.9; overflow-wrap:anywhere;">${escapeHtml(moment.snippet)}</div>
 				<div style="font-size:11px; color:var(--text-secondary); margin-top:3px;">
-					turn ${e.turnNumber}${s?` \xB7 ${d(s)}`:""}${n?` \xB7 ${d(n)}`:""}
+					turn ${moment.turnNumber}${detail ? ` \xB7 ${escapeHtml(detail)}` : ""}${timeLabel ? ` \xB7 ${escapeHtml(timeLabel)}` : ""}
 				</div>
 			</div>
-		</div>`}function Qa(e){let t=e.title||e.file.split(/[\\/]/).pop()||e.file,o=e.lastInteraction?new Date(e.lastInteraction):null,n=o&&!isNaN(o.getTime())?o.toLocaleDateString():"",s=e.totalMoments??e.moments.length,r=s>e.moments.length?` \xB7 showing ${e.moments.length} of ${s} moments`:"";return`
+		</div>`;
+  }
+  function buildCorrectionSessionHtml(session) {
+    const title = session.title || session.file.split(/[\\/]/).pop() || session.file;
+    const date = session.lastInteraction ? new Date(session.lastInteraction) : null;
+    const dateLabel = date && !isNaN(date.getTime()) ? date.toLocaleDateString() : "";
+    const totalMoments = session.totalMoments ?? session.moments.length;
+    const truncatedLabel = totalMoments > session.moments.length ? ` \xB7 showing ${session.moments.length} of ${totalMoments} moments` : "";
+    return `
 		<div style="margin:10px 0 4px; padding:10px 12px; background:var(--bg-tertiary); border-radius:6px;">
 			<div style="font-size:12px; font-weight:600; color:var(--text-primary); overflow-wrap:anywhere;">
-				${d(t)}${n||r?` <span style="font-weight:400; color:var(--text-secondary);">${n?`\xB7 ${d(n)}`:""}${d(r)}</span>`:""}
+				${escapeHtml(title)}${dateLabel || truncatedLabel ? ` <span style="font-weight:400; color:var(--text-secondary);">${dateLabel ? `\xB7 ${escapeHtml(dateLabel)}` : ""}${escapeHtml(truncatedLabel)}</span>` : ""}
 			</div>
-			${e.moments.map(Za).join("")}
-		</div>`}function el(e){if(!e||e.repos.length===0)return`
-		<div id="tab-panel-corrections" class="tab-panel"${$!=="corrections"?' style="display:none"':""}>
+			${session.moments.map(buildCorrectionMomentHtml).join("")}
+		</div>`;
+  }
+  function buildCorrectionsTabPanelHtml(report) {
+    if (!report || report.repos.length === 0) {
+      return `
+		<div id="tab-panel-corrections" class="tab-panel"${activeTab !== "corrections" ? ' style="display:none"' : ""}>
 			<div class="section">
 				<div class="section-title"><span>\u{1F501}</span><span>Corrections</span></div>
 				<div class="section-subtitle">Moments where the agent corrected itself after an error, or you had to correct the agent.</div>
@@ -2593,37 +6720,156 @@ ${hi(t)}
 					\u2728 No correction moments detected in your recent sessions \u2014 nice and smooth!
 				</div>
 			</div>
-		</div>`;let t=e.counts,o=(r,i)=>r>0?`<span style="font-size:11px; padding:2px 10px; border-radius:10px; background:var(--bg-tertiary); color:var(--text-primary);">${r} ${d(i)}</span>`:"",n=[o(t.userCorrections,"user corrections"),o(t.toolErrors,"tool errors"),o(t.editRetries,"edit retries"),o(t.editSelfCorrections,"edit self-corrections"),o(t.agentSelfCorrections,"agent self-corrections")].filter(Boolean).join(" "),s=e.repos.map(r=>`
+		</div>`;
+    }
+    const c4 = report.counts;
+    const chip = (n5, label) => n5 > 0 ? `<span style="font-size:11px; padding:2px 10px; border-radius:10px; background:var(--bg-tertiary); color:var(--text-primary);">${n5} ${escapeHtml(label)}</span>` : "";
+    const summaryChips = [
+      chip(c4.userCorrections, "user corrections"),
+      chip(c4.toolErrors, "tool errors"),
+      chip(c4.editRetries, "edit retries"),
+      chip(c4.editSelfCorrections, "edit self-corrections"),
+      chip(c4.agentSelfCorrections, "agent self-corrections")
+    ].filter(Boolean).join(" ");
+    const repoSections = report.repos.map((repo) => `
 		<div style="margin-top:18px;">
 			<div style="font-size:12px; font-weight:700; color:var(--text-primary); margin-bottom:4px;">
-				${d(r.repository)}
-				<span style="font-weight:400; color:var(--text-secondary);">\u2014 ${r.sessionsWithMoments} session${r.sessionsWithMoments!==1?"s":""} with moments</span>
+				${escapeHtml(repo.repository)}
+				<span style="font-weight:400; color:var(--text-secondary);">\u2014 ${repo.sessionsWithMoments} session${repo.sessionsWithMoments !== 1 ? "s" : ""} with moments</span>
 			</div>
-			${r.sessions.map(Qa).join("")}
-		</div>`).join("");return`
-		<div id="tab-panel-corrections" class="tab-panel"${$!=="corrections"?' style="display:none"':""}>
+			${repo.sessions.map(buildCorrectionSessionHtml).join("")}
+		</div>`).join("");
+    return `
+		<div id="tab-panel-corrections" class="tab-panel"${activeTab !== "corrections" ? ' style="display:none"' : ""}>
 			<div class="section">
 				<div class="section-title"><span>\u{1F501}</span><span>Corrections</span></div>
 				<div class="section-subtitle">
 					Moments where the agent corrected itself after an error, or you had to correct the agent \u2014
-					heuristic detection over each repository's ${e.sessionsPerRepo} most recent sessions with detected moments \u2014
+					heuristic detection over each repository's ${report.sessionsPerRepo} most recent sessions with detected moments \u2014
 					sessions without corrections are not listed. Summary counts include all detected moments; long sessions show a capped detail sample.
 					Pattern-based matches are candidates, not verdicts; open the session in the log viewer for full context.
 				</div>
-				<div style="display:flex; flex-wrap:wrap; gap:6px; margin-top:12px;">${n}</div>
-				${s}
+				<div style="display:flex; flex-wrap:wrap; gap:6px; margin-top:12px;">${summaryChips}</div>
+				${repoSections}
 			</div>
-		</div>`}function tl(e){let t=document.querySelector('.tab-button[data-tab="insights"]');if(!t)return;let o=e.filter(r=>r.status==="new").length,n=o>0?` <span style="background:rgba(96,165,250,0.4);border-radius:10px;padding:1px 6px;font-size:11px;">${o}</span>`:"";k(t,'<span class="codicon codicon-lightbulb"></span> Insights'+n)}function ol(e){let t=document.getElementById("insights-container");if(!t)return;Bo=e;let o=e.filter(i=>i.status==="new"),n=e.filter(i=>i.status!=="new"&&i.status!=="dismissed"&&i.status!=="done"),s=o.length>0?`<div style="margin-bottom:20px;">
+		</div>`;
+  }
+  function updateTabButtonCount(insights) {
+    const tabButton = document.querySelector('.tab-button[data-tab="insights"]');
+    if (!tabButton) {
+      return;
+    }
+    const newCount = insights.filter((i6) => i6.status === "new").length;
+    const badgeHtml = newCount > 0 ? ` <span style="background:rgba(96,165,250,0.4);border-radius:10px;padding:1px 6px;font-size:11px;">${newCount}</span>` : "";
+    const titleOnly = '<span class="codicon codicon-lightbulb"></span> Insights';
+    setHtml(tabButton, titleOnly + badgeHtml);
+  }
+  function refreshInsightsPanel(insights) {
+    const container = document.getElementById("insights-container");
+    if (!container) {
+      return;
+    }
+    currentInsights = insights;
+    const forYou = insights.filter((i6) => i6.status === "new");
+    const other = insights.filter((i6) => i6.status !== "new" && i6.status !== "dismissed" && i6.status !== "done");
+    const forYouSection = forYou.length > 0 ? `<div style="margin-bottom:20px;">
 			<div style="font-size:12px; font-weight:600; text-transform:uppercase; color:var(--text-secondary); letter-spacing:0.05em; margin-bottom:10px;">\u2728 For You</div>
-			${o.map(Nt).join("")}
-		</div>`:`<div style="margin-bottom:20px; padding:16px; background:var(--bg-tertiary); border-radius:8px; font-size:12px; color:var(--text-secondary); text-align:center;">
+			${forYou.map(buildInsightCardHtml).join("")}
+		</div>` : `<div style="margin-bottom:20px; padding:16px; background:var(--bg-tertiary); border-radius:8px; font-size:12px; color:var(--text-secondary); text-align:center;">
 			\u{1F389} No new insights right now \u2014 keep using Copilot and check back later!
-		</div>`,r=n.length>0?`<div>
+		</div>`;
+    const allSection = other.length > 0 ? `<div>
 			<div style="font-size:12px; font-weight:600; text-transform:uppercase; color:var(--text-secondary); letter-spacing:0.05em; margin-bottom:10px;">All Tips</div>
-			${n.map(Nt).join("")}
-		</div>`:"";k(t,s+r),Fs(),tl(e)}function nl(e){if(e)try{let t=JSON.parse(e);f.postMessage({command:"openFileFromList",paths:t})}catch(t){Z("wireCurationButtons.badPathsJson",{error:t instanceof Error?t.message:String(t)})}}function sl(e){let t=e.getAttribute("data-command");if(t)if(t==="openFile"){let o=e.getAttribute("data-path");o&&f.postMessage({command:"openFile",path:o})}else if(t==="openFileFromList")nl(e.getAttribute("data-paths"));else if(t==="manageExtension"){let o=e.getAttribute("data-extension-id");o&&f.postMessage({command:"manageExtension",extensionId:o})}else if(t==="openAgentPlugins"){let o=e.getAttribute("data-plugin-name")??"";f.postMessage({command:"openAgentPlugins",pluginName:o})}else f.postMessage({command:t})}function rl(){try{let e=document.getElementById("section-tool-curation");if(!e){pe("wire-no-section","wireCurationButtons.noSection");return}let t=e.querySelectorAll(".curation-file-btn");Z("wireCurationButtons.bind",{buttons:t.length}),t.forEach(o=>{o.addEventListener("click",()=>{try{sl(o)}catch(n){Z("wireCurationButtons.clickError",{error:n instanceof Error?n.message:String(n)})}})})}catch(e){Z("wireCurationButtons.error",{error:e instanceof Error?e.message:String(e)})}}function Fs(){let e=document.getElementById("insights-container");e&&e.querySelectorAll(".insight-action-btn").forEach(t=>{t.addEventListener("click",()=>{let o=t.getAttribute("data-insight-id"),n=t.getAttribute("data-action");if(!(!o||!n))if(n==="execute"){let s=t.getAttribute("data-command");s&&f.postMessage({command:s})}else f.postMessage({command:"insightAction",id:o,action:n})})})}function il(e,t,o,n,s,r,i,a,l,u,c,p,b,h){return`
-		<style>${ln}</style>
-		<style>${dn}</style>
+			${other.map(buildInsightCardHtml).join("")}
+		</div>` : "";
+    setHtml(container, forYouSection + allSection);
+    wireInsightCardButtons();
+    updateTabButtonCount(insights);
+  }
+  function _postOpenFileFromList(pathsJson) {
+    if (!pathsJson) {
+      return;
+    }
+    try {
+      const paths = JSON.parse(pathsJson);
+      vscode.postMessage({ command: "openFileFromList", paths });
+    } catch (error) {
+      traceCuration("wireCurationButtons.badPathsJson", { error: error instanceof Error ? error.message : String(error) });
+    }
+  }
+  function _handleCurationBtnClick(btn) {
+    const command = btn.getAttribute("data-command");
+    if (!command) {
+      return;
+    }
+    if (command === "openFile") {
+      const filePath = btn.getAttribute("data-path");
+      if (filePath) {
+        vscode.postMessage({ command: "openFile", path: filePath });
+      }
+    } else if (command === "openFileFromList") {
+      _postOpenFileFromList(btn.getAttribute("data-paths"));
+    } else if (command === "manageExtension") {
+      const extensionId = btn.getAttribute("data-extension-id");
+      if (extensionId) {
+        vscode.postMessage({ command: "manageExtension", extensionId });
+      }
+    } else if (command === "openAgentPlugins") {
+      const pluginName = btn.getAttribute("data-plugin-name") ?? "";
+      vscode.postMessage({ command: "openAgentPlugins", pluginName });
+    } else {
+      vscode.postMessage({ command });
+    }
+  }
+  function wireCurationButtons() {
+    try {
+      const section = document.getElementById("section-tool-curation");
+      if (!section) {
+        traceCurationOnce("wire-no-section", "wireCurationButtons.noSection");
+        return;
+      }
+      const buttons = section.querySelectorAll(".curation-file-btn");
+      traceCuration("wireCurationButtons.bind", { buttons: buttons.length });
+      buttons.forEach((btn) => {
+        btn.addEventListener("click", () => {
+          try {
+            _handleCurationBtnClick(btn);
+          } catch (error) {
+            traceCuration("wireCurationButtons.clickError", { error: error instanceof Error ? error.message : String(error) });
+          }
+        });
+      });
+    } catch (error) {
+      traceCuration("wireCurationButtons.error", { error: error instanceof Error ? error.message : String(error) });
+    }
+  }
+  function wireInsightCardButtons() {
+    const container = document.getElementById("insights-container");
+    if (!container) {
+      return;
+    }
+    container.querySelectorAll(".insight-action-btn").forEach((btn) => {
+      btn.addEventListener("click", () => {
+        const id = btn.getAttribute("data-insight-id");
+        const action = btn.getAttribute("data-action");
+        if (!id || !action) {
+          return;
+        }
+        if (action === "execute") {
+          const command = btn.getAttribute("data-command");
+          if (command) {
+            vscode.postMessage({ command });
+          }
+        } else {
+          vscode.postMessage({ command: "insightAction", id, action });
+        }
+      });
+    });
+  }
+  function buildUsageRootHtml(stats, customizationHtml, multiModelHtml, thinkingEffortHtml, sessionsSummaryHtml, todayTotalRefs, last30DaysTotalRefs, allToolKeys, allMcpToolKeys, allMcpServerKeys, allHighCostModels, allLowCostModels, allMediumCostModels, allUnknownModels) {
+    return `
+		<style>${theme_default}</style>
+		<style>${styles_default}</style>
 		<div class="container">
 			<div class="header">
 				<div class="header-left">
@@ -2631,16 +6877,16 @@ ${hi(t)}
 					<span class="header-title">Usage Analysis</span>
 				</div>
 				<div class="button-row">
-				${nn("btn-usage",!!e.backendConfigured)}
+				${navButtonsHtml("btn-usage", !!stats.backendConfigured)}
 				</div>
 			</div>
 
 			<div class="info-box">
-				<div class="info-box-title info-box-toggle" id="about-info-toggle" role="button" tabindex="0" aria-expanded="${!V}" aria-controls="about-info-body">
+				<div class="info-box-title info-box-toggle" id="about-info-toggle" role="button" tabindex="0" aria-expanded="${!aboutCollapsed}" aria-controls="about-info-body">
 					<span>\u{1F4CB} About This Dashboard</span>
-					<span class="info-box-chevron" aria-hidden="true">${V?"\u25B8":"\u25BE"}</span>
+					<span class="info-box-chevron" aria-hidden="true">${aboutCollapsed ? "\u25B8" : "\u25BE"}</span>
 				</div>
-				<div class="info-box-body" id="about-info-body"${V?' style="display:none"':""}>
+				<div class="info-box-body" id="about-info-body"${aboutCollapsed ? ' style="display:none"' : ""}>
 					This dashboard analyzes your GitHub Copilot usage patterns by examining session log files.
 					It tracks modes (ask/edit/agent), tool usage, context references (#file, @workspace, etc.),
 					and MCP (Model Context Protocol) tools to help you understand how you interact with Copilot.
@@ -2648,118 +6894,285 @@ ${hi(t)}
 			</div>
 
 			<div class="tab-bar">
-				<button class="tab-button ${$==="activity"?"active":""}" data-tab="activity"><span class="codicon codicon-pulse"></span> My Activity</button>
-				<button class="tab-button ${$==="sessions"?"active":""}" data-tab="sessions"><span class="codicon codicon-history"></span> Recent Sessions</button>
-				<button class="tab-button ${$==="tools"?"active":""}" data-tab="tools"><span class="codicon codicon-tools"></span> Tools &amp; Integrations</button>
-				<button class="tab-button ${$==="health"?"active":""}" data-tab="health"><span class="codicon codicon-server-environment"></span> Workspace Health</button>
-				<button class="tab-button ${$==="repos"?"active":""}" data-tab="repos"><span class="codicon codicon-git-pull-request"></span> Repository PRs</button>
-				<button class="tab-button ${$==="agent"?"active":""}" data-tab="agent"><span class="codicon codicon-cloud"></span> Cloud Agent</button>
-				<button class="tab-button ${$==="worktrees"?"active":""}" data-tab="worktrees"><span class="codicon codicon-git-branch"></span> Worktrees</button>
-				<button class="tab-button ${$==="insights"?"active":""}" data-tab="insights"><span class="codicon codicon-lightbulb"></span> Insights${(e.insights??[]).filter(S=>S.status==="new").length>0?` <span style="background:rgba(96,165,250,0.4);border-radius:10px;padding:1px 6px;font-size:11px;">${(e.insights??[]).filter(S=>S.status==="new").length}</span>`:""}</button>
-				${Ga(e.correctionReport??null)}
+				<button class="tab-button ${activeTab === "activity" ? "active" : ""}" data-tab="activity"><span class="codicon codicon-pulse"></span> My Activity</button>
+				<button class="tab-button ${activeTab === "sessions" ? "active" : ""}" data-tab="sessions"><span class="codicon codicon-history"></span> Recent Sessions</button>
+				<button class="tab-button ${activeTab === "tools" ? "active" : ""}" data-tab="tools"><span class="codicon codicon-tools"></span> Tools &amp; Integrations</button>
+				<button class="tab-button ${activeTab === "health" ? "active" : ""}" data-tab="health"><span class="codicon codicon-server-environment"></span> Workspace Health</button>
+				<button class="tab-button ${activeTab === "repos" ? "active" : ""}" data-tab="repos"><span class="codicon codicon-git-pull-request"></span> Repository PRs</button>
+				<button class="tab-button ${activeTab === "agent" ? "active" : ""}" data-tab="agent"><span class="codicon codicon-cloud"></span> Cloud Agent</button>
+				<button class="tab-button ${activeTab === "worktrees" ? "active" : ""}" data-tab="worktrees"><span class="codicon codicon-git-branch"></span> Worktrees</button>
+				<button class="tab-button ${activeTab === "insights" ? "active" : ""}" data-tab="insights"><span class="codicon codicon-lightbulb"></span> Insights${(stats.insights ?? []).filter((i6) => i6.status === "new").length > 0 ? ` <span style="background:rgba(96,165,250,0.4);border-radius:10px;padding:1px 6px;font-size:11px;">${(stats.insights ?? []).filter((i6) => i6.status === "new").length}</span>` : ""}</button>
+				${correctionsTabButtonHtml(stats.correctionReport ?? null)}
 			</div>
 
-			${P("Recent Sessions",()=>wl(e))}
-			${P("My Activity",()=>$l(e,o,n,s,r,i))}
-			${P("Tools & Integrations",()=>od(e,a,l,u,c,p,b,h))}
-			${P("Workspace Health",()=>_a(t,e))}
-			${P("Repository PRs & Cloud Agent",()=>Wa())}
-			${P("Worktrees",()=>xl())}
-			${P("Insights",()=>qa(e.insights??[]))}
-			${P("Corrections",()=>el(e.correctionReport??null))}
+			${safeSectionHtml("Recent Sessions", () => buildSessionsTabPanelHtml(stats))}
+			${safeSectionHtml("My Activity", () => buildActivityTabPanelHtml(stats, multiModelHtml, thinkingEffortHtml, sessionsSummaryHtml, todayTotalRefs, last30DaysTotalRefs))}
+			${safeSectionHtml("Tools & Integrations", () => buildToolsTabPanelHtml(stats, allToolKeys, allMcpToolKeys, allMcpServerKeys, allHighCostModels, allLowCostModels, allMediumCostModels, allUnknownModels))}
+			${safeSectionHtml("Workspace Health", () => buildHealthTabPanelHtml(customizationHtml, stats))}
+			${safeSectionHtml("Repository PRs & Cloud Agent", () => buildReposAndAgentTabPanelsHtml())}
+			${safeSectionHtml("Worktrees", () => buildWorktreesTabPanelHtml())}
+			${safeSectionHtml("Insights", () => buildInsightsTabPanelHtml(stats.insights ?? []))}
+			${safeSectionHtml("Corrections", () => buildCorrectionsTabPanelHtml(stats.correctionReport ?? null))}
 			<div class="footer">
-				Last updated: ${d(new Date(e.lastUpdated).toLocaleString())} \xB7 Updates every 5 minutes
+				Last updated: ${escapeHtml(new Date(stats.lastUpdated).toLocaleString())} \xB7 Updates every 5 minutes
 			</div>
 		</div>
-`}function al(){if(U.length===0)return'<div style="color: var(--text-muted); font-size: 12px; margin: 8px 0;">No root folders added yet. Add a folder to scan for worktrees.</div>';let e=U.length>2,t=!e||Ve,o=e?`<button class="worktree-roots-toggle" id="btn-toggle-worktree-roots" aria-expanded="${Ve}"><span class="worktree-caret">${Ve?"\u25BC":"\u25B6"}</span>${U.length} root folders found</button>`:"",n=t?`<div class="worktree-roots-list">${U.map((s,r)=>`<div class="worktree-root-item"><span title="${d(s)}">${d(s)}</span><button class="button secondary worktree-remove-root" data-index="${r}" ${R?"disabled":""}>\u2715</button></div>`).join("")}</div>`:"";return o+n}function ll(e,t){let o=e.enriched??0,n=e.enrichTotal??0,s=n>0?Math.round(o/n*100):0;return`
+`;
+  }
+  function renderWorktreeRootsList() {
+    if (worktreeRoots.length === 0) {
+      return `<div style="color: var(--text-muted); font-size: 12px; margin: 8px 0;">No root folders added yet. Add a folder to scan for worktrees.</div>`;
+    }
+    const collapsible = worktreeRoots.length > 2;
+    const showList = !collapsible || worktreeRootsExpanded;
+    const toggle = collapsible ? `<button class="worktree-roots-toggle" id="btn-toggle-worktree-roots" aria-expanded="${worktreeRootsExpanded}"><span class="worktree-caret">${worktreeRootsExpanded ? "\u25BC" : "\u25B6"}</span>${worktreeRoots.length} root folders found</button>` : "";
+    const list = showList ? `<div class="worktree-roots-list">${worktreeRoots.map(
+      (r6, i6) => `<div class="worktree-root-item"><span title="${escapeHtml(r6)}">${escapeHtml(r6)}</span><button class="button secondary worktree-remove-root" data-index="${i6}" ${worktreeScanInProgress ? "disabled" : ""}>\u2715</button></div>`
+    ).join("")}</div>` : "";
+    return toggle + list;
+  }
+  function _renderWorktreeEnrichingProgress(s4, seconds) {
+    const done = s4.enriched ?? 0;
+    const total = s4.enrichTotal ?? 0;
+    const pct = total > 0 ? Math.round(done / total * 100) : 0;
+    return `
     <div class="info-box" style="margin-top: 12px;">
       <div class="info-box-title">\u{1F4E6} Computing sizes &amp; push status\u2026</div>
-      <div>${o} / ${n} worktree${n===1?"":"s"} analyzed (${t}s)</div>
-      <div class="worktree-progress-bar"><div class="worktree-progress-fill" style="width: ${s}%;"></div></div>
-    </div>`}function dl(e,t){let o=e.phase==="walking",n=o?"\u{1F50D} Scanning folder\u2026":"\u23F3 Checking markers\u2026",s=e.dirsScanned??0,r=o?`Exploring for git worktrees \u2014 ${s} folder${s===1?"":"s"} scanned (${t}s)`:`${e.checked} / ${e.total||"?"} .git markers checked \u2014 ${e.foundCount} worktree${e.foundCount===1?"":"s"} found so far (${t}s)`,i=o?100:e.total>0?Math.round(e.checked/e.total*100):0,a=o?"worktree-progress-fill indeterminate":"worktree-progress-fill";return`
+      <div>${done} / ${total} worktree${total === 1 ? "" : "s"} analyzed (${seconds}s)</div>
+      <div class="worktree-progress-bar"><div class="worktree-progress-fill" style="width: ${pct}%;"></div></div>
+    </div>`;
+  }
+  function _renderWorktreeScanningProgress(s4, seconds) {
+    const walking = s4.phase === "walking";
+    const title = walking ? "\u{1F50D} Scanning folder\u2026" : "\u23F3 Checking markers\u2026";
+    const dirs = s4.dirsScanned ?? 0;
+    const detail = walking ? `Exploring for git worktrees \u2014 ${dirs} folder${dirs === 1 ? "" : "s"} scanned (${seconds}s)` : `${s4.checked} / ${s4.total || "?"} .git markers checked \u2014 ${s4.foundCount} worktree${s4.foundCount === 1 ? "" : "s"} found so far (${seconds}s)`;
+    const pct = walking ? 100 : s4.total > 0 ? Math.round(s4.checked / s4.total * 100) : 0;
+    const fillClass = walking ? "worktree-progress-fill indeterminate" : "worktree-progress-fill";
+    return `
     <div class="info-box" style="margin-top: 12px;">
-      <div class="info-box-title">${n}</div>
-      <div>Folder: <span style="font-family: var(--vscode-editor-font-family, monospace);">${d(e.root||"\u2026")}</span></div>
-      <div>${r}</div>
-      <div class="worktree-progress-bar"><div class="${a}" style="width: ${i}%;"></div></div>
-    </div>`}function Ws(){if(!R)return"";let e=D,t=(e.elapsedMs/1e3).toFixed(1);return e.phase==="enriching"?ll(e,t):dl(e,t)}function cl(){if(!Ge||R||L.length===0)return"";let e=d(new Date(Ge.scannedAt).toLocaleString()),t=Pe(Ge.totalBytes),o=L.length;return`<div class="info-box" style="margin-top: 12px;"><div>\u{1F333} Found automatically by the daily background scan: ${t} across ${o} worktree${o===1?"":"s"}, last checked ${e}. Scan again for the latest.</div></div>`}function qs(){return`
+      <div class="info-box-title">${title}</div>
+      <div>Folder: <span style="font-family: var(--vscode-editor-font-family, monospace);">${escapeHtml(s4.root || "\u2026")}</span></div>
+      <div>${detail}</div>
+      <div class="worktree-progress-bar"><div class="${fillClass}" style="width: ${pct}%;"></div></div>
+    </div>`;
+  }
+  function renderWorktreeProgress() {
+    if (!worktreeScanInProgress) {
+      return "";
+    }
+    const s4 = worktreeScanStatus;
+    const seconds = (s4.elapsedMs / 1e3).toFixed(1);
+    if (s4.phase === "enriching") {
+      return _renderWorktreeEnrichingProgress(s4, seconds);
+    }
+    return _renderWorktreeScanningProgress(s4, seconds);
+  }
+  function renderWorktreeBackgroundScanBanner() {
+    if (!worktreeBackgroundScanMeta || worktreeScanInProgress || worktreeResults.length === 0) {
+      return "";
+    }
+    const when = escapeHtml(new Date(worktreeBackgroundScanMeta.scannedAt).toLocaleString());
+    const size = formatFileSize(worktreeBackgroundScanMeta.totalBytes);
+    const count = worktreeResults.length;
+    return `<div class="info-box" style="margin-top: 12px;"><div>\u{1F333} Found automatically by the daily background scan: ${size} across ${count} worktree${count === 1 ? "" : "s"}, last checked ${when}. Scan again for the latest.</div></div>`;
+  }
+  function renderWorktreeControls() {
+    return `
     <div class="section">
       <div class="section-title"><span class="codicon codicon-folder-opened"></span><span>Root Folders</span></div>
-      <div id="worktree-roots-list">${al()}</div>
+      <div id="worktree-roots-list">${renderWorktreeRootsList()}</div>
       <div class="folder-input-row" style="margin-top: 8px;">
         <input
           type="text"
           id="worktree-root-input"
           class="folder-input"
           placeholder="Paste a root folder path here, e.g. C:\\code\\repos"
-          ${R?"disabled":""}
+          ${worktreeScanInProgress ? "disabled" : ""}
         />
-        <button class="button secondary" id="btn-browse-worktree-root" ${R?"disabled":""}>\u{1F4C2} Browse\u2026</button>
-        <button class="button secondary" id="btn-add-worktree-root" ${R?"disabled":""}>\u2795 Add</button>
+        <button class="button secondary" id="btn-browse-worktree-root" ${worktreeScanInProgress ? "disabled" : ""}>\u{1F4C2} Browse\u2026</button>
+        <button class="button secondary" id="btn-add-worktree-root" ${worktreeScanInProgress ? "disabled" : ""}>\u2795 Add</button>
       </div>
       <div style="margin-top: 16px;">
-        <button class="button" id="btn-scan-worktrees" ${R||W||U.length===0?"disabled":""}>\u{1F50D} Scan for Worktrees</button>
-        ${R?'<button class="button secondary" id="btn-cancel-worktree-scan">\u2715 Cancel</button>':""}
+        <button class="button" id="btn-scan-worktrees" ${worktreeScanInProgress || worktreeCleanupInProgress || worktreeRoots.length === 0 ? "disabled" : ""}>\u{1F50D} Scan for Worktrees</button>
+        ${worktreeScanInProgress ? '<button class="button secondary" id="btn-cancel-worktree-scan">\u2715 Cancel</button>' : ""}
       </div>
-      ${cl()}
-      ${rt?`<div class="info-box" style="margin-top: 12px; border-color: #d97706; background: rgba(217,119,6,0.08);"><div>\u26A0\uFE0F ${d(rt)}</div></div>`:""}
-      <div id="worktree-progress-area">${Ws()}</div>
-    </div>`}function ul(e){let t=new Map;for(let o of e){let n=o.repoLabel||"Unknown";t.has(n)||t.set(n,[]),t.get(n).push(o)}return t}function Gt(e){return e.bytes<0}function lt(e){return e.bytes>0?e.bytes:0}function pl(e){let t=Gt(e),o=a=>`<span class="worktree-pending">${R?a:"\u2014"}</span>`,n=e.pushed==="yes"?"\u2705":e.pushed==="no"?"\u{1F534}":"\u2753",s=t?o("checking\u2026"):`${n} ${d(e.pushed)}`,r=t?o("\u2026"):d(String(e.files)),i=t?o("computing\u2026"):`<span title="${e.bytes.toLocaleString()} bytes">${Pe(e.bytes)}</span>`;return`<tr>
-    <td title="${d(e.path)}" style="font-family: var(--vscode-editor-font-family, monospace); font-size: 11px; max-width: 380px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">${d(e.path)}</td>
-    <td>${d(e.branch)}</td>
-    <td>${d(e.lastCommit)}</td>
-    <td>${s}</td>
-    <td>${r}</td>
-    <td>${i}</td>
+      ${renderWorktreeBackgroundScanBanner()}
+      ${worktreeScanError ? `<div class="info-box" style="margin-top: 12px; border-color: #d97706; background: rgba(217,119,6,0.08);"><div>\u26A0\uFE0F ${escapeHtml(worktreeScanError)}</div></div>` : ""}
+      <div id="worktree-progress-area">${renderWorktreeProgress()}</div>
+    </div>`;
+  }
+  function groupWorktreesByRepo(results) {
+    const groups = /* @__PURE__ */ new Map();
+    for (const wt of results) {
+      const key = wt.repoLabel || "Unknown";
+      if (!groups.has(key)) {
+        groups.set(key, []);
+      }
+      groups.get(key).push(wt);
+    }
+    return groups;
+  }
+  function isWorktreePending(w2) {
+    return w2.bytes < 0;
+  }
+  function knownBytes(w2) {
+    return w2.bytes > 0 ? w2.bytes : 0;
+  }
+  function buildWorktreeRowHtml(w2) {
+    const pending = isWorktreePending(w2);
+    const pendingLabel = (active) => `<span class="worktree-pending">${worktreeScanInProgress ? active : "\u2014"}</span>`;
+    const pushedIcon = w2.pushed === "yes" ? "\u2705" : w2.pushed === "no" ? "\u{1F534}" : "\u2753";
+    const pushedCell = pending ? pendingLabel("checking\u2026") : `${pushedIcon} ${escapeHtml(w2.pushed)}`;
+    const filesCell = pending ? pendingLabel("\u2026") : escapeHtml(String(w2.files));
+    const sizeCell = pending ? pendingLabel("computing\u2026") : `<span title="${w2.bytes.toLocaleString()} bytes">${formatFileSize(w2.bytes)}</span>`;
+    return `<tr>
+    <td title="${escapeHtml(w2.path)}" style="font-family: var(--vscode-editor-font-family, monospace); font-size: 11px; max-width: 380px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">${escapeHtml(w2.path)}</td>
+    <td>${escapeHtml(w2.branch)}</td>
+    <td>${escapeHtml(w2.lastCommit)}</td>
+    <td>${pushedCell}</td>
+    <td>${filesCell}</td>
+    <td>${sizeCell}</td>
     <td>
-      <a href="#" class="worktree-reveal-link" data-path="${encodeURIComponent(e.path)}">Open</a>
-      <a href="#" class="worktree-delete-link" data-path="${encodeURIComponent(e.path)}" data-branch="${encodeURIComponent(e.branch)}" data-repo="${encodeURIComponent(e.repoLabel)}" data-pushed="${d(e.pushed)}" title="Remove via git worktree remove (asks for confirmation)">\u{1F5D1}\uFE0F Delete</a>
+      <a href="#" class="worktree-reveal-link" data-path="${encodeURIComponent(w2.path)}">Open</a>
+      <a href="#" class="worktree-delete-link" data-path="${encodeURIComponent(w2.path)}" data-branch="${encodeURIComponent(w2.branch)}" data-repo="${encodeURIComponent(w2.repoLabel)}" data-pushed="${escapeHtml(w2.pushed)}" title="Remove via git worktree remove (asks for confirmation)">\u{1F5D1}\uFE0F Delete</a>
     </td>
-  </tr>`}function gl(e){return`<div class="table-container">
+  </tr>`;
+  }
+  function buildWorktreeDetailsTableHtml(worktrees) {
+    const sorted = [...worktrees].sort((a3, b3) => knownBytes(b3) - knownBytes(a3));
+    const rows = sorted.map(buildWorktreeRowHtml).join("");
+    return `<div class="table-container">
     <table class="session-table">
       <thead><tr><th>Path</th><th>Branch</th><th>Last Commit</th><th>Pushed</th><th>Files</th><th>Size</th><th>Actions</th></tr></thead>
-      <tbody>${[...e].sort((n,s)=>lt(s)-lt(n)).map(pl).join("")}</tbody>
+      <tbody>${rows}</tbody>
     </table>
-  </div>`}function ml(e){let t=e.reduce((s,r)=>s+lt(r),0),o=e.some(Gt),n=`<span title="${t.toLocaleString()} bytes">${Pe(t)}</span>`;return o?`${n} <span class="worktree-pending">\u2026</span>`:n}function fl(e,t){let o=zt.has(e),n=o?"\u25BC":"\u25B6",s=d(e),r=`<tr class="worktree-repo-row${o?" expanded":""}" data-repo="${s}" aria-expanded="${o}">
-    <td><span class="worktree-caret">${n}</span> ${d(e)}</td>
-    <td>${t.length}</td>
-    <td>${ml(t)}</td>
-  </tr>`,i=`<tr class="worktree-repo-details" data-repo="${s}"${o?"":' style="display: none;"'}>
-    <td colspan="3">${gl(t)}</td>
-  </tr>`;return r+i}function Ro(e){return it!==e?"":Ye==="desc"?" \u25BC":" \u25B2"}function bl(e){return e.reduce((t,o)=>t+lt(o),0)}function yl(e,t){let o=Ye==="desc"?-1:1;if(it==="repo")return o*e[0].localeCompare(t[0]);let n=r=>it==="count"?r.length:bl(r),s=n(e[1])-n(t[1]);return s!==0?o*s:e[0].localeCompare(t[0])}function Ks(){return L.filter(e=>e.pushed==="yes"&&!Gt(e))}function hl(){let e=Ks().length,t=W||fe||R||e===0,o=fe?"\u23F3 Waiting\u2026":`\u{1F9F9} Clean Up (${e})`;return`<div class="summary-card worktree-cleanup-card">
+  </div>`;
+  }
+  function worktreeSizeText(worktrees) {
+    const totalBytes = worktrees.reduce((s4, w2) => s4 + knownBytes(w2), 0);
+    const pending = worktrees.some(isWorktreePending);
+    const size = `<span title="${totalBytes.toLocaleString()} bytes">${formatFileSize(totalBytes)}</span>`;
+    return pending ? `${size} <span class="worktree-pending">\u2026</span>` : size;
+  }
+  function buildWorktreeRepoRowsHtml(repoLabel, worktrees) {
+    const expanded = worktreeExpandedRepos.has(repoLabel);
+    const caret = expanded ? "\u25BC" : "\u25B6";
+    const repoAttr = escapeHtml(repoLabel);
+    const summaryRow = `<tr class="worktree-repo-row${expanded ? " expanded" : ""}" data-repo="${repoAttr}" aria-expanded="${expanded}">
+    <td><span class="worktree-caret">${caret}</span> ${escapeHtml(repoLabel)}</td>
+    <td>${worktrees.length}</td>
+    <td>${worktreeSizeText(worktrees)}</td>
+  </tr>`;
+    const detailsRow = `<tr class="worktree-repo-details" data-repo="${repoAttr}"${expanded ? "" : ' style="display: none;"'}>
+    <td colspan="3">${buildWorktreeDetailsTableHtml(worktrees)}</td>
+  </tr>`;
+    return summaryRow + detailsRow;
+  }
+  function getWorktreeSortIndicator(col) {
+    if (worktreeSortColumn !== col) {
+      return "";
+    }
+    return worktreeSortDir === "desc" ? " \u25BC" : " \u25B2";
+  }
+  function groupKnownBytes(worktrees) {
+    return worktrees.reduce((s4, w2) => s4 + knownBytes(w2), 0);
+  }
+  function compareWorktreeGroups(a3, b3) {
+    const dir = worktreeSortDir === "desc" ? -1 : 1;
+    if (worktreeSortColumn === "repo") {
+      return dir * a3[0].localeCompare(b3[0]);
+    }
+    const value = (g2) => worktreeSortColumn === "count" ? g2.length : groupKnownBytes(g2);
+    const diff = value(a3[1]) - value(b3[1]);
+    return diff !== 0 ? dir * diff : a3[0].localeCompare(b3[0]);
+  }
+  function getCleanupCandidates() {
+    return worktreeResults.filter((w2) => w2.pushed === "yes" && !isWorktreePending(w2));
+  }
+  function renderWorktreeCleanupCard() {
+    const pushedCount = getCleanupCandidates().length;
+    const disabled = worktreeCleanupInProgress || worktreeCleanupConfirmPending || worktreeScanInProgress || pushedCount === 0;
+    const label = worktreeCleanupConfirmPending ? "\u23F3 Waiting\u2026" : `\u{1F9F9} Clean Up (${pushedCount})`;
+    return `<div class="summary-card worktree-cleanup-card">
     <div class="summary-label">Pushed Worktrees</div>
     <div class="worktree-cleanup-card-actions">
-      <button class="button secondary" id="btn-cleanup-pushed-worktrees" ${t?"disabled":""}>${o}</button>
-      ${W?'<button class="button secondary" id="btn-cancel-cleanup">\u2715</button>':""}
+      <button class="button secondary" id="btn-cleanup-pushed-worktrees" ${disabled ? "disabled" : ""}>${label}</button>
+      ${worktreeCleanupInProgress ? '<button class="button secondary" id="btn-cancel-cleanup">\u2715</button>' : ""}
     </div>
-  </div>`}function Ss(){let e=re.filter(o=>o.status!=="deleted");return e.length===0?"":`<div class="worktree-cleanup-log">${e.map(o=>`<div class="worktree-cleanup-log-row">
-      <span>${o.status==="skipped"?"\u23ED\uFE0F":"\u274C"}</span>
-      <span class="worktree-cleanup-log-branch">${d(o.branch)}</span>
-      <span class="worktree-cleanup-log-repo">${d(o.repoLabel)}</span>
-      <span class="worktree-cleanup-log-reason">${d(o.reason||"")}</span>
-    </div>`).join("")}</div>`}function vl(){if(W){let{processed:n,total:s}=Oo,r=s>0?Math.round(n/s*100):0;return`<div class="info-box" style="margin-top: 12px;">
+  </div>`;
+  }
+  function renderWorktreeCleanupLog() {
+    const notable = worktreeCleanupLog.filter((e7) => e7.status !== "deleted");
+    if (notable.length === 0) {
+      return "";
+    }
+    const rows = notable.map((e7) => {
+      const icon = e7.status === "skipped" ? "\u23ED\uFE0F" : "\u274C";
+      return `<div class="worktree-cleanup-log-row">
+      <span>${icon}</span>
+      <span class="worktree-cleanup-log-branch">${escapeHtml(e7.branch)}</span>
+      <span class="worktree-cleanup-log-repo">${escapeHtml(e7.repoLabel)}</span>
+      <span class="worktree-cleanup-log-reason">${escapeHtml(e7.reason || "")}</span>
+    </div>`;
+    }).join("");
+    return `<div class="worktree-cleanup-log">${rows}</div>`;
+  }
+  function renderWorktreeCleanupStatus() {
+    if (worktreeCleanupInProgress) {
+      const { processed, total } = worktreeCleanupStatus;
+      const pct = total > 0 ? Math.round(processed / total * 100) : 0;
+      return `<div class="info-box" style="margin-top: 12px;">
       <div class="info-box-title">\u{1F9F9} Cleaning up pushed worktrees\u2026</div>
-      <div>${n} / ${s} processed</div>
-      <div class="worktree-progress-bar"><div class="worktree-progress-fill" style="width: ${r}%;"></div></div>
-    </div>${Ss()}`}if(re.length===0)return"";let e=re.filter(n=>n.status==="deleted").length,t=re.filter(n=>n.status==="skipped").length,o=re.filter(n=>n.status==="error").length;return`<div class="info-box" style="margin-top: 12px;">
+      <div>${processed} / ${total} processed</div>
+      <div class="worktree-progress-bar"><div class="worktree-progress-fill" style="width: ${pct}%;"></div></div>
+    </div>${renderWorktreeCleanupLog()}`;
+    }
+    if (worktreeCleanupLog.length === 0) {
+      return "";
+    }
+    const deleted = worktreeCleanupLog.filter((e7) => e7.status === "deleted").length;
+    const skipped = worktreeCleanupLog.filter((e7) => e7.status === "skipped").length;
+    const errors = worktreeCleanupLog.filter((e7) => e7.status === "error").length;
+    return `<div class="info-box" style="margin-top: 12px;">
     <div class="info-box-title">\u{1F9F9} Cleanup finished</div>
-    <div>\u2705 ${e} deleted \xB7 \u23ED\uFE0F ${t} skipped (uncommitted/unpushed) \xB7 ${o>0?`\u274C ${o} error${o===1?"":"s"}`:"0 errors"}</div>
-  </div>${Ss()}`}function Gs(){if(L.length===0)return R?'<div style="padding: 16px; color: var(--text-muted);">Discovering worktrees\u2026</div>':'<div style="padding: 16px; color: var(--text-muted);">No worktrees found yet. Add root folders above and click Scan.</div>';let e=ul(L),t=L.reduce((l,u)=>l+lt(u),0),o=L.some(Gt),n=`${Pe(t)}${o?' <span class="worktree-pending">\u2026</span>':""}`,s=`<div class="summary-cards">
-    <div class="summary-card"><div class="summary-label">\u{1F333} Worktrees</div><div class="summary-value">${L.length}</div></div>
-    <div class="summary-card"><div class="summary-label">\u{1F4E6} Repositories</div><div class="summary-value">${e.size}</div></div>
-    <div class="summary-card"><div class="summary-label">\u{1F4BE} Total Size</div><div class="summary-value" title="${t.toLocaleString()} bytes">${n}</div></div>
-    ${hl()}
-  </div>`,i=[...e.entries()].sort(yl).map(([l,u])=>fl(l,u)).join(""),a=`<div class="table-container">
+    <div>\u2705 ${deleted} deleted \xB7 \u23ED\uFE0F ${skipped} skipped (uncommitted/unpushed) \xB7 ${errors > 0 ? `\u274C ${errors} error${errors === 1 ? "" : "s"}` : "0 errors"}</div>
+  </div>${renderWorktreeCleanupLog()}`;
+  }
+  function renderWorktreeResults() {
+    if (worktreeResults.length === 0) {
+      if (worktreeScanInProgress) {
+        return '<div style="padding: 16px; color: var(--text-muted);">Discovering worktrees\u2026</div>';
+      }
+      return '<div style="padding: 16px; color: var(--text-muted);">No worktrees found yet. Add root folders above and click Scan.</div>';
+    }
+    const groups = groupWorktreesByRepo(worktreeResults);
+    const totalBytes = worktreeResults.reduce((s4, w2) => s4 + knownBytes(w2), 0);
+    const anyPending = worktreeResults.some(isWorktreePending);
+    const totalSizeHtml = `${formatFileSize(totalBytes)}${anyPending ? ' <span class="worktree-pending">\u2026</span>' : ""}`;
+    const summary = `<div class="summary-cards">
+    <div class="summary-card"><div class="summary-label">\u{1F333} Worktrees</div><div class="summary-value">${worktreeResults.length}</div></div>
+    <div class="summary-card"><div class="summary-label">\u{1F4E6} Repositories</div><div class="summary-value">${groups.size}</div></div>
+    <div class="summary-card"><div class="summary-label">\u{1F4BE} Total Size</div><div class="summary-value" title="${totalBytes.toLocaleString()} bytes">${totalSizeHtml}</div></div>
+    ${renderWorktreeCleanupCard()}
+  </div>`;
+    const sortedGroups = [...groups.entries()].sort(compareWorktreeGroups);
+    const repoRows = sortedGroups.map(([repo, wts]) => buildWorktreeRepoRowsHtml(repo, wts)).join("");
+    const table = `<div class="table-container">
     <table class="session-table worktree-repo-table">
       <thead><tr>
-        <th class="sortable" data-wt-sort="repo">Repository${Ro("repo")}</th>
-        <th class="sortable" data-wt-sort="count">Worktrees${Ro("count")}</th>
-        <th class="sortable" data-wt-sort="size">Size${Ro("size")}</th>
+        <th class="sortable" data-wt-sort="repo">Repository${getWorktreeSortIndicator("repo")}</th>
+        <th class="sortable" data-wt-sort="count">Worktrees${getWorktreeSortIndicator("count")}</th>
+        <th class="sortable" data-wt-sort="size">Size${getWorktreeSortIndicator("size")}</th>
       </tr></thead>
-      <tbody>${i}</tbody>
+      <tbody>${repoRows}</tbody>
     </table>
-  </div>`;return s+vl()+a}function xl(){return`
-    <div id="tab-panel-worktrees" class="tab-panel"${$!=="worktrees"?' style="display:none"':""}>
+  </div>`;
+    return summary + renderWorktreeCleanupStatus() + table;
+  }
+  function buildWorktreesTabPanelHtml() {
+    return `
+    <div id="tab-panel-worktrees" class="tab-panel"${activeTab !== "worktrees" ? ' style="display:none"' : ""}>
       <div class="info-box">
         <div class="info-box-title">\u{1F333} Worktree Discovery</div>
         <div>
@@ -2767,129 +7180,306 @@ ${hi(t)}
           worktree's git remote). Add one or more root folders below, then click Scan. Results stream in as they're found.
         </div>
       </div>
-      <div id="worktree-controls">${qs()}</div>
-      <div id="worktree-results">${Gs()}</div>
-    </div>`}function kl(e){let t=e.filter(n=>(n.subAgentCalls??0)>0).length;if(t===0)return"";let o=e.reduce((n,s)=>n+(s.subAgentCalls??0),0);return`<div style="margin-top:8px; font-size:12px; color:var(--text-secondary);" title="Sessions that delegated work to sub-agents (task/read_agent/write_agent/list_agents, runSubagent, delegate_*, \u2026)">
-		\u{1F916} <strong>${t}</strong> session${t===1?"":"s"} used sub-agents (${g(o)} sub-agent call${o===1?"":"s"}) in this period
-	</div>`}function wl(e){Array.isArray(e.todaySessions)&&(Uo=e.todaySessions);let t=I==="today"?Uo:Ae[I],o=t?Io(t):`<div style="color: var(--text-secondary); font-size: 13px; padding: 16px;">Loading sessions for ${pt[I]}\u2026</div>`,n=t?kl(t):"";return`
-		<div id="tab-panel-sessions" class="tab-panel"${$!=="sessions"?' style="display:none"':""}>
+      <div id="worktree-controls">${renderWorktreeControls()}</div>
+      <div id="worktree-results">${renderWorktreeResults()}</div>
+    </div>`;
+  }
+  function buildSubAgentSummaryHtml(sessions) {
+    const sessionsWithSubAgents = sessions.filter((s4) => (s4.subAgentCalls ?? 0) > 0).length;
+    if (sessionsWithSubAgents === 0) {
+      return "";
+    }
+    const totalCalls = sessions.reduce((sum, s4) => sum + (s4.subAgentCalls ?? 0), 0);
+    return `<div style="margin-top:8px; font-size:12px; color:var(--text-secondary);" title="Sessions that delegated work to sub-agents (task/read_agent/write_agent/list_agents, runSubagent, delegate_*, \u2026)">
+		\u{1F916} <strong>${sessionsWithSubAgents}</strong> session${sessionsWithSubAgents === 1 ? "" : "s"} used sub-agents (${formatNumber(totalCalls)} sub-agent call${totalCalls === 1 ? "" : "s"}) in this period
+	</div>`;
+  }
+  function buildSessionsTabPanelHtml(stats) {
+    if (Array.isArray(stats.todaySessions)) {
+      latestTodaySessions = stats.todaySessions;
+    }
+    const cachedForLookback = sessionsLookback === "today" ? latestTodaySessions : recentSessionsCache[sessionsLookback];
+    const bodyHtml = cachedForLookback ? renderTodaySessionsTable(cachedForLookback) : `<div style="color: var(--text-secondary); font-size: 13px; padding: 16px;">Loading sessions for ${PERIOD_LABELS[sessionsLookback]}\u2026</div>`;
+    const subAgentBanner = cachedForLookback ? buildSubAgentSummaryHtml(cachedForLookback) : "";
+    return `
+		<div id="tab-panel-sessions" class="tab-panel"${activeTab !== "sessions" ? ' style="display:none"' : ""}>
 			<div class="section">
 				<div class="section-title" style="display:flex; align-items:center; gap:8px;">
 					<span>\u{1F4CB}</span><span>Recent Sessions</span>
 					<span id="sessions-lookback-wrapper" style="margin-left:auto;"></span>
-					${Si()}
+					${buildSessionColumnsMenuHtml()}
 				</div>
 				<div class="section-subtitle">Individual session breakdown for the selected period \u2014 sorted by number of interactions (most active first).</div>
-				${n}
+				${subAgentBanner}
 				<div id="sessions-panel-body" style="margin-top: 12px;">
-					${o}
+					${bodyHtml}
 				</div>
 			</div>
-		</div>`}function Cl(e,t){let o=e.usedAiCredits*.01,n=Math.max(0,Math.min(t,o)),s=Math.max(0,o-n),r=e.budgetUsd,i=r>0?Math.min(100,n/r*100):0,a=r>0?Math.min(100-i,s/r*100):0,l=i+a,u=w(100-e.pctAvailable,1),c=w(e.pctAvailable,1),p=l>90?"var(--error-color, #f14c4c)":l>75?"var(--warning-color, #cca700)":"var(--accent-color, #4d9cf8)",b=i>0?`<div style="height:100%; width:${w(i,4)}%; background:${p};"></div>`:"",h=a>0?`<div title="Usage the API reports but this device has no local session data for" style="height:100%; width:${w(a,4)}%; background:${p}; background-image:repeating-linear-gradient(135deg, rgba(0,0,0,0.35) 0px, rgba(0,0,0,0.35) 3px, transparent 3px, transparent 6px);"></div>`:"",S=a>0?`<div style="display:flex; gap:14px; flex-wrap:wrap; font-size:11px; color:var(--text-secondary); margin-top:6px;">
-				<span><span style="display:inline-block; width:9px; height:9px; border-radius:2px; background:${p}; margin-right:4px; vertical-align:middle;"></span>Tracked here (${w(i,1)}%)</span>
-				<span><span style="display:inline-block; width:9px; height:9px; border-radius:2px; background:${p}; background-image:repeating-linear-gradient(135deg, rgba(0,0,0,0.35) 0px, rgba(0,0,0,0.35) 2px, transparent 2px, transparent 4px); margin-right:4px; vertical-align:middle;"></span>Other devices/cloud (${w(a,1)}%)</span>
-			</div>`:"";return`
+		</div>`;
+  }
+  function _billingApiBalanceHtml(api, copilotCostUsd) {
+    const apiUsedUsd = api.usedAiCredits * 0.01;
+    const trackedUsd = Math.max(0, Math.min(copilotCostUsd, apiUsedUsd));
+    const gapUsd = Math.max(0, apiUsedUsd - trackedUsd);
+    const budgetUsd = api.budgetUsd;
+    const trackedPct = budgetUsd > 0 ? Math.min(100, trackedUsd / budgetUsd * 100) : 0;
+    const gapPct = budgetUsd > 0 ? Math.min(100 - trackedPct, gapUsd / budgetUsd * 100) : 0;
+    const totalUsedPct = trackedPct + gapPct;
+    const usedPct = formatFixed(100 - api.pctAvailable, 1);
+    const pct = formatFixed(api.pctAvailable, 1);
+    const severityColor = totalUsedPct > 90 ? "var(--error-color, #f14c4c)" : totalUsedPct > 75 ? "var(--warning-color, #cca700)" : "var(--accent-color, #4d9cf8)";
+    const trackedSegment = trackedPct > 0 ? `<div style="height:100%; width:${formatFixed(trackedPct, 4)}%; background:${severityColor};"></div>` : "";
+    const gapSegment = gapPct > 0 ? `<div title="Usage the API reports but this device has no local session data for" style="height:100%; width:${formatFixed(gapPct, 4)}%; background:${severityColor}; background-image:repeating-linear-gradient(135deg, rgba(0,0,0,0.35) 0px, rgba(0,0,0,0.35) 3px, transparent 3px, transparent 6px);"></div>` : "";
+    const legend = gapPct > 0 ? `<div style="display:flex; gap:14px; flex-wrap:wrap; font-size:11px; color:var(--text-secondary); margin-top:6px;">
+				<span><span style="display:inline-block; width:9px; height:9px; border-radius:2px; background:${severityColor}; margin-right:4px; vertical-align:middle;"></span>Tracked here (${formatFixed(trackedPct, 1)}%)</span>
+				<span><span style="display:inline-block; width:9px; height:9px; border-radius:2px; background:${severityColor}; background-image:repeating-linear-gradient(135deg, rgba(0,0,0,0.35) 0px, rgba(0,0,0,0.35) 2px, transparent 2px, transparent 4px); margin-right:4px; vertical-align:middle;"></span>Other devices/cloud (${formatFixed(gapPct, 1)}%)</span>
+			</div>` : "";
+    return `
 		<div style="margin-bottom:12px;">
 			<div style="font-size:12px; font-weight:600; color:var(--text-secondary); margin-bottom:6px;">GitHub Copilot API (all channels)</div>
 			<div style="display:flex; gap:16px; flex-wrap:wrap; margin-bottom:8px;">
 				<div style="background:var(--bg-tertiary); border:1px solid var(--border-subtle); border-radius:6px; padding:10px 16px; text-align:center; min-width:80px;">
-					<div style="font-size:18px; font-weight:700; color:var(--text-primary);">${g(e.usedAiCredits)}</div>
+					<div style="font-size:18px; font-weight:700; color:var(--text-primary);">${formatNumber(api.usedAiCredits)}</div>
 					<div style="font-size:11px; color:var(--text-secondary); margin-top:2px;">Credits used</div>
 				</div>
 				<div style="background:var(--bg-tertiary); border:1px solid var(--border-subtle); border-radius:6px; padding:10px 16px; text-align:center; min-width:80px;">
-					<div style="font-size:18px; font-weight:700; color:var(--text-primary);">${g(e.remainingAiCredits)}</div>
+					<div style="font-size:18px; font-weight:700; color:var(--text-primary);">${formatNumber(api.remainingAiCredits)}</div>
 					<div style="font-size:11px; color:var(--text-secondary); margin-top:2px;">Credits remaining</div>
 				</div>
 				<div style="background:var(--bg-tertiary); border:1px solid var(--border-subtle); border-radius:6px; padding:10px 16px; text-align:center; min-width:80px;">
-					<div style="font-size:18px; font-weight:700; color:var(--text-primary);">${g(e.budgetAiCredits)}</div>
+					<div style="font-size:18px; font-weight:700; color:var(--text-primary);">${formatNumber(api.budgetAiCredits)}</div>
 					<div style="font-size:11px; color:var(--text-secondary); margin-top:2px;">Monthly budget</div>
 				</div>
 			</div>
 			<div style="margin-bottom:4px; font-size:11px; color:var(--text-secondary); display:flex; justify-content:space-between;">
-				<span>${u}% used</span><span>${c}% available</span>
+				<span>${usedPct}% used</span><span>${pct}% available</span>
 			</div>
 			<div style="height:8px; border-radius:4px; background:var(--border-subtle); overflow:hidden; display:flex;">
-				${b}${h}
+				${trackedSegment}${gapSegment}
 			</div>
-			${S}
+			${legend}
 			<div style="font-size:11px; color:var(--text-muted); margin-top:6px;">
-				1 AI Credit = $0.01 \xB7 Budget = $${w(e.budgetUsd,2)}/month
+				1 AI Credit = $0.01 \xB7 Budget = $${formatFixed(api.budgetUsd, 2)}/month
 			</div>
-		</div>`}function Sl(e,t,o){if(!e)return`
+		</div>`;
+  }
+  function _billingCoverageAnalysisHtml(api, copilotCostUsd, nonCopilotCostUsd) {
+    if (!api) {
+      return `
 			<div style="font-size:11px; color:var(--text-muted); margin-bottom:8px; line-height:1.5;">
 				\u2139\uFE0F No Copilot API quota data available yet. The API balance appears after the extension fetches your Copilot plan info.
 				The extension only tracks local IDE sessions \u2014 it cannot see web chat, cloud agent, or review agent usage.
-			</div>`;if(t<=0)return"";let n=e.usedAiCredits*.01,s=n-t,r=Math.round(s*100),i=r>0?`<div style="display:flex; justify-content:space-between; padding-top:6px; border-top:1px solid var(--border-subtle); color:var(--text-secondary);"><span>Gap (untracked Copilot usage)</span><span>$${w(s,2)} (${g(r)} credits)</span></div>`:"",a=o>.001?`<div style="display:flex; justify-content:space-between;"><span>Other providers (not in Copilot API)</span><span>$${w(o,2)}</span></div>`:"",l=r>0?'<div style="margin-top:8px; font-size:11px; color:var(--text-muted); line-height:1.5;">\u2139\uFE0F The gap represents Copilot usage the extension cannot track: <strong>github.com/copilot</strong> web chat, <strong>cloud agent</strong> sessions, and <strong>Copilot review agent</strong> \u2014 all counted against your AI Credit budget.</div>':'<div style="margin-top:8px; font-size:11px; color:var(--text-muted);">\u2705 Extension-tracked Copilot usage matches the API \u2014 no significant untracked usage from web chat, cloud agent, or review agent.</div>';return`
+			</div>`;
+    }
+    if (copilotCostUsd <= 0) {
+      return "";
+    }
+    const apiUsedUsd = api.usedAiCredits * 0.01;
+    const gapUsd = apiUsedUsd - copilotCostUsd;
+    const gapCredits = Math.round(gapUsd * 100);
+    const gapRow = gapCredits > 0 ? `<div style="display:flex; justify-content:space-between; padding-top:6px; border-top:1px solid var(--border-subtle); color:var(--text-secondary);"><span>Gap (untracked Copilot usage)</span><span>$${formatFixed(gapUsd, 2)} (${formatNumber(gapCredits)} credits)</span></div>` : "";
+    const otherRow = nonCopilotCostUsd > 1e-3 ? `<div style="display:flex; justify-content:space-between;"><span>Other providers (not in Copilot API)</span><span>$${formatFixed(nonCopilotCostUsd, 2)}</span></div>` : "";
+    const note = gapCredits > 0 ? `<div style="margin-top:8px; font-size:11px; color:var(--text-muted); line-height:1.5;">\u2139\uFE0F The gap represents Copilot usage the extension cannot track: <strong>github.com/copilot</strong> web chat, <strong>cloud agent</strong> sessions, and <strong>Copilot review agent</strong> \u2014 all counted against your AI Credit budget.</div>` : `<div style="margin-top:8px; font-size:11px; color:var(--text-muted);">\u2705 Extension-tracked Copilot usage matches the API \u2014 no significant untracked usage from web chat, cloud agent, or review agent.</div>`;
+    return `
 		<div style="background:var(--bg-tertiary); border:1px solid var(--border-subtle); border-radius:6px; padding:12px 14px; margin-bottom:12px;">
 			<div style="font-size:12px; font-weight:600; color:var(--text-secondary); margin-bottom:8px;">Coverage analysis</div>
 			<div style="display:flex; flex-direction:column; gap:6px; font-size:12px; color:var(--text-primary);">
-				<div style="display:flex; justify-content:space-between;"><span>API total Copilot usage</span><span style="font-weight:600;">$${w(n,2)} (${g(e.usedAiCredits)} credits)</span></div>
-				<div style="display:flex; justify-content:space-between;"><span>Extension tracked (Copilot IDE sessions)</span><span style="font-weight:600;">$${w(t,2)} (${g(Math.round(t*100))} credits)</span></div>
-				${i}${a}
+				<div style="display:flex; justify-content:space-between;"><span>API total Copilot usage</span><span style="font-weight:600;">$${formatFixed(apiUsedUsd, 2)} (${formatNumber(api.usedAiCredits)} credits)</span></div>
+				<div style="display:flex; justify-content:space-between;"><span>Extension tracked (Copilot IDE sessions)</span><span style="font-weight:600;">$${formatFixed(copilotCostUsd, 2)} (${formatNumber(Math.round(copilotCostUsd * 100))} credits)</span></div>
+				${gapRow}${otherRow}
 			</div>
-			${l}
-		</div>`}function Tl(e){let t=e.copilotApiBalance,o=e.monthBillingGroupCosts;if(!t&&(!o||Object.keys(o).length===0))return"";let n=o?.["GitHub Copilot"]??0,r=(o?Object.values(o).reduce((u,c)=>u+c,0):0)-n,i=t?Cl(t,n):"",a=o&&Object.keys(o).length>0?bn(o,t):"",l=Sl(t,n,r);return`
+			${note}
+		</div>`;
+  }
+  function buildBillingComparisonSectionHtml(stats) {
+    const api = stats.copilotApiBalance;
+    const groupCosts = stats.monthBillingGroupCosts;
+    if (!api && (!groupCosts || Object.keys(groupCosts).length === 0)) {
+      return "";
+    }
+    const copilotCostUsd = groupCosts?.["GitHub Copilot"] ?? 0;
+    const totalCostUsd = groupCosts ? Object.values(groupCosts).reduce((s4, v2) => s4 + v2, 0) : 0;
+    const nonCopilotCostUsd = totalCostUsd - copilotCostUsd;
+    const apiHtml = api ? _billingApiBalanceHtml(api, copilotCostUsd) : "";
+    const extHtml = groupCosts && Object.keys(groupCosts).length > 0 ? billingExtGroupCostsHtml(groupCosts, api) : "";
+    const deltaHtml = _billingCoverageAnalysisHtml(api, copilotCostUsd, nonCopilotCostUsd);
+    return `
 		<div class="section">
 			<div class="section-title"><span>\u{1F4B3}</span><span>AI Billing Coverage</span></div>
 			<div class="section-subtitle">Compare what the GitHub Copilot API reports across all channels with what the extension can track from local IDE session logs, alongside estimated costs from other AI providers.</div>
-			${i}
-			${a}
-			${l}
-		</div>`}function $l(e,t,o,n,s,r){let i=P("Model Cost",()=>Ma(e)),a=P("AI Billing Coverage",()=>Tl(e)),l=P("Interaction Modes",()=>`
+			${apiHtml}
+			${extHtml}
+			${deltaHtml}
+		</div>`;
+  }
+  function buildActivityTabPanelHtml(stats, multiModelHtml, thinkingEffortHtml, sessionsSummaryHtml, todayTotalRefs, last30DaysTotalRefs) {
+    const modelCostHtml = safeSectionHtml("Model Cost", () => buildModelCostSectionHtml(stats));
+    const billingComparisonHtml = safeSectionHtml("AI Billing Coverage", () => buildBillingComparisonSectionHtml(stats));
+    const modeUsageHtml = safeSectionHtml("Interaction Modes", () => `
 			<div class="section" id="section-interaction-modes">
 				<div class="section-title"><span>\u{1F3AF}</span><span>Interaction Modes</span></div>
 				<div class="section-subtitle">How you're using Copilot: Ask (chat), Edit (code edits), Agent (autonomous tasks), Plan, Custom Agent, CLI (terminal), or Copilot App (desktop-app CLI sessions)</div>
 				<div class="two-column">
-					${vs(e.today.modeUsage,"\u{1F4C5} Today")}
-					${vs(e.last30Days.modeUsage,"\u{1F4CA} Last 30 Days")}
+					${renderModeBarChart(stats.today.modeUsage, "\u{1F4C5} Today")}
+					${renderModeBarChart(stats.last30Days.modeUsage, "\u{1F4CA} Last 30 Days")}
 				</div>
-			</div>`),u=P("Context References",()=>Il(e,s,r)),c=P("Model Efficiency",()=>Zl(e)),p=P("Context Window",()=>Dl(e));return`
-		<div id="tab-panel-activity" class="tab-panel"${$!=="activity"?' style="display:none"':""}>
-			${n}
-			${a}
+			</div>`);
+    const contextRefsHtml = safeSectionHtml("Context References", () => buildContextRefsHtml(stats, todayTotalRefs, last30DaysTotalRefs));
+    const modelEfficiencyHtml = safeSectionHtml("Model Efficiency", () => buildModelEfficiencySectionHtml(stats));
+    const contextWindowHtml = safeSectionHtml("Context Window", () => buildContextWindowSectionHtml(stats));
+    return `
+		<div id="tab-panel-activity" class="tab-panel"${activeTab !== "activity" ? ' style="display:none"' : ""}>
+			${sessionsSummaryHtml}
+			${billingComparisonHtml}
 			<!-- Mode Usage Section -->
-			${l}
-			${u}
-			${t}
-			${i}
-			${c}
-			${o}
-			${p}
-		</div>`}var Al=q("__MODEL_PRICING__"),Ml=Al?.pricing??{};function Vs(e){let t=null;for(let o of e){let n=un(o,Ml);n&&(!t||n.thresholdTokens<t.thresholdTokens)&&(t={...n,model:o})}return t}function El(e){let t=e*4/1048576,o=Math.round(e/10/1e3);return`\u2248${w(t,1)} MB of code (~${g(o)}K lines)`}function Rl(e,t){let o=e/t.thresholdTokens*100,n=Math.min(o,100),s=o>100?"var(--error-color, #f14c4c)":o>=70?"var(--warning-color, #cca700)":"var(--success-color, #89d185)",r=d(ee(t.model)),i=`above it, input billing goes $${t.defaultInputCostPerMillion.toFixed(2)} \u2192 $${t.longContextInputCostPerMillion.toFixed(2)} per 1M tokens`;return`
+			${modeUsageHtml}
+			${contextRefsHtml}
+			${multiModelHtml}
+			${modelCostHtml}
+			${modelEfficiencyHtml}
+			${thinkingEffortHtml}
+			${contextWindowHtml}
+		</div>`;
+  }
+  var _modelPricingData = getWindowData("__MODEL_PRICING__");
+  var MODEL_PRICING_MAP = _modelPricingData?.pricing ?? {};
+  function _tierInfoForModels(models) {
+    let best = null;
+    for (const model of models) {
+      const info = getLongContextInfo(model, MODEL_PRICING_MAP);
+      if (info && (!best || info.thresholdTokens < best.thresholdTokens)) {
+        best = { ...info, model };
+      }
+    }
+    return best;
+  }
+  function _defaultTierCapacityText(thresholdTokens) {
+    const mb = thresholdTokens * 4 / (1024 * 1024);
+    const lines = Math.round(thresholdTokens / 10 / 1e3);
+    return `\u2248${formatFixed(mb, 1)} MB of code (~${formatNumber(lines)}K lines)`;
+  }
+  function _renderContextWindowBar(maxTokens, tier) {
+    const pct = maxTokens / tier.thresholdTokens * 100;
+    const fillPct = Math.min(pct, 100);
+    const color = pct > 100 ? "var(--error-color, #f14c4c)" : pct >= 70 ? "var(--warning-color, #cca700)" : "var(--success-color, #89d185)";
+    const modelName = escapeHtml(getModelDisplayName(tier.model));
+    const rateNote = `above it, input billing goes $${tier.defaultInputCostPerMillion.toFixed(2)} \u2192 $${tier.longContextInputCostPerMillion.toFixed(2)} per 1M tokens`;
+    return `
 		<div style="margin-top: 12px;">
 			<div style="display:flex; justify-content:space-between; font-size:12px; color:var(--text-secondary); margin-bottom:4px;">
-				<span>${g(e)} tokens \u2014 ${w(o,0)}% of the ${g(t.thresholdTokens)}-token default tier for ${r}</span>
-				<span>${g(t.thresholdTokens)}</span>
+				<span>${formatNumber(maxTokens)} tokens \u2014 ${formatFixed(pct, 0)}% of the ${formatNumber(tier.thresholdTokens)}-token default tier for ${modelName}</span>
+				<span>${formatNumber(tier.thresholdTokens)}</span>
 			</div>
 			<div style="height:8px; border-radius:4px; background:var(--border-subtle); overflow:hidden;">
-				<div style="height:100%; width:${w(n,0)}%; background:${s}; border-radius:4px;"></div>
+				<div style="height:100%; width:${formatFixed(fillPct, 0)}%; background:${color}; border-radius:4px;"></div>
 			</div>
-			<div style="font-size:11px; color:var(--text-muted); margin-top:4px;">Default tier fits ${El(t.thresholdTokens)}; ${i}.</div>
-		</div>`}function Ko(e,t,o,n){return`
+			<div style="font-size:11px; color:var(--text-muted); margin-top:4px;">Default tier fits ${_defaultTierCapacityText(tier.thresholdTokens)}; ${rateNote}.</div>
+		</div>`;
+  }
+  function _cwRow(label, value, subNote, labelTitle) {
+    const titleAttr = labelTitle ? ` title="${labelTitle}"` : "";
+    return `
 		<div style="margin-bottom: 10px;">
-			<div style="font-size: 12px; font-weight: 600; color: var(--text-secondary); margin-bottom: 2px;"${n?` title="${n}"`:""}>${e}</div>
-			<div style="font-size: 13px; color: var(--text-primary);">${t}</div>
-			${o?`<div style="font-size: 11px; color: var(--text-secondary); margin-top: 2px; line-height: 1.4;">${o}</div>`:""}
-		</div>`}function _l(e){if(e.maxRequestInputTokens<=0)return"";let t=Vs(e.maxRequestModels),o=d(e.maxRequestModels.map(s=>ee(s)).join(", ")||"\u2014"),n=t?`${w(e.maxRequestInputTokens/t.thresholdTokens*100,0)}% of the ${g(t.thresholdTokens)}-token price line \xB7 ${o}`:`${o} \u2014 no long-context surcharge for ${e.maxRequestModels.length>1?"these models":"this model"}`;return Ko("\u{1F4CF} Largest request",`${g(e.maxRequestInputTokens)} input tokens`,n,"The biggest single prompt (input incl. cached tokens) sent to a model in one request during this period")}function Pl(e){if((e.maxReachedTokens??0)<=0)return"";let t=e.maxReachedWindowLimit,o=t?`${g(e.maxReachedTokens)} of ${g(t)} (${w(e.maxReachedTokens/t*100,0)}%)`:g(e.maxReachedTokens);return Ko("\u{1FA9F} Fullest CLI window",o,void 0,"The highest context fill recorded for a Copilot CLI session in this period, versus its window limit")}function _o(e){if(!(!!e&&(e.maxRequestInputTokens>0||(e.maxReachedTokens??0)>0||Object.keys(e.tierCounts).length>0)))return'<div style="color: var(--text-muted); font-size: 11px;">No data</div>';let o=Object.entries(e.tierCounts),n=o.reduce((r,[,i])=>r+i,0),s=o.length>0?Ko("\u{1FA9C} Context tiers",o.map(([r,i])=>`${d(r)} \xD7${i}`).join(", "),`${n} Copilot CLI session${n===1?"":"s"} grouped by chosen window size \u2014 "default" is the standard window at normal rates; larger tiers unlock more context at long-context prices`,"Copilot CLI lets you pick a context-window tier per session; the count shows how many sessions used each tier"):"";return _l(e)+Pl(e)+s}function Dl(e){let t=e.last30Days.contextWindow,o=t&&t.maxRequestInputTokens>0?Vs(t.maxRequestModels):null,n=t&&o?Rl(t.maxRequestInputTokens,o):"";return`
+			<div style="font-size: 12px; font-weight: 600; color: var(--text-secondary); margin-bottom: 2px;"${titleAttr}>${label}</div>
+			<div style="font-size: 13px; color: var(--text-primary);">${value}</div>
+			${subNote ? `<div style="font-size: 11px; color: var(--text-secondary); margin-top: 2px; line-height: 1.4;">${subNote}</div>` : ""}
+		</div>`;
+  }
+  function _cwLargestRequestRow(cw) {
+    if (cw.maxRequestInputTokens <= 0) {
+      return "";
+    }
+    const tier = _tierInfoForModels(cw.maxRequestModels);
+    const modelsLabel = escapeHtml(cw.maxRequestModels.map((m2) => getModelDisplayName(m2)).join(", ") || "\u2014");
+    const thresholdNote = tier ? `${formatFixed(cw.maxRequestInputTokens / tier.thresholdTokens * 100, 0)}% of the ${formatNumber(tier.thresholdTokens)}-token price line \xB7 ${modelsLabel}` : `${modelsLabel} \u2014 no long-context surcharge for ${cw.maxRequestModels.length > 1 ? "these models" : "this model"}`;
+    return _cwRow(
+      "\u{1F4CF} Largest request",
+      `${formatNumber(cw.maxRequestInputTokens)} input tokens`,
+      thresholdNote,
+      "The biggest single prompt (input incl. cached tokens) sent to a model in one request during this period"
+    );
+  }
+  function _cwFullestWindowRow(cw) {
+    if ((cw.maxReachedTokens ?? 0) <= 0) {
+      return "";
+    }
+    const limit = cw.maxReachedWindowLimit;
+    const value = limit ? `${formatNumber(cw.maxReachedTokens)} of ${formatNumber(limit)} (${formatFixed(cw.maxReachedTokens / limit * 100, 0)}%)` : formatNumber(cw.maxReachedTokens);
+    return _cwRow(
+      "\u{1FA9F} Fullest CLI window",
+      value,
+      void 0,
+      "The highest context fill recorded for a Copilot CLI session in this period, versus its window limit"
+    );
+  }
+  function renderContextWindowPeriodHtml(cw) {
+    const hasData = !!cw && (cw.maxRequestInputTokens > 0 || (cw.maxReachedTokens ?? 0) > 0 || Object.keys(cw.tierCounts).length > 0);
+    if (!hasData) {
+      return '<div style="color: var(--text-muted); font-size: 11px;">No data</div>';
+    }
+    const tierEntries = Object.entries(cw.tierCounts);
+    const tierSessionCount = tierEntries.reduce((sum, [, c4]) => sum + c4, 0);
+    const tierRow = tierEntries.length > 0 ? _cwRow(
+      "\u{1FA9C} Context tiers",
+      tierEntries.map(([t4, c4]) => `${escapeHtml(t4)} \xD7${c4}`).join(", "),
+      `${tierSessionCount} Copilot CLI session${tierSessionCount === 1 ? "" : "s"} grouped by chosen window size \u2014 "default" is the standard window at normal rates; larger tiers unlock more context at long-context prices`,
+      "Copilot CLI lets you pick a context-window tier per session; the count shows how many sessions used each tier"
+    ) : "";
+    return _cwLargestRequestRow(cw) + _cwFullestWindowRow(cw) + tierRow;
+  }
+  function buildContextWindowSectionHtml(stats) {
+    const cw30 = stats.last30Days.contextWindow;
+    const tier30 = cw30 && cw30.maxRequestInputTokens > 0 ? _tierInfoForModels(cw30.maxRequestModels) : null;
+    const bar = cw30 && tier30 ? _renderContextWindowBar(cw30.maxRequestInputTokens, tier30) : "";
+    return `
 		<div class="section">
 			<div class="section-title"><span>\u{1FA9F}</span><span>Context Window &amp; Long-Context Pricing</span></div>
 			<div class="section-subtitle">How close your largest requests come to the long-context price line. Models with tiered pricing bill higher input rates once a request exceeds their default-tier threshold.</div>
 			<div class="three-column">
 				<div>
 					<h4 style="color: var(--text-primary); font-size: 13px; margin-bottom: 8px;">\u{1F4C5} Today</h4>
-					${_o(e.today.contextWindow)}
+					${renderContextWindowPeriodHtml(stats.today.contextWindow)}
 				</div>
 				<div>
 					<h4 style="color: var(--text-primary); font-size: 13px; margin-bottom: 8px;">\u{1F4C6} Last 30 Days</h4>
-					${_o(t)}
+					${renderContextWindowPeriodHtml(cw30)}
 				</div>
 				<div>
 					<h4 style="color: var(--text-primary); font-size: 13px; margin-bottom: 8px;">\u{1F4C5} Previous Month</h4>
-					${_o(e.lastMonth.contextWindow)}
+					${renderContextWindowPeriodHtml(stats.lastMonth.contextWindow)}
 				</div>
 			</div>
-			${n}
-		</div>`}function Dt(e,t=""){let o=e>0?"":" ctx-ref-zero";return`<td class="${`ctx-ref-num${t?" "+t:""}${o}`}">${e}</td>`}function Ts(e,t,o){let i=[e,t,o],a=Math.max(...i),l=i.map((p,b)=>{let h=2+b*(56/(i.length-1)),S=a===0?18:2+(1-p/a)*16;return`${h.toFixed(1)},${S.toFixed(1)}`}).join(" "),c=a===0?"var(--text-muted)":o>=t&&t>=e?"var(--link-color)":o<=t&&t<=e?"#f87171":"var(--text-secondary)";return`<td class="ctx-ref-spark"><svg viewBox="0 0 60 20" width="60" height="20" aria-hidden="true"><polyline points="${l}" fill="none" stroke="${c}" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round"/>${i.map((p,b)=>{let h=2+b*(56/(i.length-1)),S=a===0?18:2+(1-p/a)*16;return`<circle cx="${h.toFixed(1)}" cy="${S.toFixed(1)}" r="2" fill="${c}"/>`}).join("")}</svg></td>`}function Ll(e,t){return`
+			${bar}
+		</div>`;
+  }
+  function numCell(value, extraClass = "") {
+    const zeroClass = value > 0 ? "" : " ctx-ref-zero";
+    const cls = `ctx-ref-num${extraClass ? " " + extraClass : ""}${zeroClass}`;
+    return `<td class="${cls}">${value}</td>`;
+  }
+  function sparklineCell(lastMonth, month, today) {
+    const W = 60, H2 = 20, PAD = 2;
+    const values = [lastMonth, month, today];
+    const max = Math.max(...values);
+    const points = values.map((v2, i6) => {
+      const x2 = PAD + i6 * ((W - PAD * 2) / (values.length - 1));
+      const y3 = max === 0 ? H2 - PAD : PAD + (1 - v2 / max) * (H2 - PAD * 2);
+      return `${x2.toFixed(1)},${y3.toFixed(1)}`;
+    }).join(" ");
+    const isFlat = max === 0;
+    const color = isFlat ? "var(--text-muted)" : today >= month && month >= lastMonth ? "var(--link-color)" : today <= month && month <= lastMonth ? "#f87171" : "var(--text-secondary)";
+    return `<td class="ctx-ref-spark"><svg viewBox="0 0 ${W} ${H2}" width="${W}" height="${H2}" aria-hidden="true"><polyline points="${points}" fill="none" stroke="${color}" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round"/>${values.map((v2, i6) => {
+      const x2 = PAD + i6 * ((W - PAD * 2) / (values.length - 1));
+      const y3 = max === 0 ? H2 - PAD : PAD + (1 - v2 / max) * (H2 - PAD * 2);
+      return `<circle cx="${x2.toFixed(1)}" cy="${y3.toFixed(1)}" r="2" fill="${color}"/>`;
+    }).join("")}</svg></td>`;
+  }
+  function renderContextRefTable(rows, totals) {
+    const bodyRows = rows.slice().sort((a3, b3) => b3.last30 - a3.last30).map((row) => {
+      const titleAttr = row.title ? ` title="${escapeHtml(row.title)}"` : "";
+      return `<tr${titleAttr}><td class="ctx-ref-name">${row.label}</td>${numCell(row.today, row.today > 0 ? "ctx-ref-today-active" : "")}${numCell(row.month)}${numCell(row.lastMonth)}${numCell(row.last30)}${sparklineCell(row.lastMonth, row.month, row.today)}</tr>`;
+    }).join("");
+    return `
 		<div class="ctx-ref-table-wrap">
 			<table class="ctx-ref-table">
 				<thead>
@@ -2903,191 +7493,1413 @@ ${hi(t)}
 					</tr>
 				</thead>
 				<tbody>
-					${e.slice().sort((n,s)=>s.last30-n.last30).map(n=>`<tr${n.title?` title="${d(n.title)}"`:""}><td class="ctx-ref-name">${n.label}</td>${Dt(n.today,n.today>0?"ctx-ref-today-active":"")}${Dt(n.month)}${Dt(n.lastMonth)}${Dt(n.last30)}${Ts(n.lastMonth,n.month,n.today)}</tr>`).join("")}
+					${bodyRows}
 				</tbody>
 				<tfoot>
 					<tr class="ctx-ref-total">
 						<td class="ctx-ref-name">\u{1F4CA} Total References</td>
-						<td class="ctx-ref-num">${t.today}</td>
-						<td class="ctx-ref-num">${t.month}</td>
-						<td class="ctx-ref-num">${t.lastMonth}</td>
-						<td class="ctx-ref-num">${t.last30}</td>
-						<td class="ctx-ref-spark">${Ts(t.lastMonth,t.month,t.today).replace(/^<td[^>]*>/,"").replace(/<\/td>$/,"")}</td>
+						<td class="ctx-ref-num">${totals.today}</td>
+						<td class="ctx-ref-num">${totals.month}</td>
+						<td class="ctx-ref-num">${totals.lastMonth}</td>
+						<td class="ctx-ref-num">${totals.last30}</td>
+						<td class="ctx-ref-spark">${sparklineCell(totals.lastMonth, totals.month, totals.today).replace(/^<td[^>]*>/, "").replace(/<\/td>$/, "")}</td>
 					</tr>
 				</tfoot>
 			</table>
-		</div>`}function Ul(e,t,o){let n=c=>c||0,s=[{label:"\u{1F4C4} #file",get:c=>c.file},{label:"\u2702\uFE0F #selection",get:c=>c.selection},{label:"\u2728 Implicit Selection",title:"Text selected in your editor providing passive context to Copilot",get:c=>c.implicitSelection},{label:"\u{1F524} #symbol",get:c=>c.symbol},{label:"\u{1F5C2}\uFE0F #codebase",get:c=>c.codebase},{label:"\u{1F4C1} @workspace",get:c=>c.workspace},{label:"\u{1F4BB} @terminal",get:c=>c.terminal},{label:"\u{1F527} @vscode",get:c=>c.vscode},{label:"\u2328\uFE0F #terminalLastCommand",title:"Last command run in the terminal",get:c=>n(c.terminalLastCommand)},{label:"\u{1F5B1}\uFE0F #terminalSelection",title:"Selected terminal output",get:c=>n(c.terminalSelection)},{label:"\u{1F4CB} #clipboard",title:"Clipboard contents",get:c=>n(c.clipboard)},{label:"\u{1F4DD} #changes",title:"Uncommitted git changes",get:c=>n(c.changes)},{label:"\u{1F4E4} #outputPanel",title:"Output panel contents",get:c=>n(c.outputPanel)},{label:"\u26A0\uFE0F #problemsPanel",title:"Problems panel contents",get:c=>n(c.problemsPanel)},{label:"\u{1F500} #pr",title:"Pull request context references (#pr / #pullRequest) \u2014 Copilot PR chat understanding, review, and summary",get:c=>n(c.pullRequest)},{label:"\u{1F4F7} Images",title:"Pasted images and vision context detected in session logs",get:c=>n(c.byKind["copilot.image"])},{label:"\u{1F4CB} Prompt Files",title:".github/prompts/ prompt file uses detected in session logs",get:c=>n(c.byKind.promptFile)},{label:"\u{1F4D0} Code Lines",title:"Total lines of code referenced via #file: range selections",get:c=>n(c.codeContextLines)},{label:"\u{1F3AF} Custom Prompts",title:"Custom /command prompt uses detected in session logs",get:c=>n(c.byKind.prompt)},{label:"\u{1F4CB} Copilot Instructions",title:"copilot-instructions.md file references detected in session logs",get:c=>c.copilotInstructions},{label:"\u{1F916} Agents.md",title:"agents.md file references detected in session logs",get:c=>c.agentsMd}],r=e.last30Days.contextReferences,i=e.month.contextReferences,a=e.lastMonth.contextReferences,l=e.today.contextReferences,u=s.map(c=>({label:c.label,title:c.title,last30:c.get(r),month:c.get(i),lastMonth:c.get(a),today:c.get(l)}));return Ll(u,{last30:o,month:Re(i),lastMonth:Re(a),today:t})}function Il(e,t,o){let n=Object.keys(e.last30Days.contextReferences.byKind).length>0?`
+		</div>`;
+  }
+  function buildContextRefCardsHtml(stats, todayTotalRefs, last30DaysTotalRefs) {
+    const c4 = (v2) => v2 || 0;
+    const descriptors = [
+      { label: "\u{1F4C4} #file", get: (cr) => cr.file },
+      { label: "\u2702\uFE0F #selection", get: (cr) => cr.selection },
+      { label: "\u2728 Implicit Selection", title: "Text selected in your editor providing passive context to Copilot", get: (cr) => cr.implicitSelection },
+      { label: "\u{1F524} #symbol", get: (cr) => cr.symbol },
+      { label: "\u{1F5C2}\uFE0F #codebase", get: (cr) => cr.codebase },
+      { label: "\u{1F4C1} @workspace", get: (cr) => cr.workspace },
+      { label: "\u{1F4BB} @terminal", get: (cr) => cr.terminal },
+      { label: "\u{1F527} @vscode", get: (cr) => cr.vscode },
+      { label: "\u2328\uFE0F #terminalLastCommand", title: "Last command run in the terminal", get: (cr) => c4(cr.terminalLastCommand) },
+      { label: "\u{1F5B1}\uFE0F #terminalSelection", title: "Selected terminal output", get: (cr) => c4(cr.terminalSelection) },
+      { label: "\u{1F4CB} #clipboard", title: "Clipboard contents", get: (cr) => c4(cr.clipboard) },
+      { label: "\u{1F4DD} #changes", title: "Uncommitted git changes", get: (cr) => c4(cr.changes) },
+      { label: "\u{1F4E4} #outputPanel", title: "Output panel contents", get: (cr) => c4(cr.outputPanel) },
+      { label: "\u26A0\uFE0F #problemsPanel", title: "Problems panel contents", get: (cr) => c4(cr.problemsPanel) },
+      { label: "\u{1F500} #pr", title: "Pull request context references (#pr / #pullRequest) \u2014 Copilot PR chat understanding, review, and summary", get: (cr) => c4(cr.pullRequest) },
+      { label: "\u{1F4F7} Images", title: "Pasted images and vision context detected in session logs", get: (cr) => c4(cr.byKind["copilot.image"]) },
+      { label: "\u{1F4CB} Prompt Files", title: ".github/prompts/ prompt file uses detected in session logs", get: (cr) => c4(cr.byKind["promptFile"]) },
+      { label: "\u{1F4D0} Code Lines", title: "Total lines of code referenced via #file: range selections", get: (cr) => c4(cr.codeContextLines) },
+      { label: "\u{1F3AF} Custom Prompts", title: "Custom /command prompt uses detected in session logs", get: (cr) => c4(cr.byKind["prompt"]) },
+      { label: "\u{1F4CB} Copilot Instructions", title: "copilot-instructions.md file references detected in session logs", get: (cr) => cr.copilotInstructions },
+      { label: "\u{1F916} Agents.md", title: "agents.md file references detected in session logs", get: (cr) => cr.agentsMd }
+    ];
+    const r6 = stats.last30Days.contextReferences;
+    const m2 = stats.month.contextReferences;
+    const lm = stats.lastMonth.contextReferences;
+    const t4 = stats.today.contextReferences;
+    const rows = descriptors.map((d3) => ({
+      label: d3.label,
+      title: d3.title,
+      last30: d3.get(r6),
+      month: d3.get(m2),
+      lastMonth: d3.get(lm),
+      today: d3.get(t4)
+    }));
+    return renderContextRefTable(rows, {
+      last30: last30DaysTotalRefs,
+      month: getTotalContextRefs(m2),
+      lastMonth: getTotalContextRefs(lm),
+      today: todayTotalRefs
+    });
+  }
+  function buildContextRefsHtml(stats, todayTotalRefs, last30DaysTotalRefs) {
+    const byKindHtml = Object.keys(stats.last30Days.contextReferences.byKind).length > 0 ? `
 		<div style="margin-top: 16px; padding: 12px; background: var(--bg-tertiary); border: 1px solid var(--border-subtle); border-radius: 6px;">
 			<div style="font-size: 13px; font-weight: 600; color: var(--text-primary); margin-bottom: 8px;">\u{1F4CE} Attached Files by Type (Last 30 Days)</div>
 			<div style="font-size: 12px; color: var(--text-primary);">
-				${Object.entries(e.last30Days.contextReferences.byKind).sort(([,r],[,i])=>i-r).slice(0,5).map(([r,i])=>`<div style="margin-bottom: 4px;"><span style="color: var(--link-color);">${d(r)}:</span> ${i}</div>`).join("")}
+				${Object.entries(stats.last30Days.contextReferences.byKind).sort(([, a3], [, b3]) => b3 - a3).slice(0, 5).map(([kind, count]) => `<div style="margin-bottom: 4px;"><span style="color: var(--link-color);">${escapeHtml(kind)}:</span> ${count}</div>`).join("")}
 			</div>
 		</div>
-	`:"",s=Object.keys(e.last30Days.contextReferences.byPath).length>0?`
+	` : "";
+    const byPathHtml = Object.keys(stats.last30Days.contextReferences.byPath).length > 0 ? `
 		<div style="margin-top: 16px; padding: 12px; background: var(--bg-tertiary); border: 1px solid var(--border-subtle); border-radius: 6px;">
 			<div style="font-size: 13px; font-weight: 600; color: var(--text-primary); margin-bottom: 8px;">\u{1F4C1} Most Referenced Files (Last 30 Days)</div>
 			<div style="font-size: 11px; color: var(--text-primary);">
-				${Object.entries(e.last30Days.contextReferences.byPath).sort(([,r],[,i])=>i-r).slice(0,10).map(([r,i])=>`<div style="margin-bottom: 4px; font-family: 'Courier New', monospace;"><span style="color: var(--link-color);">${i}\xD7</span> ${d(r)}</div>`).join("")}
+				${Object.entries(stats.last30Days.contextReferences.byPath).sort(([, a3], [, b3]) => b3 - a3).slice(0, 10).map(([path, count]) => `<div style="margin-bottom: 4px; font-family: 'Courier New', monospace;"><span style="color: var(--link-color);">${count}\xD7</span> ${escapeHtml(path)}</div>`).join("")}
 			</div>
 		</div>
-	`:"";return`
+	` : "";
+    return `
 		<!-- Context References Section -->
 		<div class="section">
 			<div class="section-title"><span>\u{1F517}</span><span>Context References</span></div>
 			<div class="section-subtitle">How often you reference files, selections, symbols, and workspace context</div>
-			${Ul(e,t,o)}
-			${n}
-			${s}
-		</div>`}function zl(e){let t=ui(e);if(t.length===0)return"";let o=pi(t);return`
+			${buildContextRefCardsHtml(stats, todayTotalRefs, last30DaysTotalRefs)}
+			${byKindHtml}
+			${byPathHtml}
+		</div>`;
+  }
+  function buildUnknownMcpToolsBannerHtml(stats) {
+    const unknownTools = getUnknownMcpTools(stats);
+    if (unknownTools.length === 0) {
+      return "";
+    }
+    const issueUrl = createMcpToolIssueUrl(unknownTools);
+    const toolListHtml = unknownTools.map((tool) => {
+      const todayCount = (stats.today.toolCalls.byTool[tool] || 0) + (stats.today.mcpTools.byTool[tool] || 0);
+      const last30Count = (stats.last30Days.toolCalls.byTool[tool] || 0) + (stats.last30Days.mcpTools.byTool[tool] || 0);
+      const monthCount = (stats.month.toolCalls.byTool[tool] || 0) + (stats.month.mcpTools.byTool[tool] || 0);
+      const countParts = [];
+      if (todayCount > 0) {
+        countParts.push(`${todayCount} today`);
+      }
+      if (last30Count > todayCount) {
+        countParts.push(`${last30Count} in the last 30d`);
+      }
+      if (monthCount > last30Count) {
+        countParts.push(`${monthCount} this month`);
+      }
+      const countHtml = countParts.length > 0 ? `<span style="color:var(--text-muted);"> (${countParts.join(" | ")})</span>` : "";
+      const suppressBtn = `<button data-suppress-tool="${escapeHtml(tool)}" title="Suppress this tool from the unknown list" style="background:none; border:none; cursor:pointer; padding:0 2px; color:var(--text-muted); font-size:11px; line-height:1;" aria-label="Suppress ${escapeHtml(tool)}">\u{1F507}</button>`;
+      return `<span style="display:inline-flex; align-items:center; gap:4px; padding:2px 6px; background:var(--bg-primary); border:1px solid var(--border-color); border-radius:3px; font-family:monospace; font-size:11px;">${escapeHtml(tool)}${countHtml}${suppressBtn}</span>`;
+    }).join(" ");
+    return `
 		<div id="unknown-mcp-tools-section" style="margin-bottom: 12px; padding: 10px; background: var(--bg-secondary); border: 1px solid var(--border-color); border-radius: 6px;">
 			<div style="display:flex; flex-wrap:wrap; gap:4px; margin-bottom:10px;">
-				${t.map(s=>{let r=(e.today.toolCalls.byTool[s]||0)+(e.today.mcpTools.byTool[s]||0),i=(e.last30Days.toolCalls.byTool[s]||0)+(e.last30Days.mcpTools.byTool[s]||0),a=(e.month.toolCalls.byTool[s]||0)+(e.month.mcpTools.byTool[s]||0),l=[];r>0&&l.push(`${r} today`),i>r&&l.push(`${i} in the last 30d`),a>i&&l.push(`${a} this month`);let u=l.length>0?`<span style="color:var(--text-muted);"> (${l.join(" | ")})</span>`:"",c=`<button data-suppress-tool="${d(s)}" title="Suppress this tool from the unknown list" style="background:none; border:none; cursor:pointer; padding:0 2px; color:var(--text-muted); font-size:11px; line-height:1;" aria-label="Suppress ${d(s)}">\u{1F507}</button>`;return`<span style="display:inline-flex; align-items:center; gap:4px; padding:2px 6px; background:var(--bg-primary); border:1px solid var(--border-color); border-radius:3px; font-family:monospace; font-size:11px;">${d(s)}${u}${c}</span>`}).join(" ")}
+				${toolListHtml}
 			</div>
-			<a href="${d(o)}" target="_blank" rel="noopener noreferrer" style="display: inline-flex; align-items: center; gap: 6px; padding: 6px 12px; background: var(--button-bg); color: var(--button-fg); border-radius: 4px; text-decoration: none; font-size: 12px; font-weight: 500;">
+			<a href="${escapeHtml(issueUrl)}" target="_blank" rel="noopener noreferrer" style="display: inline-flex; align-items: center; gap: 6px; padding: 6px 12px; background: var(--button-bg); color: var(--button-fg); border-radius: 4px; text-decoration: none; font-size: 12px; font-weight: 500;">
 				<span>\u{1F4DD}</span>
 				<span>Report Unknown Tools</span>
 			</a>
 		</div>
-	`}var Bl={today:"today",last30:"last30Days",currentMonth:"month"},$s="last30",Ys="last30Days",Ht="cost",Go="calls",Vt="vendor",jt="calls",nt="desc",Js={},Vo=!0;function Yo(e){return e===null?"\u2014":e>=.01?sn(e):`$${e.toFixed(3)}`}function Ft(e){return e===null?"\u2014":Q(e*100)}function Bt(e){return e===null?"\u2014":w(e,1)}var dt=[{key:"cost",label:"Cost",axisLabel:"Average cost per turn",value:e=>e.rates.costPerCall,format:Yo},{key:"outputTokens",label:"Output tokens",axisLabel:"Average output tokens per turn",value:e=>e.rates.outputTokensPerCall,format:e=>e===null?"\u2014":gt(Math.round(e))},{key:"toolSteps",label:"Tool steps",axisLabel:"Average tool steps per turn",value:e=>e.rates.toolCallsPerCall,format:Bt}],Wt=[{key:"calls",label:"Local use",value:e=>e.counters.calls,format:e=>`${g(e??0)} turns`},...dt.map(({key:e,label:t,value:o,format:n})=>({key:e,label:t,value:o,format:n}))];function Ol(e,t){let o=t>0?e.counters.calls/t:0;return`<div class="model-use-cell">
-		<div class="model-use-track" aria-hidden="true"><span style="width:${Math.max(2,o*100).toFixed(1)}%"></span></div>
-		<strong>${Ft(o)}</strong>
-		<span>${g(e.counters.calls)} turns</span>
-	</div>`}var qt=[{sortKey:"model",label:"Model",title:"Model identifier",sortValue:e=>e.model,render:e=>d(ee(e.model))},{sortKey:"calls",label:"Local use",title:"Share of user-request turns attributed to this model",sortValue:e=>e.counters.calls,render:Ol},{sortKey:"oneShotRate",label:"One-shot",title:"Share of edit turns completed without retries or self-corrections",sortValue:e=>e.rates.oneShotRate,render:e=>Ft(e.rates.oneShotRate)},{sortKey:"retryRate",label:"Retries/edit",title:"Average immediate same-file retries per edit turn",sortValue:e=>e.rates.retryRate,render:e=>Bt(e.rates.retryRate)},{sortKey:"selfCorrectionRate",label:"Self-corr/edit",title:"Average re-edits after intervening tool calls per edit turn",sortValue:e=>e.rates.selfCorrectionRate,render:e=>Bt(e.rates.selfCorrectionRate)},{sortKey:"costPerCall",label:"Avg cost",title:"Average estimated provider cost per user-request turn",sortValue:e=>e.rates.costPerCall,render:e=>Yo(e.rates.costPerCall)},{sortKey:"outputTokensPerCall",label:"Out tok",title:"Average output tokens per user-request turn",sortValue:e=>e.rates.outputTokensPerCall,render:e=>e.rates.outputTokensPerCall===null?"\u2014":gt(Math.round(e.rates.outputTokensPerCall))},{sortKey:"toolCallsPerCall",label:"Steps",title:"Average tool invocations per user-request turn",sortValue:e=>e.rates.toolCallsPerCall,render:e=>Bt(e.rates.toolCallsPerCall)},{sortKey:"cacheHitRate",label:"Cache hit",title:"Cache-read share of input tokens",sortValue:e=>e.rates.cacheHitRate,render:e=>Ft(e.rates.cacheHitRate)}];function Nl(e){return jt!==e?"":nt==="desc"?" \u25BC":" \u25B2"}function Hl(e,t,o){let n=o.sortValue(e),s=o.sortValue(t);if(n===null&&s===null)return 0;if(n===null)return 1;if(s===null)return-1;let r=typeof n=="string"||typeof s=="string"?String(n).localeCompare(String(s)):n-s;return nt==="desc"?-r:r}function jl(e){let t=Object.entries(e).map(([n,s])=>({model:n,counters:s,rates:pn(s)})),o=qt.find(n=>n.sortKey===jt)??qt[1];return t.sort((n,s)=>Hl(n,s,o))}function Fl(e,t){if(!Vo)return{rows:e,hiddenNote:""};let o=gn(t);if(o===null)return{rows:e,hiddenNote:""};let n=e.filter(l=>l.counters.calls>o),s=e.length-n.length,r=s===1?"model":"models",i=o===1?"turn":"turns",a=s>0?`${s} low-usage ${r} hidden (\u2264${o} ${i})`:"";return{rows:n,hiddenNote:a}}var As=["--stage-1-color","--stage-2-color","--stage-3-color","--stage-4-color","--success-fg","--warning-fg","--link-color"],Wl={Anthropic:"--warning-fg",OpenAI:"--success-fg",Google:"--stage-3-color","Mistral AI":"--stage-2-color",xAI:"--stage-4-color",Alibaba:"--stage-1-color",Microsoft:"--link-color"};function Ms(e){let t=0;for(let o=0;o<e.length;o++)t=(t<<5)-t+e.charCodeAt(o)|0;return`var(${As[Math.abs(t)%As.length]})`}function Jo(e){if(Vt==="model")return Ms(e);let t=yt(e),o=Wl[t];return o?`var(${o})`:Ms(t)}function ql(e,t){return e.key==="cost"?Yo(t):e.key==="outputTokens"?gt(Math.round(t)):w(t,1)}function Kl(e,t){let o=[0,.25,.5,.75,1].map(s=>{let r=76+s*760;return`<line x1="${r}" y1="24" x2="${r}" y2="286"></line><text x="${r}" y="310" text-anchor="middle">${d(ql(e,t*s))}</text>`}).join(""),n=[0,.25,.5,.75,1].map(s=>{let r=286-s*262;return`<line x1="76" y1="${r}" x2="836" y2="${r}"></line><text x="64" y="${r+4}" text-anchor="end">${Math.round(s*100)}%</text>`}).join("");return`<g class="efficiency-grid">${o}${n}</g>`}function Gl(e,t,o,n,s,r){let i=t.value(e)??0,a=o.value(e)??0,l=e.rates.oneShotRate??0,u=76+i/n*760,c=286-l*262,p=no(a,s),b=Jo(e.model),h=ee(e.model),S=d(h),ut=`${h}: ${Ft(l)} one-shot edit rate, ${t.format(i)} ${t.axisLabel.toLowerCase()}, bubble sized by ${o.label.toLowerCase()}: ${o.format(a)}`;return`<g class="efficiency-point" style="--model-color:${b}" tabindex="0" role="img" aria-label="${d(ut)}">
-		<circle cx="${u.toFixed(1)}" cy="${c.toFixed(1)}" r="${p.toFixed(1)}"><title>${d(ut)}</title></circle>
-		<text x="${r.x.toFixed(1)}" y="${r.y.toFixed(1)}" text-anchor="${r.textAnchor}">${S}</text>
-	</g>`}function Vl(e){return Vt!=="vendor"?"":`<div class="efficiency-vendor-legend" aria-label="Model vendor colors">${[...new Set(e.map(n=>yt(n.model)))].sort().map(n=>{let s=e.find(r=>yt(r.model)===n)?.model??"";return`<span class="efficiency-legend-item" style="--model-color:${Jo(s)}"><span aria-hidden="true"></span>${d(n)}</span>`}).join("")}</div>`}function Yl(e){let t=dt.find(u=>u.key===Ht)??dt[0],o=Wt.find(u=>u.key===Go)??Wt[0],n=e.filter(u=>u.rates.oneShotRate!==null&&t.value(u)!==null).sort((u,c)=>c.counters.calls-u.counters.calls).slice(0,12);if(n.length===0)return'<div class="model-leaderboard-empty"><strong>No comparable edit data yet.</strong><span>The chart appears after local sessions record both a model and structured edit turns.</span></div>';let s=Math.max(...n.map(u=>t.value(u)??0),1e-4)*1.08,r=Math.max(...n.map(u=>o.value(u)??0),0),i=n.map(u=>{let c=t.value(u)??0,p=o.value(u)??0;return{x:76+c/s*760,y:286-(u.rates.oneShotRate??0)*262,radius:no(p,r),label:ee(u.model)}}),a=xn(i,{left:76,right:836,top:24,bottom:286}),l=n.map((u,c)=>Gl(u,t,o,s,r,a[c])).join("");return`<div class="efficiency-chart-wrap">
-		<svg class="efficiency-chart" viewBox="0 0 900 350" role="img" aria-label="One-shot edit rate compared with ${d(t.axisLabel.toLowerCase())}; bubble size represents ${d(o.label.toLowerCase())}">
-			${Kl(t,s)}
-			<text class="efficiency-axis-title" x="456" y="344" text-anchor="middle">${d(t.axisLabel)}</text>
+	`;
+  }
+  var EFFICIENCY_PERIOD_TO_DATA_KEY = {
+    today: "today",
+    last30: "last30Days",
+    currentMonth: "month"
+  };
+  var efficiencySelectedPeriod = "last30";
+  var efficiencyPeriod = "last30Days";
+  var efficiencyMetric = "cost";
+  var efficiencyBubbleMetric = "calls";
+  var efficiencyColorMode = "vendor";
+  var efficiencySortColumn = "calls";
+  var efficiencySortDirection = "desc";
+  var cachedModelEfficiency = {};
+  var efficiencyFilterLowUsage = true;
+  function formatUnitCost(value) {
+    if (value === null) {
+      return "\u2014";
+    }
+    return value >= 0.01 ? formatCost(value) : `$${value.toFixed(3)}`;
+  }
+  function formatRatePercent(value) {
+    return value === null ? "\u2014" : formatPercent(value * 100);
+  }
+  function formatPerTurn(value) {
+    return value === null ? "\u2014" : formatFixed(value, 1);
+  }
+  var EFFICIENCY_METRICS = [
+    { key: "cost", label: "Cost", axisLabel: "Average cost per turn", value: (row) => row.rates.costPerCall, format: formatUnitCost },
+    { key: "outputTokens", label: "Output tokens", axisLabel: "Average output tokens per turn", value: (row) => row.rates.outputTokensPerCall, format: (value) => value === null ? "\u2014" : formatCompact(Math.round(value)) },
+    { key: "toolSteps", label: "Tool steps", axisLabel: "Average tool steps per turn", value: (row) => row.rates.toolCallsPerCall, format: formatPerTurn }
+  ];
+  var EFFICIENCY_BUBBLE_METRICS = [
+    { key: "calls", label: "Local use", value: (row) => row.counters.calls, format: (value) => `${formatNumber(value ?? 0)} turns` },
+    ...EFFICIENCY_METRICS.map(({ key, label, value, format }) => ({ key, label, value, format }))
+  ];
+  function buildLocalUsageCell(row, totalCalls) {
+    const share = totalCalls > 0 ? row.counters.calls / totalCalls : 0;
+    return `<div class="model-use-cell">
+		<div class="model-use-track" aria-hidden="true"><span style="width:${Math.max(2, share * 100).toFixed(1)}%"></span></div>
+		<strong>${formatRatePercent(share)}</strong>
+		<span>${formatNumber(row.counters.calls)} turns</span>
+	</div>`;
+  }
+  var EFFICIENCY_COLUMN_DEFS = [
+    { sortKey: "model", label: "Model", title: "Model identifier", sortValue: (row) => row.model, render: (row) => escapeHtml(getModelDisplayName(row.model)) },
+    { sortKey: "calls", label: "Local use", title: "Share of user-request turns attributed to this model", sortValue: (row) => row.counters.calls, render: buildLocalUsageCell },
+    { sortKey: "oneShotRate", label: "One-shot", title: "Share of edit turns completed without retries or self-corrections", sortValue: (row) => row.rates.oneShotRate, render: (row) => formatRatePercent(row.rates.oneShotRate) },
+    { sortKey: "retryRate", label: "Retries/edit", title: "Average immediate same-file retries per edit turn", sortValue: (row) => row.rates.retryRate, render: (row) => formatPerTurn(row.rates.retryRate) },
+    { sortKey: "selfCorrectionRate", label: "Self-corr/edit", title: "Average re-edits after intervening tool calls per edit turn", sortValue: (row) => row.rates.selfCorrectionRate, render: (row) => formatPerTurn(row.rates.selfCorrectionRate) },
+    { sortKey: "costPerCall", label: "Avg cost", title: "Average estimated provider cost per user-request turn", sortValue: (row) => row.rates.costPerCall, render: (row) => formatUnitCost(row.rates.costPerCall) },
+    { sortKey: "outputTokensPerCall", label: "Out tok", title: "Average output tokens per user-request turn", sortValue: (row) => row.rates.outputTokensPerCall, render: (row) => row.rates.outputTokensPerCall === null ? "\u2014" : formatCompact(Math.round(row.rates.outputTokensPerCall)) },
+    { sortKey: "toolCallsPerCall", label: "Steps", title: "Average tool invocations per user-request turn", sortValue: (row) => row.rates.toolCallsPerCall, render: (row) => formatPerTurn(row.rates.toolCallsPerCall) },
+    { sortKey: "cacheHitRate", label: "Cache hit", title: "Cache-read share of input tokens", sortValue: (row) => row.rates.cacheHitRate, render: (row) => formatRatePercent(row.rates.cacheHitRate) }
+  ];
+  function getEfficiencySortIndicator(column) {
+    if (efficiencySortColumn !== column) {
+      return "";
+    }
+    return efficiencySortDirection === "desc" ? " \u25BC" : " \u25B2";
+  }
+  function compareEfficiencyRows(a3, b3, column) {
+    const av = column.sortValue(a3);
+    const bv = column.sortValue(b3);
+    if (av === null && bv === null) {
+      return 0;
+    }
+    if (av === null) {
+      return 1;
+    }
+    if (bv === null) {
+      return -1;
+    }
+    const cmp = typeof av === "string" || typeof bv === "string" ? String(av).localeCompare(String(bv)) : av - bv;
+    return efficiencySortDirection === "desc" ? -cmp : cmp;
+  }
+  function buildEfficiencyRows(usage) {
+    const rows = Object.entries(usage).map(([model, counters]) => ({ model, counters, rates: deriveModelEfficiencyRates(counters) }));
+    const column = EFFICIENCY_COLUMN_DEFS.find((item) => item.sortKey === efficiencySortColumn) ?? EFFICIENCY_COLUMN_DEFS[1];
+    return rows.sort((a3, b3) => compareEfficiencyRows(a3, b3, column));
+  }
+  function filterLowUsageRows(rows, usage) {
+    if (!efficiencyFilterLowUsage) {
+      return { rows, hiddenNote: "" };
+    }
+    const threshold = computeEfficiencyLowUsageThreshold(usage);
+    if (threshold === null) {
+      return { rows, hiddenNote: "" };
+    }
+    const filtered = rows.filter((row) => row.counters.calls > threshold);
+    const hiddenCount = rows.length - filtered.length;
+    const noun = hiddenCount === 1 ? "model" : "models";
+    const turnNoun = threshold === 1 ? "turn" : "turns";
+    const hiddenNote = hiddenCount > 0 ? `${hiddenCount} low-usage ${noun} hidden (\u2264${threshold} ${turnNoun})` : "";
+    return { rows: filtered, hiddenNote };
+  }
+  var MODEL_COLOR_VARS = ["--stage-1-color", "--stage-2-color", "--stage-3-color", "--stage-4-color", "--success-fg", "--warning-fg", "--link-color"];
+  var PROVIDER_COLOR_VARS = {
+    Anthropic: "--warning-fg",
+    OpenAI: "--success-fg",
+    Google: "--stage-3-color",
+    "Mistral AI": "--stage-2-color",
+    xAI: "--stage-4-color",
+    Alibaba: "--stage-1-color",
+    Microsoft: "--link-color"
+  };
+  function getColorForKey(key) {
+    let hash = 0;
+    for (let i6 = 0; i6 < key.length; i6++) {
+      hash = (hash << 5) - hash + key.charCodeAt(i6) | 0;
+    }
+    return `var(${MODEL_COLOR_VARS[Math.abs(hash) % MODEL_COLOR_VARS.length]})`;
+  }
+  function getEfficiencyColor(model) {
+    if (efficiencyColorMode === "model") {
+      return getColorForKey(model);
+    }
+    const provider = getModelBillingProvider(model);
+    const colorVar = PROVIDER_COLOR_VARS[provider];
+    return colorVar ? `var(${colorVar})` : getColorForKey(provider);
+  }
+  function formatMetricTick(metric, value) {
+    if (metric.key === "cost") {
+      return formatUnitCost(value);
+    }
+    if (metric.key === "outputTokens") {
+      return formatCompact(Math.round(value));
+    }
+    return formatFixed(value, 1);
+  }
+  function buildEfficiencyGrid(metric, maxX) {
+    const vertical = [0, 0.25, 0.5, 0.75, 1].map((fraction) => {
+      const x2 = 76 + fraction * 760;
+      return `<line x1="${x2}" y1="24" x2="${x2}" y2="286"></line><text x="${x2}" y="310" text-anchor="middle">${escapeHtml(formatMetricTick(metric, maxX * fraction))}</text>`;
+    }).join("");
+    const horizontal = [0, 0.25, 0.5, 0.75, 1].map((fraction) => {
+      const y3 = 286 - fraction * 262;
+      return `<line x1="76" y1="${y3}" x2="836" y2="${y3}"></line><text x="64" y="${y3 + 4}" text-anchor="end">${Math.round(fraction * 100)}%</text>`;
+    }).join("");
+    return `<g class="efficiency-grid">${vertical}${horizontal}</g>`;
+  }
+  function buildEfficiencyPoint(row, metric, bubbleMetric, maxX, maxBubbleValue, labelPlacement) {
+    const value = metric.value(row) ?? 0;
+    const bubbleValue = bubbleMetric.value(row) ?? 0;
+    const rate = row.rates.oneShotRate ?? 0;
+    const x2 = 76 + value / maxX * 760;
+    const y3 = 286 - rate * 262;
+    const radius = scaleBubbleRadius(bubbleValue, maxBubbleValue);
+    const color = getEfficiencyColor(row.model);
+    const rawLabel = getModelDisplayName(row.model);
+    const label = escapeHtml(rawLabel);
+    const aria = `${rawLabel}: ${formatRatePercent(rate)} one-shot edit rate, ${metric.format(value)} ${metric.axisLabel.toLowerCase()}, bubble sized by ${bubbleMetric.label.toLowerCase()}: ${bubbleMetric.format(bubbleValue)}`;
+    return `<g class="efficiency-point" style="--model-color:${color}" tabindex="0" role="img" aria-label="${escapeHtml(aria)}">
+		<circle cx="${x2.toFixed(1)}" cy="${y3.toFixed(1)}" r="${radius.toFixed(1)}"><title>${escapeHtml(aria)}</title></circle>
+		<text x="${labelPlacement.x.toFixed(1)}" y="${labelPlacement.y.toFixed(1)}" text-anchor="${labelPlacement.textAnchor}">${label}</text>
+	</g>`;
+  }
+  function buildEfficiencyColorLegendHtml(rows) {
+    if (efficiencyColorMode !== "vendor") {
+      return "";
+    }
+    const providers = [...new Set(rows.map((row) => getModelBillingProvider(row.model)))].sort();
+    const items = providers.map((provider) => {
+      const model = rows.find((row) => getModelBillingProvider(row.model) === provider)?.model ?? "";
+      return `<span class="efficiency-legend-item" style="--model-color:${getEfficiencyColor(model)}"><span aria-hidden="true"></span>${escapeHtml(provider)}</span>`;
+    }).join("");
+    return `<div class="efficiency-vendor-legend" aria-label="Model vendor colors">${items}</div>`;
+  }
+  function buildEfficiencyChartHtml(rows) {
+    const metric = EFFICIENCY_METRICS.find((item) => item.key === efficiencyMetric) ?? EFFICIENCY_METRICS[0];
+    const bubbleMetric = EFFICIENCY_BUBBLE_METRICS.find((item) => item.key === efficiencyBubbleMetric) ?? EFFICIENCY_BUBBLE_METRICS[0];
+    const chartRows = rows.filter((row) => row.rates.oneShotRate !== null && metric.value(row) !== null).sort((a3, b3) => b3.counters.calls - a3.counters.calls).slice(0, 12);
+    if (chartRows.length === 0) {
+      return '<div class="model-leaderboard-empty"><strong>No comparable edit data yet.</strong><span>The chart appears after local sessions record both a model and structured edit turns.</span></div>';
+    }
+    const maxX = Math.max(...chartRows.map((row) => metric.value(row) ?? 0), 1e-4) * 1.08;
+    const maxBubbleValue = Math.max(...chartRows.map((row) => bubbleMetric.value(row) ?? 0), 0);
+    const labelInputs = chartRows.map((row) => {
+      const value = metric.value(row) ?? 0;
+      const bubbleValue = bubbleMetric.value(row) ?? 0;
+      return {
+        x: 76 + value / maxX * 760,
+        y: 286 - (row.rates.oneShotRate ?? 0) * 262,
+        radius: scaleBubbleRadius(bubbleValue, maxBubbleValue),
+        label: getModelDisplayName(row.model)
+      };
+    });
+    const labelPlacements = placeBubbleLabels(labelInputs, { left: 76, right: 836, top: 24, bottom: 286 });
+    const points = chartRows.map(
+      (row, index) => buildEfficiencyPoint(row, metric, bubbleMetric, maxX, maxBubbleValue, labelPlacements[index])
+    ).join("");
+    return `<div class="efficiency-chart-wrap">
+		<svg class="efficiency-chart" viewBox="0 0 900 350" role="img" aria-label="One-shot edit rate compared with ${escapeHtml(metric.axisLabel.toLowerCase())}; bubble size represents ${escapeHtml(bubbleMetric.label.toLowerCase())}">
+			${buildEfficiencyGrid(metric, maxX)}
+			<text class="efficiency-axis-title" x="456" y="344" text-anchor="middle">${escapeHtml(metric.axisLabel)}</text>
 			<text class="efficiency-axis-title" x="17" y="155" text-anchor="middle" transform="rotate(-90 17 155)">One-shot edit rate</text>
 			<text class="efficiency-chart-hint" x="836" y="17" text-anchor="end">higher is better \u2191</text>
-			${l}
+			${points}
 		</svg>
-	</div>${Vl(n)}`}function Jl(){let e=dt.map(n=>`<button class="efficiency-metric-button${n.key===Ht?" active":""}" type="button" data-eff-metric="${n.key}" aria-pressed="${n.key===Ht}">${n.label}</button>`).join(""),t=Wt.map(n=>`<option value="${n.key}"${n.key===Go?" selected":""}>${n.label}</option>`).join(""),o=[{value:"vendor",label:"Vendor"},{value:"model",label:"Model"}].map(n=>`<option value="${n.value}"${n.value===Vt?" selected":""}>${n.label}</option>`).join("");return`<div class="efficiency-chart-controls">
-		<div class="efficiency-control"><span>X-axis</span><div class="efficiency-metric-selector" role="group" aria-label="Efficiency comparison metric">${e}</div></div>
-		<label class="efficiency-control"><span>Bubble size</span><select id="eff-bubble-metric">${t}</select></label>
-		<label class="efficiency-control"><span>Color by</span><select id="eff-color-mode">${o}</select></label>
-	</div>`}function Xl(e,t){let o=e.map(s=>{let r=qt.map(i=>`<td>${i.render(s,t)}</td>`).join("");return`<tr style="--model-color:${Jo(s.model)}">${r}</tr>`}).join("");return`<div class="model-leaderboard-table-wrap"><table class="model-leaderboard-table"><thead><tr>${qt.map(s=>`<th class="sortable" data-eff-sort="${s.sortKey}" title="${s.title}">${s.label}${Nl(s.sortKey)}</th>`).join("")}</tr></thead><tbody>${o}</tbody></table></div>`}function Xs(){let e=Js[Ys];if(!e||Object.keys(e).length===0)return'<div class="model-leaderboard-empty"><strong>No per-model efficiency data for this period.</strong><span>Run local agent sessions with model and tool-call metadata, then refresh the dashboard.</span></div>';let t=jl(e),o=t.reduce((r,i)=>r+i.counters.calls,0),n=Fl(t,e),s=n.hiddenNote?`<span class="model-leaderboard-filter-note">${n.hiddenNote}</span>`:"";return`<div class="efficiency-chart-header"><div><strong>Efficiency frontier</strong><span>One-shot edit rate is a local quality proxy, not a benchmark pass rate.</span></div>${Jl()}</div>
-		${Yl(n.rows)}
-		<div class="model-leaderboard-heading"><div><strong>Most used models locally</strong><span>Ranked by your local turns; all averages use the same selected period.</span></div>${s}</div>
-		${Xl(n.rows,o)}`}function Zl(e){return Js={today:e.today.modelEfficiency,last30Days:e.last30Days.modelEfficiency,month:e.month.modelEfficiency},`<div class="section" id="section-model-efficiency">
+	</div>${buildEfficiencyColorLegendHtml(chartRows)}`;
+  }
+  function buildChartControlsHtml() {
+    const buttons = EFFICIENCY_METRICS.map(
+      (metric) => `<button class="efficiency-metric-button${metric.key === efficiencyMetric ? " active" : ""}" type="button" data-eff-metric="${metric.key}" aria-pressed="${metric.key === efficiencyMetric}">${metric.label}</button>`
+    ).join("");
+    const bubbleOptions = EFFICIENCY_BUBBLE_METRICS.map(
+      (metric) => `<option value="${metric.key}"${metric.key === efficiencyBubbleMetric ? " selected" : ""}>${metric.label}</option>`
+    ).join("");
+    const colorOptions = [
+      { value: "vendor", label: "Vendor" },
+      { value: "model", label: "Model" }
+    ].map((option) => `<option value="${option.value}"${option.value === efficiencyColorMode ? " selected" : ""}>${option.label}</option>`).join("");
+    return `<div class="efficiency-chart-controls">
+		<div class="efficiency-control"><span>X-axis</span><div class="efficiency-metric-selector" role="group" aria-label="Efficiency comparison metric">${buttons}</div></div>
+		<label class="efficiency-control"><span>Bubble size</span><select id="eff-bubble-metric">${bubbleOptions}</select></label>
+		<label class="efficiency-control"><span>Color by</span><select id="eff-color-mode">${colorOptions}</select></label>
+	</div>`;
+  }
+  function buildEfficiencyTableHtml(rows, totalCalls) {
+    const tableRows = rows.map((row) => {
+      const cells = EFFICIENCY_COLUMN_DEFS.map((column) => `<td>${column.render(row, totalCalls)}</td>`).join("");
+      return `<tr style="--model-color:${getEfficiencyColor(row.model)}">${cells}</tr>`;
+    }).join("");
+    const headers = EFFICIENCY_COLUMN_DEFS.map(
+      (column) => `<th class="sortable" data-eff-sort="${column.sortKey}" title="${column.title}">${column.label}${getEfficiencySortIndicator(column.sortKey)}</th>`
+    ).join("");
+    return `<div class="model-leaderboard-table-wrap"><table class="model-leaderboard-table"><thead><tr>${headers}</tr></thead><tbody>${tableRows}</tbody></table></div>`;
+  }
+  function buildModelEfficiencyContentHtml() {
+    const usage = cachedModelEfficiency[efficiencyPeriod];
+    if (!usage || Object.keys(usage).length === 0) {
+      return '<div class="model-leaderboard-empty"><strong>No per-model efficiency data for this period.</strong><span>Run local agent sessions with model and tool-call metadata, then refresh the dashboard.</span></div>';
+    }
+    const allRows = buildEfficiencyRows(usage);
+    const totalCalls = allRows.reduce((sum, row) => sum + row.counters.calls, 0);
+    const filtered = filterLowUsageRows(allRows, usage);
+    const note = filtered.hiddenNote ? `<span class="model-leaderboard-filter-note">${filtered.hiddenNote}</span>` : "";
+    return `<div class="efficiency-chart-header"><div><strong>Efficiency frontier</strong><span>One-shot edit rate is a local quality proxy, not a benchmark pass rate.</span></div>${buildChartControlsHtml()}</div>
+		${buildEfficiencyChartHtml(filtered.rows)}
+		<div class="model-leaderboard-heading"><div><strong>Most used models locally</strong><span>Ranked by your local turns; all averages use the same selected period.</span></div>${note}</div>
+		${buildEfficiencyTableHtml(filtered.rows, totalCalls)}`;
+  }
+  function buildModelEfficiencySectionHtml(stats) {
+    cachedModelEfficiency = { today: stats.today.modelEfficiency, last30Days: stats.last30Days.modelEfficiency, month: stats.month.modelEfficiency };
+    return `<div class="section" id="section-model-efficiency">
 		<div class="section-title"><span>\u{1F3AF}</span><span>Local Model Leaderboard</span></div>
 		<div class="section-subtitle">Compare the models in your own sessions by local usage, one-shot edits, cost, output tokens, and tool steps. Exactness depends on what each editor records; missing structured data is shown as unavailable rather than estimated.</div>
 		<div class="model-leaderboard-controls">
 			<span id="model-efficiency-period-selector"></span>
 			<label class="model-leaderboard-filter" title="Show only models above the 25th-percentile local turn count.">
-				<input type="checkbox" id="eff-filter-low-usage"${Vo?" checked":""}>
+				<input type="checkbox" id="eff-filter-low-usage"${efficiencyFilterLowUsage ? " checked" : ""}>
 				Hide low-usage models
 			</label>
 		</div>
-		<div id="model-efficiency-content">${Xs()}</div>
-	</div>`}function Ql(){let e=document.getElementById("model-efficiency-period-selector");if(!e)return;e.replaceChildren();let{wrapper:t}=Yt({selected:$s,disabled:["last7","allTime"],disabledTitle:"Not available for model efficiency",label:"",onChange:o=>{let n=Bl[o];n&&($s=o,Ys=n,Se())}});e.append(t)}function Se(){let e=document.getElementById("model-efficiency-content");e&&k(e,Xs())}function ed(e){let t=e.getAttribute("data-eff-sort");t&&(jt===t?nt=nt==="desc"?"asc":"desc":(jt=t,nt=t==="model"?"asc":"desc"),Se())}function td(){let e=document.getElementById("section-model-efficiency");e&&(e.addEventListener("click",t=>{let o=t.target,n=o.closest("th[data-eff-sort]");if(n){ed(n);return}let s=o.closest("button[data-eff-metric]")?.dataset.effMetric;s&&dt.some(r=>r.key===s)&&(Ht=s,Se())}),e.addEventListener("change",t=>{let o=t.target;o.id==="eff-filter-low-usage"?(Vo=o.checked,Se()):o.id==="eff-bubble-metric"&&Wt.some(n=>n.key===o.value)?(Go=o.value,Se()):o.id==="eff-color-mode"&&(o.value==="vendor"||o.value==="model")&&(Vt=o.value,Se())}))}function od(e,t,o,n,s,r,i,a){return`
-		<div id="tab-panel-tools" class="tab-panel"${$!=="tools"?' style="display:none"':""}>
+		<div id="model-efficiency-content">${buildModelEfficiencyContentHtml()}</div>
+	</div>`;
+  }
+  function renderModelEfficiencyPeriodSelector() {
+    const wrapper = document.getElementById("model-efficiency-period-selector");
+    if (!wrapper) {
+      return;
+    }
+    wrapper.replaceChildren();
+    const { wrapper: selectorWrapper } = createPeriodSelector({
+      selected: efficiencySelectedPeriod,
+      disabled: ["last7", "allTime"],
+      disabledTitle: "Not available for model efficiency",
+      label: "",
+      onChange: (value) => {
+        const dataKey = EFFICIENCY_PERIOD_TO_DATA_KEY[value];
+        if (!dataKey) {
+          return;
+        }
+        efficiencySelectedPeriod = value;
+        efficiencyPeriod = dataKey;
+        rerenderModelEfficiencyContent();
+      }
+    });
+    wrapper.append(selectorWrapper);
+  }
+  function rerenderModelEfficiencyContent() {
+    const content = document.getElementById("model-efficiency-content");
+    if (content) {
+      setHtml(content, buildModelEfficiencyContentHtml());
+    }
+  }
+  function handleEfficiencySortClick(th) {
+    const column = th.getAttribute("data-eff-sort");
+    if (!column) {
+      return;
+    }
+    if (efficiencySortColumn === column) {
+      efficiencySortDirection = efficiencySortDirection === "desc" ? "asc" : "desc";
+    } else {
+      efficiencySortColumn = column;
+      efficiencySortDirection = column === "model" ? "asc" : "desc";
+    }
+    rerenderModelEfficiencyContent();
+  }
+  function setupModelEfficiencySection() {
+    const section = document.getElementById("section-model-efficiency");
+    if (!section) {
+      return;
+    }
+    section.addEventListener("click", (event) => {
+      const target = event.target;
+      const header = target.closest("th[data-eff-sort]");
+      if (header) {
+        handleEfficiencySortClick(header);
+        return;
+      }
+      const metric = target.closest("button[data-eff-metric]")?.dataset.effMetric;
+      if (metric && EFFICIENCY_METRICS.some((item) => item.key === metric)) {
+        efficiencyMetric = metric;
+        rerenderModelEfficiencyContent();
+      }
+    });
+    section.addEventListener("change", (event) => {
+      const target = event.target;
+      if (target.id === "eff-filter-low-usage") {
+        efficiencyFilterLowUsage = target.checked;
+        rerenderModelEfficiencyContent();
+      } else if (target.id === "eff-bubble-metric" && EFFICIENCY_BUBBLE_METRICS.some((item) => item.key === target.value)) {
+        efficiencyBubbleMetric = target.value;
+        rerenderModelEfficiencyContent();
+      } else if (target.id === "eff-color-mode" && (target.value === "vendor" || target.value === "model")) {
+        efficiencyColorMode = target.value;
+        rerenderModelEfficiencyContent();
+      }
+    });
+  }
+  function buildToolsTabPanelHtml(stats, allToolKeys, allMcpToolKeys, allMcpServerKeys, allHighCostModels, allLowCostModels, allMediumCostModels, allUnknownModels) {
+    return `
+		<div id="tab-panel-tools" class="tab-panel"${activeTab !== "tools" ? ' style="display:none"' : ""}>
 			<!-- Tool Calls Section -->
 			<div class="section">
 				<div class="section-title"><span>\u{1F527}</span><span>Tool Usage</span></div>
-				<div class="section-subtitle">Functions and tools invoked by Copilot during interactions${at?' (automatic tool calls hidden \u2014 disable "Hide Automatic Tool Calls" in settings to show them)':""}</div>
+				<div class="section-subtitle">Functions and tools invoked by Copilot during interactions${hideAutomaticToolCalls ? ' (automatic tool calls hidden \u2014 disable "Hide Automatic Tool Calls" in settings to show them)' : ""}</div>
 				<div class="three-column">
 					<div>
 					<h4 style="color: var(--text-primary); font-size: 13px; margin-bottom: 8px;">\u{1F4C5} Today</h4>
 					<div class="list">
-						<div style="font-size: 14px; font-weight: 600; color: var(--text-primary); margin-bottom: 8px;">Total Tool Calls: ${g(e.today.toolCalls.total)}</div>
-						${Y(J(e.today.toolCalls.byTool,t),10,tt,!0)}
+						<div style="font-size: 14px; font-weight: 600; color: var(--text-primary); margin-bottom: 8px;">Total Tool Calls: ${formatNumber(stats.today.toolCalls.total)}</div>
+						${renderToolsTable(unionFill(stats.today.toolCalls.byTool, allToolKeys), 10, lookupToolName, true)}
 					</div>
 				</div>
 				<div>
 					<h4 style="color: var(--text-primary); font-size: 13px; margin-bottom: 8px;">\u{1F4C6} Last 30 Days</h4>
 					<div class="list">
-						<div style="font-size: 14px; font-weight: 600; color: var(--text-primary); margin-bottom: 8px;">Total Tool Calls: ${g(e.last30Days.toolCalls.total)}</div>
-							${Y(J(e.last30Days.toolCalls.byTool,t),10,tt,!0)}
+						<div style="font-size: 14px; font-weight: 600; color: var(--text-primary); margin-bottom: 8px;">Total Tool Calls: ${formatNumber(stats.last30Days.toolCalls.total)}</div>
+							${renderToolsTable(unionFill(stats.last30Days.toolCalls.byTool, allToolKeys), 10, lookupToolName, true)}
 						</div>
 					</div>
 				<div>
 					<h4 style="color: var(--text-primary); font-size: 13px; margin-bottom: 8px;">\u{1F4C5} Previous Month</h4>
 					<div class="list">
-						<div style="font-size: 14px; font-weight: 600; color: var(--text-primary); margin-bottom: 8px;">Total Tool Calls: ${g(e.month.toolCalls.total)}</div>
-							${Y(J(e.month.toolCalls.byTool,t),10,tt,!0)}
+						<div style="font-size: 14px; font-weight: 600; color: var(--text-primary); margin-bottom: 8px;">Total Tool Calls: ${formatNumber(stats.month.toolCalls.total)}</div>
+							${renderToolsTable(unionFill(stats.month.toolCalls.byTool, allToolKeys), 10, lookupToolName, true)}
 						</div>
 					</div>
 				</div>
 			</div>
 
-			${Pa(e,o,n)}
-			${Fa(It??e.curationAnalysis)}
-			${Ja(e.repeatedTasks??null)}
+			${buildMcpToolsSectionHtml(stats, allMcpToolKeys, allMcpServerKeys)}
+			${buildCurationSectionHtml(currentCurationAnalysis ?? stats.curationAnalysis)}
+			${buildSkillSuggestionsSectionHtml(stats.repeatedTasks ?? null)}
 			<!-- Multi-Model Usage Section -->
 			<div class="section">
 				<div class="section-title"><span>\u{1F500}</span><span>Multi-Model Usage</span></div>
 				<div class="section-subtitle">Track model diversity and switching patterns in your conversations</div>
 				<div class="three-column">
-					${Mo("\u{1F4C5} Today",e.today.modelSwitching,r,i,s,a)}
-					${Mo("\u{1F4C6} Last 30 Days",e.last30Days.modelSwitching,r,i,s,a)}
-					${Mo("\u{1F4C5} Previous Month",e.month.modelSwitching,r,i,s,a)}
+					${renderMultiModelPeriod("\u{1F4C5} Today", stats.today.modelSwitching, allLowCostModels, allMediumCostModels, allHighCostModels, allUnknownModels)}
+					${renderMultiModelPeriod("\u{1F4C6} Last 30 Days", stats.last30Days.modelSwitching, allLowCostModels, allMediumCostModels, allHighCostModels, allUnknownModels)}
+					${renderMultiModelPeriod("\u{1F4C5} Previous Month", stats.month.modelSwitching, allLowCostModels, allMediumCostModels, allHighCostModels, allUnknownModels)}
 				</div>
 			</div>
-		</div>`}function nd(e,t){try{return k(e,t()),!0}catch(o){let n=o instanceof Error?o.message:String(o);return console.error(`[usage-webview] renderLayout failed: ${n}`),k(e,`<div style="padding: 32px; text-align: center; font-size: 14px;">
+		</div>`;
+  }
+  function assignUsageRootHtml(root, build) {
+    try {
+      setHtml(root, build());
+      return true;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error(`[usage-webview] renderLayout failed: ${message}`);
+      setHtml(root, `<div style="padding: 32px; text-align: center; font-size: 14px;">
 			<div style="color: var(--vscode-foreground); opacity: 0.7; margin-bottom: 12px;">\u26A0\uFE0F Something went wrong rendering the dashboard.</div>
-			${Kt().outerHTML}
-		</div>`),!1}}function sd(e){let t=e.customizationMatrix??E?.customizationMatrix??null;return H=t??null,(!H||H.workspaces.length===0)&&(B=null),Array.isArray(e.currentWorkspacePaths)&&(_s=e.currentWorkspacePaths),e.curationAnalysis?(It=e.curationAnalysis,Z("renderLayout.curation.cached",{availableTools:It.availableTools.length,unusedTools:It.unusedTools.length})):pe("render-no-curation-update","renderLayout.curation.notProvidedInUpdate"),t}function Zs(e){let t=document.getElementById("root");if(!t)return;let o=sd(e),n=P("Workspace Customization",()=>Aa(o)),s=Ra(e),r=Re(e.today.contextReferences),i=Re(e.last30Days.contextReferences),a=P("Thinking Effort",()=>Ea(e)),l=`
+			${createRefreshButton().outerHTML}
+		</div>`);
+      return false;
+    }
+  }
+  function syncRenderLayoutState(stats) {
+    const matrix = stats.customizationMatrix ?? initialData?.customizationMatrix ?? null;
+    hygieneMatrixState = matrix ?? null;
+    if (!hygieneMatrixState || hygieneMatrixState.workspaces.length === 0) {
+      selectedRepoPath = null;
+    }
+    if (Array.isArray(stats.currentWorkspacePaths)) {
+      currentWorkspacePaths = stats.currentWorkspacePaths;
+    }
+    if (stats.curationAnalysis) {
+      currentCurationAnalysis = stats.curationAnalysis;
+      traceCuration("renderLayout.curation.cached", {
+        availableTools: currentCurationAnalysis.availableTools.length,
+        unusedTools: currentCurationAnalysis.unusedTools.length
+      });
+    } else {
+      traceCurationOnce("render-no-curation-update", "renderLayout.curation.notProvidedInUpdate");
+    }
+    return matrix;
+  }
+  function renderLayout(stats) {
+    const root = document.getElementById("root");
+    if (!root) {
+      return;
+    }
+    const matrix = syncRenderLayoutState(stats);
+    const customizationHtml = safeSectionHtml("Workspace Customization", () => buildCustomizationSectionHtml(matrix));
+    const allKeys = buildUsageAllKeysSets(stats);
+    const todayTotalRefs = getTotalContextRefs(stats.today.contextReferences);
+    const last30DaysTotalRefs = getTotalContextRefs(stats.last30Days.contextReferences);
+    const thinkingEffortHtml = safeSectionHtml("Thinking Effort", () => buildThinkingEffortSectionHtml(stats));
+    const sessionsSummaryHtml = `
 		<!-- Summary Section -->
 		<div class="section">
 			<div class="section-title"><span>\u{1F4C8}</span><span>Sessions Summary</span></div>
 			<div class="stats-grid">
-				<div class="stat-card"><div class="stat-label">\u{1F4C5} Today Sessions</div><div class="stat-value">${g(e.today.sessions)}</div></div>
-				<div class="stat-card"><div class="stat-label">\u{1F4C6} Last 30 Days Sessions</div><div class="stat-value">${g(e.last30Days.sessions)}</div></div>
-				<div class="stat-card"><div class="stat-label">\u{1F4C5} This Month Sessions</div><div class="stat-value">${g(e.month.sessions)}</div></div>
-				<div class="stat-card"><div class="stat-label">\u{1F4C5} Last Month Sessions</div><div class="stat-value">${g(e.lastMonth.sessions)}</div></div>
+				<div class="stat-card"><div class="stat-label">\u{1F4C5} Today Sessions</div><div class="stat-value">${formatNumber(stats.today.sessions)}</div></div>
+				<div class="stat-card"><div class="stat-label">\u{1F4C6} Last 30 Days Sessions</div><div class="stat-value">${formatNumber(stats.last30Days.sessions)}</div></div>
+				<div class="stat-card"><div class="stat-label">\u{1F4C5} This Month Sessions</div><div class="stat-value">${formatNumber(stats.month.sessions)}</div></div>
+				<div class="stat-card"><div class="stat-label">\u{1F4C5} Last Month Sessions</div><div class="stat-value">${formatNumber(stats.lastMonth.sessions)}</div></div>
 			</div>
-		</div>`;nd(t,()=>il(e,n,"",a,l,r,i,s.allToolKeys,s.allMcpToolKeys,s.allMcpServerKeys,s.allHighCostModels,s.allLowCostModels,s.allMediumCostModels,s.allUnknownModels))&&(id(),rd(),ad(),rl(),X(),va(),td(),Ql(),Us(),Yi(),ld(),Bo=e.insights??[],Fs(),er())}function rd(){let e=document.getElementById("about-info-toggle"),t=document.getElementById("about-info-body");if(!e||!t)return;let o=e.querySelector(".info-box-chevron"),n=()=>{V=!V,t.style.display=V?"none":"",e.setAttribute("aria-expanded",String(!V)),o&&(o.textContent=V?"\u25B8":"\u25BE"),f.setState({...f.getState()??{},aboutCollapsed:V})};e.addEventListener("click",n),e.addEventListener("keydown",s=>{(s.key==="Enter"||s.key===" ")&&(s.preventDefault(),n())})}function id(){document.getElementById("btn-refresh")?.addEventListener("click",()=>{f.postMessage({command:"refresh"})}),document.getElementById("btn-details")?.addEventListener("click",()=>{f.postMessage({command:"showDetails"})}),document.getElementById("btn-chart")?.addEventListener("click",()=>{f.postMessage({command:"showChart"})}),document.getElementById("btn-diagnostics")?.addEventListener("click",()=>{f.postMessage({command:"showDiagnostics"})}),document.getElementById("btn-maturity")?.addEventListener("click",()=>{f.postMessage({command:"showMaturity"})}),document.getElementById("btn-dashboard")?.addEventListener("click",()=>{f.postMessage({command:"showDashboard"})}),document.getElementById("btn-environmental")?.addEventListener("click",()=>{f.postMessage({command:"showEnvironmental"})}),document.getElementById("btn-efficiency")?.addEventListener("click",()=>{f.postMessage({command:"showEfficiency"})}),an(f)}function Es(e,t){e&&(e.disabled=!0,e.textContent=t,e.setAttribute("appearance","secondary"))}function ad(){document.getElementById("btn-analyse-repo")?.addEventListener("click",()=>{let e=document.getElementById("btn-analyse-repo");st=!0,Es(e,"Analyzing..."),f.postMessage({command:"analyseRepository"})}),document.getElementById("btn-analyse-all")?.addEventListener("click",()=>{let e=document.getElementById("btn-analyse-all");Es(e,"Analyzing All..."),me=!0,ge=!0,B=null;for(let t of H?.workspaces??[])t.workspacePath.startsWith("<unresolved:")||$e.add(t.workspacePath);X(),f.postMessage({command:"analyseAllRepositories"})}),document.getElementById("repo-list-pane")?.addEventListener("click",e=>{let o=e.target.closest(".btn-repo-action");if(!o)return;let n=o.getAttribute("data-workspace-path"),s=o.getAttribute("data-action");if(!(!n||!s)){if(s==="details"){B=n,ge=!1,X();return}s==="analyze"&&($e.add(n),me=!1,X(),f.postMessage({command:"analyseRepository",workspacePath:n}))}}),document.getElementById("repo-details-pane")?.addEventListener("click",e=>{e.target.closest("#btn-switch-repository")&&(ge=!0,X())})}function ld(){Array.from(document.getElementsByClassName("cf-copy")).forEach(e=>{e.addEventListener("click",t=>{let o=t.currentTarget,n=o.getAttribute("data-path")||"";navigator.clipboard&&n&&navigator.clipboard.writeText(n).then(()=>{o.textContent="Copied",setTimeout(()=>{o.textContent="Copy"},1200)}).catch(()=>{f.postMessage({command:"copyFailed",path:n})})})})}function dd(e){Po(),e.data?.locale&&Xt(e.data.locale),typeof e.data?.use24HourTime=="boolean"&&(Ot=e.data.use24HourTime),typeof e.data?.hideAutomaticToolCalls=="boolean"&&(at=e.data.hideAutomaticToolCalls);let t=Oi(e.data);t?(Ho=!1,Is(t.recentSessions),Zs(t),Ls(),X(),Ze&&Hs(Ze),Qe&&js(Qe)):(pe("update-invalid-sanitized","handleUpdateStats.sanitizeReturnedNull"),Ps("Received invalid data from the extension. Try refreshing."))}function Qs(e){if(!e)return;let t=document.getElementById("unknown-mcp-tools-section");t&&(t.querySelectorAll("button[data-suppress-tool]").forEach(o=>{o.getAttribute("data-suppress-tool")===e&&o.closest("span")?.remove()}),t.querySelectorAll("button[data-suppress-tool]").length===0&&t.remove())}function cd(){$="tools",document.querySelectorAll(".tab-button").forEach(o=>{o.classList.toggle("active",o.getAttribute("data-tab")==="tools")}),document.querySelectorAll(".tab-panel").forEach(o=>{o.style.display="none"});let e=document.getElementById("tab-panel-tools");e&&(e.style.display="block");let t=document.getElementById("unknown-mcp-tools-section");t&&(t.scrollIntoView({behavior:"smooth",block:"center"}),t.style.transition="box-shadow 0.3s ease",t.style.boxShadow="0 0 0 3px var(--vscode-focusBorder)",setTimeout(()=>{t.style.boxShadow=""},2e3))}function ud(e){Ze=xa(e),Ze.authenticated||(Do=!1),Hs(Ze)}function pd(e){!e||typeof e!="object"||(Qe=yn(e),Qe.authenticated||(Lo=!1),js(Qe))}function gd(e){if(!Array.isArray(e))return;let t=zs(e);ol(t)}function md(e){switch(e.command){case"usageLoadingProgress":return ai(e),!0;case"usageRefreshing":return Po(),Xe=0,No("Refreshing Usage Analysis"),!0;case"updateStatsError":return Po(),Ps("Failed to calculate usage analysis. Check the Output panel for details."),!0}return!1}function fd(e){switch(e.command){case"repoAnalysisResults":try{Pd(e.data,e.workspacePath)}catch(t){console.error("Failed to render repo analysis results",t),Rs(t instanceof Error?t.message:String(t),e.workspacePath)}return!0;case"repoAnalysisError":return Rs(e.error,e.workspacePath),!0;case"repoAnalysisBatchComplete":return Dd(),!0}return!1}function bd(e){if(!md(e)&&!fd(e))switch(e.command){case"updateStats":dd(e);break;case"toolSuppressed":Qs(e.toolName);break;case"highlightUnknownTools":cd();break;case"repoPrStatsLoaded":ud(e.data);break;case"repoPrStatsProgress":xs("#repos-pr-content","repos-pr-progress","Fetching PRs\u2026",e.done,e.total);break;case"agentSessionsLoaded":pd(e.data);break;case"recentSessionsLoaded":$i(e);break;case"agentSessionsProgress":xs("#agent-sessions-content","agent-sessions-progress","Fetching agent sessions\u2026",e.done,e.total);break;case"updateInsights":gd(e.insights);break;case"switchTab":yd(e);break;default:ha(e);break}}function yd(e){let t=String(e.tab);if(!hn(t))return;$=t,Lt=typeof e.anchor=="string"&&e.anchor?e.anchor:null,document.querySelector(`.tab-button[data-tab="${t}"]`)?.click(),er()}function er(){if(!Lt)return;let e=document.getElementById(Lt);e&&(Lt=null,setTimeout(()=>e.scrollIntoView({behavior:"smooth",block:"start"}),50))}cn(e=>{bd(e)});f.postMessage({command:"usageWebviewReady"});function hd(e){return H?.workspaces.find(o=>o.workspacePath===e)?.workspaceName||e}function vd(e){let t=ct.get(e);if(t?.data?.summary){let o=ie(t.data.summary.percentage);return`${Math.round(o)}%`}return t?.error?"Error":"\u2014"}function ie(e){let t=typeof e=="number"?e:Number(e);return Number.isFinite(t)?t:0}var xd={"git-repo":"https://docs.github.com/en/get-started/using-git/about-git",gitignore:"https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files","env-example":"https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions",editorconfig:"https://editorconfig.org/",linter:"https://docs.github.com/en/code-security/code-scanning/introduction-to-code-scanning/about-code-scanning",formatter:"https://docs.github.com/en/contributing/style-guide-and-content-model/style-guide","type-safety":"https://docs.github.com/en/code-security/code-scanning/reference/code-ql-built-in-queries/javascript-typescript-built-in-queries","commit-messages":"https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/about-commits","conventional-commits":"https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/available-rules-for-rulesets","ci-config":"https://docs.github.com/en/actions/about-github-actions/understanding-github-actions",scripts:"https://docs.github.com/en/actions/tutorials/build-and-test-code/nodejs","task-runner":"https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/add-scripts",devcontainer:"https://docs.github.com/en/codespaces/setting-up-your-project-for-codespaces/adding-a-dev-container-configuration",dockerfile:"https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry","version-pinning":"https://docs.github.com/en/codespaces/setting-up-your-project-for-codespaces/adding-a-dev-container-configuration/setting-up-your-nodejs-project-for-codespaces",license:"https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/licensing-a-repository"},kd={versionControl:"\u{1F504} Version Control",codeQuality:"\u2728 Code Quality",cicd:"\u{1F680} CI/CD",environment:"\u{1F527} Environment",documentation:"\u{1F4DA} Documentation"};function wd(e){let t=m("div");t.setAttribute("style","display: flex; justify-content: space-between; align-items: center; margin-bottom: 12px;");let o=m("div");o.setAttribute("style","font-size: 14px; font-weight: 600; color: var(--text-primary);"),o.textContent="\u{1F4CA} Repository Hygiene Score";let n=m("div");return n.setAttribute("style","font-size: 24px; font-weight: 700; color: var(--link-color);"),n.textContent=`${Math.round(ie(e.percentage))}%`,t.append(o,n),t}function Cd(e){let t=m("div");t.setAttribute("style","display: grid; grid-template-columns: repeat(3, 1fr); gap: 8px; margin-bottom: 12px;");let o=[{count:e.passedChecks,label:"Passed",cardStyle:"text-align: center; padding: 8px; background: rgba(34, 197, 94, 0.1); border: 1px solid rgba(34, 197, 94, 0.3); border-radius: 4px;",countStyle:"font-size: 18px; font-weight: 600; color: var(--success-fg);"},{count:e.warningChecks,label:"Warnings",cardStyle:"text-align: center; padding: 8px; background: rgba(245, 158, 11, 0.1); border: 1px solid rgba(245, 158, 11, 0.3); border-radius: 4px;",countStyle:"font-size: 18px; font-weight: 600; color: var(--warning-fg);"},{count:e.failedChecks,label:"Failed",cardStyle:"text-align: center; padding: 8px; background: rgba(239, 68, 68, 0.1); border: 1px solid rgba(239, 68, 68, 0.3); border-radius: 4px;",countStyle:"font-size: 18px; font-weight: 600; color: #ef4444;"}];for(let n of o){let s=m("div");s.setAttribute("style",n.cardStyle);let r=m("div");r.setAttribute("style",n.countStyle),r.textContent=String(ie(n.count));let i=m("div");i.setAttribute("style","font-size: 10px; color: var(--text-secondary);"),i.textContent=n.label,s.append(r,i),t.appendChild(s)}return t}function Sd(e){let t=e?.status==="pass"||e?.status==="warning"?e.status:"fail";return{status:t,emoji:t==="pass"?"\u2705":t==="warning"?"\u26A0\uFE0F":"\u274C",color:t==="pass"?"#22c55e":t==="warning"?"#f59e0b":"#ef4444"}}function Td(e,t){let o=m("div");o.setAttribute("style","flex: 1;");let n=m("div");n.setAttribute("style",`font-size: 12px; font-weight: 600; color: ${t};`),n.textContent=typeof e?.label=="string"?e.label:"";let s=m("div");if(s.setAttribute("style","font-size: 11px; color: var(--text-secondary); margin-top: 2px;"),s.textContent=typeof e?.detail=="string"?e.detail:"",o.append(n,s),typeof e?.hint=="string"&&e.hint.length>0){let i=m("div");i.setAttribute("style","font-size: 10px; color: var(--link-color); margin-top: 4px; font-style: italic;"),i.textContent=`\u{1F4A1} ${e.hint}`,o.appendChild(i)}let r=xd[typeof e?.id=="string"?e.id:""];if(r){let i=m("a");i.setAttribute("href",r),i.setAttribute("style","font-size: 10px; color: var(--link-color); margin-top: 4px; display: inline-block;"),i.setAttribute("title","View official documentation"),i.textContent="\u{1F4D6} View documentation",o.appendChild(i)}return o}function $d(e){let{emoji:t,color:o}=Sd(e),n=m("div");n.setAttribute("style","padding: 8px; border-bottom: 1px solid var(--border-subtle); display: flex; align-items: flex-start; gap: 8px;");let s=m("span");s.setAttribute("style","flex-shrink: 0; padding-top: 1px;"),k(s,j(t));let r=m("span");return r.setAttribute("style","font-size: 10px; color: var(--text-muted); min-width: 30px; text-align: right;"),r.textContent=`+${ie(e?.weight)}`,n.append(s,Td(e,o),r),n}function Ad(e,t,o){let n=m("div");n.setAttribute("style","margin-bottom: 12px; background: var(--bg-secondary); border: 1px solid var(--border-color); border-radius: 4px; overflow: hidden;");let s=m("div");s.setAttribute("style","padding: 8px 12px; background: var(--list-hover-bg); border-bottom: 1px solid var(--border-color); display: flex; justify-content: space-between; align-items: center;");let r=m("span");r.setAttribute("style","font-size: 12px; font-weight: 600; color: var(--text-primary);"),r.textContent=kd[e]||e;let i=o?.categories?.[e],a=m("span");a.setAttribute("style","font-size: 11px; color: var(--link-color); font-weight: 600;"),a.textContent=`${Math.round(ie(i?.percentage))}%`,s.append(r,a),n.appendChild(s);for(let l of t)n.appendChild($d(l));return n}function Md(e){let t=m("div");t.setAttribute("style","margin-top: 16px; background: var(--bg-secondary); border: 1px solid var(--border-color); border-radius: 4px; overflow: hidden;");let o=m("div");o.setAttribute("style","padding: 8px 12px; background: var(--list-hover-bg); border-bottom: 1px solid var(--border-color);");let n=m("span");n.setAttribute("style","font-size: 12px; font-weight: 600; color: var(--text-primary);"),n.textContent="\u{1F4A1} Top Recommendations",o.appendChild(n),t.appendChild(o);for(let s of e.slice(0,5)){let r=s?.priority==="high"||s?.priority==="medium"?s.priority:"low",i=r==="high"?"#ef4444":r==="medium"?"#f59e0b":"#60a5fa",a=m("div");a.setAttribute("style","padding: 8px; border-bottom: 1px solid var(--border-subtle); display: flex; gap: 8px;");let l=m("span");l.setAttribute("style",`font-size: 10px; font-weight: 600; color: ${i}; min-width: 50px;`),l.textContent=String(r).toUpperCase();let u=m("div");u.setAttribute("style","flex: 1;");let c=m("div");c.setAttribute("style","font-size: 11px; color: var(--text-primary);"),c.textContent=typeof s?.action=="string"?s.action:"";let p=m("div");p.setAttribute("style","font-size: 10px; color: var(--text-muted); margin-top: 2px;"),p.textContent=typeof s?.impact=="string"?s.impact:"",u.append(c,p);let b=m("span");b.setAttribute("style","font-size: 10px; color: var(--text-muted); min-width: 30px; text-align: right;"),b.textContent=`+${ie(s?.weight)}`,a.append(l,u,b),t.appendChild(a)}return t}function Ed(e,t){let o=m("div");o.setAttribute("style","margin-top: 16px; padding: 12px; background: rgba(96, 165, 250, 0.07); border: 1px solid rgba(96, 165, 250, 0.3); border-radius: 4px; display: flex; align-items: center; justify-content: space-between; gap: 12px;");let n=m("div");n.setAttribute("style","font-size: 11px; color: var(--text-secondary); flex: 1;"),n.textContent="Let Copilot help you fix the identified issues in this repository.";let s=document.createElement("vscode-button");return s.setAttribute("style","min-width: 180px;"),s.textContent="\u{1F916} Ask Copilot to Improve",s.addEventListener("click",()=>{let i=`Please help me improve this repository by addressing the following best practice issues:
+		</div>`;
+    const rendered = assignUsageRootHtml(root, () => buildUsageRootHtml(
+      stats,
+      customizationHtml,
+      "",
+      thinkingEffortHtml,
+      sessionsSummaryHtml,
+      todayTotalRefs,
+      last30DaysTotalRefs,
+      allKeys.allToolKeys,
+      allKeys.allMcpToolKeys,
+      allKeys.allMcpServerKeys,
+      allKeys.allHighCostModels,
+      allKeys.allLowCostModels,
+      allKeys.allMediumCostModels,
+      allKeys.allUnknownModels
+    ));
+    if (!rendered) {
+      return;
+    }
+    wireNavigationButtons();
+    wireAboutInfoToggle();
+    wireRepositoryButtons();
+    wireCurationButtons();
+    renderRepositoryHygienePanels();
+    setupTabs();
+    setupModelEfficiencySection();
+    renderModelEfficiencyPeriodSelector();
+    renderSessionsLookbackSelector();
+    setupWorktreesHandlers();
+    wireCopyButtons();
+    currentInsights = stats.insights ?? [];
+    wireInsightCardButtons();
+    scrollToPendingTabAnchor();
+  }
+  function wireAboutInfoToggle() {
+    const toggle = document.getElementById("about-info-toggle");
+    const body = document.getElementById("about-info-body");
+    if (!toggle || !body) {
+      return;
+    }
+    const chevron = toggle.querySelector(".info-box-chevron");
+    const applyToggle = () => {
+      aboutCollapsed = !aboutCollapsed;
+      body.style.display = aboutCollapsed ? "none" : "";
+      toggle.setAttribute("aria-expanded", String(!aboutCollapsed));
+      if (chevron) {
+        chevron.textContent = aboutCollapsed ? "\u25B8" : "\u25BE";
+      }
+      vscode.setState({ ...vscode.getState() ?? {}, aboutCollapsed });
+    };
+    toggle.addEventListener("click", applyToggle);
+    toggle.addEventListener("keydown", (event) => {
+      if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        applyToggle();
+      }
+    });
+  }
+  function wireNavigationButtons() {
+    document.getElementById("btn-refresh")?.addEventListener("click", () => {
+      vscode.postMessage({ command: "refresh" });
+    });
+    document.getElementById("btn-details")?.addEventListener("click", () => {
+      vscode.postMessage({ command: "showDetails" });
+    });
+    document.getElementById("btn-chart")?.addEventListener("click", () => {
+      vscode.postMessage({ command: "showChart" });
+    });
+    document.getElementById("btn-diagnostics")?.addEventListener("click", () => {
+      vscode.postMessage({ command: "showDiagnostics" });
+    });
+    document.getElementById("btn-maturity")?.addEventListener("click", () => {
+      vscode.postMessage({ command: "showMaturity" });
+    });
+    document.getElementById("btn-dashboard")?.addEventListener("click", () => {
+      vscode.postMessage({ command: "showDashboard" });
+    });
+    document.getElementById("btn-environmental")?.addEventListener("click", () => {
+      vscode.postMessage({ command: "showEnvironmental" });
+    });
+    document.getElementById("btn-efficiency")?.addEventListener("click", () => {
+      vscode.postMessage({ command: "showEfficiency" });
+    });
+    wireExtensionPointButtons(vscode);
+  }
+  function setButtonAnalyzingState(btn, analyzingText) {
+    if (!btn) {
+      return;
+    }
+    btn.disabled = true;
+    btn.textContent = analyzingText;
+    btn.setAttribute("appearance", "secondary");
+  }
+  function wireRepositoryButtons() {
+    document.getElementById("btn-analyse-repo")?.addEventListener("click", () => {
+      const btn = document.getElementById("btn-analyse-repo");
+      isSingleRepoAnalysisInProgress = true;
+      setButtonAnalyzingState(btn, "Analyzing...");
+      vscode.postMessage({ command: "analyseRepository" });
+    });
+    document.getElementById("btn-analyse-all")?.addEventListener("click", () => {
+      const btn = document.getElementById("btn-analyse-all");
+      setButtonAnalyzingState(btn, "Analyzing All...");
+      isBatchAnalysisInProgress = true;
+      isSwitchingRepository = true;
+      selectedRepoPath = null;
+      for (const ws of hygieneMatrixState?.workspaces ?? []) {
+        if (!ws.workspacePath.startsWith("<unresolved:")) {
+          repoAnalysisInFlight.add(ws.workspacePath);
+        }
+      }
+      renderRepositoryHygienePanels();
+      vscode.postMessage({ command: "analyseAllRepositories" });
+    });
+    document.getElementById("repo-list-pane")?.addEventListener("click", (e7) => {
+      const target = e7.target;
+      const actionButton = target.closest(".btn-repo-action");
+      if (!actionButton) {
+        return;
+      }
+      const workspacePath = actionButton.getAttribute("data-workspace-path");
+      const action = actionButton.getAttribute("data-action");
+      if (!workspacePath || !action) {
+        return;
+      }
+      if (action === "details") {
+        selectedRepoPath = workspacePath;
+        isSwitchingRepository = false;
+        renderRepositoryHygienePanels();
+        return;
+      }
+      if (action === "analyze") {
+        repoAnalysisInFlight.add(workspacePath);
+        isBatchAnalysisInProgress = false;
+        renderRepositoryHygienePanels();
+        vscode.postMessage({ command: "analyseRepository", workspacePath });
+      }
+    });
+    document.getElementById("repo-details-pane")?.addEventListener("click", (e7) => {
+      const target = e7.target;
+      if (target.closest("#btn-switch-repository")) {
+        isSwitchingRepository = true;
+        renderRepositoryHygienePanels();
+      }
+    });
+  }
+  function wireCopyButtons() {
+    Array.from(document.getElementsByClassName("cf-copy")).forEach((el2) => {
+      el2.addEventListener("click", (ev) => {
+        const target = ev.currentTarget;
+        const path = target.getAttribute("data-path") || "";
+        if (navigator.clipboard && path) {
+          navigator.clipboard.writeText(path).then(() => {
+            target.textContent = "Copied";
+            setTimeout(() => {
+              target.textContent = "Copy";
+            }, 1200);
+          }).catch(() => {
+            vscode.postMessage({ command: "copyFailed", path });
+          });
+        }
+      });
+    });
+  }
+  function handleUpdateStats(message) {
+    clearLoadingTimeout();
+    if (message.data?.locale) {
+      setFormatLocale(message.data.locale);
+    }
+    if (typeof message.data?.use24HourTime === "boolean") {
+      use24HourTime = message.data.use24HourTime;
+    }
+    if (typeof message.data?.hideAutomaticToolCalls === "boolean") {
+      hideAutomaticToolCalls = message.data.hideAutomaticToolCalls;
+    }
+    const sanitized = sanitizeStats(message.data);
+    if (sanitized) {
+      _ulLoadingActive = false;
+      replaceRecentSessionsCache(sanitized.recentSessions);
+      renderLayout(sanitized);
+      setupSessionsTableSort();
+      renderRepositoryHygienePanels();
+      if (repoPrStatsData) {
+        updateReposPrPanel(repoPrStatsData);
+      }
+      if (agentSessionsData) {
+        updateAgentSessionsPanel(agentSessionsData);
+      }
+    } else {
+      traceCurationOnce("update-invalid-sanitized", "handleUpdateStats.sanitizeReturnedNull");
+      showLoadError("Received invalid data from the extension. Try refreshing.");
+    }
+  }
+  function handleToolSuppressed(toolName) {
+    if (!toolName) {
+      return;
+    }
+    const section = document.getElementById("unknown-mcp-tools-section");
+    if (!section) {
+      return;
+    }
+    section.querySelectorAll("button[data-suppress-tool]").forEach((btn) => {
+      if (btn.getAttribute("data-suppress-tool") === toolName) {
+        btn.closest("span")?.remove();
+      }
+    });
+    if (section.querySelectorAll("button[data-suppress-tool]").length === 0) {
+      section.remove();
+    }
+  }
+  function handleHighlightUnknownTools() {
+    activeTab = "tools";
+    document.querySelectorAll(".tab-button").forEach((btn) => {
+      btn.classList.toggle("active", btn.getAttribute("data-tab") === "tools");
+    });
+    document.querySelectorAll(".tab-panel").forEach((panel) => {
+      panel.style.display = "none";
+    });
+    const toolsPanel = document.getElementById("tab-panel-tools");
+    if (toolsPanel) {
+      toolsPanel.style.display = "block";
+    }
+    const el2 = document.getElementById("unknown-mcp-tools-section");
+    if (el2) {
+      el2.scrollIntoView({ behavior: "smooth", block: "center" });
+      el2.style.transition = "box-shadow 0.3s ease";
+      el2.style.boxShadow = "0 0 0 3px var(--vscode-focusBorder)";
+      setTimeout(() => {
+        el2.style.boxShadow = "";
+      }, 2e3);
+    }
+  }
+  function handleRepoPrStatsLoaded(data) {
+    repoPrStatsData = sanitizeRepoPrStatsData(data);
+    if (!repoPrStatsData.authenticated) {
+      repoPrStatsLoaded = false;
+    }
+    updateReposPrPanel(repoPrStatsData);
+  }
+  function handleAgentSessionsLoaded(data) {
+    if (!data || typeof data !== "object") {
+      return;
+    }
+    agentSessionsData = sanitizeAgentSessionsData(data);
+    if (!agentSessionsData.authenticated) {
+      agentSessionsLoaded = false;
+    }
+    updateAgentSessionsPanel(agentSessionsData);
+  }
+  function handleUpdateInsights(rawInsights) {
+    if (!Array.isArray(rawInsights)) {
+      return;
+    }
+    const sanitized = sanitizeInsights(rawInsights);
+    refreshInsightsPanel(sanitized);
+  }
+  function handleLoadingStateMessage(message) {
+    switch (message.command) {
+      case "usageLoadingProgress":
+        updateUsageLoadingProgress(message);
+        return true;
+      case "usageRefreshing":
+        clearLoadingTimeout();
+        _ulLastStepIdx = 0;
+        renderUsageLoadingState("Refreshing Usage Analysis");
+        return true;
+      case "updateStatsError":
+        clearLoadingTimeout();
+        showLoadError("Failed to calculate usage analysis. Check the Output panel for details.");
+        return true;
+    }
+    return false;
+  }
+  function handleRepoAnalysisMessage(message) {
+    switch (message.command) {
+      case "repoAnalysisResults":
+        try {
+          displayRepoAnalysisResults(message.data, message.workspacePath);
+        } catch (err) {
+          console.error("Failed to render repo analysis results", err);
+          displayRepoAnalysisError(err instanceof Error ? err.message : String(err), message.workspacePath);
+        }
+        return true;
+      case "repoAnalysisError":
+        displayRepoAnalysisError(message.error, message.workspacePath);
+        return true;
+      case "repoAnalysisBatchComplete":
+        handleBatchAnalysisComplete();
+        return true;
+    }
+    return false;
+  }
+  function handleExtensionMessage(message) {
+    if (handleLoadingStateMessage(message)) {
+      return;
+    }
+    if (handleRepoAnalysisMessage(message)) {
+      return;
+    }
+    switch (message.command) {
+      case "updateStats":
+        handleUpdateStats(message);
+        break;
+      case "toolSuppressed":
+        handleToolSuppressed(message.toolName);
+        break;
+      case "highlightUnknownTools":
+        handleHighlightUnknownTools();
+        break;
+      case "repoPrStatsLoaded":
+        handleRepoPrStatsLoaded(message.data);
+        break;
+      case "repoPrStatsProgress":
+        updateProgressPanel("#repos-pr-content", "repos-pr-progress", "Fetching PRs\u2026", message.done, message.total);
+        break;
+      case "agentSessionsLoaded":
+        handleAgentSessionsLoaded(message.data);
+        break;
+      case "recentSessionsLoaded":
+        handleRecentSessionsLoaded(message);
+        break;
+      case "agentSessionsProgress":
+        updateProgressPanel("#agent-sessions-content", "agent-sessions-progress", "Fetching agent sessions\u2026", message.done, message.total);
+        break;
+      case "updateInsights":
+        handleUpdateInsights(message.insights);
+        break;
+      case "switchTab":
+        handleSwitchTab(message);
+        break;
+      default:
+        handleWorktreeMessage(message);
+        break;
+    }
+  }
+  function handleSwitchTab(message) {
+    const tab = String(message.tab);
+    if (!isSwitchableTab(tab)) {
+      return;
+    }
+    activeTab = tab;
+    pendingTabAnchor = typeof message.anchor === "string" && message.anchor ? message.anchor : null;
+    const btn = document.querySelector(`.tab-button[data-tab="${tab}"]`);
+    btn?.click();
+    scrollToPendingTabAnchor();
+  }
+  function scrollToPendingTabAnchor() {
+    if (!pendingTabAnchor) {
+      return;
+    }
+    const anchor = document.getElementById(pendingTabAnchor);
+    if (anchor) {
+      pendingTabAnchor = null;
+      setTimeout(() => anchor.scrollIntoView({ behavior: "smooth", block: "start" }), 50);
+    }
+  }
+  registerMessageHandler((message) => {
+    handleExtensionMessage(message);
+  });
+  vscode.postMessage({ command: "usageWebviewReady" });
+  function getWorkspaceName(workspacePath) {
+    const workspace = hygieneMatrixState?.workspaces.find((ws) => ws.workspacePath === workspacePath);
+    return workspace?.workspaceName || workspacePath;
+  }
+  function getScoreLabel(workspacePath) {
+    const record = repoAnalysisState.get(workspacePath);
+    if (record?.data?.summary) {
+      const percentage = toFiniteNumber(record.data.summary.percentage);
+      return `${Math.round(percentage)}%`;
+    }
+    if (record?.error) {
+      return "Error";
+    }
+    return "\u2014";
+  }
+  function toFiniteNumber(value) {
+    const numeric = typeof value === "number" ? value : Number(value);
+    return Number.isFinite(numeric) ? numeric : 0;
+  }
+  var REPO_DOCS_LINKS = {
+    "git-repo": "https://docs.github.com/en/get-started/using-git/about-git",
+    "gitignore": "https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files",
+    "env-example": "https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions",
+    "editorconfig": "https://editorconfig.org/",
+    "linter": "https://docs.github.com/en/code-security/code-scanning/introduction-to-code-scanning/about-code-scanning",
+    "formatter": "https://docs.github.com/en/contributing/style-guide-and-content-model/style-guide",
+    "type-safety": "https://docs.github.com/en/code-security/code-scanning/reference/code-ql-built-in-queries/javascript-typescript-built-in-queries",
+    "commit-messages": "https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/about-commits",
+    "conventional-commits": "https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/available-rules-for-rulesets",
+    "ci-config": "https://docs.github.com/en/actions/about-github-actions/understanding-github-actions",
+    "scripts": "https://docs.github.com/en/actions/tutorials/build-and-test-code/nodejs",
+    "task-runner": "https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/add-scripts",
+    "devcontainer": "https://docs.github.com/en/codespaces/setting-up-your-project-for-codespaces/adding-a-dev-container-configuration",
+    "dockerfile": "https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry",
+    "version-pinning": "https://docs.github.com/en/codespaces/setting-up-your-project-for-codespaces/adding-a-dev-container-configuration/setting-up-your-nodejs-project-for-codespaces",
+    "license": "https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/licensing-a-repository"
+  };
+  var REPO_CATEGORY_LABELS = {
+    versionControl: "\u{1F504} Version Control",
+    codeQuality: "\u2728 Code Quality",
+    cicd: "\u{1F680} CI/CD",
+    environment: "\u{1F527} Environment",
+    documentation: "\u{1F4DA} Documentation"
+  };
+  function buildScoreHeaderElement(summary) {
+    const header = el("div");
+    header.setAttribute("style", "display: flex; justify-content: space-between; align-items: center; margin-bottom: 12px;");
+    const title = el("div");
+    title.setAttribute("style", "font-size: 14px; font-weight: 600; color: var(--text-primary);");
+    title.textContent = "\u{1F4CA} Repository Hygiene Score";
+    const score = el("div");
+    score.setAttribute("style", "font-size: 24px; font-weight: 700; color: var(--link-color);");
+    score.textContent = `${Math.round(toFiniteNumber(summary.percentage))}%`;
+    header.append(title, score);
+    return header;
+  }
+  function buildStatsGridElement(summary) {
+    const statsGrid = el("div");
+    statsGrid.setAttribute("style", "display: grid; grid-template-columns: repeat(3, 1fr); gap: 8px; margin-bottom: 12px;");
+    const statCards = [
+      { count: summary.passedChecks, label: "Passed", cardStyle: "text-align: center; padding: 8px; background: rgba(34, 197, 94, 0.1); border: 1px solid rgba(34, 197, 94, 0.3); border-radius: 4px;", countStyle: "font-size: 18px; font-weight: 600; color: var(--success-fg);" },
+      { count: summary.warningChecks, label: "Warnings", cardStyle: "text-align: center; padding: 8px; background: rgba(245, 158, 11, 0.1); border: 1px solid rgba(245, 158, 11, 0.3); border-radius: 4px;", countStyle: "font-size: 18px; font-weight: 600; color: var(--warning-fg);" },
+      { count: summary.failedChecks, label: "Failed", cardStyle: "text-align: center; padding: 8px; background: rgba(239, 68, 68, 0.1); border: 1px solid rgba(239, 68, 68, 0.3); border-radius: 4px;", countStyle: "font-size: 18px; font-weight: 600; color: #ef4444;" }
+    ];
+    for (const statCard of statCards) {
+      const card = el("div");
+      card.setAttribute("style", statCard.cardStyle);
+      const count = el("div");
+      count.setAttribute("style", statCard.countStyle);
+      count.textContent = String(toFiniteNumber(statCard.count));
+      const label = el("div");
+      label.setAttribute("style", "font-size: 10px; color: var(--text-secondary);");
+      label.textContent = statCard.label;
+      card.append(count, label);
+      statsGrid.appendChild(card);
+    }
+    return statsGrid;
+  }
+  function resolveCheckStatus(check) {
+    const status = check?.status === "pass" || check?.status === "warning" ? check.status : "fail";
+    const emoji = status === "pass" ? "\u2705" : status === "warning" ? "\u26A0\uFE0F" : "\u274C";
+    const color = status === "pass" ? "#22c55e" : status === "warning" ? "#f59e0b" : "#ef4444";
+    return { status, emoji, color };
+  }
+  function buildCheckContentElement(check, statusColor) {
+    const content = el("div");
+    content.setAttribute("style", "flex: 1;");
+    const checkLabel = el("div");
+    checkLabel.setAttribute("style", `font-size: 12px; font-weight: 600; color: ${statusColor};`);
+    checkLabel.textContent = typeof check?.label === "string" ? check.label : "";
+    const checkDetail = el("div");
+    checkDetail.setAttribute("style", "font-size: 11px; color: var(--text-secondary); margin-top: 2px;");
+    checkDetail.textContent = typeof check?.detail === "string" ? check.detail : "";
+    content.append(checkLabel, checkDetail);
+    if (typeof check?.hint === "string" && check.hint.length > 0) {
+      const hint = el("div");
+      hint.setAttribute("style", "font-size: 10px; color: var(--link-color); margin-top: 4px; font-style: italic;");
+      hint.textContent = `\u{1F4A1} ${check.hint}`;
+      content.appendChild(hint);
+    }
+    const docUrl = REPO_DOCS_LINKS[typeof check?.id === "string" ? check.id : ""];
+    if (docUrl) {
+      const docLink = el("a");
+      docLink.setAttribute("href", docUrl);
+      docLink.setAttribute("style", "font-size: 10px; color: var(--link-color); margin-top: 4px; display: inline-block;");
+      docLink.setAttribute("title", "View official documentation");
+      docLink.textContent = "\u{1F4D6} View documentation";
+      content.appendChild(docLink);
+    }
+    return content;
+  }
+  function buildCheckRowElement(check) {
+    const { emoji, color } = resolveCheckStatus(check);
+    const checkRow = el("div");
+    checkRow.setAttribute("style", "padding: 8px; border-bottom: 1px solid var(--border-subtle); display: flex; align-items: flex-start; gap: 8px;");
+    const icon = el("span");
+    icon.setAttribute("style", "flex-shrink: 0; padding-top: 1px;");
+    setHtml(icon, statusBadgeHtml(emoji));
+    const weight = el("span");
+    weight.setAttribute("style", "font-size: 10px; color: var(--text-muted); min-width: 30px; text-align: right;");
+    weight.textContent = `+${toFiniteNumber(check?.weight)}`;
+    checkRow.append(icon, buildCheckContentElement(check, color), weight);
+    return checkRow;
+  }
+  function buildCategorySectionElement(categoryId, categoryChecks, summary) {
+    const section = el("div");
+    section.setAttribute("style", "margin-bottom: 12px; background: var(--bg-secondary); border: 1px solid var(--border-color); border-radius: 4px; overflow: hidden;");
+    const sectionHeader = el("div");
+    sectionHeader.setAttribute("style", "padding: 8px 12px; background: var(--list-hover-bg); border-bottom: 1px solid var(--border-color); display: flex; justify-content: space-between; align-items: center;");
+    const categoryName = el("span");
+    categoryName.setAttribute("style", "font-size: 12px; font-weight: 600; color: var(--text-primary);");
+    categoryName.textContent = REPO_CATEGORY_LABELS[categoryId] || categoryId;
+    const categorySummary = summary?.categories?.[categoryId];
+    const categoryPct = el("span");
+    categoryPct.setAttribute("style", "font-size: 11px; color: var(--link-color); font-weight: 600;");
+    categoryPct.textContent = `${Math.round(toFiniteNumber(categorySummary?.percentage))}%`;
+    sectionHeader.append(categoryName, categoryPct);
+    section.appendChild(sectionHeader);
+    for (const check of categoryChecks) {
+      section.appendChild(buildCheckRowElement(check));
+    }
+    return section;
+  }
+  function buildRecommendationsSectionElement(recommendations) {
+    const section = el("div");
+    section.setAttribute("style", "margin-top: 16px; background: var(--bg-secondary); border: 1px solid var(--border-color); border-radius: 4px; overflow: hidden;");
+    const hdr = el("div");
+    hdr.setAttribute("style", "padding: 8px 12px; background: var(--list-hover-bg); border-bottom: 1px solid var(--border-color);");
+    const hdrTitle = el("span");
+    hdrTitle.setAttribute("style", "font-size: 12px; font-weight: 600; color: var(--text-primary);");
+    hdrTitle.textContent = "\u{1F4A1} Top Recommendations";
+    hdr.appendChild(hdrTitle);
+    section.appendChild(hdr);
+    for (const rec of recommendations.slice(0, 5)) {
+      const priority = rec?.priority === "high" || rec?.priority === "medium" ? rec.priority : "low";
+      const priorityColor = priority === "high" ? "#ef4444" : priority === "medium" ? "#f59e0b" : "#60a5fa";
+      const row = el("div");
+      row.setAttribute("style", "padding: 8px; border-bottom: 1px solid var(--border-subtle); display: flex; gap: 8px;");
+      const priorityLabel = el("span");
+      priorityLabel.setAttribute("style", `font-size: 10px; font-weight: 600; color: ${priorityColor}; min-width: 50px;`);
+      priorityLabel.textContent = String(priority).toUpperCase();
+      const content = el("div");
+      content.setAttribute("style", "flex: 1;");
+      const action = el("div");
+      action.setAttribute("style", "font-size: 11px; color: var(--text-primary);");
+      action.textContent = typeof rec?.action === "string" ? rec.action : "";
+      const impact = el("div");
+      impact.setAttribute("style", "font-size: 10px; color: var(--text-muted); margin-top: 2px;");
+      impact.textContent = typeof rec?.impact === "string" ? rec.impact : "";
+      content.append(action, impact);
+      const weight = el("span");
+      weight.setAttribute("style", "font-size: 10px; color: var(--text-muted); min-width: 30px; text-align: right;");
+      weight.textContent = `+${toFiniteNumber(rec?.weight)}`;
+      row.append(priorityLabel, content, weight);
+      section.appendChild(row);
+    }
+    return section;
+  }
+  function buildCopilotSectionElement(failedChecks, workspacePath) {
+    const copilotSection = el("div");
+    copilotSection.setAttribute("style", "margin-top: 16px; padding: 12px; background: rgba(96, 165, 250, 0.07); border: 1px solid rgba(96, 165, 250, 0.3); border-radius: 4px; display: flex; align-items: center; justify-content: space-between; gap: 12px;");
+    const copilotText = el("div");
+    copilotText.setAttribute("style", "font-size: 11px; color: var(--text-secondary); flex: 1;");
+    copilotText.textContent = "Let Copilot help you fix the identified issues in this repository.";
+    const copilotBtn = document.createElement("vscode-button");
+    copilotBtn.setAttribute("style", "min-width: 180px;");
+    copilotBtn.textContent = "\u{1F916} Ask Copilot to Improve";
+    copilotBtn.addEventListener("click", () => {
+      const failedLines = failedChecks.map((c4) => `- ${c4.label}: ${c4.detail || ""}${c4.hint ? ` (${c4.hint})` : ""}`).join("\n");
+      const prompt = `Please help me improve this repository by addressing the following best practice issues:
 
-${e.map(l=>`- ${l.label}: ${l.detail||""}${l.hint?` (${l.hint})`:""}`).join(`
-`)}
+${failedLines}
 
-For each issue, please provide specific steps or code changes to fix it.`;if(!t||_s.some(l=>l.toLowerCase()===t.toLowerCase()))f.postMessage({command:"openCopilotChatWithPrompt",prompt:i});else{let l=t.split(/[/\\]/).filter(Boolean).pop()??t;o.replaceChildren(),o.setAttribute("style","margin-top: 16px; padding: 12px; background: rgba(251, 191, 36, 0.07); border: 1px solid rgba(251, 191, 36, 0.4); border-radius: 4px; display: flex; flex-direction: column; gap: 8px;");let u=m("div");u.setAttribute("style","font-size: 11px; color: var(--warning-fg);"),u.textContent=`\u26A0\uFE0F Open "${l}" in VS Code first, then paste this prompt into Copilot Chat:`;let c=m("pre");c.setAttribute("style","font-size: 10px; color: var(--text-secondary); background: var(--bg-secondary); border: 1px solid var(--border-color); border-radius: 4px; padding: 8px; white-space: pre-wrap; word-break: break-word; max-height: 120px; overflow-y: auto; font-family: monospace; margin: 0;"),c.textContent=i;let p=document.createElement("vscode-button");p.setAttribute("appearance","secondary"),p.textContent="\u{1F4CB} Copy prompt",p.addEventListener("click",()=>{navigator.clipboard.writeText(i).then(()=>{p.textContent="\u2705 Copied!",setTimeout(()=>{p.textContent="\u{1F4CB} Copy prompt"},2e3)})}),o.append(u,c,p)}}),o.append(n,s),o}function tr(e,t){let o=e?.summary||{},n=Array.isArray(e?.checks)?e.checks:[],s=Array.isArray(e?.recommendations)?[...e.recommendations]:[],r=m("div");r.appendChild(wd(o)),r.appendChild(Cd(o));let i=m("div");i.setAttribute("style","font-size: 11px; color: var(--text-muted); text-align: center; margin-bottom: 16px;"),i.textContent=`Score: ${ie(o.totalScore)} / ${ie(o.maxScore)} points`,r.appendChild(i);let a={high:1,medium:2,low:3};s.sort((c,p)=>(a[c?.priority]||99)-(a[p?.priority]||99));let l={};for(let c of n){let p=typeof c?.category=="string"&&c.category.length>0?c.category:"other";l[p]||(l[p]=[]),l[p].push(c)}for(let[c,p]of Object.entries(l))r.appendChild(Ad(c,p,o));s.length>0&&r.appendChild(Md(s));let u=n.filter(c=>c?.status==="fail"||c?.status==="warning");return u.length>0&&r.appendChild(Ed(u,t)),r}function Rd(e,t,o){let n={sessions:"width: 60px; text-align: right; flex-shrink: 0; font-size: 11px; color: var(--text-primary);",interactions:"width: 80px; text-align: right; flex-shrink: 0; font-size: 11px; color: var(--text-primary);",score:"width: 60px; text-align: right; flex-shrink: 0; font-size: 11px; color: var(--text-primary);"},s=`
+For each issue, please provide specific steps or code changes to fix it.`;
+      const isRepoOpen = !workspacePath || currentWorkspacePaths.some((p3) => p3.toLowerCase() === workspacePath.toLowerCase());
+      if (isRepoOpen) {
+        vscode.postMessage({ command: "openCopilotChatWithPrompt", prompt });
+      } else {
+        const repoFolderName = workspacePath.split(/[/\\]/).filter(Boolean).pop() ?? workspacePath;
+        copilotSection.replaceChildren();
+        copilotSection.setAttribute("style", "margin-top: 16px; padding: 12px; background: rgba(251, 191, 36, 0.07); border: 1px solid rgba(251, 191, 36, 0.4); border-radius: 4px; display: flex; flex-direction: column; gap: 8px;");
+        const instructions = el("div");
+        instructions.setAttribute("style", "font-size: 11px; color: var(--warning-fg);");
+        instructions.textContent = `\u26A0\uFE0F Open "${repoFolderName}" in VS Code first, then paste this prompt into Copilot Chat:`;
+        const promptBox = el("pre");
+        promptBox.setAttribute("style", "font-size: 10px; color: var(--text-secondary); background: var(--bg-secondary); border: 1px solid var(--border-color); border-radius: 4px; padding: 8px; white-space: pre-wrap; word-break: break-word; max-height: 120px; overflow-y: auto; font-family: monospace; margin: 0;");
+        promptBox.textContent = prompt;
+        const copyBtn = document.createElement("vscode-button");
+        copyBtn.setAttribute("appearance", "secondary");
+        copyBtn.textContent = "\u{1F4CB} Copy prompt";
+        copyBtn.addEventListener("click", () => {
+          navigator.clipboard.writeText(prompt).then(() => {
+            copyBtn.textContent = "\u2705 Copied!";
+            setTimeout(() => {
+              copyBtn.textContent = "\u{1F4CB} Copy prompt";
+            }, 2e3);
+          });
+        });
+        copilotSection.append(instructions, promptBox, copyBtn);
+      }
+    });
+    copilotSection.append(copilotText, copilotBtn);
+    return copilotSection;
+  }
+  function buildRepoAnalysisBodyElement(data, workspacePath) {
+    const summary = data?.summary || {};
+    const checks = Array.isArray(data?.checks) ? data.checks : [];
+    const recommendations = Array.isArray(data?.recommendations) ? [...data.recommendations] : [];
+    const container = el("div");
+    container.appendChild(buildScoreHeaderElement(summary));
+    container.appendChild(buildStatsGridElement(summary));
+    const scoreSummary = el("div");
+    scoreSummary.setAttribute("style", "font-size: 11px; color: var(--text-muted); text-align: center; margin-bottom: 16px;");
+    scoreSummary.textContent = `Score: ${toFiniteNumber(summary.totalScore)} / ${toFiniteNumber(summary.maxScore)} points`;
+    container.appendChild(scoreSummary);
+    const priorityOrder = { high: 1, medium: 2, low: 3 };
+    recommendations.sort((a3, b3) => (priorityOrder[a3?.priority] || 99) - (priorityOrder[b3?.priority] || 99));
+    const categories = {};
+    for (const check of checks) {
+      const categoryId = typeof check?.category === "string" && check.category.length > 0 ? check.category : "other";
+      if (!categories[categoryId]) {
+        categories[categoryId] = [];
+      }
+      categories[categoryId].push(check);
+    }
+    for (const [categoryId, categoryChecks] of Object.entries(categories)) {
+      container.appendChild(buildCategorySectionElement(categoryId, categoryChecks, summary));
+    }
+    if (recommendations.length > 0) {
+      container.appendChild(buildRecommendationsSectionElement(recommendations));
+    }
+    const failedChecks = checks.filter((c4) => c4?.status === "fail" || c4?.status === "warning");
+    if (failedChecks.length > 0) {
+      container.appendChild(buildCopilotSectionElement(failedChecks, workspacePath));
+    }
+    return container;
+  }
+  function renderRepoListPane(listPane, visibleWorkspaces, hasSelectedRepository) {
+    const colStyles = {
+      sessions: "width: 60px; text-align: right; flex-shrink: 0; font-size: 11px; color: var(--text-primary);",
+      interactions: "width: 80px; text-align: right; flex-shrink: 0; font-size: 11px; color: var(--text-primary);",
+      score: "width: 60px; text-align: right; flex-shrink: 0; font-size: 11px; color: var(--text-primary);"
+    };
+    const headerHtml = `
 		<div style="padding: 4px 12px; display: flex; align-items: center; gap: 10px; border-bottom: 1px solid var(--border-color); background: var(--bg-secondary);">
 			<div style="flex: 1; min-width: 0; font-size: 10px; font-weight: 600; color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.04em;">Repository</div>
-			<div style="${n.sessions} font-weight: 600; color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.04em;">Sessions</div>
-			<div style="${n.interactions} font-weight: 600; color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.04em;">Interactions</div>
-			<div style="${n.score} font-weight: 600; color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.04em;">Score</div>
+			<div style="${colStyles.sessions} font-weight: 600; color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.04em;">Sessions</div>
+			<div style="${colStyles.interactions} font-weight: 600; color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.04em;">Interactions</div>
+			<div style="${colStyles.score} font-weight: 600; color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.04em;">Score</div>
 			<div style="width: 110px; flex-shrink: 0;"></div>
 		</div>
-	`;k(e,s+t.map((r,i)=>{let a=ct.get(r.workspacePath),l=$e.has(r.workspacePath),u=!!a?.data?.summary,c=vd(r.workspacePath),p=l?"Analyzing\u2026":u?"Details":"Analyze",b=u&&!l?"details":"analyze",h=B===r.workspacePath&&o,S=l||h,ut=l?' appearance="secondary"':"",or=Number(r.sessionCount)||0,nr=Number(r.interactionCount)||0;return`
-			<div class="repo-item" style="padding: 6px 12px; border-bottom: ${i<t.length-1?"1px solid var(--border-subtle)":"none"}; display: flex; align-items: center; gap: 10px;">
+	`;
+    setHtml(listPane, headerHtml + visibleWorkspaces.map((ws, idx) => {
+      const record = repoAnalysisState.get(ws.workspacePath);
+      const inFlight = repoAnalysisInFlight.has(ws.workspacePath);
+      const hasResult = !!record?.data?.summary;
+      const scoreLabel = getScoreLabel(ws.workspacePath);
+      const buttonLabel = inFlight ? "Analyzing\u2026" : hasResult ? "Details" : "Analyze";
+      const buttonAction = hasResult && !inFlight ? "details" : "analyze";
+      const isCurrentSelection = selectedRepoPath === ws.workspacePath && hasSelectedRepository;
+      const buttonDisabled = inFlight || isCurrentSelection;
+      const buttonAppearance = inFlight ? ' appearance="secondary"' : "";
+      const sessions = Number(ws.sessionCount) || 0;
+      const interactions = Number(ws.interactionCount) || 0;
+      return `
+			<div class="repo-item" style="padding: 6px 12px; border-bottom: ${idx < visibleWorkspaces.length - 1 ? "1px solid var(--border-subtle)" : "none"}; display: flex; align-items: center; gap: 10px;">
 				<div style="flex: 1; min-width: 0;">
-					<div class="repo-name" style="font-size: 12px; font-weight: 600; color: var(--text-primary); font-family: 'Courier New', monospace; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;" title="${d(r.workspacePath)}">
-						${d(r.workspaceName)}
+					<div class="repo-name" style="font-size: 12px; font-weight: 600; color: var(--text-primary); font-family: 'Courier New', monospace; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;" title="${escapeHtml(ws.workspacePath)}">
+						${escapeHtml(ws.workspaceName)}
 					</div>
 				</div>
-				<div style="${n.sessions}">${or}</div>
-				<div style="${n.interactions}">${nr}</div>
-				<div style="${n.score}">${d(c)}</div>
-				<vscode-button class="btn-repo-action" data-action="${b}" data-workspace-path="${d(r.workspacePath)}" ${S?'disabled="true"':""}${ut} style="width: 110px; flex-shrink: 0;">
-					${p}
+				<div style="${colStyles.sessions}">${sessions}</div>
+				<div style="${colStyles.interactions}">${interactions}</div>
+				<div style="${colStyles.score}">${escapeHtml(scoreLabel)}</div>
+				<vscode-button class="btn-repo-action" data-action="${buttonAction}" data-workspace-path="${escapeHtml(ws.workspacePath)}" ${buttonDisabled ? 'disabled="true"' : ""}${buttonAppearance} style="width: 110px; flex-shrink: 0;">
+					${buttonLabel}
 				</vscode-button>
 			</div>
-		`}).join(""))}function _d(e,t,o){e.replaceChildren();let n=m("div","repo-details-card");n.setAttribute("style","padding: 12px; background: var(--bg-secondary); border: 1px solid var(--border-color); border-radius: 6px;");let s=m("div","repo-details-card-header");s.setAttribute("style","display: flex; justify-content: space-between; align-items: center; gap: 8px; margin-bottom: 10px;");let r=m("div");r.setAttribute("style","font-size: 12px; color: var(--text-secondary);"),r.textContent="Repository: ";let i=m("span");i.setAttribute("style","color: var(--text-primary); font-weight: 600; font-family: 'Courier New', monospace;"),i.textContent=o,r.appendChild(i);let a=document.createElement("vscode-button");a.id="btn-switch-repository",a.setAttribute("style","min-width: 120px;"),a.textContent="Switch Repository",s.append(r,a),n.append(s,tr(t.data,B??void 0)),e.appendChild(n)}function X(){let e=document.getElementById("repo-list-pane"),t=document.getElementById("repo-list-pane-container"),o=document.getElementById("repo-details-pane"),n=document.getElementById("repo-details-pane-container");if(!e||!t||!o||!n||!H)return;let s=!!B&&!ge,r=s?H.workspaces.filter(l=>l.workspacePath===B):H.workspaces;if(t.classList.remove("repo-hygiene-pane-collapsed"),n.classList.toggle("repo-hygiene-pane-collapsed",!s),Rd(e,r,s),!s||!B){o.replaceChildren();return}let i=hd(B),a=ct.get(B);if(a?.data){_d(o,a,i);return}if(a?.error){k(o,`
+		`;
+    }).join(""));
+  }
+  function renderRepoDetailSuccess(detailsPane, record, workspaceName) {
+    detailsPane.replaceChildren();
+    const card = el("div", "repo-details-card");
+    card.setAttribute("style", "padding: 12px; background: var(--bg-secondary); border: 1px solid var(--border-color); border-radius: 6px;");
+    const header = el("div", "repo-details-card-header");
+    header.setAttribute("style", "display: flex; justify-content: space-between; align-items: center; gap: 8px; margin-bottom: 10px;");
+    const label = el("div");
+    label.setAttribute("style", "font-size: 12px; color: var(--text-secondary);");
+    label.textContent = "Repository: ";
+    const repoName = el("span");
+    repoName.setAttribute("style", "color: var(--text-primary); font-weight: 600; font-family: 'Courier New', monospace;");
+    repoName.textContent = workspaceName;
+    label.appendChild(repoName);
+    const switchButton = document.createElement("vscode-button");
+    switchButton.id = "btn-switch-repository";
+    switchButton.setAttribute("style", "min-width: 120px;");
+    switchButton.textContent = "Switch Repository";
+    header.append(label, switchButton);
+    card.append(header, buildRepoAnalysisBodyElement(record.data, selectedRepoPath ?? void 0));
+    detailsPane.appendChild(card);
+  }
+  function renderRepositoryHygienePanels() {
+    const listPane = document.getElementById("repo-list-pane");
+    const listContainer = document.getElementById("repo-list-pane-container");
+    const detailsPane = document.getElementById("repo-details-pane");
+    const detailsContainer = document.getElementById("repo-details-pane-container");
+    if (!listPane || !listContainer || !detailsPane || !detailsContainer || !hygieneMatrixState) {
+      return;
+    }
+    const hasSelectedRepository = !!selectedRepoPath && !isSwitchingRepository;
+    const visibleWorkspaces = hasSelectedRepository ? hygieneMatrixState.workspaces.filter((ws) => ws.workspacePath === selectedRepoPath) : hygieneMatrixState.workspaces;
+    listContainer.classList.remove("repo-hygiene-pane-collapsed");
+    detailsContainer.classList.toggle("repo-hygiene-pane-collapsed", !hasSelectedRepository);
+    renderRepoListPane(listPane, visibleWorkspaces, hasSelectedRepository);
+    if (!hasSelectedRepository || !selectedRepoPath) {
+      detailsPane.replaceChildren();
+      return;
+    }
+    const workspaceName = getWorkspaceName(selectedRepoPath);
+    const record = repoAnalysisState.get(selectedRepoPath);
+    if (record?.data) {
+      renderRepoDetailSuccess(detailsPane, record, workspaceName);
+      return;
+    }
+    if (record?.error) {
+      setHtml(detailsPane, `
 			<div style="padding: 12px; background: rgba(239, 68, 68, 0.1); border: 1px solid rgba(239, 68, 68, 0.3); border-radius: 6px;">
 				<div style="display: flex; justify-content: space-between; align-items: center; gap: 8px; margin-bottom: 8px;">
-					<div style="font-size: 11px; color: #fca5a5;">Repository: ${d(i)}</div>
+					<div style="font-size: 11px; color: #fca5a5;">Repository: ${escapeHtml(workspaceName)}</div>
 					<vscode-button id="btn-switch-repository" style="min-width: 120px;">Switch Repository</vscode-button>
 				</div>
 				<div style="font-size: 12px; font-weight: 600; color: #ef4444; margin-bottom: 4px;">\u274C Analysis Failed</div>
-				<div style="font-size: 11px; color: #fca5a5;">${d(a.error)}</div>
+				<div style="font-size: 11px; color: #fca5a5;">${escapeHtml(record.error)}</div>
 			</div>
-		`);return}k(o,`
+		`);
+      return;
+    }
+    setHtml(detailsPane, `
 		<div style="padding: 12px; background: var(--bg-secondary); border: 1px solid var(--border-color); border-radius: 6px;">
 			<div style="display: flex; justify-content: space-between; align-items: center; gap: 8px; margin-bottom: 8px;">
-				<div style="font-size: 12px; color: var(--text-secondary);">Repository: <span style="color: var(--text-primary); font-weight: 600; font-family: 'Courier New', monospace;">${d(i)}</span></div>
+				<div style="font-size: 12px; color: var(--text-secondary);">Repository: <span style="color: var(--text-primary); font-weight: 600; font-family: 'Courier New', monospace;">${escapeHtml(workspaceName)}</span></div>
 				<vscode-button id="btn-switch-repository" style="min-width: 120px;">Switch Repository</vscode-button>
 			</div>
 			<div style="font-size: 11px; color: var(--text-muted);">No analysis data yet. Click Analyze in the list.</div>
 		</div>
-	`)}function Pd(e,t){if(t){$e.delete(t),ct.set(t,{data:e,error:void 0}),me||(B=t,ge=!1),X();return}let o=document.getElementById("btn-analyse-repo");o&&(st=!1,o.disabled=!1,o.textContent="Analyze Repo for Best Practices",o.removeAttribute("appearance"));let n=document.getElementById("repo-analysis-results");if(n){n.replaceChildren();let s=m("div","repo-analysis-card");s.setAttribute("style","padding: 12px; background: var(--bg-secondary); border: 1px solid var(--border-color); border-radius: 6px; margin-bottom: 12px;"),s.appendChild(tr(e,t)),n.appendChild(s)}}function Rs(e,t){if(t){$e.delete(t),ct.set(t,{data:void 0,error:e}),me||(B=t,ge=!1),X();return}let o=document.getElementById("btn-analyse-repo");o&&(st=!1,o.disabled=!1,o.textContent="Analyze Repo for Best Practices",o.removeAttribute("appearance"));let n=document.getElementById("repo-analysis-results");n&&k(n,`
+	`);
+  }
+  function displayRepoAnalysisResults(data, workspacePath) {
+    if (workspacePath) {
+      repoAnalysisInFlight.delete(workspacePath);
+      repoAnalysisState.set(workspacePath, { data, error: void 0 });
+      if (!isBatchAnalysisInProgress) {
+        selectedRepoPath = workspacePath;
+        isSwitchingRepository = false;
+      }
+      renderRepositoryHygienePanels();
+      return;
+    }
+    const btn = document.getElementById("btn-analyse-repo");
+    if (btn) {
+      isSingleRepoAnalysisInProgress = false;
+      btn.disabled = false;
+      btn.textContent = "Analyze Repo for Best Practices";
+      btn.removeAttribute("appearance");
+    }
+    const resultsHost = document.getElementById("repo-analysis-results");
+    if (resultsHost) {
+      resultsHost.replaceChildren();
+      const card = el("div", "repo-analysis-card");
+      card.setAttribute("style", "padding: 12px; background: var(--bg-secondary); border: 1px solid var(--border-color); border-radius: 6px; margin-bottom: 12px;");
+      card.appendChild(buildRepoAnalysisBodyElement(data, workspacePath));
+      resultsHost.appendChild(card);
+    }
+  }
+  function displayRepoAnalysisError(error, workspacePath) {
+    if (workspacePath) {
+      repoAnalysisInFlight.delete(workspacePath);
+      repoAnalysisState.set(workspacePath, { data: void 0, error });
+      if (!isBatchAnalysisInProgress) {
+        selectedRepoPath = workspacePath;
+        isSwitchingRepository = false;
+      }
+      renderRepositoryHygienePanels();
+      return;
+    }
+    const btn = document.getElementById("btn-analyse-repo");
+    if (btn) {
+      isSingleRepoAnalysisInProgress = false;
+      btn.disabled = false;
+      btn.textContent = "Analyze Repo for Best Practices";
+      btn.removeAttribute("appearance");
+    }
+    const resultsHost = document.getElementById("repo-analysis-results");
+    if (resultsHost) {
+      setHtml(resultsHost, `
 			<div style="padding: 12px; background: rgba(239, 68, 68, 0.1); border: 1px solid rgba(239, 68, 68, 0.3); border-radius: 6px; margin-bottom: 12px;">
 				<div style="font-size: 12px; font-weight: 600; color: #ef4444; margin-bottom: 4px;">\u274C Analysis Failed</div>
-				<div style="font-size: 11px; color: #fca5a5;">${d(e)}</div>
+				<div style="font-size: 11px; color: #fca5a5;">${escapeHtml(error)}</div>
 			</div>
-		`)}function Dd(){me=!1,ge=!0,B=null,$e.clear(),X();let e=document.getElementById("btn-analyse-all");if(e){e.disabled=!1,e.removeAttribute("appearance");let o=E?.customizationMatrix?.workspaces?.length||0;e.textContent=`Analyze All Repositories (${o})`}}async function Ld(){if(await Promise.resolve().then(()=>(fs(),ms)),!E){No("Loading usage analysis..."),Ut=setTimeout(()=>{let t=document.getElementById("root");if(t&&t.querySelector("#usage-loading-card")){let o=document.createElement("div");o.style.cssText="padding: 32px; text-align: center; font-size: 14px;";let n=document.createElement("div");n.style.cssText="color: var(--vscode-foreground); opacity: 0.7; margin-bottom: 12px;",n.textContent="\u23F3 Taking longer than expected\u2026 Session files may be large or the scan is still in progress.",o.append(n,Kt()),t.textContent="",t.append(o)}},3e4);return}Xt(E.locale),Ot=E.use24HourTime!==!1,at=E.hideAutomaticToolCalls!==!1,Is(E.recentSessions);let e=E.sessionColumnSettings?.enabledColumns;if(Array.isArray(e)){let t=e.filter(o=>Ds.includes(o));Me=new Set(t)}Zs(E),Ls(),document.addEventListener("click",t=>{let n=t.target.getAttribute("data-suppress-tool");n&&(Qs(n),f.postMessage({command:"suppressUnknownTool",toolName:n}))})}Ld().catch(e=>{console.error("[Usage Analysis] Bootstrap failed:",e);let t=document.getElementById("root");if(t){let o=document.createElement("div");o.style.cssText="padding: 32px; text-align: center; font-size: 14px;";let n=document.createElement("div");n.style.cssText="color: var(--vscode-errorForeground, #f48771); margin-bottom: 16px;",n.textContent="Failed to initialize usage analysis. Please try refreshing.",o.append(n,Kt()),t.textContent="",t.append(o)}});})();
+		`);
+    }
+  }
+  function handleBatchAnalysisComplete() {
+    isBatchAnalysisInProgress = false;
+    isSwitchingRepository = true;
+    selectedRepoPath = null;
+    repoAnalysisInFlight.clear();
+    renderRepositoryHygienePanels();
+    const btn = document.getElementById("btn-analyse-all");
+    if (btn) {
+      btn.disabled = false;
+      btn.removeAttribute("appearance");
+      const matrix = initialData?.customizationMatrix;
+      const count = matrix?.workspaces?.length || 0;
+      btn.textContent = `Analyze All Repositories (${count})`;
+    }
+  }
+  async function bootstrap() {
+    await Promise.resolve().then(() => (init_vscode_button2(), vscode_button_exports));
+    if (!initialData) {
+      renderUsageLoadingState("Loading usage analysis...");
+      loadingTimeoutId = setTimeout(() => {
+        const r6 = document.getElementById("root");
+        if (r6 && r6.querySelector("#usage-loading-card")) {
+          const hint = document.createElement("div");
+          hint.style.cssText = "padding: 32px; text-align: center; font-size: 14px;";
+          const msg = document.createElement("div");
+          msg.style.cssText = "color: var(--vscode-foreground); opacity: 0.7; margin-bottom: 12px;";
+          msg.textContent = "\u23F3 Taking longer than expected\u2026 Session files may be large or the scan is still in progress.";
+          hint.append(msg, createRefreshButton());
+          r6.textContent = "";
+          r6.append(hint);
+        }
+      }, 3e4);
+      return;
+    }
+    setFormatLocale(initialData.locale);
+    use24HourTime = initialData.use24HourTime !== false;
+    hideAutomaticToolCalls = initialData.hideAutomaticToolCalls !== false;
+    replaceRecentSessionsCache(initialData.recentSessions);
+    const savedColumns = initialData.sessionColumnSettings?.enabledColumns;
+    if (Array.isArray(savedColumns)) {
+      const valid = savedColumns.filter((c4) => ALL_SESSION_COLUMN_IDS.includes(c4));
+      enabledSessionColumns = new Set(valid);
+    }
+    renderLayout(initialData);
+    setupSessionsTableSort();
+    document.addEventListener("click", (event) => {
+      const target = event.target;
+      const toolName = target.getAttribute("data-suppress-tool");
+      if (toolName) {
+        handleToolSuppressed(toolName);
+        vscode.postMessage({ command: "suppressUnknownTool", toolName });
+      }
+    });
+  }
+  void bootstrap().catch((err) => {
+    console.error("[Usage Analysis] Bootstrap failed:", err);
+    const root = document.getElementById("root");
+    if (root) {
+      const container = document.createElement("div");
+      container.style.cssText = "padding: 32px; text-align: center; font-size: 14px;";
+      const msg = document.createElement("div");
+      msg.style.cssText = "color: var(--vscode-errorForeground, #f48771); margin-bottom: 16px;";
+      msg.textContent = "Failed to initialize usage analysis. Please try refreshing.";
+      container.append(msg, createRefreshButton());
+      root.textContent = "";
+      root.append(container);
+    }
+  });
+})();
 /*! Bundled license information:
 
 @lit/reactive-element/css-tag.js:
@@ -3138,3 +8950,4 @@ lit-html/directives/if-defined.js:
    * SPDX-License-Identifier: BSD-3-Clause
    *)
 */
+//# sourceMappingURL=usage.js.map

--- a/visualstudio-extension/src/AIEngineeringFluency/webview/usage.js
+++ b/visualstudio-extension/src/AIEngineeringFluency/webview/usage.js
@@ -1602,7 +1602,7 @@ To suppress this warning, set window.${CONFIG_KEY} to true`);
     thisWeek: "This week",
     allTime: "All time"
   };
-  var CANONICAL_PERIODS = ["today", "last7", "last30", "currentMonth", "allTime"];
+  var CANONICAL_PERIODS = ["today", "last7", "last30", "last90", "currentMonth", "allTime"];
   function setOptionSelected(option, value, selected) {
     if (value === selected) {
       option.selected = true;
@@ -1961,6 +1961,51 @@ To suppress this warning, set window.${CONFIG_KEY} to true`);
 
   // src/webview/usage/recentSessionsSanitizer.ts
   var RECENT_SESSION_PERIODS = ["last7", "last30", "currentMonth"];
+  var REQUIRED_NUMBER_FIELDS = [
+    "interactions",
+    "toolCalls",
+    "inputTokens",
+    "outputTokens",
+    "thinkingTokens",
+    "cachedTokens",
+    "totalTokens",
+    "estimatedCost"
+  ];
+  var OPTIONAL_NUMBER_FIELDS = [
+    "truncationCount",
+    "maxRequestInputTokens",
+    "contextWindowLimit",
+    "contextReachedTokens",
+    "durationMs",
+    "activeDurationMs",
+    "subAgentCalls"
+  ];
+  var OPTIONAL_STRING_FIELDS = ["contextTier", "workspace"];
+  function isFiniteNumber(value) {
+    return typeof value === "number" && Number.isFinite(value);
+  }
+  function isTodaySessionSummary(value) {
+    if (!value || typeof value !== "object") {
+      return false;
+    }
+    const session = value;
+    if (session.title !== null && typeof session.title !== "string") {
+      return false;
+    }
+    if (typeof session.filePath !== "string" || typeof session.editor !== "string" || typeof session.lastActivity !== "string") {
+      return false;
+    }
+    if (!Array.isArray(session.models) || !session.models.every((model) => typeof model === "string")) {
+      return false;
+    }
+    if (!REQUIRED_NUMBER_FIELDS.every((field) => isFiniteNumber(session[field]))) {
+      return false;
+    }
+    if (!OPTIONAL_NUMBER_FIELDS.every((field) => session[field] === void 0 || isFiniteNumber(session[field]))) {
+      return false;
+    }
+    return OPTIONAL_STRING_FIELDS.every((field) => session[field] === void 0 || typeof session[field] === "string");
+  }
   function sanitizeRecentSessionBuckets(raw) {
     if (!raw || typeof raw !== "object") {
       return void 0;
@@ -1972,9 +2017,7 @@ To suppress this warning, set window.${CONFIG_KEY} to true`);
       if (!Array.isArray(sessions)) {
         return void 0;
       }
-      result[period] = sessions.filter(
-        (session) => !!session && typeof session === "object" && typeof session.interactions === "number"
-      );
+      result[period] = sessions.filter(isTodaySessionSummary);
     }
     return result;
   }
@@ -7879,7 +7922,7 @@ ${_renderMultiModelMixedCostSessions(switching)}
     wrapper.replaceChildren();
     const { wrapper: selectorWrapper } = createPeriodSelector({
       selected: efficiencySelectedPeriod,
-      disabled: ["last7", "allTime"],
+      disabled: ["last7", "last90", "allTime"],
       disabledTitle: "Not available for model efficiency",
       label: "",
       onChange: (value) => {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -304,6 +304,7 @@ import { ConfirmationMessages } from './backend/ui/messages';
 import { getNonce, buildCspMeta, getCodiconStylesheetTag } from './utils/webviewUtils';
 import { isGuidMcpTool, isMcpFamilyResolvedTool } from '../../src/utils/toolUtils';
 import { toLocalDayKey } from '../../src/utils/dayKeys';
+import { buildRecentSessionBuckets as bucketRecentSessions } from '../../src/recentSessions';
 import { determineOnboardingAction } from './onboarding';
 import { mergeNotifiedEditors, mergeSeenEditors } from './editorDiscovery';
 
@@ -4418,15 +4419,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 		results: ({ sessionFile: string; sessionData: SessionFileCache; mtime: number } | null | undefined)[],
 		now: Date
 	): { last7: TodaySessionSummary[]; last30: TodaySessionSummary[]; currentMonth: TodaySessionSummary[] } {
-		const last7Key = getTimeWindowStartDayKey('last7', now);
-		const last30Key = getTimeWindowStartDayKey('last30', now);
-		const monthKey = getTimeWindowStartDayKey('currentMonth', now);
-		const items = this.buildRecentSessionItems(results);
-		return {
-			last7: items.filter(it => it.activityKey >= last7Key).map(it => it.value),
-			last30: items.filter(it => it.activityKey >= last30Key).map(it => it.value),
-			currentMonth: items.filter(it => it.activityKey >= monthKey).map(it => it.value),
-		};
+		return bucketRecentSessions(this.buildRecentSessionItems(results), now);
 	}
 
 	private buildRecentSessionBucket(

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -6,6 +6,7 @@ import { ContextReferenceUsage, getTotalContextRefs } from '../shared/contextRef
 import { escapeHtml, formatCompact, formatCost, formatDurationShort, formatFileSize, formatFixed, formatNumber, formatPercent, getTimeSince, safeSectionHtml, setFormatLocale } from '../shared/formatUtils';
 import { wireExtensionPointButtons } from '../shared/extensionPoints';
 import { initializeWebviewLocalization, setCurrentLanguage } from '../shared/localization';
+import { RECENT_SESSION_PERIODS, sanitizeRecentSessionBuckets } from './recentSessionsSanitizer';
 import type { McpToolUsage, ModeUsage, ModelSwitchingAnalysis as BaseModelSwitchingAnalysis, ToolCallUsage } from '../shared/types';
 // CSS imported as text via esbuild
 import themeStyles from '../shared/theme.css';
@@ -184,6 +185,7 @@ type UsageAnalysisStats = {
 	currentWorkspacePaths?: string[];
 	suppressedUnknownTools?: string[];
 	todaySessions?: TodaySessionSummary[];
+	recentSessions?: { last7: TodaySessionSummary[]; last30: TodaySessionSummary[]; currentMonth: TodaySessionSummary[] };
 	use24HourTime?: boolean;
 	/** When true (default), rows tagged "auto" are hidden from the Tool Usage tables so only intentional tool calls are shown. */
 	hideAutomaticToolCalls?: boolean;
@@ -1377,6 +1379,17 @@ function handleRecentSessionsLoaded(message: any): void {
 	}
 }
 
+function replaceRecentSessionsCache(raw: unknown): void {
+	for (const period of RECENT_SESSION_PERIODS) {
+		delete recentSessionsCache[period];
+	}
+	const buckets = sanitizeRecentSessionBuckets(raw);
+	if (!buckets) { return; }
+	for (const period of RECENT_SESSION_PERIODS) {
+		recentSessionsCache[period] = buckets[period] as TodaySessionSummary[];
+	}
+}
+
 function unionFill(map: { [key: string]: number }, keys: string[]): { [key: string]: number } {
 	const result: { [key: string]: number } = { ...map };
 	for (const k of keys) {
@@ -1615,6 +1628,22 @@ function sanitizeOptionalReports(sanitized: UsageAnalysisStats, raw: any): void 
 	sanitized.repeatedTasks = sanitizeRepeatedTaskReport(raw.repeatedTasks);
 }
 
+function applySessionSummaries(sanitized: UsageAnalysisStats, raw: any): void {
+	if (Array.isArray(raw.todaySessions)) {
+		sanitized.todaySessions = raw.todaySessions.filter(
+			(session: any) => session && typeof session === 'object' && typeof session.interactions === 'number'
+		) as TodaySessionSummary[];
+	}
+	const recentSessions = sanitizeRecentSessionBuckets(raw.recentSessions);
+	if (recentSessions) {
+		sanitized.recentSessions = recentSessions as {
+			last7: TodaySessionSummary[];
+			last30: TodaySessionSummary[];
+			currentMonth: TodaySessionSummary[];
+		};
+	}
+}
+
 function sanitizeStats(raw: any): UsageAnalysisStats | null {
 	if (!raw || typeof raw !== 'object') {
 		traceCurationOnce('sanitize-invalid-root', 'sanitizeStats.invalidRoot');
@@ -1653,12 +1682,7 @@ function sanitizeStats(raw: any): UsageAnalysisStats | null {
 			) as MissedPotentialWorkspace[];
 		}
 
-		// Pass-through todaySessions (array of session summary objects)
-		if (Array.isArray(raw.todaySessions)) {
-			sanitized.todaySessions = raw.todaySessions.filter(
-				(s: any) => s && typeof s === 'object' && typeof s.interactions === 'number'
-			) as TodaySessionSummary[];
-		}
+		applySessionSummaries(sanitized, raw);
 
 		// Sanitize insights
 		if (Array.isArray(raw.insights)) {
@@ -5022,10 +5046,8 @@ function handleUpdateStats(message: any): void {
 	const sanitized = sanitizeStats(message.data);
 	if (sanitized) {
 		_ulLoadingActive = false;
-		// New stats invalidate any lazily-loaded lookback data; it is re-requested on demand.
-		for (const key of Object.keys(recentSessionsCache)) {
-			delete recentSessionsCache[key];
-		}
+		// CLI-backed hosts include all buckets; VS Code omits them and keeps using lazy loading.
+		replaceRecentSessionsCache(sanitized.recentSessions);
 		renderLayout(sanitized);
 		setupSessionsTableSort();
 		renderRepositoryHygienePanels();
@@ -5685,6 +5707,7 @@ async function bootstrap(): Promise<void> {
 	setFormatLocale(initialData.locale);
 	use24HourTime = initialData.use24HourTime !== false;
 	hideAutomaticToolCalls = initialData.hideAutomaticToolCalls !== false;
+	replaceRecentSessionsCache(initialData.recentSessions);
 	const savedColumns = initialData.sessionColumnSettings?.enabledColumns;
 	if (Array.isArray(savedColumns)) {
 		const valid = savedColumns.filter((c): c is SessionColumnId => (ALL_SESSION_COLUMN_IDS as string[]).includes(c));

--- a/vscode-extension/src/webview/usage/recentSessionsSanitizer.ts
+++ b/vscode-extension/src/webview/usage/recentSessionsSanitizer.ts
@@ -1,0 +1,21 @@
+export const RECENT_SESSION_PERIODS = ['last7', 'last30', 'currentMonth'] as const;
+
+export type RecentSessionPeriod = typeof RECENT_SESSION_PERIODS[number];
+export type SanitizedSessionSummary = Record<string, unknown> & { interactions: number };
+export type SanitizedRecentSessionBuckets = Record<RecentSessionPeriod, SanitizedSessionSummary[]>;
+
+export function sanitizeRecentSessionBuckets(raw: unknown): SanitizedRecentSessionBuckets | undefined {
+	if (!raw || typeof raw !== 'object') { return undefined; }
+
+	const source = raw as Record<string, unknown>;
+	const result = {} as SanitizedRecentSessionBuckets;
+	for (const period of RECENT_SESSION_PERIODS) {
+		const sessions = source[period];
+		if (!Array.isArray(sessions)) { return undefined; }
+		result[period] = sessions.filter(
+			(session): session is SanitizedSessionSummary =>
+				!!session && typeof session === 'object' && typeof (session as Record<string, unknown>).interactions === 'number'
+		);
+	}
+	return result;
+}

--- a/vscode-extension/src/webview/usage/recentSessionsSanitizer.ts
+++ b/vscode-extension/src/webview/usage/recentSessionsSanitizer.ts
@@ -1,8 +1,50 @@
+import type { TodaySessionSummary } from '../../../../src/types';
+
 export const RECENT_SESSION_PERIODS = ['last7', 'last30', 'currentMonth'] as const;
 
 export type RecentSessionPeriod = typeof RECENT_SESSION_PERIODS[number];
-export type SanitizedSessionSummary = Record<string, unknown> & { interactions: number };
-export type SanitizedRecentSessionBuckets = Record<RecentSessionPeriod, SanitizedSessionSummary[]>;
+export type SanitizedRecentSessionBuckets = Record<RecentSessionPeriod, TodaySessionSummary[]>;
+
+const REQUIRED_NUMBER_FIELDS = [
+	'interactions',
+	'toolCalls',
+	'inputTokens',
+	'outputTokens',
+	'thinkingTokens',
+	'cachedTokens',
+	'totalTokens',
+	'estimatedCost',
+] as const;
+
+const OPTIONAL_NUMBER_FIELDS = [
+	'truncationCount',
+	'maxRequestInputTokens',
+	'contextWindowLimit',
+	'contextReachedTokens',
+	'durationMs',
+	'activeDurationMs',
+	'subAgentCalls',
+] as const;
+
+const OPTIONAL_STRING_FIELDS = ['contextTier', 'workspace'] as const;
+
+function isFiniteNumber(value: unknown): value is number {
+	return typeof value === 'number' && Number.isFinite(value);
+}
+
+function isTodaySessionSummary(value: unknown): value is TodaySessionSummary {
+	if (!value || typeof value !== 'object') { return false; }
+
+	const session = value as Record<string, unknown>;
+	if (session.title !== null && typeof session.title !== 'string') { return false; }
+	if (typeof session.filePath !== 'string' || typeof session.editor !== 'string' || typeof session.lastActivity !== 'string') {
+		return false;
+	}
+	if (!Array.isArray(session.models) || !session.models.every(model => typeof model === 'string')) { return false; }
+	if (!REQUIRED_NUMBER_FIELDS.every(field => isFiniteNumber(session[field]))) { return false; }
+	if (!OPTIONAL_NUMBER_FIELDS.every(field => session[field] === undefined || isFiniteNumber(session[field]))) { return false; }
+	return OPTIONAL_STRING_FIELDS.every(field => session[field] === undefined || typeof session[field] === 'string');
+}
 
 export function sanitizeRecentSessionBuckets(raw: unknown): SanitizedRecentSessionBuckets | undefined {
 	if (!raw || typeof raw !== 'object') { return undefined; }
@@ -12,10 +54,7 @@ export function sanitizeRecentSessionBuckets(raw: unknown): SanitizedRecentSessi
 	for (const period of RECENT_SESSION_PERIODS) {
 		const sessions = source[period];
 		if (!Array.isArray(sessions)) { return undefined; }
-		result[period] = sessions.filter(
-			(session): session is SanitizedSessionSummary =>
-				!!session && typeof session === 'object' && typeof (session as Record<string, unknown>).interactions === 'number'
-		);
+		result[period] = sessions.filter(isTodaySessionSummary);
 	}
 	return result;
 }

--- a/vscode-extension/test/unit/recentSessions.test.ts
+++ b/vscode-extension/test/unit/recentSessions.test.ts
@@ -3,33 +3,56 @@ import * as assert from 'node:assert/strict';
 import { buildRecentSessionBuckets } from '../../../src/recentSessions';
 import { sanitizeRecentSessionBuckets } from '../../src/webview/usage/recentSessionsSanitizer';
 
+const validSessionSummary = {
+	title: 'Recent session',
+	filePath: 'session.jsonl',
+	interactions: 3,
+	toolCalls: 2,
+	inputTokens: 100,
+	outputTokens: 50,
+	thinkingTokens: 10,
+	cachedTokens: 20,
+	totalTokens: 180,
+	estimatedCost: 0.01,
+	editor: 'VS Code',
+	models: ['gpt-5'],
+	lastActivity: '2026-08-31T12:00:00.000Z',
+};
+
 describe('buildRecentSessionBuckets', () => {
 	test('buckets recent sessions and sorts each period by interactions', () => {
 		const result = buildRecentSessionBuckets([
 			{ activityKey: '2026-08-31', interactions: 2, value: 'recent-low' },
 			{ activityKey: '2026-08-30', interactions: 8, value: 'recent-high' },
 			{ activityKey: '2026-08-15', interactions: 5, value: 'month-only' },
+			{ activityKey: '2026-08-25', interactions: 6, value: 'outside-last7' },
 			{ activityKey: '2026-07-20', interactions: 20, value: 'too-old' },
 		], new Date(2026, 8, 1, 12));
 
 		assert.deepEqual(result.last7, ['recent-high', 'recent-low']);
-		assert.deepEqual(result.last30, ['recent-high', 'month-only', 'recent-low']);
+		assert.deepEqual(result.last30, ['recent-high', 'outside-last7', 'month-only', 'recent-low']);
 		assert.deepEqual(result.currentMonth, []);
 	});
 });
 
 describe('sanitizeRecentSessionBuckets', () => {
-	test('filters malformed summaries while preserving every supported period', () => {
+	test('filters incomplete or malformed summaries while preserving every supported period', () => {
 		const result = sanitizeRecentSessionBuckets({
-			last7: [{ interactions: 3, filePath: 'session.jsonl' }, null, { interactions: '3' }],
+			last7: [
+				validSessionSummary,
+				null,
+				{ interactions: 1 },
+				{ ...validSessionSummary, estimatedCost: undefined },
+				{ ...validSessionSummary, models: ['gpt-5', 5] },
+			],
 			last30: [],
-			currentMonth: [{ interactions: 1 }],
+			currentMonth: [{ ...validSessionSummary, title: null, workspace: 'token-tracker' }],
 		});
 
 		assert.deepEqual(result, {
-			last7: [{ interactions: 3, filePath: 'session.jsonl' }],
+			last7: [validSessionSummary],
 			last30: [],
-			currentMonth: [{ interactions: 1 }],
+			currentMonth: [{ ...validSessionSummary, title: null, workspace: 'token-tracker' }],
 		});
 	});
 

--- a/vscode-extension/test/unit/recentSessions.test.ts
+++ b/vscode-extension/test/unit/recentSessions.test.ts
@@ -1,0 +1,39 @@
+import { describe, test } from 'node:test';
+import * as assert from 'node:assert/strict';
+import { buildRecentSessionBuckets } from '../../../src/recentSessions';
+import { sanitizeRecentSessionBuckets } from '../../src/webview/usage/recentSessionsSanitizer';
+
+describe('buildRecentSessionBuckets', () => {
+	test('buckets recent sessions and sorts each period by interactions', () => {
+		const result = buildRecentSessionBuckets([
+			{ activityKey: '2026-08-31', interactions: 2, value: 'recent-low' },
+			{ activityKey: '2026-08-30', interactions: 8, value: 'recent-high' },
+			{ activityKey: '2026-08-15', interactions: 5, value: 'month-only' },
+			{ activityKey: '2026-07-20', interactions: 20, value: 'too-old' },
+		], new Date(2026, 8, 1, 12));
+
+		assert.deepEqual(result.last7, ['recent-high', 'recent-low']);
+		assert.deepEqual(result.last30, ['recent-high', 'month-only', 'recent-low']);
+		assert.deepEqual(result.currentMonth, []);
+	});
+});
+
+describe('sanitizeRecentSessionBuckets', () => {
+	test('filters malformed summaries while preserving every supported period', () => {
+		const result = sanitizeRecentSessionBuckets({
+			last7: [{ interactions: 3, filePath: 'session.jsonl' }, null, { interactions: '3' }],
+			last30: [],
+			currentMonth: [{ interactions: 1 }],
+		});
+
+		assert.deepEqual(result, {
+			last7: [{ interactions: 3, filePath: 'session.jsonl' }],
+			last30: [],
+			currentMonth: [{ interactions: 1 }],
+		});
+	});
+
+	test('rejects partial payloads so callers can use their lazy-loading fallback', () => {
+		assert.equal(sanitizeRecentSessionBuckets({ last7: [] }), undefined);
+	});
+});


### PR DESCRIPTION
## Why

Switching the Recent Sessions period in Visual Studio or JetBrains left the shared Usage Analysis view stuck on "Loading sessions...". Those hosts render the shared webview but do not implement its VS Code-only `loadRecentSessions` message.

## What changed

- Add a shared recent-session bucketing helper used by both VS Code and the CLI.
- Include `last7`, `last30`, and `currentMonth` session summaries in CLI usage-analysis payloads.
- Sanitize and hydrate those buckets in the shared webview while preserving VS Code's existing lazy-loading fallback.
- Refresh the committed Visual Studio Usage Analysis bundle.
- Add regression coverage for bucket boundaries, payload sanitization, and the CLI host contract.

## Validation

- VS Code extension unit tests
- CLI unit tests
- Visual Studio extension build
- JetBrains plugin tests