### PR TITLE
Fix workspace health matrix dropping non-VS Code editor sessions

### DIFF
--- a/src/workspaceHelpers.ts
+++ b/src/workspaceHelpers.ts
@@ -948,6 +948,23 @@ export function resolveWorkspaceFolderFromSessionPath(sessionFilePath: string, w
 }
 
 /**
+ * Resolves a session file's workspace folder for cross-editor workspace attribution
+ * (e.g. the Copilot Customization Files health matrix). `resolveWorkspaceFolderFromSessionPath`
+ * only understands VS Code's `workspaceStorage/<id>` layout, so non-VS Code editors
+ * (Copilot CLI, JetBrains, Claude Code, etc.) never resolve through it and would otherwise
+ * be silently dropped instead of counted or surfaced as "Unresolved". Falls back to a
+ * workspace/cwd path already resolved onto the session data (e.g. Copilot CLI's
+ * `workspace.yaml` `cwd` or `session-store.db` `cwd` column) when the VS Code lookup fails.
+ */
+export function resolveWorkspaceFolderWithFallback(
+	sessionFilePath: string,
+	workspaceIdToFolderCache: Map<string, string | undefined>,
+	fallbackWorkspacePath?: string
+): string | undefined {
+	return resolveWorkspaceFolderFromSessionPath(sessionFilePath, workspaceIdToFolderCache) ?? fallbackWorkspacePath;
+}
+
+/**
  * Best-effort workspace display name for a session summary. Prefers an explicit
  * workspace folder path cached on the session, then the repository name, then
  * workspaceStorage folder resolution. Returns undefined when attribution is

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -223,6 +223,7 @@ import {
   parseWorkspaceStorageJsonFile as _parseWorkspaceStorageJsonFile,
   extractWorkspaceIdFromSessionPath as _extractWorkspaceIdFromSessionPath,
   resolveWorkspaceFolderFromSessionPath as _resolveWorkspaceFolderFromSessionPath,
+  resolveWorkspaceFolderWithFallback as _resolveWorkspaceFolderWithFallback,
   globToRegExp as _globToRegExp,
   resolveExactWorkspacePath as _resolveExactWorkspacePath,
   scanWorkspaceCustomizationFiles as _scanWorkspaceCustomizationFiles,
@@ -4646,11 +4647,17 @@ class CopilotTokenTracker implements vscode.Disposable {
 	private trackWorkspaceForSession(
 		sessionFile: string, interactions: number,
 		sessionCounts: Map<string, number>, interactionCounts: Map<string, number>,
-		unresolvedIds: Set<string>, unresolvedCounts: Map<string, number>
+		unresolvedIds: Set<string>, unresolvedCounts: Map<string, number>,
+		fallbackWorkspacePath?: string
 	): void {
 		const workspaceId = _extractWorkspaceIdFromSessionPath(sessionFile);
 		try {
-			const workspaceFolder = _resolveWorkspaceFolderFromSessionPath(sessionFile, this._workspaceIdToFolderCache);
+			// Prefer VS Code's workspaceStorage-based resolution (covers Copilot Chat sessions).
+			// Non-VS Code editors (Copilot CLI, JetBrains, Claude Code, etc.) don't live under a
+			// "workspaceStorage" folder, so fall back to the workspace/cwd path already resolved
+			// onto sessionData (e.g. Copilot CLI's workspace.yaml `cwd` or session-store.db `cwd`)
+			// so those workspaces still show up in the Copilot Customization Files health matrix.
+			const workspaceFolder = _resolveWorkspaceFolderWithFallback(sessionFile, this._workspaceIdToFolderCache, fallbackWorkspacePath);
 			if (workspaceFolder) {
 				const norm = path.normalize(workspaceFolder);
 				sessionCounts.set(norm, (sessionCounts.get(norm) || 0) + 1);
@@ -4751,7 +4758,8 @@ class CopilotTokenTracker implements vscode.Disposable {
 			this._incrementDelegationSessions(periods.last30DaysStats, sessionData);
 			this.trackWorkspaceForSession(sessionFile, interactions,
 				wsMaps.workspaceSessionCounts, wsMaps.workspaceInteractionCounts,
-				wsMaps.unresolvedWorkspaceIds, wsMaps.unresolvedWorkspaceInteractionCounts);
+				wsMaps.unresolvedWorkspaceIds, wsMaps.unresolvedWorkspaceInteractionCounts,
+				sessionData.workspaceFolderPath);
 			this._accumulateSkillCallsByEditor(sessionFile, analysis, sessionData.workspaceFolderPath);
 		}
 		if (lastActivityUtcKey >= periods.monthUtcStartKey) {

--- a/vscode-extension/test/unit/workspaceHelpers.test.ts
+++ b/vscode-extension/test/unit/workspaceHelpers.test.ts
@@ -1036,6 +1036,7 @@ import {
     resolveExactWorkspacePath,
     extractRepositoryFromContentReferences,
     resolveWorkspaceFolderFromSessionPath,
+    resolveWorkspaceFolderWithFallback,
 } from '../../../src/workspaceHelpers';
 
 test('escapeRegexSpecials: escapes dot', () => {
@@ -1677,6 +1678,34 @@ test('resolveWorkspaceFolderFromSessionPath: returns cached undefined on repeate
     resolveWorkspaceFolderFromSessionPath(path1, cache);
     // Now the cache should have been populated (even if undefined — no workspace.json exists)
     assert.ok(cache.has('abc123') || true); // cache may or may not have it depending on fs
+});
+
+// ---------------------------------------------------------------------------
+// resolveWorkspaceFolderWithFallback: cross-editor workspace attribution
+// ---------------------------------------------------------------------------
+
+test('resolveWorkspaceFolderWithFallback: returns VS Code workspaceStorage resolution when available', () => {
+    const cache = new Map<string, string | undefined>();
+    // Pre-seed cache so the VS Code lookup "succeeds" without touching the filesystem.
+    cache.set('abc123', '/resolved/vscode/workspace');
+    const path1 = '/home/user/.config/Code/User/workspaceStorage/abc123/chatSessions/session.json';
+    const result = resolveWorkspaceFolderWithFallback(path1, cache, '/fallback/cli/cwd');
+    assert.equal(result, '/resolved/vscode/workspace');
+});
+
+test('resolveWorkspaceFolderWithFallback: falls back to the supplied path when session is not workspaceStorage-scoped', () => {
+    const cache = new Map<string, string | undefined>();
+    // Copilot CLI session files live under ~/.copilot/session-state/<uuid>/events.jsonl — no workspaceStorage segment.
+    const cliSessionFile = '/home/user/.copilot/session-state/uuid-1/events.jsonl';
+    const result = resolveWorkspaceFolderWithFallback(cliSessionFile, cache, '/home/user/repos/devex-metrics');
+    assert.equal(result, '/home/user/repos/devex-metrics');
+});
+
+test('resolveWorkspaceFolderWithFallback: returns undefined when neither resolution nor fallback is available', () => {
+    const cache = new Map<string, string | undefined>();
+    const cliSessionFile = '/home/user/.copilot/session-state/uuid-1/events.jsonl';
+    const result = resolveWorkspaceFolderWithFallback(cliSessionFile, cache, undefined);
+    assert.equal(result, undefined);
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The "Copilot Customization Files" workspace health matrix on the Usage Analysis view only counts VS Code Copilot Chat sessions. `trackWorkspaceForSession` resolved a session's workspace folder solely via `resolveWorkspaceFolderFromSessionPath`, which only understands VS Code's `workspaceStorage/<id>/...` path layout.

Sessions from any non-VS Code editor — Copilot CLI (`~/.copilot/session-state/<uuid>/events.jsonl`), JetBrains, Claude Code, etc. — never have a `workspaceStorage` segment, so:
- `resolveWorkspaceFolderFromSessionPath` returns `undefined`
- `extractWorkspaceIdFromSessionPath` (the "Unresolved" fallback) also returns `undefined` for the same reason

...meaning those sessions were **silently dropped entirely** — not counted, and not even surfaced as an "Unresolved" row. This is why repos worked on primarily via Copilot CLI (e.g. `devex-metrics`, `devops-actions`) never appeared in the matrix, even though `sessionData.workspaceFolderPath` was already being resolved for those sessions elsewhere (via Copilot CLI's `workspace.yaml` `cwd` / `session-store.db` `cwd` column) and used successfully for other features (e.g. skill-call attribution).

## Fix

- Added `resolveWorkspaceFolderWithFallback()` in `src/workspaceHelpers.ts`: tries the VS Code `workspaceStorage` resolution first, falling back to a supplied workspace/cwd path.
- Wired it into `trackWorkspaceForSession` in `vscode-extension/src/extension.ts`, passing `sessionData.workspaceFolderPath` (already resolved per-editor by the adapter layer) as the fallback.
- The existing `deduplicateCopilotWorktrees` pass already canonicalizes Copilot CLI worktree paths (`~/.copilot/copilot-worktrees/<repo>/...`) back to the main repo checkout, so worktree-based CLI sessions correctly roll up into a single workspace row.

## Testing
- Added unit tests for `resolveWorkspaceFolderWithFallback` covering: VS Code resolution taking priority, falling back to the supplied path for non-VS Code sessions, and returning `undefined` when neither is available.
- `npm run compile` — clean.
- `workspaceHelpers.test.ts` — 266/266 passing.
- Targeted eslint on changed files — no new warnings/errors.