### PR TITLE
fix(toolnames): visible warning on dedup-blocked PRs + camelCase tool-ID matching

### DIFF
--- a/.github/scripts/test_toolnames_utils.py
+++ b/.github/scripts/test_toolnames_utils.py
@@ -10,7 +10,12 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from toolnames_utils import find_invalid_friendly_names, looks_like_json_fragment
+from toolnames_utils import (
+    canonicalize_tool_id,
+    find_invalid_friendly_names,
+    find_matches_for_new_tool,
+    looks_like_json_fragment,
+)
 
 
 class LooksLikeJsonFragmentTests(unittest.TestCase):
@@ -65,6 +70,42 @@ class FindInvalidFriendlyNamesTests(unittest.TestCase):
     def test_empty_when_all_valid(self) -> None:
         tool_names = {"read_file": "Read File", "grep": "Grep"}
         self.assertEqual(find_invalid_friendly_names(tool_names), [])
+
+
+class CanonicalizeToolIdCamelCaseTests(unittest.TestCase):
+    def test_pascal_case_matches_snake_case(self) -> None:
+        # Regression test for issue #1942: "ListAgents" (PascalCase, as
+        # reported by one host) should canonicalize the same as the
+        # "list_agents" entry already in toolNames.json.
+        self.assertEqual(canonicalize_tool_id("ListAgents"), canonicalize_tool_id("list_agents"))
+
+    def test_camel_case_matches_snake_case(self) -> None:
+        self.assertEqual(canonicalize_tool_id("readFile"), canonicalize_tool_id("read_file"))
+
+    def test_acronym_run_splits_before_trailing_word(self) -> None:
+        self.assertEqual(canonicalize_tool_id("HTTPServer"), canonicalize_tool_id("http_server"))
+
+    def test_plain_snake_case_is_unchanged(self) -> None:
+        self.assertEqual(canonicalize_tool_id("list_agents"), "list_agents")
+
+    def test_prefix_rule_action_suffix_also_gets_camel_case_split(self) -> None:
+        # The action portion after a recognized MCP prefix must also be
+        # camel-cased and lowercased consistently, so two registrations of
+        # the same upstream tool canonicalize identically even when one
+        # host reports the action in PascalCase.
+        self.assertEqual(
+            canonicalize_tool_id("github-mcp-server-SearchCode"),
+            canonicalize_tool_id("mcp_github_mcp_s2_search_code"),
+        )
+
+
+class FindMatchesForNewToolCamelCaseTests(unittest.TestCase):
+    def test_pascal_case_tool_id_resolves_as_canonical_equivalent(self) -> None:
+        known = {"list_agents": "List Agents"}
+        matches = find_matches_for_new_tool("ListAgents", known)
+        self.assertEqual(matches["canonical_equivalent"], [("list_agents", "List Agents")])
+        self.assertEqual(matches["exact"], [])
+        self.assertEqual(matches["case_variant"], [])
 
 
 if __name__ == "__main__":

--- a/.github/scripts/toolnames_utils.py
+++ b/.github/scripts/toolnames_utils.py
@@ -50,6 +50,22 @@ def _normalize_separators(value: str) -> str:
     return value.replace(".", "_").replace("-", "_")
 
 
