### PR TITLE
Collapse long-tail models into an "Other models" group in the local leaderboard

### DIFF
--- a/src/modelEfficiency.ts
+++ b/src/modelEfficiency.ts
@@ -489,3 +489,32 @@ export function computeEfficiencyLowUsageThreshold(usage: ModelEfficiencyUsage):
 	if (calls.length < 4) { return null; }
 	return calls[Math.floor((calls.length - 1) * 0.25)];
 }
+
+/**
+ * Detects a natural "long tail" cutoff in per-model local usage and returns the names of the
+ * models that fall after it, so the UI can collapse them into an "Other models" group.
+ *
+ * Ranks models by call count (descending) and finds the steepest proportional drop between two
+ * consecutive models. Everything at or after that drop is treated as the tail, but only when the
+ * drop is a genuine cliff (usage falls to less than half) and at least two models remain in the
+ * tail — otherwise usage tapers off gradually and no grouping is applied (empty set returned).
+ */
+export function computeLongTailModels(usage: ModelEfficiencyUsage): Set<string> {
+	const ranked = Object.entries(usage)
+		.map(([model, counters]) => ({ model, calls: counters.calls }))
+		.sort((a, b) => b.calls - a.calls);
+	let cutoffIndex = -1;
+	let smallestRatio = 1;
+	for (let i = 1; i < ranked.length; i++) {
+		const previousCalls = ranked[i - 1].calls;
+		if (previousCalls <= 0) { continue; }
+		const ratio = ranked[i].calls / previousCalls;
+		if (ratio < smallestRatio) {
+			smallestRatio = ratio;
+			cutoffIndex = i;
+		}
+	}
+	const tailLength = cutoffIndex === -1 ? 0 : ranked.length - cutoffIndex;
+	if (cutoffIndex === -1 || smallestRatio >= 0.5 || tailLength < 2) { return new Set(); }
+	return new Set(ranked.slice(cutoffIndex).map(entry => entry.model));
+}

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -16,7 +16,7 @@ import { registerMessageHandler } from '../shared/messageHandler';
 import { getModelDisplayName } from '../../../../src/webview/shared/modelUtils';
 import { getModelBillingProvider } from '../../../../src/chartDataBuilder';
 import { getLongContextInfo } from '../../../../src/tokenEstimation';
-import { deriveModelEfficiencyRates, computeEfficiencyLowUsageThreshold } from '../../../../src/modelEfficiency';
+import { deriveModelEfficiencyRates, computeEfficiencyLowUsageThreshold, computeLongTailModels } from '../../../../src/modelEfficiency';
 import type { ModelPricing, ModelEfficiencyUsage, ModelEfficiencyCounters } from '../../../../src/types';
 import { sanitizeCustomizationMatrix } from './customizationSanitizer';
 import { applyBillingFields, type CopilotApiBalance } from './billingStatsSanitizer';
@@ -4404,6 +4404,8 @@ let efficiencySortColumn: EfficiencySortColumn = 'calls';
 let efficiencySortDirection: 'asc' | 'desc' = 'desc';
 let cachedModelEfficiency: Partial<Record<EfficiencyPeriodKey, ModelEfficiencyUsage | undefined>> = {};
 let efficiencyFilterLowUsage = true;
