### PR TITLE
fix(cloud-agent): resolve account-wide task repository IDs to owner/repo

### DIFF
--- a/docs/features/CLOUD-AGENT-COST.md
+++ b/docs/features/CLOUD-AGENT-COST.md
@@ -50,10 +50,23 @@ counted once. Repositories found only through the account listing are labelled *
 If the account-wide listing fails (for example, a token without the "Agent tasks" permission), the
 tab degrades to the workspace repositories and says so.
 
+### Resolving the account-wide listing's bare repository ID
+
+The account-wide `/agents/tasks` listing does **not** return an `owner/repo`, a `full_name`, or an
+`html_url` for a task's repository — only `repository: { id: <number> }`. Without a further lookup,
+every task from this listing would incorrectly land in the "no repository" bucket even when it
+clearly belongs to a real repo.
+
+`collectAgentSessions()` resolves this by calling `GET /repositories/{id}` for each distinct
+repository ID it can't otherwise resolve, before building any rows. The result is cached per ID for
+the pass (many tasks in the same repo share one ID) and the number of lookups is capped
+(`MAX_REPO_ID_LOOKUPS_PER_REFRESH`) to bound API usage; any IDs left over stay unresolved for this
+pass and are retried on the next hourly refresh.
+
 ## Cost control: one hourly snapshot, one window
 
-Collecting the data costs one list call per repository, one for the account, and one detail call
-per task, so it is deliberately rationed:
+Collecting the data costs one list call per repository, one for the account, one repository-ID
+lookup per distinct unresolved repo, and one detail call per task, so it is deliberately rationed:
 
 - **Cached on disk** in the extension's global storage
   (`agenttasks_<cacheId>.snapshot.json`), shared by every VS Code window of that edition —

--- a/vscode-extension/src/agentSessionsService.ts
+++ b/vscode-extension/src/agentSessionsService.ts
@@ -26,6 +26,16 @@ const MAX_TASKS_DETAIL_PER_REPO = 50;
 export const MAX_TASK_DETAILS_PER_REFRESH = 200;
 
 /**
+ * Maximum number of `GET /repositories/{id}` lookups per refresh, used to resolve the bare
+ * `repository.id` the account-wide listing returns into an `owner/repo` pair. Each distinct
+ * repository ID costs one call regardless of how many tasks reference it, so this is a much
+ * smaller cap than the task-detail one — a very active account still touches only a handful of
+ * distinct repos per pass. IDs left over after the cap fall back into the "no repository" bucket
+ * for this pass and are retried on the next hourly refresh.
+ */
+export const MAX_REPO_ID_LOOKUPS_PER_REFRESH = 50;
+
+/**
  * Detect whether an agent session came from the GitHub Copilot cloud agent or a CLI/remote session.
  *
  * Heuristic from the agents API:
@@ -81,6 +91,8 @@ export type FetchTaskDetailFn = (
 ) => Promise<TaskDetailResult>;
 
 export type FetchAccountTaskDetailFn = (taskId: string, token: string) => Promise<TaskDetailResult>;
+
+export type FetchRepositoryByIdFn = (id: number, token: string) => Promise<{ owner: string; repo: string } | undefined>;
 
 export type GitHubJsonResult = { body?: any; statusCode?: number; error?: string };
 type GitHubJsonTransport = (path: string, token: string) => Promise<GitHubJsonResult>;
@@ -191,6 +203,22 @@ export async function fetchAccountAgentTaskDetail(taskId: string, token: string)
 	return toTaskDetailResult(await requestGitHubJson(`/agents/tasks/${encodeURIComponent(taskId)}`, token));
 }
 
+/**
+ * Resolve a bare repository ID (as returned by the account-wide `/agents/tasks` listing, which only
+ * guarantees `repository.id`) to an `owner/repo` pair via `GET /repositories/{id}`. Any signed-in
+ * user can call this endpoint for a public or accessible repo; it returns undefined on any failure
+ * (private repo the token can't see, deleted repo, transport error) so the caller can fall back to
+ * the "no repository" bucket instead of failing the whole pass.
+ */
+export async function fetchRepositoryById(id: number, token: string): Promise<{ owner: string; repo: string } | undefined> {
+	const { body, error } = await requestGitHubJson(`/repositories/${id}`, token);
+	if (error || !body || typeof body !== 'object') { return undefined; }
+	return splitFullName(body.full_name)
+		?? (typeof body.owner?.login === 'string' && body.owner.login && typeof body.name === 'string' && body.name
+			? { owner: body.owner.login, repo: body.name }
+			: undefined);
+}
+
 // ---------------------------------------------------------------------------
 // Session usage parsing
 // ---------------------------------------------------------------------------