+def _camel_to_snake(value: str) -> str:
+    """Insert underscores at camelCase/PascalCase word boundaries.
+
+    Different hosts report the same underlying tool under different naming
+    conventions — e.g. one client's `ListAgents` is another's `list_agents`
+    (see issue #1942). This inserts an underscore before a capital letter
+    that follows a lowercase letter or digit ("ListAgents" -> "List_Agents"),
+    and also splits a run of capitals followed by a lowercase letter
+    ("HTTPServer" -> "HTTP_Server"), so a later `.lower()` collapses both
+    naming conventions to the same snake_case form.
+    """
+    value = re.sub(r"(?<=[a-z0-9])(?=[A-Z])", "_", value)
+    value = re.sub(r"(?<=[A-Z])(?=[A-Z][a-z])", "_", value)
+    return value
+
+
 def _compile_prefix_pattern(prefix: str) -> re.Pattern[str]:
     """Build a regex that also matches numeric-suffixed collision variants.
 
@@ -80,8 +96,8 @@ def canonicalize_tool_id(tool_id: str) -> str:
         match = pattern.match(lowered)
         if match:
             action = tool_id[match.end():]
-            return replacement + _normalize_separators(action)
-    return _normalize_separators(tool_id)
+            return replacement + _normalize_separators(_camel_to_snake(action)).lower()
+    return _normalize_separators(_camel_to_snake(tool_id)).lower()
 
 
 def _normalize_friendly_name(name: str) -> str:

--- a/.github/workflows/check-toolnames.yml
+++ b/.github/workflows/check-toolnames.yml
@@ -507,20 +507,33 @@ jobs:
 
       - name: Update toolNames.json with new entries
         if: steps.extract.outputs.has_missing == 'true'
+        id: update
         run: |
           python3 - << 'PYEOF'
-          import json, re, sys
+          import json, os, re, sys
 
           sys.path.insert(0, ".github/scripts")
           from toolnames_utils import find_friendly_duplicates, find_matches_for_new_tool, looks_like_json_fragment
 
           TOOLNAMES_FILE = "src/toolNames.json"
+          SKIP_REASONS_FILE = "/tmp/slm-skip-reasons.json"
+
+          skip_reasons = []
+
+          def write_skip_reasons():
+              with open(SKIP_REASONS_FILE, "w") as f:
+                  json.dump(skip_reasons, f)
+
+          def skip(tool_id, reason):
+              print(f"Skipping {tool_id!r} — {reason}", file=sys.stderr)
+              skip_reasons.append({"tool_id": tool_id, "reason": reason})
 
           with open("/tmp/slm-names.json") as f:
               new_entries = json.load(f)
 
           if not new_entries:
               print("No new entries to add.", file=sys.stderr)
+              write_skip_reasons()
               sys.exit(0)
 
           with open(TOOLNAMES_FILE) as f:
@@ -531,40 +544,49 @@ jobs:
               # Final backstop: never write a JSON-like friendly name, even
               # if the generation step's own fallback was somehow bypassed.
               if looks_like_json_fragment(friendly_name):
-                  print(
-                      f"Skipping {tool_id!r} — friendly name {friendly_name!r} looks like a "
-                      "stray JSON/dict fragment, not a valid display name",
-                      file=sys.stderr
+                  skip(
+                      tool_id,
+                      f"friendly name {friendly_name!r} looks like a stray JSON/dict "
+                      "fragment, not a valid display name"
                   )
                   continue
               matches = find_matches_for_new_tool(tool_id, known_tools)
               if matches["exact"]:
-                  print(f"Skipping {tool_id!r} — already present", file=sys.stderr)
+                  skip(tool_id, "already present")
                   continue
               if matches["case_variant"]:
                   existing_id = matches["case_variant"][0][0]
-                  print(f"Skipping {tool_id!r} — case variant of {existing_id!r}", file=sys.stderr)
+                  skip(tool_id, f"case variant of {existing_id!r}")
                   continue
               if matches["canonical_equivalent"]:
                   existing_id = matches["canonical_equivalent"][0][0]
-                  print(f"Skipping {tool_id!r} — canonical equivalent of {existing_id!r}", file=sys.stderr)
+                  skip(tool_id, f"canonical equivalent of {existing_id!r}")
                   continue
               if matches["family_equivalent"]:
-                  print(f"Skipping {tool_id!r} — resolves via known MCP family pattern", file=sys.stderr)
+                  skip(tool_id, "resolves via known MCP family pattern")
                   continue
               friendly_dups = find_friendly_duplicates(friendly_name, known_tools)
               if friendly_dups:
                   existing_id, existing_friendly = friendly_dups[0]
-                  print(
-                      f"Skipping {tool_id!r} — friendly name '{friendly_name}' already used by "
-                      f"{existing_id!r} ({existing_friendly})",
-                      file=sys.stderr
+                  skip(
+                      tool_id,
+                      f"friendly name '{friendly_name}' already used by "
+                      f"{existing_id!r} ({existing_friendly})"
                   )
                   continue
               to_add[tool_id] = friendly_name
 
+          write_skip_reasons()
+
           if not to_add:
               print("All entries already present after dedup. Nothing to write.", file=sys.stderr)
+              print(
+                  f"::warning::add-toolnames-with-slm generated {len(new_entries)} friendly "
+                  f"name(s) but all were skipped by dedup, so no PR was opened. See the "
+                  "'Update toolNames.json with new entries' step log for per-tool reasons."
+              )
+              with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+                  f.write("added_count=0\n")
               sys.exit(0)
 
           ordered_items = list(known_tools.items()) + list(to_add.items())
@@ -585,6 +607,8 @@ jobs:
           with open(TOOLNAMES_FILE, "w") as f:
               f.write(new_content)
           print(f"✅ Wrote {len(to_add)} new entries to toolNames.json", file=sys.stderr)
+          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+              f.write(f"added_count={len(to_add)}\n")
           PYEOF
           
       - name: Restore gradlew files to prevent stash conflicts
@@ -665,7 +689,15 @@ jobs:
                   lines.append("")
                   lines.append("> ⚠️ Also check whether any of these tools should be added to `automaticTools.json`.")
               else:
-                  lines.append("> ℹ️ No PR was opened (either no changes were needed or generation failed).")
+                  skip_path = "/tmp/slm-skip-reasons.json"
+                  skip_reasons = json.load(open(skip_path)) if os.path.exists(skip_path) else []
+                  lines.append("> ⚠️ **No PR was opened** — every generated name was rejected by dedup, so `toolNames.json` was left unchanged:")
+                  lines.append(">")
+                  if skip_reasons:
+                      for item in skip_reasons:
+                          lines.append(f"> - `{esc(item['tool_id'])}`: {esc(item['reason'])}")
+                  else:
+                      lines.append("> - (no per-tool reason was recorded — check the workflow run log below)")
               lines.append("")
               lines.append(f"_Workflow run: {server_url}/{repo}/actions/runs/{run_id}_")
               comment = "\n".join(lines)

--- a/src/utils/toolUtils.ts
+++ b/src/utils/toolUtils.ts
@@ -154,3 +154,56 @@ export function resolveMcpFamilyToolName(id: string): string | undefined {
 export function isMcpFamilyResolvedTool(id: string): boolean {
 	return resolveMcpFamilyToolName(id) !== undefined;
 }
+
+/**
+ * Insert underscores at camelCase/PascalCase word boundaries, e.g.
+ * "ListAgents" -> "List_Agents" and "HTTPServer" -> "HTTP_Server".
+ *
+ * Different hosts report the same underlying tool under different naming
+ * conventions — one client's `ListAgents` is another's `list_agents` (see
+ * issue #1942) — so splitting camelCase before lowercasing/folding
+ * separators lets `canonicalizeToolId` treat both spellings as the same id.
+ *
+ * Mirrors `_camel_to_snake()` in `.github/scripts/toolnames_utils.py`.
+ * Keep the two in sync if either changes.
+ */
+function camelToSnake(value: string): string {
+	return value
+		.replace(/(?<=[a-z0-9])(?=[A-Z])/g, '_')
+		.replace(/(?<=[A-Z])(?=[A-Z][a-z])/g, '_');
+}
+
+/**
+ * Canonical form of a tool ID for equivalence comparisons: camelCase-split,
+ * lowercased, then `.`/`-` folded to `_`.
+ *
+ * Mirrors a simplified form of `canonicalize_tool_id()` in
+ * `.github/scripts/toolnames_utils.py` — that script's MCP-prefix collision
+ * rules aren't duplicated here since prefix variants for known MCP tool
+ * families are already handled by `resolveMcpFamilyToolName` above.
+ */
+export function canonicalizeToolId(id: string): string {
+	return camelToSnake(id).toLowerCase().replace(/[.-]/g, '_');
+}
+
+/**
+ * Look up a tool ID's friendly name in a toolNames.json-shaped map, trying
+ * progressively looser matches: exact key, case-insensitive key, then a
+ * canonicalized (camelCase/separator-normalized) key. The canonical fallback
+ * recognizes e.g. `ListAgents` as the same tool as an existing `list_agents`
+ * entry without needing a duplicate entry for every casing/separator variant
+ * a host might use (see issue #1942).
+ *
+ * Returns `undefined` when none of those match, so callers can fall back to
+ * GUID/MCP-family resolution or flag the tool as unknown.
+ */
+export function lookupKnownToolName(id: string, toolNameMap: Record<string, string>): string | undefined {
+	if (toolNameMap[id]) { return toolNameMap[id]; }
+	const lower = id.toLowerCase();
+	if (toolNameMap[lower]) { return toolNameMap[lower]; }
+	const canonicalId = canonicalizeToolId(id);
+	for (const key of Object.keys(toolNameMap)) {
+		if (canonicalizeToolId(key) === canonicalId) { return toolNameMap[key]; }
+	}
+	return undefined;
+}

--- a/src/workspaceHelpers.ts
+++ b/src/workspaceHelpers.ts
@@ -20,7 +20,7 @@ import {
 	toPlatformPath
 } from './utils/pathUtils';
 import { withErrorRecoverySync } from './utils/errors';
-import { isGuidMcpTool } from './utils/toolUtils';
+import { isGuidMcpTool, lookupKnownToolName } from './utils/toolUtils';
 
 export {
 	fileUriToPath,
@@ -691,7 +691,7 @@ export function normalizeMcpToolName(toolName: string): string {
  */
 export function extractMcpServerName(toolName: string, toolNameMap: { [key: string]: string } = {}): string {
 	// First, try to get the display name from toolNames.json and extract the server part
-	const displayName = toolNameMap[toolName] ?? toolNameMap[toolName.toLowerCase()];
+	const displayName = lookupKnownToolName(toolName, toolNameMap);
 	if (displayName && displayName.includes(':')) {
 		// Extract the part before the colon (e.g., "GitHub MCP" from "GitHub MCP: Issue Read")
 		return displayName.split(':')[0].trim();

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -304,7 +304,7 @@ import { ConfirmationMessages } from './backend/ui/messages';
 
 // --- Utilities ---
 import { getNonce, buildCspMeta, getCodiconStylesheetTag } from './utils/webviewUtils';
-import { isGuidMcpTool, isMcpFamilyResolvedTool } from '../../src/utils/toolUtils';
+import { isGuidMcpTool, isMcpFamilyResolvedTool, lookupKnownToolName } from '../../src/utils/toolUtils';
 import { toLocalDayKey } from '../../src/utils/dayKeys';
 import { buildRecentSessionBuckets as bucketRecentSessions } from '../../src/recentSessions';
 import { determineOnboardingAction } from './onboarding';
@@ -1719,7 +1719,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 		const suppressed = new Set<string>(
 			vscode.workspace.getConfiguration('aiEngineeringFluency').get<string[]>('suppressedUnknownTools', [])
 		);
-		return Array.from(allTools).filter(tool => !this.toolNameMap[tool] && !this.toolNameMap[tool.toLowerCase()] && !isGuidMcpTool(tool) && !isMcpFamilyResolvedTool(tool) && !suppressed.has(tool)).sort();
+		return Array.from(allTools).filter(tool => !lookupKnownToolName(tool, this.toolNameMap) && !isGuidMcpTool(tool) && !isMcpFamilyResolvedTool(tool) && !suppressed.has(tool)).sort();
 	}
 
 	private async showUnknownMcpToolsBanner(): Promise<void> {

--- a/vscode-extension/src/insightsEngine.ts
+++ b/vscode-extension/src/insightsEngine.ts
@@ -14,7 +14,7 @@ import type {
 } from '../../src/types';
 import toolNamesData from '../../src/toolNames.json';
 import modelPricingData from '../../src/modelPricing.json';
-import { resolveGuidMcpToolName, resolveMcpFamilyToolName } from '../../src/utils/toolUtils';
+import { resolveGuidMcpToolName, resolveMcpFamilyToolName, lookupKnownToolName } from '../../src/utils/toolUtils';
 import { getLongContextInfo, type LongContextInfo } from '../../src/tokenEstimation';
 import type { ModelPricing } from '../../src/types';
 
@@ -26,7 +26,7 @@ const TOOL_NAME_MAP: Record<string, string> = toolNamesData as Record<string, st
 
 /**
  * Returns a human-friendly display name for an MCP tool ID.
- * 1. Exact match in toolNames.json
+ * 1. Exact, case-insensitive, or canonicalized (camelCase/separator) match in toolNames.json
  * 2. GUID-keyed MCP pattern (e.g. M365 Connector)
  * 3. Known MCP family (GitHub/Playwright/Context7/Tavily/Claude Browser) + known action,
  *    regardless of server-registration prefix (see issue #1760)
@@ -34,7 +34,8 @@ const TOOL_NAME_MAP: Record<string, string> = toolNamesData as Record<string, st
  * 5. Fall back to the raw ID
  */
 function friendlyToolName(id: string): string {
-	if (TOOL_NAME_MAP[id]) { return TOOL_NAME_MAP[id]; }
+	const known = lookupKnownToolName(id, TOOL_NAME_MAP);
+	if (known) { return known; }
 	const guid = resolveGuidMcpToolName(id);
 	if (guid) { return guid; }
 	const family = resolveMcpFamilyToolName(id);

--- a/vscode-extension/src/webview/logviewer/main.ts
+++ b/vscode-extension/src/webview/logviewer/main.ts
@@ -172,7 +172,7 @@ if (initialData?.localization) {
 	setCurrentLanguage(language);
 }
 
-import { resolveGuidMcpToolName, resolveMcpFamilyToolName } from '../../../../src/utils/toolUtils';
+import { resolveGuidMcpToolName, resolveMcpFamilyToolName, lookupKnownToolName } from '../../../../src/utils/toolUtils';
 
 // Tool name map is injected by the extension host as window.__TOOL_NAMES__
 const TOOL_NAME_MAP: { [key: string]: string } | null = getWindowData<Record<string, string>>('__TOOL_NAMES__') ?? null;
@@ -194,7 +194,7 @@ function lookupToolName(id: string): string {
 if (!TOOL_NAME_MAP) {
 return id;
 }
-return TOOL_NAME_MAP[id] ?? TOOL_NAME_MAP[id.toLowerCase()] ?? resolveGuidMcpToolName(id) ?? resolveMcpFamilyToolName(id) ?? id;
+return lookupKnownToolName(id, TOOL_NAME_MAP) ?? resolveGuidMcpToolName(id) ?? resolveMcpFamilyToolName(id) ?? id;
 }
 
 function getEffortDisplayName(level: string): string {

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -720,7 +720,7 @@ function getEffortDisplayName(level: string): string {
 	return EFFORT_DISPLAY_NAMES[level] ?? level;
 }
 
-import { resolveGuidMcpToolName, isGuidMcpTool, resolveMcpFamilyToolName, isMcpFamilyResolvedTool } from '../../../../src/utils/toolUtils';
+import { resolveGuidMcpToolName, isGuidMcpTool, resolveMcpFamilyToolName, isMcpFamilyResolvedTool, lookupKnownToolName } from '../../../../src/utils/toolUtils';
 
 // Tool name maps are injected by the extension host as window.__TOOL_NAMES__ and window.__AUTOMATIC_TOOLS__
 const TOOL_NAME_MAP: { [key: string]: string } | null = getWindowData<Record<string, string>>('__TOOL_NAMES__') ?? null;
@@ -731,7 +731,7 @@ function lookupToolName(id: string): string {
 	if (!TOOL_NAME_MAP) {
 		return id;
 	}
-	return TOOL_NAME_MAP[id] ?? TOOL_NAME_MAP[id.toLowerCase()] ?? resolveGuidMcpToolName(id) ?? resolveMcpFamilyToolName(id) ?? id;
+	return lookupKnownToolName(id, TOOL_NAME_MAP) ?? resolveGuidMcpToolName(id) ?? resolveMcpFamilyToolName(id) ?? id;
 }
 
 function lookupMcpToolName(id: string): string {
@@ -764,11 +764,11 @@ function getUnknownMcpTools(stats: UsageAnalysisStats): string[] {
 
 	const suppressed = new Set<string>(stats.suppressedUnknownTools ?? []);
 	
-	// Filter to only unknown tools (not a key in the map, case-insensitively, and not
+	// Filter to only unknown tools (not a key in the map, case-insensitively or canonically, and not
 	// resolvable via a known GUID/family pattern) and not suppressed. Tools resolved via
 	// isMcpFamilyResolvedTool are a recognized MCP tool under a new server-registration
 	// spelling (see issue #1760) — they shouldn't generate another "add missing name" report.
-	return Array.from(allTools).filter(tool => !TOOL_NAME_MAP?.[tool] && !TOOL_NAME_MAP?.[tool.toLowerCase()] && !isGuidMcpTool(tool) && !isMcpFamilyResolvedTool(tool) && !suppressed.has(tool)).sort();
+	return Array.from(allTools).filter(tool => !(TOOL_NAME_MAP && lookupKnownToolName(tool, TOOL_NAME_MAP)) && !isGuidMcpTool(tool) && !isMcpFamilyResolvedTool(tool) && !suppressed.has(tool)).sort();
 }
 
 function createMcpToolIssueUrl(unknownTools: string[]): string {

--- a/vscode-extension/test/unit/utils-toolUtils.test.ts
+++ b/vscode-extension/test/unit/utils-toolUtils.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import * as assert from 'node:assert/strict';
 
-import { resolveGuidMcpToolName, isGuidMcpTool, resolveMcpFamilyToolName, isMcpFamilyResolvedTool } from '../../../src/utils/toolUtils';
+import { resolveGuidMcpToolName, isGuidMcpTool, resolveMcpFamilyToolName, isMcpFamilyResolvedTool, canonicalizeToolId, lookupKnownToolName } from '../../../src/utils/toolUtils';
 
 // ── resolveGuidMcpToolName ───────────────────────────────────────────────────
 
@@ -135,4 +135,45 @@ test('resolveMcpFamilyToolName: resolves Microsoft Learn docs tools under a mixe
 test('resolveMcpFamilyToolName: resolves GitHub get_label under an unseen server alias', () => {
 	assert.equal(resolveMcpFamilyToolName('mcp_github_mcp_s13be_get_label'), 'GitHub MCP: Get Label');
 	assert.equal(resolveMcpFamilyToolName('mcp_github_mcp_s13be_issue_write'), 'GitHub MCP: Issue Write');
+});
+
+// ── canonicalizeToolId ───────────────────────────────────────────────────────
+// Regression coverage for issue #1942: "ListAgents" (PascalCase, as reported
+// by one host) should canonicalize the same as an existing "list_agents"
+// entry, mirroring canonicalize_tool_id() in .github/scripts/toolnames_utils.py.
+
+test('canonicalizeToolId: PascalCase matches snake_case', () => {
+	assert.equal(canonicalizeToolId('ListAgents'), canonicalizeToolId('list_agents'));
+});
+
+test('canonicalizeToolId: camelCase matches snake_case', () => {
+	assert.equal(canonicalizeToolId('readFile'), canonicalizeToolId('read_file'));
+});
+
+test('canonicalizeToolId: acronym run splits before the trailing word', () => {
+	assert.equal(canonicalizeToolId('HTTPServer'), canonicalizeToolId('http_server'));
+});
+
+test('canonicalizeToolId: plain snake_case is unchanged', () => {
+	assert.equal(canonicalizeToolId('list_agents'), 'list_agents');
+});
+
+// ── lookupKnownToolName ──────────────────────────────────────────────────────
+
+test('lookupKnownToolName: returns exact match', () => {
+	assert.equal(lookupKnownToolName('list_agents', { list_agents: 'List Agents' }), 'List Agents');
+});
+
+test('lookupKnownToolName: returns case-insensitive match', () => {
+	assert.equal(lookupKnownToolName('List_Agents', { list_agents: 'List Agents' }), 'List Agents');
+});
+
+test('lookupKnownToolName: returns canonicalized match for a PascalCase id', () => {
+	// The exact scenario from issue #1942: a host reports "ListAgents" but
+	// toolNames.json only has the snake_case "list_agents" entry.
+	assert.equal(lookupKnownToolName('ListAgents', { list_agents: 'List Agents' }), 'List Agents');
+});
+
+test('lookupKnownToolName: returns undefined when nothing matches', () => {
+	assert.equal(lookupKnownToolName('totally_unknown_tool', { list_agents: 'List Agents' }), undefined);
 });


### PR DESCRIPTION
## Background

Investigating [run 33964659023](https://github.com/rajbos/ai-engineering-fluency/actions/runs/33964659023) (from issue #1942), which reported the `add-toolnames-with-slm` job as fully green even though no PR was opened.

## Commit 1 — visible warning when dedup blocks the PR

The SLM generated `ListAgents` → "List Agents", but a later dedup check found the friendly name already used by `list_agents`, so `toolNames.json` was correctly left unchanged and `create-pull-request` no-op'd. Every step still exited 0, so the run looked all-green with no signal of why no PR appeared.

- The "Update toolNames.json with new entries" step now records a per-tool skip reason and emits a `::warning::` annotation when everything gets skipped, so the run shows a visible warning instead of a silent green check.
- The issue comment posted at the end now lists the specific skip reason(s) instead of a generic "no PR was opened" message.

## Commit 2 — root cause: camelCase/PascalCase tool IDs weren't recognized

Digging into *why* `ListAgents` was flagged as missing in the first place (even though `list_agents` → "List Agents" already existed): `canonicalize_tool_id()` in `.github/scripts/toolnames_utils.py` only normalized `.`/`-` separators — it never split camelCase/PascalCase word boundaries, so `ListAgents` canonicalized to `"listagents"` while `list_agents` canonicalized to `"list_agents"`. They never matched, so both the "Toolnames Checkup" job and the `add-toolnames-with-slm` extract step legitimately treated it as missing.

- Added `_camel_to_snake()` to insert underscores at camelCase boundaries (handles both simple boundaries and acronym runs like `HTTPServer` → `HTTP_Server`).
- Applied `.lower()` consistently on both the prefix-matched action suffix and the fallback path (the fallback previously preserved original casing — a latent bug of its own).
- Added regression tests in `test_toolnames_utils.py` covering `ListAgents`/`list_agents`, `readFile`/`read_file`, `HTTPServer`/`http_server`, and the MCP-prefix action-suffix case.

**Verification:** `python3 .github/scripts/test_toolnames_utils.py -v` — all 14 tests pass. `python3 .github/scripts/toolnames_utils.py` against the current `src/toolNames.json` reports the same 114 strict-duplicate / 38 canonical-equivalent groups before and after this change, confirming no new duplicates are introduced among existing entries.

Closes #1942.