### PR TITLE
Hide decimals for CO2/water tooltip values at 1000+

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -3119,8 +3119,9 @@ class CopilotTokenTracker implements vscode.Disposable {
 		// Trailing &nbsp; padding on the "Today" column widens it a bit, giving the two
 		// value columns visual breathing room without VS Code table cell CSS to lean on.
 		const pad = (cell: string) => `${cell}&nbsp;&nbsp;&nbsp;&nbsp;`;
-		const grams = (n: number) => `${n.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} grams`;
-		const liters = (n: number) => `${n.toLocaleString(undefined, { minimumFractionDigits: 3, maximumFractionDigits: 3 })} liters`;
+		// Hide decimals once the value reaches 1000+ so large totals stay readable.
+		const grams = (n: number) => `${n.toLocaleString(undefined, Math.abs(n) >= 1000 ? { maximumFractionDigits: 0 } : { minimumFractionDigits: 2, maximumFractionDigits: 2 })} grams`;
+		const liters = (n: number) => `${n.toLocaleString(undefined, Math.abs(n) >= 1000 ? { maximumFractionDigits: 0 } : { minimumFractionDigits: 3, maximumFractionDigits: 3 })} liters`;
 		tooltip.appendMarkdown(`|  | 📅 ${l10n.t('tooltip.todayLabel')} | 📊 ${secondaryLabel} |\n|:---|:---|:---|\n`);
 		tooltip.appendMarkdown(`| ${l10n.t('tooltip.tokensLabel')} : | ${pad(detailedStats.today.tokens.toLocaleString())} | ${secondaryStats.tokens.toLocaleString()} |\n`);
 		tooltip.appendMarkdown(`| ${l10n.t('tooltip.copilotCostLabel')} : | ${pad(`$ ${(detailedStats.today.estimatedCostCopilot ?? 0).toFixed(2)}`)} | $ ${(secondaryStats.estimatedCostCopilot ?? 0).toFixed(2)} |\n`);

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -3125,9 +3125,16 @@ class CopilotTokenTracker implements vscode.Disposable {
 		// Trailing &nbsp; padding on the "Today" column widens it a bit, giving the two
 		// value columns visual breathing room without VS Code table cell CSS to lean on.
 		const pad = (cell: string) => `${cell}&nbsp;&nbsp;&nbsp;&nbsp;`;
-		// Hide decimals once the value reaches 1000+ so large totals stay readable.
-		const grams = (n: number) => `${n.toLocaleString(undefined, Math.abs(n) >= 1000 ? { maximumFractionDigits: 0 } : { minimumFractionDigits: 2, maximumFractionDigits: 2 })} grams`;
-		const liters = (n: number) => `${n.toLocaleString(undefined, Math.abs(n) >= 1000 ? { maximumFractionDigits: 0 } : { minimumFractionDigits: 3, maximumFractionDigits: 3 })} liters`;
+		// Hide decimals once the rounded display value reaches 1000+ so large totals stay readable.
+		const formatUsageValue = (n: number, fractionDigits: number, unit: string) => {
+			const rounded = Math.round(n * (10 ** fractionDigits)) / (10 ** fractionDigits);
+			const format = Math.abs(rounded) >= 1000
+				? { minimumFractionDigits: 0, maximumFractionDigits: 0 }
+				: { minimumFractionDigits: fractionDigits, maximumFractionDigits: fractionDigits };
+			return `${n.toLocaleString(undefined, format)} ${unit}`;
+		};
+		const grams = (n: number) => formatUsageValue(n, 2, 'grams');
+		const liters = (n: number) => formatUsageValue(n, 3, 'liters');
 		tooltip.appendMarkdown(`|  | 📅 ${l10n.t('tooltip.todayLabel')} | 📊 ${secondaryLabel} |\n|:---|:---|:---|\n`);
 		tooltip.appendMarkdown(`| ${l10n.t('tooltip.tokensLabel')} : | ${pad(detailedStats.today.tokens.toLocaleString())} | ${secondaryStats.tokens.toLocaleString()} |\n`);
 		tooltip.appendMarkdown(`| ${l10n.t('tooltip.copilotCostLabel')} : | ${pad(`$ ${(detailedStats.today.estimatedCostCopilot ?? 0).toFixed(2)}`)} | $ ${(secondaryStats.estimatedCostCopilot ?? 0).toFixed(2)} |\n`);

--- a/vscode-extension/test/unit/workspaceHelpers.test.ts
+++ b/vscode-extension/test/unit/workspaceHelpers.test.ts
@@ -1882,21 +1882,21 @@ import { resolveDebugLogCandidatePaths } from '../../../src/workspaceHelpers';
 const TTFT_SESSION_ID = 'e84b3e82-c1fb-43de-8f52-367f4c74826a';
 
 test('resolveDebugLogCandidatePaths: returns one candidate per known extension-folder spelling', () => {
-    const sessionFile = nodePath.join('home', 'user', 'workspaceStorage', 'abc123', 'chatSessions', `${TTFT_SESSION_ID}.json`);
+    const sessionFile = path.join('home', 'user', 'workspaceStorage', 'abc123', 'chatSessions', `${TTFT_SESSION_ID}.json`);
     const candidates = resolveDebugLogCandidatePaths(sessionFile);
     assert.ok(candidates);
     assert.equal(candidates!.length, 4);
-    assert.ok(candidates!.every(p => p.includes(TTFT_SESSION_ID) && p.endsWith(nodePath.join('debug-logs', TTFT_SESSION_ID, 'main.jsonl'))));
+    assert.ok(candidates!.every(p => p.includes(TTFT_SESSION_ID) && p.endsWith(path.join('debug-logs', TTFT_SESSION_ID, 'main.jsonl'))));
     assert.ok(candidates!.some(p => p.includes('GitHub.copilot-chat')));
     assert.ok(candidates!.some(p => p.includes('github.copilot-chat')));
 });
 
 test('resolveDebugLogCandidatePaths: returns undefined for a non-UUID session file', () => {
-    const sessionFile = nodePath.join('home', 'user', 'workspaceStorage', 'abc123', 'chatSessions', 'not-a-uuid.json');
+    const sessionFile = path.join('home', 'user', 'workspaceStorage', 'abc123', 'chatSessions', 'not-a-uuid.json');
     assert.equal(resolveDebugLogCandidatePaths(sessionFile), undefined);
 });
 
 test('resolveDebugLogCandidatePaths: returns undefined for a UUID-named file outside workspaceStorage', () => {
-    const sessionFile = nodePath.join('home', 'user', '.copilot', 'session-state', `${TTFT_SESSION_ID}.jsonl`);
+    const sessionFile = path.join('home', 'user', '.copilot', 'session-state', `${TTFT_SESSION_ID}.jsonl`);
     assert.equal(resolveDebugLogCandidatePaths(sessionFile), undefined);
 });


### PR DESCRIPTION
## Summary
- Status bar tooltip shows CO2 (grams) and water (liters) estimates with fixed decimal places even when the value is in the thousands, making large numbers hard to scan (e.g. `100,657.72 grams`, `150,986.573 liters`).
- When the value reaches 1000 or more, decimals are now hidden (e.g. `100,658 grams`, `150,987 liters`); values below 1000 keep their existing decimal precision (2 for grams, 3 for liters).

## Also fixed
- Merging in latest `main` surfaced a pre-existing bug in `workspaceHelpers.test.ts` (undefined `nodePath` instead of `path`) that broke the unit test suite; fixed it so `npm run test:node` passes.

## Testing
- `npm run compile` — passes
- `npm run test:node` — all suites pass