### PR TITLE
Fix resolveSessionWorkspaceName showing worktree name instead of repo name

### DIFF
--- a/src/workspaceHelpers.ts
+++ b/src/workspaceHelpers.ts
@@ -11,6 +11,7 @@ import customizationPatternsData from './customizationPatterns.json';
 import { resolveFileUri } from './workspacePathResolver';
 import {
 	fileUriToPath,
+	getRepoNameFromWorkspacePath,
 	hasWindowsDriveSegment,
 	normalizePath,
 	normalizePathForComparison,
@@ -999,12 +1000,12 @@ export function resolveSessionWorkspaceName(
 	sessionFilePath: string,
 	workspaceIdToFolderCache?: Map<string, string | undefined>
 ): string | undefined {
-	if (sessionData.workspaceFolderPath) { return path.basename(sessionData.workspaceFolderPath); }
+	if (sessionData.workspaceFolderPath) { return getRepoNameFromWorkspacePath(sessionData.workspaceFolderPath); }
 	if (sessionData.repository) { return sessionData.repository; }
 	if (!workspaceIdToFolderCache) { return undefined; }
 	try {
 		const workspaceFolder = resolveWorkspaceFolderFromSessionPath(sessionFilePath, workspaceIdToFolderCache);
-		if (workspaceFolder) { return path.basename(workspaceFolder); }
+		if (workspaceFolder) { return getRepoNameFromWorkspacePath(workspaceFolder); }
 	} catch { /* attribution is optional */ }
 	return undefined;
 }

--- a/vscode-extension/test/unit/workspaceHelpers.test.ts
+++ b/vscode-extension/test/unit/workspaceHelpers.test.ts
@@ -1844,6 +1844,67 @@ test('resolveSessionWorkspaceName: app-store worktree workspaceFolderPath resolv
     assert.equal(name, 'my-repo');
 });
 
