### PR TITLE
refactor: decompose startTimerIfEnabled into focused private helpers

### DIFF
--- a/vscode-extension/src/backend/services/syncService.ts
+++ b/vscode-extension/src/backend/services/syncService.ts
@@ -159,6 +159,62 @@ export class SyncService {
 	}
 
 	/**
+	 * Determine whether the sync timer is allowed to start, logging the reason when it isn't.
+	 */
+	private _canStartSyncTimer(settings: BackendSettings, isConfigured: boolean): boolean {
+		const sharingPolicy = computeBackendSharingPolicy({
+			enabled: settings.enabled,
+			profile: settings.sharingProfile,
+			shareWorkspaceMachineNames: settings.shareWorkspaceMachineNames
+		});
+		if (!sharingPolicy.allowCloudSync) {
+			this.deps.logger.log(`Backend sync: not starting timer (cloud sync disabled, profile: ${settings.sharingProfile})`);
+			return false;
+		}
+		if (!isConfigured) {
+			this.deps.logger.log('Backend sync: not starting timer (backend not configured)');
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * Handle a failed periodic (timer-driven) sync: track consecutive failures,
+	 * surface a user-facing warning/error at the relevant thresholds, and stop
+	 * the timer once failures exceed {@link MAX_CONSECUTIVE_FAILURES}.
+	 */
+	private _handleTimerSyncFailure(e: unknown): void {
+		const err = e as { message?: string } | undefined;
+		this.deps.logger.warn(`Backend sync timer failed: ${err?.message ?? e}`);
+		this.consecutiveFailures++;
+
+		// Show user-facing warning after first few failures
+		if (this.consecutiveFailures === 3) {
+			vscode.window.showWarningMessage(
+				'Backend sync is experiencing issues. Check the output panel for details.',
+				'Show Output'
+			).then(choice => {
+				if (choice === 'Show Output') {
+					// User can manually open output panel via command palette
+				}
+			});
+		}
+
+		if (this.consecutiveFailures >= this.MAX_CONSECUTIVE_FAILURES) {
+			this.deps.logger.warn(`Backend sync: stopping timer after ${this.MAX_CONSECUTIVE_FAILURES} consecutive failures`);
+			vscode.window.showErrorMessage(
+				'Backend sync stopped after repeated failures. Check your Azure configuration.',
+				'Configure Backend'
+			).then(choice => {
+				if (choice === 'Configure Backend') {
+					vscode.commands.executeCommand('aiEngineeringFluency.configureBackend');
+				}
+			});
+			this.stopTimer();
+		}
+	}
+
+	/**
 	 * Start the background sync timer if backend is enabled.
 	 * @param settings - Backend settings to check if sync should be enabled
 	 * @param isConfigured - Whether the backend is fully configured
@@ -166,51 +222,13 @@ export class SyncService {
 	startTimerIfEnabled(settings: BackendSettings, isConfigured: boolean): void {
 		try {
 			this.stopTimer();
-			const sharingPolicy = computeBackendSharingPolicy({
-				enabled: settings.enabled,
-				profile: settings.sharingProfile,
-				shareWorkspaceMachineNames: settings.shareWorkspaceMachineNames
-			});
-			if (!sharingPolicy.allowCloudSync || !isConfigured) {
-				if (!sharingPolicy.allowCloudSync) {
-					this.deps.logger.log(`Backend sync: not starting timer (cloud sync disabled, profile: ${settings.sharingProfile})`);
-				} else if (!isConfigured) {
-					this.deps.logger.log('Backend sync: not starting timer (backend not configured)');
-				}
+			if (!this._canStartSyncTimer(settings, isConfigured)) {
 				return;
 			}
 			const intervalMs = BACKEND_SYNC_MIN_INTERVAL_MS;
 			this.deps.logger.log(`Backend sync: starting timer with interval ${intervalMs}ms (${intervalMs / 60000} minutes)`);
 			this.backendSyncInterval = setInterval(() => {
-				this.syncToBackendStore(false, settings, isConfigured).catch((e) => {
-					this.deps.logger.warn(`Backend sync timer failed: ${e?.message ?? e}`);
-					this.consecutiveFailures++;
-					
-					// Show user-facing warning after first few failures
-					if (this.consecutiveFailures === 3) {
-						vscode.window.showWarningMessage(
-							'Backend sync is experiencing issues. Check the output panel for details.',
-							'Show Output'
-						).then(choice => {
-							if (choice === 'Show Output') {
-								// User can manually open output panel via command palette
-							}
-						});
-					}
-					
-					if (this.consecutiveFailures >= this.MAX_CONSECUTIVE_FAILURES) {
-						this.deps.logger.warn(`Backend sync: stopping timer after ${this.MAX_CONSECUTIVE_FAILURES} consecutive failures`);
-						vscode.window.showErrorMessage(
-							'Backend sync stopped after repeated failures. Check your Azure configuration.',
-							'Configure Backend'
-						).then(choice => {
-							if (choice === 'Configure Backend') {
-								vscode.commands.executeCommand('aiEngineeringFluency.configureBackend');
-							}
-						});
-						this.stopTimer();
-					}
-				});
+				this.syncToBackendStore(false, settings, isConfigured).catch((e) => this._handleTimerSyncFailure(e));
 			}, intervalMs);
 			// Immediate initial sync (forced to ensure settings changes take effect)
 			this.syncToBackendStore(true, settings, isConfigured).catch((e) => {


### PR DESCRIPTION
## Motivation

ESLint `max-lines-per-function` flags `SyncService.startTimerIfEnabled` (57 lines at a threshold of 50). The method mixed three concerns — the sharing-policy/configuration gate, the periodic-sync failure handling (consecutive-failure tracking, user warnings, timer shutdown), and the timer/initial-sync orchestration — which made the control flow hard to follow.

## Change

Decomposed `startTimerIfEnabled` into focused private helpers. No public or exported signatures changed; behaviour is identical.

| Helper | Responsibility |
|---|---|
| `_canStartSyncTimer(settings, isConfigured)` | Compute the sharing policy and decide whether the timer may start, logging the specific skip reason (cloud sync disabled / not configured). Returns `boolean`. |
| `_handleTimerSyncFailure(e)` | Handle a failed timer-driven sync: increment `consecutiveFailures`, show the warning at 3 failures, and show the error + `stopTimer()` once `MAX_CONSECUTIVE_FAILURES` is reached. |

`startTimerIfEnabled` is now a short orchestrator: stop any existing timer, gate via `_canStartSyncTimer`, schedule the interval (delegating failures to `_handleTimerSyncFailure`), and kick off the forced initial sync.

## Verification

- `tsc --noEmit` — clean
- `npm run test:node` — all unit tests pass (incl. `backend-syncService.test.js`, `backend-syncService-utils.test.js`)
- `node esbuild.js --production` — build succeeds
- `eslint src/backend/services/syncService.ts` — no new warnings; the `startTimerIfEnabled` violation is resolved

### Pre-existing warnings not addressed

`syncToSharingServer` in the same file still exceeds the line threshold (61 lines) — pre-existing and out of scope for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