@@ -264,12 +292,16 @@ function repoFromRepositoryObject(repository: any, task: any): { owner: string; 
 }
 
 /**
- * Resolve the repository a task belongs to.
+ * Resolve the repository a task belongs to from the fields already on the task object.
  *
- * The published schema only guarantees `repository.id`, while the live API returns richer repo
- * objects, so every known spelling is tried before falling back to parsing the task's URLs.
- * Returns undefined for tasks with no repository — e.g. ad-hoc sessions started from cloud chat
- * before a repo is picked — which are grouped into their own bucket.
+ * The live API returns richer repo objects on the repo-scoped listing, so every known spelling is
+ * tried before falling back to parsing the task's URLs. Returns undefined when none of those are
+ * present — most notably, the account-wide `/agents/tasks` listing only guarantees
+ * `repository.id` (a bare numeric ID, no owner/name/URL at all), which this function cannot turn
+ * into an `owner/repo` pair by itself. Callers that need to resolve that case should read
+ * `repositoryIdFromTask()` and look the ID up with `fetchRepositoryById()`. Also returns undefined
+ * for tasks with no repository at all — e.g. ad-hoc sessions started from cloud chat before a repo
+ * is picked — which are grouped into their own bucket.
  */
 export function resolveTaskRepo(task: any): { owner: string; repo: string } | undefined {
 	const repository = task?.repository;
@@ -278,6 +310,12 @@ export function resolveTaskRepo(task: any): { owner: string; repo: string } | un
 		if (resolved) { return resolved; }
 	}
 	return repoFromUrl(task?.html_url);
+}
+
+/** Read the bare numeric repository ID off a task, if present — see `resolveTaskRepo()`. */
+export function repositoryIdFromTask(task: any): number | undefined {
+	const id = task?.repository?.id;
+	return typeof id === 'number' && Number.isFinite(id) ? id : undefined;
 }
 
 /** Stable map key for a repository summary; account tasks with no repo share the empty key. */
@@ -446,8 +484,11 @@ export interface CollectAgentSessionsOptions {
 	fetchAccountTaskPage?: FetchAccountTaskPageFn;
 	fetchTaskDetail?: FetchTaskDetailFn;
 	fetchAccountTaskDetail?: FetchAccountTaskDetailFn;
+	fetchRepositoryById?: FetchRepositoryByIdFn;
 	/** Cap on task-detail calls for this pass (default MAX_TASK_DETAILS_PER_REFRESH). */
 	maxTaskDetails?: number;
+	/** Cap on repository-ID lookups for this pass (default MAX_REPO_ID_LOOKUPS_PER_REFRESH). */
+	maxRepoIdLookups?: number;
 	/** Reports coarse progress (list calls + detail calls) so the panel can show a bar. */
 	onProgress?: (done: number, total: number) => void;
 }
@@ -530,6 +571,49 @@ async function collectWorkspaceTasks(
 	}
 }
 