+// Regression coverage for the exact bug class fixed here: resolveSessionWorkspaceName must
+// route every workspaceFolderPath through the worktree-aware getRepoNameFromWorkspacePath(),
+// not a plain path.basename(). Each of these mirrors a layout already covered by
+// utils-pathUtils.test.ts's getRepoNameFromWorkspacePath suite so a future revert to
+// path.basename() fails broadly, not just for a single naming convention.
+const worktreeWorkspaceFolderPathCases: { name: string; workspaceFolderPath: string; expected: string }[] = [
+    {
+        name: 'app-store worktree with an owner sub-segment',
+        workspaceFolderPath: path.join('C:', 'Users', 'me', '.copilot', 'copilot-worktrees', 'my-repo', 'owner-org', 'rajbos-bookish-engine'),
+        expected: 'my-repo',
+    },
+    {
+        name: 'user-repo copilot-worktrees layout (repo before the marker)',
+        workspaceFolderPath: path.join('C:', 'Users', 'me', 'repos', 'my-repo', 'copilot-worktrees', 'session-123'),
+        expected: 'my-repo',
+    },
+    {
+        name: 'claude worktree layout',
+        workspaceFolderPath: path.join('C:', 'Users', 'me', 'repos', 'my-repo', '.claude', 'worktrees', 'feature-x'),
+        expected: 'my-repo',
+    },
+    {
+        name: 'Copilot App "<repo>.worktrees" layout',
+        workspaceFolderPath: path.join('C:', 'Users', 'me', 'repos', 'my-repo.worktrees', 'copilot-worktree-2026-02-07T20-38-48'),
+        expected: 'my-repo',
+    },
+];
+for (const { name, workspaceFolderPath, expected } of worktreeWorkspaceFolderPathCases) {
+    test(`resolveSessionWorkspaceName: ${name} resolves to the repo, not the worktree name`, () => {
+        const resolvedName = resolveSessionWorkspaceName(
+            { workspaceFolderPath },
+            path.join('C:', 'Users', 'me', '.copilot', 'session-store.db#session-id')
+        );
+        assert.equal(resolvedName, expected);
+    });
+}
+
+test('resolveSessionWorkspaceName: workspaceStorage-resolved worktree path also collapses to the repo name', () => {
+    // Proves the *other* call site this fix touched: when VS Code's workspaceStorage
+    // resolution succeeds (rather than falling back to workspaceFolderPath), the resolved
+    // folder must still go through getRepoNameFromWorkspacePath(), not path.basename().
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wh-rsws-wt-'));
+    try {
+        const workspaceFolder = path.join(tmpDir, '.copilot', 'copilot-worktrees', 'my-repo', 'rajbos-bookish-engine');
+        fs.mkdirSync(workspaceFolder, { recursive: true });
+        const workspaceStorage = path.join(tmpDir, 'workspaceStorage', 'wsid456');
+        fs.mkdirSync(workspaceStorage, { recursive: true });
+        fs.writeFileSync(
+            path.join(workspaceStorage, 'workspace.json'),
+            JSON.stringify({ folder: workspaceFolder }),
+            'utf8'
+        );
+        const sessionFile = path.join(workspaceStorage, 'chatSessions', 'session.json');
+        const cache = new Map<string, string | undefined>();
+        const name = resolveSessionWorkspaceName({}, sessionFile, cache);
+        assert.equal(name, 'my-repo');
+    } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+});
+
 test('resolveSessionWorkspaceName: falls back to repository when workspaceFolderPath is absent', () => {
     const name = resolveSessionWorkspaceName(
         { repository: 'owner/repo' },

--- a/vscode-extension/test/unit/workspaceHelpers.test.ts
+++ b/vscode-extension/test/unit/workspaceHelpers.test.ts
@@ -2,6 +2,7 @@
 import test from 'node:test';
 import * as assert from 'node:assert/strict';
 import * as fs from 'node:fs';
+import * as os from 'node:os';
 import * as path from 'node:path';
 import {
     getModeType,
@@ -1834,6 +1835,15 @@ test('resolveSessionWorkspaceName: prefers workspaceFolderPath over repository',
     assert.equal(name, 'my-project');
 });
 
+test('resolveSessionWorkspaceName: app-store worktree workspaceFolderPath resolves to the repo, not the worktree name', () => {
+    const workspaceFolderPath = path.join('C:', 'Users', 'me', '.copilot', 'copilot-worktrees', 'my-repo', 'rajbos-bookish-engine');
+    const name = resolveSessionWorkspaceName(
+        { workspaceFolderPath },
+        path.join('C:', 'Users', 'me', '.copilot', 'session-store.db#session-id')
+    );
+    assert.equal(name, 'my-repo');
+});
+
 test('resolveSessionWorkspaceName: falls back to repository when workspaceFolderPath is absent', () => {
     const name = resolveSessionWorkspaceName(
         { repository: 'owner/repo' },
@@ -1843,7 +1853,10 @@ test('resolveSessionWorkspaceName: falls back to repository when workspaceFolder
 });
 
 test('resolveSessionWorkspaceName: falls back to workspaceStorage resolution', () => {
-    const tmpDir = fs.mkdtempSync(path.join(process.cwd(), 'wh-rsws-'));
+    // Use the OS temp dir (not process.cwd()) so this stays hermetic even when the test
+    // suite itself runs from inside a "copilot-worktrees" checkout, which would otherwise
+    // make getRepoNameFromWorkspacePath collapse the synthetic path to the real repo name.
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wh-rsws-'));
     try {
         const workspaceFolder = path.join(tmpDir, 'my-vscode-project');
         fs.mkdirSync(workspaceFolder, { recursive: true });


### PR DESCRIPTION
## Problem

The "Copilot Customization Files" workspace health matrix (and per-session workspace attribution) sometimes shows a git worktree/branch name (e.g. `rajbos-bookish-engine`) instead of the actual repository name (e.g. `ai-engineering-fluency`), splitting one repo's sessions across several bogus rows.

## Root cause

`resolveSessionWorkspaceName()` in `src/workspaceHelpers.ts` re-exported the worktree-aware `getRepoNameFromWorkspacePath()` helper (added in #1704 to fix this exact class of bug elsewhere), but never actually called it — it used plain `path.basename(sessionData.workspaceFolderPath)` instead. For app-store worktree sessions (`.copilot/copilot-worktrees/<repo>/<worktree>`, e.g. Copilot CLI sessions), `path.basename()` yields the transient worktree/branch folder name instead of the repository name.

## Fix

Use `getRepoNameFromWorkspacePath()` for both the `workspaceFolderPath` and the workspaceStorage-resolved fallback paths in `resolveSessionWorkspaceName()`, matching the pattern already applied elsewhere (`extension.ts` line ~6200).

## Testing

- Added a regression test reproducing the exact worktree-path scenario.
- Fixed an existing test (`falls back to workspaceStorage resolution`) that was inadvertently relying on `process.cwd()` not living inside a worktree checkout — switched it to `os.tmpdir()` for hermeticity.
- `workspaceHelpers.test.ts`: 270/270 pass.
- `utils-pathUtils.test.ts`: 42/42 pass.