### PR TITLE
Fix label overlap in efficiency frontier chart for tightly clustered bubbles

### DIFF
--- a/vscode-extension/src/webview/usage/modelLeaderboard.ts
+++ b/vscode-extension/src/webview/usage/modelLeaderboard.ts
@@ -50,17 +50,35 @@ function createLabelPlacement(
 	};
 }
 
+const STACK_SLOTS = 5;
+const STACK_STEP = LABEL_HEIGHT + 3;
+
+/**
+ * Vertical offsets to try beside a bubble, ordered by preference. Beyond the immediate
+ * above/below slots this keeps stepping further away, so tightly clustered bubbles (which
+ * only have a couple of pixels between them) can still find a free row instead of settling
+ * for a placement that overlaps an already-placed label.
+ */
+function getStackedSideOffsets(input: BubbleLabelInput, bounds: BubbleLabelBounds): number[] {
+	const preferBelowFirst = input.y < (bounds.top + bounds.bottom) / 2;
+	const offsets: number[] = [];
+	for (let step = 0; step < STACK_SLOTS; step++) {
+		const below = input.y + 18 + step * STACK_STEP;
+		const above = input.y - 10 - step * STACK_STEP;
+		offsets.push(...(preferBelowFirst ? [below, above] : [above, below]));
+	}
+	return offsets;
+}
+
 function getLabelCandidates(input: BubbleLabelInput, bounds: BubbleLabelBounds): BubbleLabelPlacement[] {
 	const right = input.x + input.radius + LABEL_GAP;
 	const left = input.x - input.radius - LABEL_GAP;
 	const above = input.y - input.radius - 6;
 	const below = input.y + input.radius + LABEL_HEIGHT;
-	const sideY = input.y < bounds.top + 22 ? [input.y + 18, input.y - 10] : [input.y - 10, input.y + 18];
+	const stackedOffsets = getStackedSideOffsets(input, bounds);
 	return [
-		createLabelPlacement(input, right, sideY[0], 'start'),
-		createLabelPlacement(input, right, sideY[1], 'start'),
-		createLabelPlacement(input, left, sideY[0], 'end'),
-		createLabelPlacement(input, left, sideY[1], 'end'),
+		...stackedOffsets.map(y => createLabelPlacement(input, right, y, 'start')),
+		...stackedOffsets.map(y => createLabelPlacement(input, left, y, 'end')),
 		createLabelPlacement(input, input.x, above, 'middle'),
 		createLabelPlacement(input, input.x, below, 'middle'),
 	];

--- a/vscode-extension/test/unit/modelLeaderboard.test.ts
+++ b/vscode-extension/test/unit/modelLeaderboard.test.ts
@@ -50,6 +50,23 @@ test('placeBubbleLabels: separates labels for neighboring bubbles', () => {
 	}
 });
 
+test('placeBubbleLabels: separates labels for near-overlapping bubbles clustered in a corner', () => {
+	// Regression test: bubbles this close together (nearly touching, all near the
+	// top-left corner) used to run out of usable label slots and overlap.
+	const bubbles = [
+		{ x: 245, y: 40, radius: 8, label: 'GPT-5.6 Terra' },
+		{ x: 248, y: 40, radius: 12, label: 'GPT-5.6 Sol' },
+		{ x: 300, y: 40, radius: 6, label: 'Claude Fable 5' },
+	];
+	const placements = placeBubbleLabels(bubbles, { left: 76, right: 836, top: 24, bottom: 286 });
+
+	for (let i = 0; i < placements.length; i++) {
+		for (let j = i + 1; j < placements.length; j++) {
+			assert.equal(labelsOverlap(placements[i], placements[j]), false);
+		}
+	}
+});
+
 test('placeBubbleLabels: keeps long labels inside the chart bounds', () => {
 	const bounds = { left: 76, right: 836, top: 24, bottom: 286 };
 	const [placement] = placeBubbleLabels([


### PR DESCRIPTION
## Problem
On the "Local Model Leaderboard" → "Efficiency frontier" chart, when several models cluster tightly together (nearly touching bubbles, common near a chart corner), their labels overlap and become unreadable (e.g. `GPT-5.6Claude Fable 5`).

## Root cause
`placeBubbleLabels` in `vscode-extension/src/webview/usage/modelLeaderboard.ts` only tried 6 discrete candidate positions per bubble (right/above/below/left with 2 vertical offsets). When 3+ bubbles are packed closely, especially near an edge, those slots run out and the algorithm settles for an overlapping placement because all remaining candidates score even worse (chart-edge overflow).

## Fix
Expanded the side candidates into a stacked set of positions, ordered by preference (away from the nearest edge first, stepping progressively further out). This gives tightly clustered points enough free rows to avoid overlap while keeping the existing "prefer upper-right, avoid overflow/collisions" scoring logic.

## Testing
- Added a regression test reproducing the tightly-clustered corner scenario (`placeBubbleLabels: separates labels for near-overlapping bubbles clustered in a corner`).
- `npm run test:node` — all tests pass.
- `npm run compile` — builds cleanly.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>