+/**
+ * Resolve the tasks whose repository could not be read from the task object directly (the
+ * account-wide listing typically only returns a bare `repository.id`) by looking that ID up
+ * through `GET /repositories/{id}`. Distinct IDs are looked up once and cached for the whole pass,
+ * since many tasks in the same repo share one ID, and the lookup count is capped to bound API
+ * usage — IDs left over stay unresolved for this pass and land in the "no repository" bucket.
+ */
+async function resolveRepositoryIds(
+	tasks: any[],
+	options: CollectAgentSessionsOptions,
+): Promise<Map<number, { owner: string; repo: string } | undefined>> {
+	const fetchRepoById = options.fetchRepositoryById ?? fetchRepositoryById;
+	const maxLookups = options.maxRepoIdLookups ?? MAX_REPO_ID_LOOKUPS_PER_REFRESH;
+
+	const unresolvedIds = new Set<number>();
+	for (const task of tasks) {
+		if (resolveTaskRepo(task)) { continue; }
+		const id = repositoryIdFromTask(task);
+		if (id !== undefined) { unresolvedIds.add(id); }
+	}
+
+	const idsToFetch = [...unresolvedIds].slice(0, maxLookups);
+	const idCache = new Map<number, { owner: string; repo: string } | undefined>();
+	const CONCURRENCY = 5;
+	for (let i = 0; i < idsToFetch.length; i += CONCURRENCY) {
+		const batch = idsToFetch.slice(i, i + CONCURRENCY);
+		const results = await Promise.all(batch.map(id => fetchRepoById(id, options.token)));
+		batch.forEach((id, index) => idCache.set(id, results[index]));
+	}
+	return idCache;
+}
+
+/** Resolve one account-listing task's repo: its own fields first, then the ID-lookup cache. */
+function resolveAccountTaskRepo(
+	task: any,
+	idCache: Map<number, { owner: string; repo: string } | undefined>,
+): { owner: string; repo: string } | undefined {
+	const resolved = resolveTaskRepo(task);
+	if (resolved) { return resolved; }
+	const id = repositoryIdFromTask(task);
+	return id !== undefined ? idCache.get(id) : undefined;
+}
+
 /** List the authenticated user's tasks across all repositories, adding any repos not seen yet. */
 async function collectAccountTasks(
 	options: CollectAgentSessionsOptions,
@@ -543,8 +627,10 @@ async function collectAccountTasks(
 	);
 	if (error) { return { available: false, error: describeTaskFetchError(statusCode) }; }
 
+	const idCache = await resolveRepositoryIds(tasks, options);
+
 	for (const task of tasks) {
-		const resolved = resolveTaskRepo(task);
+		const resolved = resolveAccountTaskRepo(task, idCache);
 		const key = repoKey(resolved?.owner ?? '', resolved?.repo ?? '');
 		upsertRow(rows, key, resolved?.owner ?? '', resolved?.repo ?? '', 'account');
 		const existing = candidates.get(task.id);
@@ -600,6 +686,11 @@ function sortRepoRows(rows: AgentRepoSummary[]): AgentRepoSummary[] {
  * the workspace's git remotes (which also surface tasks other people started in those repos) and
  * the account-wide `/agents/tasks` listing (which surfaces tasks started from github.com in repos
  * that aren't checked out locally, plus ad-hoc cloud chat tasks with no repository at all).
+ *
+ * The account-wide listing only guarantees a bare `repository.id` on each task, so those are
+ * resolved to `owner/repo` via `GET /repositories/{id}` (capped, cached per distinct ID for the
+ * pass) before rows are built — otherwise every account-only task would wrongly land in the "no
+ * repository" bucket even though it belongs to a real repo.
  *
  * Tasks are deduplicated by ID across both listings, so a task visible in both is counted once.
  * The number of task-detail calls is capped: the newest tasks are detailed first and any repo with

--- a/vscode-extension/src/agentSessionsService.ts
+++ b/vscode-extension/src/agentSessionsService.ts
@@ -614,6 +614,19 @@ function resolveAccountTaskRepo(
 	return id !== undefined ? idCache.get(id) : undefined;
 }
 
+/**
+ * Key an account-listing task should be filed under. Falls back to an already-known candidate's
+ * key when the account object itself can't be resolved (bare-ID lookup failed or was capped), so a
+ * task already attributed to a repo via the workspace listing doesn't spawn a spurious empty
+ * "no repository" row.
+ */
+function accountTaskKey(
+	resolved: { owner: string; repo: string } | undefined,
+	existingCandidate: AgentTaskCandidate | undefined,
+): string {
+	return repoKey(resolved?.owner ?? '', resolved?.repo ?? '') || existingCandidate?.key || '';
+}
+
 /** List the authenticated user's tasks across all repositories, adding any repos not seen yet. */
 async function collectAccountTasks(
 	options: CollectAgentSessionsOptions,
@@ -630,11 +643,11 @@ async function collectAccountTasks(
 	const idCache = await resolveRepositoryIds(tasks, options);
 
 	for (const task of tasks) {
+		const existingCandidate = candidates.get(task.id);
 		const resolved = resolveAccountTaskRepo(task, idCache);
-		const key = repoKey(resolved?.owner ?? '', resolved?.repo ?? '');
+		const key = accountTaskKey(resolved, existingCandidate);
 		upsertRow(rows, key, resolved?.owner ?? '', resolved?.repo ?? '', 'account');
-		const existing = candidates.get(task.id);
-		if (existing) { continue; }
+		if (existingCandidate) { continue; }
 		candidates.set(task.id, { id: task.id, key, owner: resolved?.owner, repo: resolved?.repo, sortAt: taskSortAt(task) });
 	}
 	return { available: true };

--- a/vscode-extension/test/unit/agentSessionsService.test.ts
+++ b/vscode-extension/test/unit/agentSessionsService.test.ts
@@ -465,6 +465,29 @@ test('collectAgentSessions: a task in both listings is detailed once and marked 
 	assert.equal(result.totalTasks, 1);
 });
 
+test('collectAgentSessions: a shared task whose account-listing repo-ID lookup fails does not spawn a spurious "no repository" row', async () => {
+	// Same task ID appears in both listings: the workspace listing resolves it via `owner`/`repo`
+	// filters, but the account-wide object only carries a bare repository ID whose lookup fails.
+	const workspaceTask = makeAccountTask('shared', undefined, '2026-08-01T00:00:00Z');
+	const accountTask = makeAccountTaskWithRepoId('shared', 4242, '2026-08-01T00:00:00Z');
+	const result = await collectAgentSessions({
+		token: 'token',
+		since: SINCE,
+		workspaceRepos: [{ owner: 'octo', repo: 'demo' }],
+		fetchTaskPage: async ({ page, archived }) => (!archived && page === 1 ? { tasks: [workspaceTask] } : { tasks: [] }),
+		fetchAccountTaskPage: async ({ page, archived }) => (!archived && page === 1 ? { tasks: [accountTask] } : { tasks: [] }),
+		fetchTaskDetail: async () => ({ sessions: [makeSession('cloud-model', 6)] }),
+		fetchAccountTaskDetail: async () => ({ sessions: [] }),
+		fetchRepositoryById: async () => undefined,
+	});
+
+	assert.equal(result.repos.length, 1, 'the failed account-side lookup must not create a second, unassigned row');
+	assert.equal(result.repos[0].owner, 'octo');
+	assert.equal(result.repos[0].repo, 'demo');
+	assert.equal(result.repos[0].discovery, 'both');
+	assert.equal(result.repos[0].tasksTotal, 1);
+});
+
 test('collectAgentSessions: tasks with no repository land in their own bucket, detailed by ID', async () => {
 	let byIdCalls = 0;
 	const result = await collectAgentSessions({

--- a/vscode-extension/test/unit/agentSessionsService.test.ts
+++ b/vscode-extension/test/unit/agentSessionsService.test.ts
@@ -5,10 +5,12 @@ import {
 	detectSessionSource,
 	fetchAgentSessionsForRepo,
 	readSessionUsage,
+	repositoryIdFromTask,
 	requestGitHubJson,
 	resolveTaskRepo,
 	type AgentRepoSummary,
 	type FetchAccountTaskPageFn,
+	type FetchRepositoryByIdFn,
 	type FetchTaskPageFn,
 	type FetchTaskDetailFn,
 } from '../../src/agentSessionsService';
@@ -286,6 +288,21 @@ test('resolveTaskRepo: returns undefined for a task with no resolvable repositor
 });
 
 // ---------------------------------------------------------------------------
+// repositoryIdFromTask — the bare numeric ID the account-wide listing guarantees
+// ---------------------------------------------------------------------------
+
+test('repositoryIdFromTask: reads a numeric repository.id', () => {
+	assert.equal(repositoryIdFromTask({ repository: { id: 42 } }), 42);
+});
+
+test('repositoryIdFromTask: returns undefined when there is no usable ID', () => {
+	assert.equal(repositoryIdFromTask({ repository: { full_name: 'octo/demo' } }), undefined);
+	assert.equal(repositoryIdFromTask({ repository: { id: 'not-a-number' } }), undefined);
+	assert.equal(repositoryIdFromTask({}), undefined);
+	assert.equal(repositoryIdFromTask(undefined), undefined);
+});
+
+// ---------------------------------------------------------------------------
 // collectAgentSessions — workspace repos merged with the account-wide task list
 // ---------------------------------------------------------------------------
 
@@ -326,6 +343,105 @@ test('collectAgentSessions: finds account tasks in repos that are not open in th
 	assert.equal(result.repos[0].repo, 'remote-repo');
 	assert.equal(result.repos[0].discovery, 'account');
 	assert.equal(result.totalCredits, 4);
+});
+
+/** Task as the account-wide listing typically returns it: only a bare `repository.id`. */
+function makeAccountTaskWithRepoId(id: string, repoId: number, updatedAt = '2026-08-01T00:00:00Z'): any {
+	return {
+		id, name: `Task ${id}`, state: 'completed', updated_at: updatedAt, created_at: updatedAt,
+		repository: { id: repoId },
+	};
+}
+
+test('collectAgentSessions: resolves a bare repository.id via GET /repositories/{id}', async () => {
+	const accountPage = firstPageOnly([makeAccountTaskWithRepoId('a1', 555)]);
+	const lookedUp: number[] = [];
+	const fetchRepositoryById: FetchRepositoryByIdFn = async (id) => {
+		lookedUp.push(id);
+		return id === 555 ? { owner: 'octo', repo: 'byid' } : undefined;
+	};
+	const result = await collectAgentSessions({
+		token: 'token',
+		since: SINCE,
+		workspaceRepos: [],
+		fetchTaskPage: NO_TASKS,
+		fetchAccountTaskPage: async ({ page, archived }) => (archived ? { tasks: [] } : accountPage(page)),
+		fetchTaskDetail: async () => ({ sessions: [makeSession('cloud-model', 3)] }),
+		fetchAccountTaskDetail: async () => ({ sessions: [] }),
+		fetchRepositoryById,
+	});
+
+	assert.deepEqual(lookedUp, [555]);
+	assert.equal(result.repos.length, 1);
+	assert.equal(result.repos[0].owner, 'octo');
+	assert.equal(result.repos[0].repo, 'byid');
+	assert.ok(!result.repos[0].unassigned);
+	assert.equal(result.repos[0].discovery, 'account');
+	assert.equal(result.totalCredits, 3);
+});
+
+test('collectAgentSessions: dedups repository-ID lookups across tasks sharing the same repo', async () => {
+	const accountPage = firstPageOnly([
+		makeAccountTaskWithRepoId('a1', 777, '2026-08-01T00:00:00Z'),
+		makeAccountTaskWithRepoId('a2', 777, '2026-08-02T00:00:00Z'),
+	]);
+	let lookups = 0;
+	const fetchRepositoryById: FetchRepositoryByIdFn = async () => { lookups++; return { owner: 'octo', repo: 'shared-by-id' }; };
+	const result = await collectAgentSessions({
+		token: 'token',
+		since: SINCE,
+		workspaceRepos: [],
+		fetchTaskPage: NO_TASKS,
+		fetchAccountTaskPage: async ({ page, archived }) => (archived ? { tasks: [] } : accountPage(page)),
+		fetchTaskDetail: async () => ({ sessions: [] }),
+		fetchAccountTaskDetail: async () => ({ sessions: [] }),
+		fetchRepositoryById,
+	});
+
+	assert.equal(lookups, 1, 'one lookup per distinct repository ID, not per task');
+	assert.equal(result.repos.length, 1);
+	assert.equal(result.repos[0].tasksTotal, 2);
+});
+
+test('collectAgentSessions: a task whose repository-ID lookup fails still lands in the "no repository" bucket', async () => {
+	const accountPage = firstPageOnly([makeAccountTaskWithRepoId('a1', 999)]);
+	const result = await collectAgentSessions({
+		token: 'token',
+		since: SINCE,
+		workspaceRepos: [],
+		fetchTaskPage: NO_TASKS,
+		fetchAccountTaskPage: async ({ page, archived }) => (archived ? { tasks: [] } : accountPage(page)),
+		fetchTaskDetail: async () => ({ sessions: [] }),
+		fetchAccountTaskDetail: async () => ({ sessions: [] }),
+		fetchRepositoryById: async () => undefined,
+	});
+
+	assert.equal(result.repos.length, 1);
+	assert.equal(result.repos[0].unassigned, true);
+});
+
+test('collectAgentSessions: repository-ID lookups are capped, leaving the rest in the "no repository" bucket', async () => {
+	const tasks = [
+		makeAccountTaskWithRepoId('a1', 1),
+		makeAccountTaskWithRepoId('a2', 2),
+		makeAccountTaskWithRepoId('a3', 3),
+	];
+	const accountPage = firstPageOnly(tasks);
+	const result = await collectAgentSessions({
+		token: 'token',
+		since: SINCE,
+		workspaceRepos: [],
+		maxRepoIdLookups: 2,
+		fetchTaskPage: NO_TASKS,
+		fetchAccountTaskPage: async ({ page, archived }) => (archived ? { tasks: [] } : accountPage(page)),
+		fetchTaskDetail: async () => ({ sessions: [] }),
+		fetchAccountTaskDetail: async () => ({ sessions: [] }),
+		fetchRepositoryById: async (id) => ({ owner: 'octo', repo: `repo-${id}` }),
+	});
+
+	const resolvedRepos = result.repos.filter(r => !r.unassigned);
+	assert.equal(resolvedRepos.length, 2, 'only the first two distinct IDs are looked up');
+	assert.ok(result.repos.some(r => r.unassigned), 'the ID left over falls back to the unassigned bucket');
 });
 
 test('collectAgentSessions: a task in both listings is detailed once and marked as seen from both', async () => {


### PR DESCRIPTION
## Why

Confirmed against the live `/agents/tasks` API: the account-wide listing only ever returns a bare `repository: { id: <number> }` — no `full_name`, `owner`, `name`, or `html_url` anywhere on the task object. `resolveTaskRepo()` (added in #1875) can't turn that into an owner/repo pair by itself, so **every** account-only task was silently landing in the "no repository (cloud chat)" bucket, even when it clearly belonged to a real, resolvable repo. In practice this meant the Cloud Agent tab showed mostly (or only) the unassigned bucket instead of a per-repo breakdown.

## What changed

- Added `fetchRepositoryById()` (`GET /repositories/{id}`) to resolve a bare repository ID to `owner/repo`.
- `collectAgentSessions()` now resolves the account-listing's unresolved repository IDs before building rows: distinct IDs are looked up once and cached for the pass (many tasks in the same repo share one ID), and lookups are capped (`MAX_REPO_ID_LOOKUPS_PER_REFRESH = 50`) to bound API usage — any IDs left over stay in the "no repository" bucket for that pass and are retried on the next hourly refresh.
- Extracted `resolveRepositoryIds()` / `resolveAccountTaskRepo()` helpers to keep `collectAccountTasks()` under the complexity lint threshold.
- Updated `docs/features/CLOUD-AGENT-COST.md` to document the new resolution step.
- Added unit tests: resolving a bare ID, deduping lookups across tasks sharing a repo, falling back to "no repository" when the lookup fails, and the lookup cap.

## Testing

- `npm run validate` (type-check + lint + build) — clean, same 3 pre-existing unrelated warnings as `main`
- `npm run test:node` — full suite passes (including new `agentSessionsService.test.ts` cases)

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>