### PR TITLE
fix: skip edits whose replacement is the bare NO_EDITS sentinel

### DIFF
--- a/.github/workflows/scripts/apply_fixes.py
+++ b/.github/workflows/scripts/apply_fixes.py
@@ -183,6 +183,14 @@ def main() -> int:
         if not search.strip():
             print(f"  skip (empty search): {file_path}", file=sys.stderr)
             continue
+        if replace.strip() == "NO_EDITS":
+            # The model sometimes misuses the whole-response abstention sentinel
+            # (see INSTRUCTIONS) as the REPLACE text of an individual edit block
+            # instead of abstaining entirely. Applying it verbatim would corrupt
+            # the file with a bare "NO_EDITS" token, so treat it as an abstention
+            # for this edit rather than a real replacement.
+            print(f"  skip (replacement is bare NO_EDITS sentinel): {file_path}", file=sys.stderr)
+            continue
 
         result = apply_edit(file_path, search, replace)
         print(f"  {result}: {file_path}", file=sys.stderr)


### PR DESCRIPTION
## What happened

PR #1949 (auto-generated by the Agent Review workflow, .github/workflows/scripts/apply_fixes.py) corrupted scode-extension/test/unit/parserRobustness.test.ts by replacing two 	est('...', async () => { declaration lines with the literal text NO_EDITS.

## Root cause

pply_fixes.py instructs the local Ollama model to output the bare line NO_EDITS when it should abstain from proposing any edits at all. Here the model instead used NO_EDITS as the REPLACE text of an individual edit block, and the script applied it verbatim with no guard against a replacement consisting solely of the sentinel text.

## Fix

Skip (and log) any edit whose REPLACE text is exactly NO_EDITS.

## Follow-up

PR #1949 has been closed as broken — see the comment on that PR for details.