### PR TITLE
test: cover startTimerIfEnabled skip-reason logging

### DIFF
--- a/vscode-extension/test/unit/backend-syncService.test.ts
+++ b/vscode-extension/test/unit/backend-syncService.test.ts
@@ -130,6 +130,29 @@ test('startTimerIfEnabled starts timer when configured and cloud sync is allowed
 	svc.dispose();
 });
 
+test('startTimerIfEnabled logs the cloud-sync-disabled reason when the profile forbids cloud sync', () => {
+	const logs: string[] = [];
+	const svc = makeService({ log: (m) => logs.push(m) });
+	svc.startTimerIfEnabled(
+		{ enabled: true, sharingProfile: 'off', shareWorkspaceMachineNames: false } as any,
+		true
+	);
+	assert.ok(logs.some(m => m.includes('cloud sync disabled') && m.includes('off')));
+	svc.dispose();
+});
+
+test('startTimerIfEnabled logs the not-configured reason when cloud sync is allowed but backend is unconfigured', () => {
+	const logs: string[] = [];
+	const svc = makeService({ log: (m) => logs.push(m) });
+	svc.startTimerIfEnabled(
+		{ enabled: true, sharingProfile: 'soloFull', shareWorkspaceMachineNames: false } as any,
+		false
+	);
+	assert.ok(logs.some(m => m.includes('backend not configured')));
+	assert.ok(!logs.some(m => m.includes('cloud sync disabled')));
+	svc.dispose();
+});
+
 test('stopTimer is idempotent', () => {
 	const svc = makeService();
 	svc.stopTimer();


### PR DESCRIPTION
Follow-up to #1913, which merged without a test companion (the "Test coverage companion check" failed but was non-blocking).

Adds two unit tests to `backend-syncService.test.ts` verifying the skip-reason logging in `SyncService.startTimerIfEnabled` (the `_canStartSyncTimer` gate extracted in #1913):

- logs `cloud sync disabled` + the profile name when the sharing profile forbids cloud sync
- logs `backend not configured` (and not the cloud-sync message) when cloud sync is allowed but the backend is unconfigured

Test-only change. `tsc -p tsconfig.tests.json` and `npm run test:node` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)