### PR TITLE
skills-eval: report model count and per-skill suggested next steps

### DIFF
--- a/.github/workflows/scripts/skills-eval.mjs
+++ b/.github/workflows/scripts/skills-eval.mjs
@@ -18,7 +18,6 @@
 import { spawnSync } from "node:child_process";
 import {
   appendFileSync,
-  existsSync,
   mkdtempSync,
   readFileSync,
   readdirSync,
@@ -63,15 +62,21 @@ const resolvedModels = new Set();
 
 function scrapeResolvedModel(beforeFiles) {
   try {
-    const newFile = readdirSync(cliLogDir).find((f) => !beforeFiles.has(f));
-    if (!newFile) {
-      return undefined;
+    // A single CLI call can emit more than one log file, so scan every new one
+    // and delete them all — leaving strays behind would grow unboundedly across
+    // the run, and reading only the first could miss the file with the model.
+    const newFiles = readdirSync(cliLogDir).filter((f) => !beforeFiles.has(f));
+    let resolved;
+    for (const file of newFiles) {
+      const logPath = path.join(cliLogDir, file);
+      try {
+        resolved ??= readFileSync(logPath, "utf-8").match(/"model":\s*"([^"]+)"/)?.[1];
+      } catch {
+        // Unreadable log file — keep going, the next one may still have it.
+      }
+      rmSync(logPath, { force: true });
     }
-    const logPath = path.join(cliLogDir, newFile);
-    const content = readFileSync(logPath, "utf-8");
-    rmSync(logPath, { force: true });
-    const match = content.match(/"model":\s*"([^"]+)"/);
-    return match?.[1];
+    return resolved;
   } catch {
     return undefined; // Best-effort only — never let log scraping break the eval run.
   }
@@ -89,7 +94,15 @@ function copilotCliProvider() {
     model: modelName,
     async complete(prompt) {
       const started = Date.now();
-      const beforeFiles = new Set(readdirSync(cliLogDir));
+      // Snapshot the log dir so scrapeResolvedModel can tell which files this
+      // call produced. Guarded because a throw here would abort the whole run
+      // (see the ProviderResult error note below) for a purely cosmetic stat.
+      let beforeFiles = new Set();
+      try {
+        beforeFiles = new Set(readdirSync(cliLogDir));
+      } catch {
+        // Log dir unreadable — scraping degrades to the placeholder model name.
+      }
       const args = [
         "--yes",
         "@github/copilot",
@@ -193,24 +206,27 @@ function escapeHtml(value) {
 // `eval-*` followed by a slash, because that sequence closes the comment early.
 function collectFailingAssertions(skillDir) {
   const failures = [];
-  if (!existsSync(skillDir)) {
+  // Read first and handle the failure, rather than checking existence and then
+  // reading: the check-then-use pattern is a TOCTOU race (CodeQL
+  // js/file-system-race) and needs the same error handling anyway.
+  let entries;
+  try {
+    entries = readdirSync(skillDir, { withFileTypes: true });
+  } catch {
     return failures;
   }
-  for (const entry of readdirSync(skillDir, { withFileTypes: true })) {
+  for (const entry of entries) {
     if (!entry.isDirectory() || !entry.name.startsWith("eval-")) {
       continue;
     }
     const evalDir = path.join(skillDir, entry.name);
     for (const mode of ["with_skill", "without_skill"]) {
       const gradingPath = path.join(evalDir, mode, "grading.json");
-      if (!existsSync(gradingPath)) {
-        continue;
-      }
       let grading;
       try {
         grading = JSON.parse(readFileSync(gradingPath, "utf-8"));
       } catch {
-        continue;
+        continue; // Missing (mode never ran) or malformed — nothing to report.
       }
       for (const r of grading.assertion_results ?? []) {
         if (!r.passed) {
@@ -269,9 +285,18 @@ function buildSuggestion(skillDir, benchmark) {
   };
 }
 
-if (result.reportPath && existsSync(result.reportPath)) {
-  let html = readFileSync(result.reportPath, "utf-8");
+// Read the report rather than checking existence and then reading it: the
+// check-then-use pattern is a TOCTOU race (CodeQL js/file-system-race), and a
+// missing report is already an expected case (the run may have failed before
+// the renderer got to it).
+let html;
+try {
+  html = result.reportPath ? readFileSync(result.reportPath, "utf-8") : undefined;
+} catch {
+  html = undefined;
+}
 
+if (html !== undefined) {
   // Model count + name stat, so it's obvious at a glance how many distinct
   // models this run actually evaluated with (today always 1: same model for
   // target and judge) and which one, without hunting for the separate

--- a/.github/workflows/scripts/skills-eval.mjs
+++ b/.github/workflows/scripts/skills-eval.mjs
@@ -31,6 +31,10 @@ const { evaluateSkills, consoleReporter } = await import(
 );
 
 const modelName = process.env.COPILOT_MODEL || "copilot-cli-default";
+// Kept as separate names so the model count reported below is derived from the
+// values actually handed to evaluateSkills, rather than assumed to be 1.
+const targetModel = modelName;
+const judgeModel = modelName;
 const skillsRoot = process.env.SKILLS_ROOT || ".github/skills";
 const workspace = process.env.EVAL_WORKSPACE || "./agent-skills-workspace";
 
@@ -104,8 +108,8 @@ const result = await evaluateSkills({
   root: skillsRoot,
   workspace,
   baseline: true,
-  target: { model: modelName, provider },
-  judge: { model: modelName, provider },
+  target: { model: targetModel, provider },
+  judge: { model: judgeModel, provider },
   concurrency: 1,
   workspaceLayout: "iteration",
   report: true,
@@ -113,10 +117,11 @@ const result = await evaluateSkills({
   onEvent: consoleReporter(),
 });
 
-// target and judge are always this same driver's single `modelName` today —
-// there is no multi-model matrix. Computed as a de-duplicated set (rather than
-// hardcoded to 1) so this stays correct if target/judge ever diverge.
-const modelsUsed = Array.from(new Set([modelName, modelName]));
+// The target and judge are both driven by this script's single model today, so
+// this set has one entry. Deriving it from the two values actually passed to
+// evaluateSkills (rather than hardcoding 1) keeps the count honest if they ever
+// diverge into a real multi-model matrix.
+const modelsUsed = Array.from(new Set([targetModel, judgeModel]));
 
 // ── Per-skill "suggested next step" (report only) ───────────────────────────
 // agent-skills-eval's own HTML report (report.js, vendored via npm — not ours
@@ -132,7 +137,9 @@ function escapeHtml(value) {
     .replace(/"/g, "&quot;");
 }
 
-/** Scans `<skillDir>/eval-*/{with_skill,without_skill}/grading.json` for failed assertions. */
+// Scans `<skillDir>/eval-<slug>/<mode>/grading.json` for failed assertions.
+// NB: a line comment on purpose — a JSDoc block here cannot contain the glob
+// `eval-*` followed by a slash, because that sequence closes the comment early.
 function collectFailingAssertions(skillDir) {
   const failures = [];
   if (!existsSync(skillDir)) {

--- a/.github/workflows/scripts/skills-eval.mjs
+++ b/.github/workflows/scripts/skills-eval.mjs
@@ -258,9 +258,16 @@ function buildSuggestion(skillDir, benchmark) {
         `— evidence: "${f.evidence}". Add explicit guidance to SKILL.md covering this gap, then re-run.`,
     };
   }
+  // Every field below is optional-chained: benchmark.json's shape isn't
+  // contractually guaranteed by the SDK, and a missing/renamed field here must
+  // fall through to the safe "ok" default rather than throw and fail the
+  // workflow after the (potentially ~10 minute) eval has already run.
   const rs = benchmark?.run_summary;
-  if (rs?.without_skill && rs.delta) {
-    if (rs.with_skill.pass_rate.mean === 1 && rs.without_skill.pass_rate.mean === 1 && rs.delta.pass_rate === 0) {
+  const withMean = rs?.with_skill?.pass_rate?.mean;
+  const withoutMean = rs?.without_skill?.pass_rate?.mean;
+  const deltaPassRate = rs?.delta?.pass_rate;
+  if (withMean !== undefined && withoutMean !== undefined && deltaPassRate !== undefined) {
+    if (withMean === 1 && withoutMean === 1 && deltaPassRate === 0) {
       return {
         cls: "warn",
         text:
@@ -269,11 +276,11 @@ function buildSuggestion(skillDir, benchmark) {
           "skill-specific facts (exact paths, line numbers, function names) not inferable from general repo knowledge.",
       };
     }
-    if (rs.delta.pass_rate < 0) {
+    if (deltaPassRate < 0) {
       return {
         cls: "bad",
         text:
-          `with_skill scored lower than without_skill (Δ ${(rs.delta.pass_rate * 100).toFixed(1)}pp) — ` +
+          `with_skill scored lower than without_skill (Δ ${(deltaPassRate * 100).toFixed(1)}pp) — ` +
           "the skill's instructions may be actively confusing the model here. Review the failing assertions " +
           "above and correct the relevant SKILL.md section.",
       };
@@ -366,11 +373,20 @@ if (process.env.GITHUB_OUTPUT && result.reportPath) {
   appendFileSync(process.env.GITHUB_OUTPUT, `report-dir=${path.dirname(result.reportPath)}\n`);
 }
 
+// Backtick-escape each model name so a workflow_dispatch COPILOT_MODEL input
+// (or an unexpected value scraped from the CLI log) can't break out of the
+// Markdown code span it's rendered in below.
+const modelNamesForSummary = modelsUsed.map((m) => m.replace(/`/g, "'")).join("`, `");
+// The "same model used for target and judge" note is only true while a single
+// model backs both roles — keep it conditional so it can't go stale if this
+// ever becomes a real multi-model matrix (modelsUsed.length > 1).
+const modelSummaryNote = modelsUsed.length === 1 ? " — same model used for target and judge" : "";
+
 const lines = [
   "## Agent Skills Eval (weekly, Copilot CLI)",
   "",
   `- Skills with evals: **${result.skills.length}**`,
-  `- Model(s) evaluated: **${modelsUsed.length}** (\`${modelsUsed.join("`, `")}\`) — same model used for target and judge`,
+  `- Model(s) evaluated: **${modelsUsed.length}** (\`${modelNamesForSummary}\`)${modelSummaryNote}`,
   `- Runs passed: **${result.passed}** · failed: **${result.failed}**`,
   `- Artifact \`agent-skills-eval-workspace\` → \`${workspaceRel}\` (raw prompts, outputs, gradings)`,
   ...(reportInWorkspaceArtifact

--- a/.github/workflows/scripts/skills-eval.mjs
+++ b/.github/workflows/scripts/skills-eval.mjs
@@ -16,7 +16,7 @@
 //   - EVAL_WORKSPACE      artifact output dir (default ./agent-skills-workspace)
 
 import { spawnSync } from "node:child_process";
-import { appendFileSync } from "node:fs";
+import { appendFileSync, existsSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 
@@ -113,6 +113,152 @@ const result = await evaluateSkills({
   onEvent: consoleReporter(),
 });
 
+// target and judge are always this same driver's single `modelName` today —
+// there is no multi-model matrix. Computed as a de-duplicated set (rather than
+// hardcoded to 1) so this stays correct if target/judge ever diverge.
+const modelsUsed = Array.from(new Set([modelName, modelName]));
+
+// ── Per-skill "suggested next step" (report only) ───────────────────────────
+// agent-skills-eval's own HTML report (report.js, vendored via npm — not ours
+// to edit) shows pass/fail data but no actionable guidance. We post-process
+// the generated index.html below to inject a data-driven suggestion box per
+// skill, computed from the same grading.json/benchmark.json files the report
+// itself reads.
+function escapeHtml(value) {
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/** Scans `<skillDir>/eval-*/{with_skill,without_skill}/grading.json` for failed assertions. */
+function collectFailingAssertions(skillDir) {
+  const failures = [];
+  if (!existsSync(skillDir)) {
+    return failures;
+  }
+  for (const entry of readdirSync(skillDir, { withFileTypes: true })) {
+    if (!entry.isDirectory() || !entry.name.startsWith("eval-")) {
+      continue;
+    }
+    const evalDir = path.join(skillDir, entry.name);
+    for (const mode of ["with_skill", "without_skill"]) {
+      const gradingPath = path.join(evalDir, mode, "grading.json");
+      if (!existsSync(gradingPath)) {
+        continue;
+      }
+      let grading;
+      try {
+        grading = JSON.parse(readFileSync(gradingPath, "utf-8"));
+      } catch {
+        continue;
+      }
+      for (const r of grading.assertion_results ?? []) {
+        if (!r.passed) {
+          failures.push({ evalSlug: entry.name, mode, text: r.text, evidence: r.evidence });
+        }
+      }
+    }
+  }
+  return failures;
+}
+
+/**
+ * Builds a concrete, data-driven "what to do next" suggestion for one skill,
+ * prioritizing the most actionable signal available:
+ *   1. A concrete failing assertion (with judge evidence) in with_skill mode.
+ *   2. Both modes at 100% with zero delta — the eval isn't discriminating.
+ *   3. with_skill scoring worse than without_skill — the skill may be actively
+ *      confusing the model.
+ *   4. Otherwise, no action needed this run.
+ */
+function buildSuggestion(skillDir, benchmark) {
+  const withSkillFailures = collectFailingAssertions(skillDir).filter((f) => f.mode === "with_skill");
+  if (withSkillFailures.length > 0) {
+    const f = withSkillFailures[0];
+    return {
+      cls: "bad",
+      text:
+        `Judge FAILED an assertion in with_skill / ${f.evalSlug}: "${f.text}" ` +
+        `— evidence: "${f.evidence}". Add explicit guidance to SKILL.md covering this gap, then re-run.`,
+    };
+  }
+  const rs = benchmark?.run_summary;
+  if (rs?.without_skill && rs.delta) {
+    if (rs.with_skill.pass_rate.mean === 1 && rs.without_skill.pass_rate.mean === 1 && rs.delta.pass_rate === 0) {
+      return {
+        cls: "warn",
+        text:
+          "Both with_skill and without_skill scored 100% (Δ 0.0pp) — this eval isn't discriminating; " +
+          "the model already answers correctly without the skill. Write harder assertions that require " +
+          "skill-specific facts (exact paths, line numbers, function names) not inferable from general repo knowledge.",
+      };
+    }
+    if (rs.delta.pass_rate < 0) {
+      return {
+        cls: "bad",
+        text:
+          `with_skill scored lower than without_skill (Δ ${(rs.delta.pass_rate * 100).toFixed(1)}pp) — ` +
+          "the skill's instructions may be actively confusing the model here. Review the failing assertions " +
+          "above and correct the relevant SKILL.md section.",
+      };
+    }
+  }
+  return {
+    cls: "ok",
+    text: "No failing assertions this run, and the skill matches or outperforms the baseline — no action needed.",
+  };
+}
+
+if (result.reportPath && existsSync(result.reportPath)) {
+  let html = readFileSync(result.reportPath, "utf-8");
+
+  // Model count stat, so it's obvious at a glance how many distinct models
+  // this run actually evaluated with (today always 1: same model for target
+  // and judge).
+  html = html.replace(
+    '<div class="totals">',
+    `<div class="totals">\n      <div class="stat"><span class="label">models evaluated</span><span class="value">${modelsUsed.length}</span></div>`
+  );
+
+  // Suggestion box styling — appended alongside the report's own <style>
+  // block rather than editing it, since report.js is vendored via npm.
+  html = html.replace(
+    "</head>",
+    `  <style>
+  .suggestion { margin: 10px 0 0; padding: 10px 12px; border-radius: 6px; font-size: 13px; border-left: 4px solid var(--border); }
+  .suggestion.ok { border-left-color: var(--ok); background: var(--ok-bg); }
+  .suggestion.warn { border-left-color: var(--warn); background: var(--warn-bg); }
+  .suggestion.bad { border-left-color: var(--bad); background: var(--bad-bg); }
+  </style>
+</head>`
+  );
+
+  for (const s of result.skills) {
+    const skillDir = path.dirname(s.benchmarkPath);
+    let benchmark;
+    try {
+      benchmark = JSON.parse(readFileSync(s.benchmarkPath, "utf-8"));
+    } catch {
+      benchmark = undefined;
+    }
+    const suggestion = buildSuggestion(skillDir, benchmark);
+    const anchorIdx = html.indexOf(`id="skill-${s.slug}"`);
+    if (anchorIdx === -1) {
+      continue;
+    }
+    const evalsIdx = html.indexOf('<div class="evals">', anchorIdx);
+    if (evalsIdx === -1) {
+      continue;
+    }
+    const box = `<div class="suggestion ${suggestion.cls}"><strong>Suggested next step:</strong> ${escapeHtml(suggestion.text)}</div>\n      `;
+    html = html.slice(0, evalsIdx) + box + html.slice(evalsIdx);
+  }
+
+  writeFileSync(result.reportPath, html, "utf-8");
+}
+
 // ── GitHub Actions step summary ──────────────────────────────────────────────
 // Report runner-relative paths: the absolute /home/runner/... paths are
 // meaningless once the job is gone, so point at the artifact contents instead.
@@ -140,6 +286,7 @@ const lines = [
   "## Agent Skills Eval (weekly, Copilot CLI)",
   "",
   `- Skills with evals: **${result.skills.length}**`,
+  `- Model(s) evaluated: **${modelsUsed.length}** (\`${modelsUsed.join("`, `")}\`) — same model used for target and judge`,
   `- Runs passed: **${result.passed}** · failed: **${result.failed}**`,
   `- Artifact \`agent-skills-eval-workspace\` → \`${workspaceRel}\` (raw prompts, outputs, gradings)`,
   ...(reportInWorkspaceArtifact

--- a/.github/workflows/scripts/skills-eval.mjs
+++ b/.github/workflows/scripts/skills-eval.mjs
@@ -16,7 +16,16 @@
 //   - EVAL_WORKSPACE      artifact output dir (default ./agent-skills-workspace)
 
 import { spawnSync } from "node:child_process";
-import { appendFileSync, existsSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import {
+  appendFileSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 
@@ -38,6 +47,36 @@ const judgeModel = modelName;
 const skillsRoot = process.env.SKILLS_ROOT || ".github/skills";
 const workspace = process.env.EVAL_WORKSPACE || "./agent-skills-workspace";
 
+// ── Resolving the *actual* model name ────────────────────────────────────────
+// When COPILOT_MODEL is unset, `modelName` above is just the placeholder
+// string "copilot-cli-default" — it does not say which real model (e.g. a
+// specific GPT/Claude variant) the CLI picked. The CLI itself doesn't have a
+// flag that prints "the model I'd use" without actually running a prompt, but
+// every call — explicit --model or not — logs a `"model": "<name>"` field in
+// its wire-level debug log. So each CLI invocation below runs with
+// `--log-level debug --log-dir <scratch dir>`, and the log is scraped for
+// that field right after the call, giving us the real resolved model name
+// even when the CLI was left to pick its own default. Log files are deleted
+// immediately after scraping to avoid piling up disk usage across the run.
+const cliLogDir = mkdtempSync(path.join(os.tmpdir(), "copilot-cli-logs-"));
+const resolvedModels = new Set();
+
+function scrapeResolvedModel(beforeFiles) {
+  try {
+    const newFile = readdirSync(cliLogDir).find((f) => !beforeFiles.has(f));
+    if (!newFile) {
+      return undefined;
+    }
+    const logPath = path.join(cliLogDir, newFile);
+    const content = readFileSync(logPath, "utf-8");
+    rmSync(logPath, { force: true });
+    const match = content.match(/"model":\s*"([^"]+)"/);
+    return match?.[1];
+  } catch {
+    return undefined; // Best-effort only — never let log scraping break the eval run.
+  }
+}
+
 /**
  * Provider that completes prompts by running the Copilot CLI once per call.
  * Locked down for untrusted-ish prompt content: no tool approvals are granted
@@ -50,6 +89,7 @@ function copilotCliProvider() {
     model: modelName,
     async complete(prompt) {
       const started = Date.now();
+      const beforeFiles = new Set(readdirSync(cliLogDir));
       const args = [
         "--yes",
         "@github/copilot",
@@ -66,6 +106,10 @@ function copilotCliProvider() {
         "--deny-tool",
         "url",
         "--secret-env-vars=GH_TOKEN,COPILOT_GITHUB_TOKEN,GITHUB_TOKEN",
+        "--log-level",
+        "debug",
+        "--log-dir",
+        cliLogDir,
       ];
       if (process.env.COPILOT_MODEL) {
         args.push("--model", process.env.COPILOT_MODEL);
@@ -84,13 +128,15 @@ function copilotCliProvider() {
           : `exit code ${run.status}: ${(run.stderr || "").trim().slice(0, 2000)}`;
         console.error(`copilot CLI call failed after ${latencyMs}ms — ${detail}`);
       }
+      const resolvedModel = scrapeResolvedModel(beforeFiles) || modelName;
+      resolvedModels.add(resolvedModel);
       // On failure, return a ProviderResult with `error` set rather than
       // throwing: the framework's run-eval replaces the output with
       // "ERROR: <error>" so the judge fails the case closed, whereas a throw
       // would abort the entire evaluation run.
       return {
         provider: "copilot-cli",
-        model: modelName,
+        model: resolvedModel,
         output,
         latencyMs,
         inputTokens: 0,
@@ -117,11 +163,16 @@ const result = await evaluateSkills({
   onEvent: consoleReporter(),
 });
 
-// The target and judge are both driven by this script's single model today, so
-// this set has one entry. Deriving it from the two values actually passed to
-// evaluateSkills (rather than hardcoding 1) keeps the count honest if they ever
-// diverge into a real multi-model matrix.
-const modelsUsed = Array.from(new Set([targetModel, judgeModel]));
+// The target and judge are both driven by this script's single Copilot CLI
+// provider today, so this set has one entry in practice. It's built from the
+// models actually resolved by each CLI call (scraped from its debug log, see
+// scrapeResolvedModel above) rather than the requested `modelName`, so a run
+// left on the CLI's own default reports the real model (e.g. "claude-sonnet-5")
+// instead of the opaque "copilot-cli-default" placeholder. Falls back to
+// modelName if scraping failed for every call (e.g. no calls were made).
+const modelsUsed = resolvedModels.size > 0 ? Array.from(resolvedModels) : [modelName];
+
+rmSync(cliLogDir, { recursive: true, force: true });
 
 // ── Per-skill "suggested next step" (report only) ───────────────────────────
 // agent-skills-eval's own HTML report (report.js, vendored via npm — not ours

--- a/.github/workflows/scripts/skills-eval.mjs
+++ b/.github/workflows/scripts/skills-eval.mjs
@@ -214,12 +214,13 @@ function buildSuggestion(skillDir, benchmark) {
 if (result.reportPath && existsSync(result.reportPath)) {
   let html = readFileSync(result.reportPath, "utf-8");
 
-  // Model count stat, so it's obvious at a glance how many distinct models
-  // this run actually evaluated with (today always 1: same model for target
-  // and judge).
+  // Model count + name stat, so it's obvious at a glance how many distinct
+  // models this run actually evaluated with (today always 1: same model for
+  // target and judge) and which one, without hunting for the separate
+  // target/judge line in the header meta.
   html = html.replace(
     '<div class="totals">',
-    `<div class="totals">\n      <div class="stat"><span class="label">models evaluated</span><span class="value">${modelsUsed.length}</span></div>`
+    `<div class="totals">\n      <div class="stat"><span class="label">models evaluated</span><span class="value">${modelsUsed.length}</span><span class="muted" style="display:block;margin-top:2px;">${escapeHtml(modelsUsed.join(", "))}</span></div>`
   );
 
   // Suggestion box styling — appended alongside the report's own <style>


### PR DESCRIPTION
## What

Makes the Agent Skills Eval output actually actionable, following on from #1917 which only made the HTML report easy to *find*.

Three additions:

1. **Model count and name** - the report header and the step summary now state how many distinct models the run evaluated with, and name them. Today that is always 1 (the same Copilot CLI model acts as both target and judge), which was not obvious from either output.
2. **The *real* model, not the placeholder** - when `COPILOT_MODEL` is unset the script only knew the opaque label `copilot-cli-default`, which does not say which model the CLI actually picked. Every CLI call now runs with `--log-level debug --log-dir <scratch dir>`, and the wire-level `"model": "<name>"` field is scraped out of the resulting log, so the report names the model that really ran (e.g. `claude-sonnet-5`). Log files are deleted immediately after scraping and the scratch dir is removed at the end. Falls back to the placeholder if scraping ever fails.
3. **Per-skill "Suggested next step"** - the upstream `agent-skills-eval` report shows pass/fail data but no guidance on what to do about it. The script now post-processes the generated `index.html` to inject a data-driven suggestion box per skill, computed from the same `grading.json` / `benchmark.json` files the report already reads. It prioritises, in order:
   - a concrete failing assertion in `with_skill` mode, quoted with the judge's own evidence;
   - both arms at 100% with zero delta, i.e. the eval is not discriminating and is not proving the skill adds anything;
   - `with_skill` scoring *worse* than the baseline, i.e. the skill may be actively confusing the model.

The upstream report renderer is vendored via npm, so post-processing the emitted HTML is the least invasive way to add this.

## Two bugs found and fixed before merge

**A latent runtime crash.** The JSDoc on `collectFailingAssertions` contained the glob `eval-*/`, and the `*/` in that glob **terminates the block comment**. What follows then parses as real code, so `node --check` passes cleanly but the module throws at runtime:

```
ReferenceError: with_skill is not defined
```

Nasty failure mode: the crash lands *after* the ~10-minute eval has already run, and *before* `report-dir` is written to `GITHUB_OUTPUT` - so the job fails and the HTML report artifact is never uploaded. Fixed by using a line comment. Lesson for this file: `node --check` is not sufficient validation, the logic has to actually be executed.

**A CodeQL high-severity alert** (`js/file-system-race`) on the report post-processing. `existsSync()` followed by `readFileSync()` / `writeFileSync()` on the same path is a check-then-use race. Fixed at the source rather than suppressed: the existence checks are gone and the reads happen inside `try`/`catch`. All three sites (report read, skill directory listing, `grading.json` read) already needed error handling for the missing case, so this is simpler code as well as race-free.

Also fixed `Array.from(new Set([modelName, modelName]))`, which could only ever yield `1` despite a comment claiming it would track target/judge divergence.

## Robustness

Because all of this runs at the *end* of a ~10-minute eval, anything that throws there wastes the whole run and loses the report artifact. So every new failure path degrades quietly instead:

- the report read, the skill-directory listing and each `grading.json` read are all guarded;
- `buildSuggestion` optional-chains every `benchmark.json` field it touches, falling through to the safe "ok" suggestion if the SDK ever renames one;
- the log-directory snapshot taken before each CLI call is guarded, since a throw there would propagate out of the provider and abort the entire evaluation for a purely cosmetic stat;
- model names are backtick-escaped before going into the Markdown step summary, so a `workflow_dispatch` `COPILOT_MODEL` input cannot break out of the code span;
- the "same model used for target and judge" note only renders while there is exactly one model, so it cannot go stale if this ever becomes a real matrix.

## Verification

Nothing here was reasoned about on paper only.

- **`--log-dir` / `--log-level` are real flags** - confirmed against `@github/copilot --help`.
- **The debug log really carries the model** - confirmed by finding `"model": "claude-sonnet-5"` in an actual CLI log on disk. Some short-lived logs have no model field at all, which is exactly why the fallback exists.
- **The post-processing block was extracted and run against a real eval workspace artifact**, exercising genuine judge output rather than fixtures:
  - `models evaluated` stat injected, HTML stays well-formed (one `</head>`, one injected `<style>`, boxes nested correctly inside each skill article)
  - both suggestion branches fire - the `bad` failing-assertion branch and the `warn` non-discriminating branch
  - missing report path and missing skill directory both degrade quietly instead of throwing
  - the scraper finds the model in the second of two new log files and deletes both
- **A full live CI run** of `Agent Skills Eval` on this branch's head completed successfully, and its `agent-skills-eval-report` artifact was downloaded and inspected: it contains `models evaluated 1 / claude-sonnet-5` and both suggestion boxes, and the step summary reads ``Model(s) evaluated: **1** (`claude-sonnet-5`) - same model used for target and judge``.
- **CodeQL is clean**: "No new alerts in code changed by this pull request."

Example of what the report now says, from that run:

> **[warn]** Both with_skill and without_skill scored 100% (delta 0.0pp) - this eval isn't discriminating; the model already answers correctly without the skill. Write harder assertions that require skill-specific facts (exact paths, line numbers, function names) not inferable from general repo knowledge.

And from an earlier run that had a real failure:

> **[bad]** Judge FAILED an assertion in with_skill / `eval-knows-where-copilot-session-log-files-live`: "The output distinguishes the .json format (VS Code Copilot Chat) from the .jsonl format..." - evidence: "Output labels formats as (.json) vs (.jsonl) in section headers but never explains that .jsonl means 'one JSON event per line'..."

All SDK assumptions were checked against `agent-skills-eval@0.1.1`'s actual `dist/`: `result.skills[].slug` / `.benchmarkPath` exist, `grading.json` really uses `assertion_results[].{text,passed,evidence}`, `benchmark.json` really uses `run_summary.{with_skill,without_skill}.pass_rate.mean` and `run_summary.delta.pass_rate`, the report markup really has `<div class="totals">` / `id="skill-<slug>"` / `<div class="evals">`, and the `--ok/--warn/--bad` CSS variables are on `:root`. The `eval-` directory-prefix filter matches the SDK's own convention in `run-eval.js`.

## Note on CI

Pushing this branch triggers the `skills-eval` workflow (it watches its own paths), so the change is exercised end to end by a real run on every push.
