### PR TITLE
Fix task-category data loss in periodic refresh aggregation (Charts By Task week/month)

### DIFF
--- a/src/statsHelpers.ts
+++ b/src/statsHelpers.ts
@@ -6,6 +6,7 @@
  */
 
 import type { ModelUsage, EditorUsage, DailyTokenStats, SessionFileCache, LanguageUsage, DailyRollupEntry } from './types';
+import type { TaskCategory } from './taskClassification';
 import { isUnsafeObjectKey } from './utils/protoGuard';
 import { toLocalDayKey } from './utils/dayKeys';
 import { getCustomProviderGroup } from './webview/shared/modelUtils';
@@ -584,12 +585,12 @@ interface PeriodAccumulators {
 
 function getOrCreateDailyEntry(dailyStatsMap: Map<string, DailyTokenStats>, dayKey: string): DailyTokenStats {
 	if (!dailyStatsMap.has(dayKey)) {
-		dailyStatsMap.set(dayKey, { date: dayKey, tokens: 0, sessions: 0, interactions: 0, modelUsage: {}, editorUsage: {}, repositoryUsage: {} });
+		dailyStatsMap.set(dayKey, { date: dayKey, tokens: 0, sessions: 0, interactions: 0, modelUsage: {}, editorUsage: {}, repositoryUsage: {}, taskCategoryUsage: {} });
 	}
 	return dailyStatsMap.get(dayKey)!;
 }
 
-function addToDailyEntry(entry: DailyTokenStats, tokens: number, interactions: number, editorType: string, repository: string, modelUsage: ModelUsage): void {
+function addToDailyEntry(entry: DailyTokenStats, tokens: number, interactions: number, editorType: string, repository: string, modelUsage: ModelUsage, taskCategory?: TaskCategory): void {
 	entry.tokens += tokens; entry.sessions += 1; entry.interactions += interactions;
 	if (!entry.editorUsage[editorType]) { entry.editorUsage[editorType] = { tokens: 0, sessions: 0 }; }
 	entry.editorUsage[editorType].tokens += tokens; entry.editorUsage[editorType].sessions += 1;
@@ -609,6 +610,12 @@ function addToDailyEntry(entry: DailyTokenStats, tokens: number, interactions: n
 		if (isUnsafeObjectKey(model)) { continue; }
 		if (!entry.editorModelUsage[editorType][model].sessions) { entry.editorModelUsage[editorType][model].sessions = 0; }
 		entry.editorModelUsage[editorType][model].sessions += 1;
+	}
+	if (taskCategory) {
+		if (!entry.taskCategoryUsage) { entry.taskCategoryUsage = {}; }
+		if (!entry.taskCategoryUsage[taskCategory]) { entry.taskCategoryUsage[taskCategory] = { tokens: 0, sessions: 0 }; }
+		entry.taskCategoryUsage[taskCategory].tokens += tokens;
+		entry.taskCategoryUsage[taskCategory].sessions += 1;
 	}
 }
 
@@ -646,7 +653,7 @@ function accumulatePeriod(acc: PeriodAccumulator, tokens: number, estimated: num
 	}
 }
 
-function processOneRollupDay(dayKey: string, dayRollup: any, flags: { addedToLast30Days: boolean; addedToMonth: boolean; addedToLastMonth: boolean; addedToToday: boolean }, acc: PeriodAccumulators, dates: UtcDateRanges, editorType: string, dailyStatsMap: Map<string, DailyTokenStats>, repository: string): void {
+function processOneRollupDay(dayKey: string, dayRollup: any, flags: { addedToLast30Days: boolean; addedToMonth: boolean; addedToLastMonth: boolean; addedToToday: boolean }, acc: PeriodAccumulators, dates: UtcDateRanges, editorType: string, dailyStatsMap: Map<string, DailyTokenStats>, repository: string, taskCategory?: TaskCategory): void {
 	const inLast30Days = dayKey >= dates.last30DaysUtcStartKey;
 	const inLastMonth = dayKey >= dates.lastMonthUtcStartKey && dayKey <= dates.lastMonthUtcEndKey;
 	if (!inLast30Days && !inLastMonth) { return; }
@@ -655,7 +662,7 @@ function processOneRollupDay(dayKey: string, dayRollup: any, flags: { addedToLas
 	const cached = dayRollup.cachedReadTokens ?? 0;
 	if (inLast30Days) {
 		const entry = getOrCreateDailyEntry(dailyStatsMap, dayKey);
-		addToDailyEntry(entry, dayTokens, dayInteractions, editorType, repository, dayRollup.modelUsage);
+		addToDailyEntry(entry, dayTokens, dayInteractions, editorType, repository, dayRollup.modelUsage, taskCategory);
 		accumulatePeriod(acc.last30DaysStats, dayTokens, dayRollup.tokens, dayRollup.actualTokens, dayRollup.thinkingTokens, cached, dayInteractions, !flags.addedToLast30Days, editorType, dayRollup.modelUsage, dayRollup.copilotExactCostDollars);
 		flags.addedToLast30Days = true;
 	}
@@ -689,7 +696,7 @@ function processRollupPath(input: SessionAggregateInput, acc: PeriodAccumulators
 	const repository = sessionData.repository || 'Unknown';
 	const flags = { addedToLast30Days: false, addedToMonth: false, addedToLastMonth: false, addedToToday: false };
 	for (const [dayKey, dayRollup] of Object.entries(sessionData.dailyRollups!)) {
-		processOneRollupDay(dayKey, dayRollup, flags, acc, dates, editorType, dailyStatsMap, repository);
+		processOneRollupDay(dayKey, dayRollup, flags, acc, dates, editorType, dailyStatsMap, repository, sessionData.taskCategory);
 	}
 	if (flags.addedToLast30Days && sessionData.linesAdded !== undefined) {
 		const dayKeys = Object.keys(sessionData.dailyRollups!).sort();
@@ -721,7 +728,7 @@ function processFallbackPath(input: SessionAggregateInput, acc: PeriodAccumulato
 	if (!inLast30Days && !inLastMonth) { return true; }
 	if (inLast30Days) {
 		const dailyEntry = getOrCreateDailyEntry(dailyStatsMap, lastActivityUtcKey);
-		addToDailyEntry(dailyEntry, tokens, sessionData.interactions, editorType, repository, sessionData.modelUsage);
+		addToDailyEntry(dailyEntry, tokens, sessionData.interactions, editorType, repository, sessionData.modelUsage, sessionData.taskCategory);
 		if (sessionData.linesAdded !== undefined) { attributeLocToDay(dailyEntry, sessionData, editorType, repository); }
 		accumulatePeriod(acc.last30DaysStats, tokens, estimatedTokens, actualTokens, thinking, cached, sessionData.interactions, true, editorType, sessionData.modelUsage, sessionData.copilotExactCostDollars);
 	}

--- a/vscode-extension/test/unit/statsHelpers.test.ts
+++ b/vscode-extension/test/unit/statsHelpers.test.ts
@@ -464,6 +464,38 @@ assert.equal(result.last30DaysStats.tokens, 120);
 assert.equal(result.skippedCount, 0);
 });
 
+test('aggregatePeriodStats: rollup path – populates taskCategoryUsage on the daily entry (regression: chart By Task week/month bug)', () => {
+const ranges = makeRanges('2025-03-15');
+const input: SessionAggregateInput = {
+editorType: 'vscode',
+mtime: new Date('2025-03-15T10:00:00.000Z').getTime(),
+sessionData: makeSession({
+taskCategory: 'Coding',
+dailyRollups: {
+'2025-03-15': { tokens: 100, actualTokens: 120, thinkingTokens: 0, interactions: 2, modelUsage: {} },
+},
+}),
+};
+const result = aggregatePeriodStats([input], ranges);
+const day = result.dailyStatsMap.get('2025-03-15');
+assert.ok(day, 'daily entry should exist');
+assert.deepEqual(day!.taskCategoryUsage, { Coding: { tokens: 120, sessions: 1 } });
+});
+
+test('aggregatePeriodStats: fallback path – populates taskCategoryUsage on the daily entry (regression: chart By Task week/month bug)', () => {
+const ranges = makeRanges('2025-03-15');
+const input: SessionAggregateInput = {
+editorType: 'vscode',
+mtime: new Date('2025-03-14T10:00:00.000Z').getTime(),
+lastInteraction: '2025-03-14T10:00:00.000Z',
+sessionData: makeSession({ tokens: 50, taskCategory: 'Debugging' }),
+};
+const result = aggregatePeriodStats([input], ranges);
+const day = result.dailyStatsMap.get('2025-03-14');
+assert.ok(day, 'daily entry should exist');
+assert.deepEqual(day!.taskCategoryUsage, { Debugging: { tokens: 50, sessions: 1 } });
+});
+
 test('aggregatePeriodStats: rollup path – counts sub-agent sessions once per period', () => {
 const ranges = makeRanges('2025-03-15');
 const withSubAgents: SessionAggregateInput = {


### PR DESCRIPTION
## Bug

In the Charts webview, the "By Task" split (task-category stacked bars) showed data correctly in the **Day** view but rendered no stacked bars at all in **Week** or **Month** views (only the Sessions line), despite the token axis scaling correctly.

## Root cause

`aggregatePeriodStats()` in `src/statsHelpers.ts` (used by `calculateDetailedStats()`, which runs on every periodic background refresh via `updateTokenStats()`) never populated `taskCategoryUsage` on the daily entries it builds — unlike the full `calculateDailyStats()` path that originally seeds the chart's `lastFullDailyStats` cache.

Because `updateTokenStats()` merges each refresh's fresh daily stats into `lastFullDailyStats` via a full per-date overwrite (`mergeIntoFullDailyStats`), every periodic refresh silently erased `taskCategoryUsage` for the recent ~30–60 day window that the refresh recomputes.

This didn't show up on the **Day** view because it has a special bypass (`last30` + `day` returns the raw, unfiltered `dailyPeriod`), so it still displayed plenty of older, uncorrupted days. **Week/Month** views are always filtered down to exactly the last-30-day window — precisely the corrupted range — so their By Task split rendered with zero data.

## Fix

Thread `taskCategory` through the aggregation helpers in `src/statsHelpers.ts` (`processOneRollupDay`, `processRollupPath`, `processFallbackPath`, `addToDailyEntry`, `getOrCreateDailyEntry`), mirroring the existing pattern already used in `extension.ts`'s `addUsageToDailyEntry`.

## Testing

- Added two regression tests in `vscode-extension/test/unit/statsHelpers.test.ts` asserting `taskCategoryUsage` is populated via both the daily-rollup and session-fallback aggregation paths.
- `npm run compile` — clean.
- `statsHelpers.test.ts`: 98/98 passing (96 existing + 2 new).
- `chartDataBuilder.test.ts`: 37/37 passing (unaffected downstream consumer).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>