### PR TITLE
Fix Repository Hygiene Analysis false positive for missing README

### DIFF
--- a/vscode-extension/src/backend/repoHygieneSkill.ts
+++ b/vscode-extension/src/backend/repoHygieneSkill.ts
@@ -14,12 +14,13 @@ This skill analyzes repository structure and configuration to identify hygiene i
 
 ## Overview
 
-The skill performs 16 automated checks across 4 categories:
+The skill performs 17 automated checks across 5 categories:
 
 - **Version Control**: Git setup, ignore files, environment templates
 - **Code Quality**: Linters, formatters, type safety configuration
 - **CI/CD & Automation**: Continuous integration, standard scripts, task runners
 - **Environment**: Dev containers, Docker, runtime version pinning
+- **Documentation**: Root README file
 
 Each check has a weight (2-5) indicating its importance. The skill returns a structured JSON report with:
 
@@ -152,6 +153,16 @@ Each check has a weight (2-5) indicating its importance. The skill returns a str
 - **Description**: License file clarifies usage rights for contributors and agents
 - **Paths**: \`['LICENSE', 'LICENSE.md', 'LICENCE']\`
 
+### Category: Documentation (Weight: 5/76 total)
+
+#### 17. README File
+- **ID**: \`readme\`
+- **Weight**: 5 (Critical)
+- **Type**: File check
+- **Description**: README describes project purpose, setup, and usage for contributors and agents
+- **Paths**: \`['README.md', 'README', 'readme.md']\` (repository root only — check the file tree provided, do not assume it is missing just because it is not the first entry)
+- **Hint**: \`touch README.md  # describe project purpose, setup, and usage\`
+
 ## Total Weights: 81 points
 - Version Control: 13 points (16%)
 - Code Quality: 17 points (21%)
@@ -163,7 +174,7 @@ Each check has a weight (2-5) indicating its importance. The skill returns a str
 
 Return a structured JSON object with:
 - summary: Overall scores and category breakdowns
-- checks: Array of 16 check results (id, category, label, status, weight, found, detail, hint)
+- checks: Array of 17 check results (id, category, label, status, weight, found, detail, hint)
 - recommendations: Prioritized action items (priority, category, action, weight, impact)
 - metadata: Scan version, timestamp, repository info
 

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -7568,7 +7568,7 @@ Return ONLY the JSON object, no markdown formatting, no explanations.`;
 			'.eslintrc', 'eslint.config', '.prettierrc', 'prettier.config',
 			'tsconfig.json', 'jsconfig.json', 'package.json', 'Makefile',
 			'Dockerfile', 'docker-compose', '.github/workflows', '.devcontainer',
-			'LICENSE', '.nvmrc', '.node-version'
+			'LICENSE', '.nvmrc', '.node-version', 'README'
 		];
 
 		try {


### PR DESCRIPTION
## Problem
The "Repository Hygiene Analysis" in the AI Usage Analysis view reported "No README.md found at repository root" even though `README.md` exists at the repo root.

## Root cause
`getWorkspaceFileTree()` in `vscode-extension/src/extension.ts` builds a filtered file listing that gets embedded in the prompt sent to the Copilot model for analysis. Its `configPatterns` allow-list never included `README`, so an existing root `README.md` was silently dropped from the listing the LLM sees — the model then (correctly, given its incomplete input) reported it missing.

Additionally, `repoHygieneSkill.ts` documented only 16 checks across 4 categories, while the prompt/JSON schema in `extension.ts` asked for 17 checks across 5 categories (including a `documentation` category worth 5 points). The README check itself was never actually defined in the skill instructions, so the model had to improvise on how to detect it.

## Fix
- Added `README` to `configPatterns` in `getWorkspaceFileTree` so it's included in the file tree passed to the model.
- Added the missing "Documentation" category / check #17 (README File) definition to `repoHygieneSkill.ts`, aligning the skill doc with the 17-checks/5-categories schema already expected by `extension.ts`.

## Validation
- `npm run compile` — succeeds
- `npm run validate` (type-check + lint + build) — succeeds, only pre-existing unrelated complexity warnings