+/** Whether the collapsed "Other models" long-tail group is expanded. Persists across re-renders. */
+let efficiencyOtherModelsOpen = false;
 
 type EfficiencyColumnDef = {
 	sortKey: EfficiencySortColumn;
@@ -4638,15 +4640,32 @@ function buildChartControlsHtml(): string {
 	</div>`;
 }
 
-function buildEfficiencyTableHtml(rows: EfficiencyRow[], totalCalls: number): string {
-	const tableRows = rows.map(row => {
+function buildEfficiencyTableRowsHtml(rows: EfficiencyRow[], totalCalls: number): string {
+	return rows.map(row => {
 		const cells = EFFICIENCY_COLUMN_DEFS.map(column => `<td>${column.render(row, totalCalls)}</td>`).join('');
 		return `<tr style="--model-color:${getEfficiencyColor(row.model)}">${cells}</tr>`;
 	}).join('');
-	const headers = EFFICIENCY_COLUMN_DEFS.map(column =>
+}
+
+function buildEfficiencyTableHeadersHtml(): string {
+	return EFFICIENCY_COLUMN_DEFS.map(column =>
 		`<th class="sortable" data-eff-sort="${column.sortKey}" title="${column.title}">${column.label}${getEfficiencySortIndicator(column.sortKey)}</th>`
 	).join('');
-	return `<div class="model-leaderboard-table-wrap"><table class="model-leaderboard-table"><thead><tr>${headers}</tr></thead><tbody>${tableRows}</tbody></table></div>`;
+}
+
+function buildEfficiencyTableHtml(rows: EfficiencyRow[], totalCalls: number, longTailModels: Set<string>): string {
+	const mainRows = longTailModels.size > 0 ? rows.filter(row => !longTailModels.has(row.model)) : rows;
+	const otherRows = longTailModels.size > 0 ? rows.filter(row => longTailModels.has(row.model)) : [];
+	const headers = buildEfficiencyTableHeadersHtml();
+	const table = `<div class="model-leaderboard-table-wrap"><table class="model-leaderboard-table"><thead><tr>${headers}</tr></thead><tbody>${buildEfficiencyTableRowsHtml(mainRows, totalCalls)}</tbody></table></div>`;
+	if (otherRows.length === 0) { return table; }
+	const otherCalls = otherRows.reduce((sum, row) => sum + row.counters.calls, 0);
+	const otherShare = totalCalls > 0 ? otherCalls / totalCalls : 0;
+	const otherTable = `<div class="model-leaderboard-table-wrap"><table class="model-leaderboard-table"><thead><tr>${headers}</tr></thead><tbody>${buildEfficiencyTableRowsHtml(otherRows, totalCalls)}</tbody></table></div>`;
+	return `${table}<details class="model-leaderboard-other" id="model-leaderboard-other"${efficiencyOtherModelsOpen ? ' open' : ''}>
+		<summary>Other models (${otherRows.length}, ${formatRatePercent(otherShare)} of turns)</summary>
+		${otherTable}
+	</details>`;
 }
 
 function buildModelEfficiencyContentHtml(): string {
@@ -4658,10 +4677,12 @@ function buildModelEfficiencyContentHtml(): string {
 	const totalCalls = allRows.reduce((sum, row) => sum + row.counters.calls, 0);
 	const filtered = filterLowUsageRows(allRows, usage);
 	const note = filtered.hiddenNote ? `<span class="model-leaderboard-filter-note">${filtered.hiddenNote}</span>` : '';
+	const filteredUsage: ModelEfficiencyUsage = Object.fromEntries(filtered.rows.map(row => [row.model, row.counters]));
+	const longTailModels = computeLongTailModels(filteredUsage);
 	return `<div class="efficiency-chart-header"><div><strong>Efficiency frontier</strong><span>One-shot edit rate is a local quality proxy, not a benchmark pass rate.</span></div>${buildChartControlsHtml()}</div>
 		${buildEfficiencyChartHtml(filtered.rows)}
 		<div class="model-leaderboard-heading"><div><strong>Most used models locally</strong><span>Ranked by your local turns; all averages use the same selected period.</span></div>${note}</div>
-		${buildEfficiencyTableHtml(filtered.rows, totalCalls)}`;
+		${buildEfficiencyTableHtml(filtered.rows, totalCalls, longTailModels)}`;
 }
 
 function buildModelEfficiencySectionHtml(stats: UsageAnalysisStats): string {
@@ -4721,6 +4742,15 @@ function handleEfficiencySortClick(th: HTMLElement): void {
 function setupModelEfficiencySection(): void {
 	const section = document.getElementById('section-model-efficiency');
 	if (!section) { return; }
+	// The "Other models" <details> is recreated on every re-render (sort, filter toggle, etc.),
+	// which would otherwise always snap back to collapsed. `toggle` doesn't bubble, so listen
+	// during the capture phase to catch it regardless of which re-rendered element raises it.
+	section.addEventListener('toggle', (event) => {
+		const target = event.target as HTMLElement;
+		if (target.id === 'model-leaderboard-other') {
+			efficiencyOtherModelsOpen = (target as HTMLDetailsElement).open;
+		}
+	}, true);
 	section.addEventListener('click', (event) => {
 		const target = event.target as HTMLElement;
 		const header = target.closest<HTMLElement>('th[data-eff-sort]');

--- a/vscode-extension/src/webview/usage/styles.css
+++ b/vscode-extension/src/webview/usage/styles.css
@@ -504,6 +504,26 @@ body {
 	background: var(--model-color);
 }
 
+.model-leaderboard-other {
+	margin-top: 8px;
+}
+
+.model-leaderboard-other > summary {
+	cursor: pointer;
+	user-select: none;
+	font-size: 12px;
+	color: var(--text-secondary);
+	padding: 4px 0;
+}
+
+.model-leaderboard-other > summary:hover {
+	color: var(--link-color);
+}
+
+.model-leaderboard-other[open] > summary {
+	margin-bottom: 6px;
+}
+
 .model-use-cell {
 	display: grid;
 	grid-template-columns: 82px 42px auto;

--- a/vscode-extension/test/unit/modelEfficiency.test.ts
+++ b/vscode-extension/test/unit/modelEfficiency.test.ts
@@ -10,6 +10,7 @@ import {
     deriveModelEfficiencyRates,
     createEmptyModelEfficiencyCounters,
     computeEfficiencyLowUsageThreshold,
+    computeLongTailModels,
     computeModelTokenShares,
     accumulateDailyModelTokens,
     accumulateDailyModelCounters,
@@ -298,6 +299,57 @@ test('computeEfficiencyLowUsageThreshold: correctly identifies Q1 across larger 
         usage[`model-${i}`] = { ...createEmptyModelEfficiencyCounters(), calls };
     });
     assert.equal(computeEfficiencyLowUsageThreshold(usage), 2);
+});
+
+// ---------------------------------------------------------------------------
+// computeLongTailModels
+// ---------------------------------------------------------------------------
+
+function usageWithCalls(counts: Record<string, number>): ModelEfficiencyUsage {
+    const usage: ModelEfficiencyUsage = {};
+    for (const [model, calls] of Object.entries(counts)) {
+        usage[model] = { ...createEmptyModelEfficiencyCounters(), calls };
+    }
+    return usage;
+}
+
+test('computeLongTailModels: groups everything after the steepest proportional drop', () => {
+    // Mirrors a real "Most used models locally" table: a clear cliff between the 4th (82 calls)
+    // and 5th (20 calls) model, with only gentle tapering elsewhere.
+    const usage = usageWithCalls({
+        kimi: 309, sol: 144, sonnet5: 120, opus5: 82,
+        unknown: 20, hydrafusion: 16, mistralMedium: 14, sonnet46: 12, terra: 12, maiCode: 11,
+        synthetic: 3, gpt54: 3, devstral: 3, fable5: 2, mistral2: 2, auto: 1, mistralMedium2: 1, codestral: 1,
+    });
+    const longTail = computeLongTailModels(usage);
+    assert.deepEqual(
+        [...longTail].sort(),
+        ['auto', 'codestral', 'devstral', 'fable5', 'gpt54', 'hydrafusion', 'maiCode', 'mistral2', 'mistralMedium', 'mistralMedium2', 'sonnet46', 'synthetic', 'terra', 'unknown'].sort(),
+    );
+    assert.ok(!longTail.has('opus5'), 'the model just before the cliff must stay in the main list');
+    assert.ok(!longTail.has('kimi'), 'top models must stay in the main list');
+});
+
+test('computeLongTailModels: returns an empty set when usage tapers off gradually', () => {
+    const usage = usageWithCalls({ a: 100, b: 80, c: 65, d: 55, e: 48 });
+    assert.equal(computeLongTailModels(usage).size, 0);
+});
+
+test('computeLongTailModels: returns an empty set when the resulting tail would have fewer than two models', () => {
+    // Steep drop exists (100 → 5), but only one model would land in the tail.
+    const usage = usageWithCalls({ a: 100, b: 5 });
+    assert.equal(computeLongTailModels(usage).size, 0);
+});
+
+test('computeLongTailModels: a clear cliff among just three models still produces a two-model tail', () => {
+    const usage = usageWithCalls({ a: 100, b: 3, c: 1 });
+    assert.deepEqual([...computeLongTailModels(usage)].sort(), ['b', 'c']);
+});
+
+test('computeLongTailModels: ignores zero-call models when scanning for the cliff', () => {
+    const usage = usageWithCalls({ a: 100, b: 40, c: 0, d: 0 });
+    const longTail = computeLongTailModels(usage);
+    assert.deepEqual([...longTail].sort(), ['c', 'd']);
 });
 
 // ---------------------------------------------------------------------------

--- a/vscode-extension/test/unit/usageWebviewMessageFlow.test.ts
+++ b/vscode-extension/test/unit/usageWebviewMessageFlow.test.ts
@@ -52,6 +52,22 @@ function emptyPeriod(): Record<string, unknown> {
 	};
 }
 
+function emptyModelEfficiencyCounters(calls: number): Record<string, unknown> {
+	return {
+		calls, toolCalls: 0, editTurns: 0, oneShotEditTurns: 0, retries: 0, selfCorrections: 0,
+		editToolCalls: 0, inputTokens: 0, outputTokens: 0, cachedReadTokens: 0, cost: 0,
+	};
+}
+
+/** Local usage counts mirroring a real long-tail leaderboard: a clear cliff after the 4th model. */
+function longTailModelEfficiency(): Record<string, unknown> {
+	const counts: Record<string, number> = {
+		kimi: 309, sol: 144, sonnet5: 120, opus5: 82,
+		unknown: 20, hydrafusion: 16, mistralMedium: 14, sonnet46: 12, terra: 12, maiCode: 11,
+	};
+	return Object.fromEntries(Object.entries(counts).map(([model, calls]) => [model, emptyModelEfficiencyCounters(calls)]));
+}
+
 function buildStats(): Record<string, unknown> {
 	return {
 		today: emptyPeriod(),
@@ -67,6 +83,13 @@ function buildStats(): Record<string, unknown> {
 		currentWorkspacePaths: [],
 		insights: [],
 	};
+}
+
+/** `buildStats()` with a long-tail "Most used models locally" dataset for `last30Days`. */
+function buildStatsWithLongTailModelEfficiency(): Record<string, unknown> {
+	const stats = buildStats();
+	stats.last30Days = { ...(stats.last30Days as Record<string, unknown>), modelEfficiency: longTailModelEfficiency() };
+	return stats;
 }
 
 interface Harness {
@@ -294,4 +317,45 @@ test('a throwing message handler is reported to the host instead of failing sile
 	const trace = harness.posted.find((m) => m.command === 'usageWebviewTrace' && m.stage === 'handleExtensionMessage.threw');
 	assert.ok(trace, 'a render exception must surface in the extension Output channel');
 	assert.equal(trace.details.command, 'repoPrStatsLoaded');
+});
+
+test('collapses the long-tail of the local model leaderboard into a closed "Other models" group', async () => {
+	const harness = await bootWebview(buildStatsWithLongTailModelEfficiency());
+
+	const wraps = harness.window.document.querySelectorAll('.model-leaderboard-table-wrap');
+	assert.equal(wraps.length, 2, 'expects a main table plus one collapsed "other models" table');
+
+	const details = harness.window.document.getElementById('model-leaderboard-other');
+	assert.ok(details, 'expects a collapsible "Other models" group in the DOM');
+	assert.equal(details.open, false, 'the group must be collapsed by default');
+	// The default "hide low-usage models" filter drops the 3 lowest-call models (Q1 threshold)
+	// first, leaving 7; the long tail is then everything after the cliff among those 7.
+	assert.match(details.querySelector('summary').textContent, /Other models \(3,/, 'expects the 3 remaining long-tail models grouped');
+
+	const mainRows = wraps[0].querySelectorAll('tbody tr');
+	assert.equal(mainRows.length, 4, 'the 4 models before the cliff stay in the main table');
+
+	const otherRows = details.querySelectorAll('tbody tr');
+	assert.equal(otherRows.length, 3, 'the 3 models after the cliff move into the other-models table');
+});
+
+test('remembers the "Other models" open state across a leaderboard re-render', async () => {
+	const harness = await bootWebview(buildStatsWithLongTailModelEfficiency());
+
+	const details = harness.window.document.getElementById('model-leaderboard-other');
+	assert.equal(details.open, false);
+
+	// Open it, mirroring what a real click on <summary> does, then dispatch the `toggle` event
+	// the webview listens for (capture phase, since `toggle` does not bubble).
+	details.open = true;
+	details.dispatchEvent(new harness.window.Event('toggle'));
+
+	// Sorting re-renders just the leaderboard content, recreating the <details> element from
+	// scratch; without persisted state it would always snap back to collapsed.
+	const modelHeader = harness.window.document.querySelector('th[data-eff-sort="model"]');
+	modelHeader.click();
+
+	const detailsAfterSort = harness.window.document.getElementById('model-leaderboard-other');
+	assert.ok(detailsAfterSort, 'expects the "Other models" group to still exist after sorting');
+	assert.equal(detailsAfterSort.open, true, 'the open state must survive the re-render');
 });


### PR DESCRIPTION
## What
The "Most used models locally" table in the Usage Analysis webview (AI Usage Analysis tab) now detects a natural "long tail" cutoff in local usage and collapses everything after it into a closed, expandable **Other models** group — mirroring the collapsible pattern already used elsewhere in this webview (e.g. unused skills / MCP servers).

## Why
With many models in local history, the table gets long and the least-used tail (small, similar percentages) adds noise without much signal. Instead of a fixed count/percentage cutoff, this detects where usage actually falls off a cliff.

## How the cutoff is chosen
`computeLongTailModels()` (new, in `src/modelEfficiency.ts`, shared/testable logic) ranks models by call count (descending) and finds the steepest proportional drop between two consecutive models. Everything at or after that drop becomes the tail, but only when:
- the drop is a genuine cliff (usage falls to less than half), and
- at least two models remain in the tail.

Otherwise (gradual taper-off) no grouping is applied and all models stay in one list. This matches the example that motivated the change: a table with `10.8% → 2.6%` between the 4th and 5th models groups everything from the 5th model onward.

## UI behavior
- The main table keeps the "important" models; a `<details>` section below is titled "Other models (N, X% of turns)" and starts collapsed.
- The open/closed state is preserved across sorts and the existing "Hide low-usage models" filter toggle (previously every re-render reset any `<details>` to its default state).
- Applies on top of the existing "Hide low-usage models" filter — the cutoff is computed from whatever's currently visible.

## Testing
- Added unit tests for `computeLongTailModels` in `modelEfficiency.test.ts` (cliff detection, no-cliff/gradual taper, minimum tail size, zero-call handling).
- Added DOM-level tests in `usageWebviewMessageFlow.test.ts` verifying the grouping renders correctly and the open state survives a table re-render (sort click).
- `npm run validate` and `npm run test:node` pass (pre-existing warnings in unrelated files untouched).

Note: the Visual Studio / JetBrains hosts ship the same `usage` webview bundle but their committed copies are already stale relative to `main` for reasons unrelated to this change (several other views too) — refreshing those is left out of scope for this PR.