### PR TITLE
ci(skills-eval): upload the HTML report as its own artifact

### DIFF
--- a/.github/workflows/scripts/skills-eval.mjs
+++ b/.github/workflows/scripts/skills-eval.mjs
@@ -117,11 +117,15 @@ const result = await evaluateSkills({
 // Report runner-relative paths: the absolute /home/runner/... paths are
 // meaningless once the job is gone, so point at the artifact contents instead.
 const rel = (p) => (p ? path.relative(process.cwd(), p).split(path.sep).join("/") : undefined);
-const workspaceRel = rel(result.workspaceRoot);
-// Path of the report inside the workspace artifact, whose contents are stored
-// relative to the workspace root (e.g. `iteration-1/report/index.html`).
+// `agent-skills-eval-workspace` is uploaded from the EVAL_WORKSPACE directory,
+// so its contents are stored relative to that. Note this is NOT
+// `result.workspaceRoot`, which under the "iteration" layout points one level
+// deeper at the current iteration-N directory.
+const uploadRoot = path.resolve(workspace);
+const workspaceRel = rel(uploadRoot);
+// Path of the report inside that artifact, e.g. `iteration-1/report/index.html`.
 const reportInWorkspaceArtifact = result.reportPath
-  ? path.relative(result.workspaceRoot, result.reportPath).split(path.sep).join("/")
+  ? path.relative(uploadRoot, result.reportPath).split(path.sep).join("/")
   : undefined;
 
 // Hand the report directory to the workflow so it can be uploaded as a flat,

--- a/.github/workflows/scripts/skills-eval.mjs
+++ b/.github/workflows/scripts/skills-eval.mjs
@@ -118,7 +118,11 @@ const result = await evaluateSkills({
 // meaningless once the job is gone, so point at the artifact contents instead.
 const rel = (p) => (p ? path.relative(process.cwd(), p).split(path.sep).join("/") : undefined);
 const workspaceRel = rel(result.workspaceRoot);
-const reportRel = rel(result.reportPath);
+// Path of the report inside the workspace artifact, whose contents are stored
+// relative to the workspace root (e.g. `iteration-1/report/index.html`).
+const reportInWorkspaceArtifact = result.reportPath
+  ? path.relative(result.workspaceRoot, result.reportPath).split(path.sep).join("/")
+  : undefined;
 
 const lines = [
   "## Agent Skills Eval (weekly, Copilot CLI)",
@@ -126,9 +130,10 @@ const lines = [
   `- Skills with evals: **${result.skills.length}**`,
   `- Runs passed: **${result.passed}** · failed: **${result.failed}**`,
   `- Artifact \`agent-skills-eval-workspace\` → \`${workspaceRel}\` (raw prompts, outputs, gradings)`,
-  ...(reportRel
+  ...(reportInWorkspaceArtifact
     ? [
-        `- Artifact \`agent-skills-eval-report\` → HTML report (\`${reportRel}\` in the workspace artifact); download and open \`index.html\` in a browser`,
+        "- Artifact `agent-skills-eval-report` → the HTML report on its own; download it and open `index.html` in a browser",
+        `- The same report is also inside \`agent-skills-eval-workspace\` at \`${reportInWorkspaceArtifact}\``,
       ]
     : ["- No HTML report was generated for this run."]),
   "",

--- a/.github/workflows/scripts/skills-eval.mjs
+++ b/.github/workflows/scripts/skills-eval.mjs
@@ -114,12 +114,23 @@ const result = await evaluateSkills({
 });
 
 // ── GitHub Actions step summary ──────────────────────────────────────────────
+// Report runner-relative paths: the absolute /home/runner/... paths are
+// meaningless once the job is gone, so point at the artifact contents instead.
+const rel = (p) => (p ? path.relative(process.cwd(), p).split(path.sep).join("/") : undefined);
+const workspaceRel = rel(result.workspaceRoot);
+const reportRel = rel(result.reportPath);
+
 const lines = [
   "## Agent Skills Eval (weekly, Copilot CLI)",
   "",
   `- Skills with evals: **${result.skills.length}**`,
   `- Runs passed: **${result.passed}** · failed: **${result.failed}**`,
-  `- Artifacts: \`${result.workspaceRoot}\`${result.reportPath ? ` · report: \`${result.reportPath}\`` : ""}`,
+  `- Artifact \`agent-skills-eval-workspace\` → \`${workspaceRel}\` (raw prompts, outputs, gradings)`,
+  ...(reportRel
+    ? [
+        `- Artifact \`agent-skills-eval-report\` → HTML report (\`${reportRel}\` in the workspace artifact); download and open \`index.html\` in a browser`,
+      ]
+    : ["- No HTML report was generated for this run."]),
   "",
   "| Skill | Evals | Pass rate |",
   "|---|---|---|",

--- a/.github/workflows/scripts/skills-eval.mjs
+++ b/.github/workflows/scripts/skills-eval.mjs
@@ -124,6 +124,14 @@ const reportInWorkspaceArtifact = result.reportPath
   ? path.relative(result.workspaceRoot, result.reportPath).split(path.sep).join("/")
   : undefined;
 
+// Hand the report directory to the workflow so it can be uploaded as a flat,
+// report-only artifact. upload-artifact roots an artifact at the non-glob
+// prefix of its `path`, so passing the concrete report directory (rather than a
+// glob spanning the workspace) is what puts index.html at the artifact root.
+if (process.env.GITHUB_OUTPUT && result.reportPath) {
+  appendFileSync(process.env.GITHUB_OUTPUT, `report-dir=${path.dirname(result.reportPath)}\n`);
+}
+
 const lines = [
   "## Agent Skills Eval (weekly, Copilot CLI)",
   "",
@@ -132,7 +140,7 @@ const lines = [
   `- Artifact \`agent-skills-eval-workspace\` → \`${workspaceRel}\` (raw prompts, outputs, gradings)`,
   ...(reportInWorkspaceArtifact
     ? [
-        "- Artifact `agent-skills-eval-report` → the HTML report on its own; download it and open `index.html` in a browser",
+        "- Artifact `agent-skills-eval-report` → the HTML report on its own; download it and open `index.html` at the artifact root",
         `- The same report is also inside \`agent-skills-eval-workspace\` at \`${reportInWorkspaceArtifact}\``,
       ]
     : ["- No HTML report was generated for this run."]),

--- a/.github/workflows/skills-eval.yml
+++ b/.github/workflows/skills-eval.yml
@@ -77,11 +77,23 @@ jobs:
           EVAL_WORKSPACE: ./agent-skills-workspace
         run: node .github/workflows/scripts/skills-eval.mjs
 
-      - name: Upload eval workspace and report
+      - name: Upload eval workspace (raw prompts, outputs and gradings)
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: agent-skills-eval-workspace
           path: agent-skills-workspace/
+          if-no-files-found: warn
+          retention-days: 90
+
+      # The HTML report also lives inside the workspace artifact above, but it is
+      # buried several levels deep in a large zip. Upload it separately so it can
+      # be downloaded and opened on its own.
+      - name: Upload HTML report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: agent-skills-eval-report
+          path: agent-skills-workspace/**/report/**
           if-no-files-found: warn
           retention-days: 90

--- a/.github/workflows/skills-eval.yml
+++ b/.github/workflows/skills-eval.yml
@@ -68,6 +68,7 @@ jobs:
           npm install --ignore-scripts --no-audit --no-fund agent-skills-eval@0.1.1
 
       - name: Run agent-skills-eval via the Copilot CLI
+        id: eval
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
           COPILOT_GITHUB_TOKEN: ${{ secrets.GH_PAT }}
@@ -86,14 +87,15 @@ jobs:
           if-no-files-found: warn
           retention-days: 90
 
-      # The HTML report also lives inside the workspace artifact above, but it is
-      # buried several levels deep in a large zip. Upload it separately so it can
-      # be downloaded and opened on its own.
+      # The report also lives inside the workspace artifact above, but it is
+      # buried several levels deep in a large zip. Upload the report directory
+      # itself (reported by the eval script) so this artifact unzips to a bare
+      # index.html that can be opened directly.
       - name: Upload HTML report
-        if: always()
+        if: always() && steps.eval.outputs.report-dir != ''
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: agent-skills-eval-report
-          path: agent-skills-workspace/**/report/**
+          path: ${{ steps.eval.outputs.report-dir }}
           if-no-files-found: warn
           retention-days: 90


### PR DESCRIPTION
## What

The Agent Skills Eval workflow's HTML report (`agent-skills-workspace/iteration-N/report/index.html`) *was* already being uploaded — it's inside the `agent-skills-eval-workspace` artifact — but it's buried several levels deep in a large zip, and the step summary printed the absolute runner path (`/home/runner/work/.../report/index.html`), which is meaningless once the job is gone. The net effect was that the report looked missing and couldn't be validated.

## Changes

- **`.github/workflows/skills-eval.yml`** — added a second `upload-artifact` step that publishes just the report as `agent-skills-eval-report` (`agent-skills-workspace/**/report/**`), alongside the existing full-workspace artifact.
- **`.github/workflows/scripts/skills-eval.mjs`** — the step summary now prints workspace-relative paths and names both artifacts, instead of absolute runner paths.

## Verification

- Downloaded the artifact from the last successful run (`33411295655`) and confirmed `iteration-1/report/index.html` (103 KB) is present — so the report content itself was fine, only its discoverability was the problem.
- `node --check` on the script and a YAML parse of the workflow both pass.