### PR TITLE
fix: prevent inline JSON/dict fragments in toolNames.json friendly names

### DIFF
--- a/.github/scripts/test_toolnames_utils.py
+++ b/.github/scripts/test_toolnames_utils.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Unit tests for toolnames_utils.py's JSON-fragment detection.
+
+Run directly with: python3 .github/scripts/test_toolnames_utils.py
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from toolnames_utils import find_invalid_friendly_names, looks_like_json_fragment
+
+
+class LooksLikeJsonFragmentTests(unittest.TestCase):
+    def test_flags_the_pr_1930_regression(self) -> None:
+        # The exact bad value PR #1930 added: str()-ing a nested dict
+        # response from the SLM instead of rejecting it.
+        self.assertTrue(
+            looks_like_json_fragment("{'run_workflow': 'Playwright MCP: Run Workflow'}")
+        )
+
+    def test_flags_curly_braces(self) -> None:
+        self.assertTrue(looks_like_json_fragment('{"a": "b"}'))
+
+    def test_flags_square_brackets(self) -> None:
+        self.assertTrue(looks_like_json_fragment("[Run Workflow]"))
+
+    def test_allows_plain_friendly_names(self) -> None:
+        for name in [
+            "GitHub MCP (Remote): Issue Read",
+            "Playwright MCP: Run Workflow",
+            "Search Files",
+            "Ask User Question",
+            "Get Doc Info",
+        ]:
+            with self.subTest(name=name):
+                self.assertFalse(looks_like_json_fragment(name))
+
+    def test_allows_names_with_parentheses_and_colons(self) -> None:
+        self.assertFalse(looks_like_json_fragment("GitHub MCP (Local): Get Commit"))
+
+
+class FindInvalidFriendlyNamesTests(unittest.TestCase):
+    def test_returns_only_invalid_entries(self) -> None:
+        tool_names = {
+            "read_file": "Read File",
+            "MCP": "{'run_workflow': 'Playwright MCP: Run Workflow'}",
+            "run_workflow": "Run Workflow",
+        }
+        self.assertEqual(
+            find_invalid_friendly_names(tool_names),
+            [("MCP", "{'run_workflow': 'Playwright MCP: Run Workflow'}")],
+        )
+
+    def test_empty_when_all_valid(self) -> None:
+        tool_names = {"read_file": "Read File", "grep": "Grep"}
+        self.assertEqual(find_invalid_friendly_names(tool_names), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_toolnames_utils.py
+++ b/.github/scripts/test_toolnames_utils.py
@@ -41,6 +41,14 @@ class LooksLikeJsonFragmentTests(unittest.TestCase):
     def test_allows_names_with_parentheses_and_colons(self) -> None:
         self.assertFalse(looks_like_json_fragment("GitHub MCP (Local): Get Commit"))
 
+    def test_flags_non_string_values_instead_of_raising(self) -> None:
+        # A backstop check must not crash on unexpected input (e.g. a nested
+        # dict that slipped past an earlier validation step) — it should
+        # treat it as invalid, not raise TypeError.
+        for value in [{"run_workflow": "Playwright MCP: Run Workflow"}, ["a", "b"], None, 42]:
+            with self.subTest(value=value):
+                self.assertTrue(looks_like_json_fragment(value))
+
 
 class FindInvalidFriendlyNamesTests(unittest.TestCase):
     def test_returns_only_invalid_entries(self) -> None:

--- a/.github/scripts/toolnames_utils.py
+++ b/.github/scripts/toolnames_utils.py
@@ -89,6 +89,32 @@ def _normalize_friendly_name(name: str) -> str:
     return re.sub(r"\s+", " ", name.strip().lower())
 
 
+# A friendly display name is a short human-readable label (e.g. "Playwright
+# MCP: Run Workflow") and should never contain JSON/dict structural
+# characters. Seeing one usually means a generator accidentally serialized a
+# nested object instead of a plain string — e.g. PR #1930 added
+# "MCP": "{'run_workflow': 'Playwright MCP: Run Workflow'}" because the SLM
+# used by add-toolnames-with-slm returned a nested object for that tool ID
+# and the code stringified it with str() instead of rejecting it.
+_JSON_FRAGMENT_RE = re.compile(r"[{}\[\]]")
+
+
+def looks_like_json_fragment(value: str) -> bool:
+    """Flag friendly-name strings that look like a stray JSON/dict fragment."""
+    return bool(_JSON_FRAGMENT_RE.search(value))
+
+
+def find_invalid_friendly_names(
+    tool_names: dict[str, str]
+) -> list[tuple[str, str]]:
+    """Return (tool_id, friendly) pairs whose friendly name is JSON-like."""
+    return [
+        (tool_id, friendly)
+        for tool_id, friendly in tool_names.items()
+        if looks_like_json_fragment(friendly)
+    ]
+
+
 # Known MCP tool families: keyed by a display prefix, matched by (a) a keyword
 # appearing anywhere in the (normalized) tool id and (b) the id ending in one
 # of the family's known action names. This mirrors src/utils/toolUtils.ts's
@@ -310,6 +336,12 @@ def find_new_duplicate_groups(
     return new_strict, new_canonical
 
 
+def _print_invalid_friendly_names(invalid: list[tuple[str, str]]) -> None:
+    print(f"\nFound {len(invalid)} entr{'y' if len(invalid) == 1 else 'ies'} with a JSON-like friendly name:")
+    for tool_id, friendly in sorted(invalid):
+        print(f"  {tool_id!r} -> {friendly!r}")
+
+
 def _print_report(
     strict_duplicates: dict[str, list[tuple[str, str]]],
     canonical_equivalents: dict[str, list[tuple[str, str]]]
@@ -355,15 +387,23 @@ def main() -> int:
     else:
         strict_duplicates, canonical_equivalents = find_duplicate_groups(tool_names)
 
-    if not strict_duplicates and not canonical_equivalents:
+    # Unlike duplicates, a JSON-like friendly name is never legitimate, so it
+    # always fails the build — even if it was already present at the base
+    # commit — rather than only when newly introduced.
+    invalid_friendly_names = find_invalid_friendly_names(tool_names)
+
+    if not strict_duplicates and not canonical_equivalents and not invalid_friendly_names:
         print("No duplicate-like entries found.")
         return 0
 
     _print_report(strict_duplicates, canonical_equivalents)
+    if invalid_friendly_names:
+        _print_invalid_friendly_names(invalid_friendly_names)
 
-    # Treat strict duplicates as a failing condition for CI; canonical
-    # equivalents are surfaced but do not fail the build on their own.
-    return 1 if strict_duplicates else 0
+    # Treat strict duplicates and JSON-like friendly names as failing
+    # conditions for CI; canonical equivalents are surfaced but do not fail
+    # the build on their own.
+    return 1 if (strict_duplicates or invalid_friendly_names) else 0
 
 
 if __name__ == "__main__":

--- a/.github/scripts/toolnames_utils.py
+++ b/.github/scripts/toolnames_utils.py
@@ -99,8 +99,19 @@ def _normalize_friendly_name(name: str) -> str:
 _JSON_FRAGMENT_RE = re.compile(r"[{}\[\]]")
 
 
-def looks_like_json_fragment(value: str) -> bool:
-    """Flag friendly-name strings that look like a stray JSON/dict fragment."""
+def looks_like_json_fragment(value: Any) -> bool:
+    """Flag friendly-name values that are invalid as a display name.
+
+    A friendly name must be a plain string; a value that is itself a dict or
+    list (e.g. a nested object the SLM returned without being str()-ed) is
+    just as invalid as a string containing stray JSON structural characters,
+    so both are treated as "looks like JSON" rather than raising a
+    TypeError. This keeps callers — especially the final backstop before
+    writing to toolNames.json — safe even if an earlier validation step is
+    bypassed or a future caller passes untrusted data straight through.
+    """
+    if not isinstance(value, str):
+        return True
     return bool(_JSON_FRAGMENT_RE.search(value))
 
 

--- a/.github/workflows/check-toolnames.yml
+++ b/.github/workflows/check-toolnames.yml
@@ -407,6 +407,12 @@ jobs:
               "  Claude Code IDs look like mcp__<server>__<tool>.",
               "- Tool IDs without any MCP prefix: just Title Case the words.",
               '- Never output placeholder text like "Tool Name Not Found" or "Unknown".',
+              "- Every value must be a plain string, never a nested JSON object or array.",
+              '  WRONG: {"MCP": {"run_workflow": "Playwright MCP: Run Workflow"}}',
+              '  RIGHT: {"MCP_run_workflow": "Playwright MCP: Run Workflow"}',
+              "  If a tool ID looks like it could describe multiple actions, pick the",
+              "  single best display name for that exact ID as given — do not invent",
+              "  sub-keys or restructure the input.",
               "",
               "EXISTING MAPPINGS (follow these patterns):",
               sample_lines,
@@ -414,7 +420,9 @@ jobs:
               "INPUT:",
               tool_ids_json,
               "",
-              "OUTPUT: JSON object only, no explanation.",
+              "OUTPUT: a flat JSON object only, no explanation. Every key must be exactly",
+              "one of the INPUT tool IDs (same spelling), and every value a plain string",
+              "with no braces, brackets, or quotes of its own.",
           ])
 
           payload = {

--- a/.github/workflows/check-toolnames.yml
+++ b/.github/workflows/check-toolnames.yml
@@ -348,6 +348,9 @@ jobs:
           python3 - << 'PYEOF'
           import json, re, sys, urllib.request, urllib.error, os
 
+          sys.path.insert(0, ".github/scripts")
+          from toolnames_utils import looks_like_json_fragment
+
           with open("/tmp/missing-tools.json") as f:
               missing_tools = json.load(f)
 
@@ -445,8 +448,21 @@ jobs:
               PLACEHOLDERS = {"tool name not found", "unknown", "not found", "n/a", "none", "unknown tool"}
               validated = {}
               for tool in missing_tools:
-                  friendly = str(generated.get(tool, "")).strip()
-                  if not friendly or len(friendly) > 200 or friendly.lower() in PLACEHOLDERS:
+                  raw = generated.get(tool, "")
+                  # The model occasionally nests a sub-object under a key
+                  # instead of a plain string (e.g. {"MCP": {"run_workflow":
+                  # "Playwright MCP: Run Workflow"}}). str()-ing that dict
+                  # produces a Python-repr string like
+                  # "{'run_workflow': 'Playwright MCP: Run Workflow'}", which
+                  # is not a valid friendly name — treat it as missing rather
+                  # than forwarding the raw structure.
+                  friendly = "" if isinstance(raw, (dict, list)) else str(raw).strip()
+                  if (
+                      not friendly
+                      or len(friendly) > 200
+                      or friendly.lower() in PLACEHOLDERS
+                      or looks_like_json_fragment(friendly)
+                  ):
                       # Local fallback transformation
                       s = re.sub(r'[_\-.]', ' ', tool)
                       s = re.sub(r'([a-z])([A-Z])', r'\1 \2', s)
@@ -488,7 +504,7 @@ jobs:
           import json, re, sys
 
           sys.path.insert(0, ".github/scripts")
-          from toolnames_utils import find_friendly_duplicates, find_matches_for_new_tool
+          from toolnames_utils import find_friendly_duplicates, find_matches_for_new_tool, looks_like_json_fragment
 
           TOOLNAMES_FILE = "src/toolNames.json"
 
@@ -504,6 +520,15 @@ jobs:
 
           to_add = {}
           for tool_id, friendly_name in new_entries.items():
+              # Final backstop: never write a JSON-like friendly name, even
+              # if the generation step's own fallback was somehow bypassed.
+              if looks_like_json_fragment(friendly_name):
+                  print(
+                      f"Skipping {tool_id!r} — friendly name {friendly_name!r} looks like a "
+                      "stray JSON/dict fragment, not a valid display name",
+                      file=sys.stderr
+                  )
+                  continue
               matches = find_matches_for_new_tool(tool_id, known_tools)
               if matches["exact"]:
                   print(f"Skipping {tool_id!r} — already present", file=sys.stderr)

--- a/.github/workflows/lint-toolnames.yml
+++ b/.github/workflows/lint-toolnames.yml
@@ -14,12 +14,14 @@ on:
     paths:
       - "src/toolNames.json"
       - ".github/scripts/toolnames_utils.py"
+      - ".github/scripts/test_toolnames_utils.py"
       - ".github/workflows/lint-toolnames.yml"
   push:
     branches: [main]
     paths:
       - "src/toolNames.json"
       - ".github/scripts/toolnames_utils.py"
+      - ".github/scripts/test_toolnames_utils.py"
       - ".github/workflows/lint-toolnames.yml"
   workflow_dispatch:
 
@@ -47,6 +49,9 @@ jobs:
           # is actually present locally for the `git show` diff below;
           # the default shallow depth=1 checkout only fetches the head commit.
           fetch-depth: 0
+
+      - name: Run toolnames_utils unit tests
+        run: python3 .github/scripts/test_toolnames_utils.py -v
 
       - name: Check for duplicate-like entries
         id: check


### PR DESCRIPTION
## Summary

PR #1930 (opened by the `add-toolnames-with-slm` workflow) added this entry to `src/toolNames.json`:

```json
"MCP": "{'run_workflow': 'Playwright MCP: Run Workflow'}"
```

The SLM (Qwen2.5-1.5B) occasionally returns a nested JSON object for a tool ID instead of a plain string (e.g. `{"MCP": {"run_workflow": "Playwright MCP: Run Workflow"}}`), and the generation script's `str(generated.get(tool, "")).strip()` silently stringified that nested dict into a Python-repr string instead of rejecting it — producing an invalid, JSON-shaped friendly name in the committed file.

This PR adds three layers of defense against inline JSON ending up as a `toolNames.json` value:

1. **Root cause fix** (`.github/workflows/check-toolnames.yml`, `add-toolnames-with-slm` job): the "Generate friendly names with SLM" step now detects non-string (`dict`/`list`) SLM output and any friendly name that looks like a JSON/dict fragment, falling back to the existing deterministic local transformation (Title Case the tool ID) instead of forwarding the raw structure.
2. **Backstop** (same workflow, "Update toolNames.json with new entries" step): before writing new entries to `src/toolNames.json`, any friendly name that still looks JSON-like is skipped, even if the generation step's fallback were somehow bypassed.
3. **CI safety net** (`.github/scripts/toolnames_utils.py`, used by `.github/workflows/lint-toolnames.yml`): added `looks_like_json_fragment()` / `find_invalid_friendly_names()` and wired them into `main()` so the lint job now fails the build if *any* entry in `src/toolNames.json` has a friendly name containing `{`, `}`, `[`, or `]` — catching this regardless of how the entry was introduced (SLM, manual edit, or other tooling), not just newly-introduced ones.

## Test plan

- [x] Ran `python3 .github/scripts/toolnames_utils.py --base <copy of current file>` to confirm the lint check still passes cleanly (exit 0) against the current `src/toolNames.json`.
- [x] Reproduced PR #1930's exact bad entry (`"MCP": "{'run_workflow': 'Playwright MCP: Run Workflow'}"`) in a scratch copy of `src/toolNames.json` and confirmed `toolnames_utils.py --base ...` now exits 1 and reports it under "Found 1 entry with a JSON-like friendly name".
- [x] Simulated the SLM validation loop with a nested-dict response (`{"MCP": {"run_workflow": "..."}, "run_workflow": "Run Workflow"}`) and confirmed it now falls back to a Title Case transformation instead of stringifying the dict.
- [x] Validated `.github/workflows/check-toolnames.yml` is still valid YAML after the edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U2LvnygEnLbKFazHnRuL1T

---
_Generated by [Claude Code](https://claude.ai/code/session_01U2LvnygEnLbKFazHnRuL1T)_