### PR TITLE
Stream session discovery per-adapter instead of waiting for all

### DIFF
--- a/src/sessionDiscovery.ts
+++ b/src/sessionDiscovery.ts
@@ -177,29 +177,20 @@ export class SessionDiscovery {
 		}
 	}
 
-	/** Collect deduplicated files from adapter results, calling onBatch for each new batch. */
-	private collectAdapterFiles(
-		results: PromiseSettledResult<{ sessionFiles: string[] }>[],
-		adapters: IEcosystemAdapter[],
+	/** Dedup a single adapter's files against `seen`, appending new ones to `allDeduped` and emitting `onBatch`. */
+	private addDedupedBatch(
+		files: string[],
 		seen: Set<string>,
 		allDeduped: string[],
 		onBatch?: (files: string[]) => void,
 	): void {
-		for (let i = 0; i < results.length; i++) {
-			const result = results[i];
-			if (result.status === 'rejected') {
-				this.deps.warn(`Could not discover ${adapters[i].displayName} sessions: ${result.reason}`);
-				this._lastDiscoveryHadError = true;
-				continue;
-			}
-			const batch: string[] = [];
-			for (const f of result.value.sessionFiles) {
-				const key = normalizePathForDedup(f);
-				if (seen.has(key)) { continue; }
-				seen.add(key); batch.push(f);
-			}
-			if (batch.length > 0) { allDeduped.push(...batch); if (onBatch) { onBatch(batch); } }
+		const batch: string[] = [];
+		for (const f of files) {
+			const key = normalizePathForDedup(f);
+			if (seen.has(key)) { continue; }
+			seen.add(key); batch.push(f);
 		}
+		if (batch.length > 0) { allDeduped.push(...batch); if (onBatch) { onBatch(batch); } }
 	}
 
 	/** Collect deduplicated Windsurf session files and add them to allDeduped. */
@@ -220,16 +211,42 @@ export class SessionDiscovery {
 		}
 	}
 
+	/**
+	 * Runs every discoverable adapter concurrently and pushes each adapter's
+	 * files into `onBatch` the instant *that adapter* resolves — not after the
+	 * slowest one finishes. This matters because some adapters do genuinely
+	 * heavyweight first-run work (e.g. CursorAdapter lazily initializes a
+	 * sql.js/WASM module and reads Cursor's entire global state.vscdb into
+	 * memory). Waiting for `Promise.allSettled()` across *all* adapters before
+	 * emitting any batch would starve the streaming worker pool in
+	 * `_preloadSessionFiles` — it would sit idle until Cursor (or any other
+	 * slow adapter) completes, even though every other adapter finished
+	 * quickly. Awaiting each adapter's own promise independently lets fast
+	 * adapters' files start parsing immediately while slow ones keep running.
+	 */
 	private async discoverFromAdapters(onBatch?: (files: string[]) => void): Promise<string[]> {
 		const seen = new Set<string>();
 		const allDeduped: string[] = [];
 		const discoveryStartMs = Date.now();
 		const discoverableAdapters = this.deps.ecosystems.filter(isDiscoverable);
 		this.deps.log(`🔍 Searching for session files via ${discoverableAdapters.length} discoverable ecosystem adapter(s) (parallel)`);
-		const results = await Promise.allSettled(discoverableAdapters.map(eco => eco.discover(this.deps.log)));
-		this.collectAdapterFiles(results, discoverableAdapters, seen, allDeduped, onBatch);
-		await this.collectWindsurfFiles(seen, allDeduped, onBatch);
-		const dupCount = results.reduce((n, r) => n + (r.status === 'fulfilled' ? r.value.sessionFiles.length : 0), 0) - allDeduped.length;
+
+		let totalRaw = 0;
+		const adapterTasks = discoverableAdapters.map(eco =>
+			eco.discover(this.deps.log).then(
+				result => {
+					totalRaw += result.sessionFiles.length;
+					this.addDedupedBatch(result.sessionFiles, seen, allDeduped, onBatch);
+				},
+				error => {
+					this.deps.warn(`Could not discover ${eco.displayName} sessions: ${error}`);
+					this._lastDiscoveryHadError = true;
+				}
+			)
+		);
+		await Promise.all([...adapterTasks, this.collectWindsurfFiles(seen, allDeduped, onBatch)]);
+
+		const dupCount = totalRaw - allDeduped.length;
 		if (dupCount > 0) { this.deps.log(`🧹 Deduplicated ${dupCount} duplicate session path(s)`); }
 		this.deps.log(`✨ Total: ${allDeduped.length} session file(s) discovered in ${((Date.now() - discoveryStartMs) / 1000).toFixed(1)}s`);
 		if (allDeduped.length === 0) { this.deps.warn('⚠️ No session files found - Have you used GitHub Copilot Chat yet?'); }

--- a/vscode-extension/test/unit/sessionDiscovery-streaming.test.ts
+++ b/vscode-extension/test/unit/sessionDiscovery-streaming.test.ts
@@ -1,0 +1,90 @@
+import './vscode-shim-register';
+import test from 'node:test';
+import * as assert from 'node:assert/strict';
+
+import { SessionDiscovery } from '../../../src/sessionDiscovery';
+import type { IEcosystemAdapter, DiscoveryResult } from '../../../src/ecosystemAdapter';
+
+/**
+ * Regression test for the "slow Cursor discovery blocks everyone else" bug:
+ * SessionDiscovery.getCopilotSessionFilesStreaming() must invoke `onBatch` for
+ * each adapter's files as soon as *that adapter* resolves, not only after
+ * every adapter (including a slow one) has settled. Previously discovery
+ * collected all Promise.allSettled results before calling onBatch even once,
+ * so a slow adapter (e.g. Cursor's first-run sql.js/WASM init) delayed the
+ * streaming worker pool in _preloadSessionFiles from starting on any file,
+ * even ones already found by fast adapters.
+ */
+function makeFakeAdapter(id: string, files: string[], delayMs: number): IEcosystemAdapter {
+	return {
+		id,
+		displayName: id,
+		handles: () => false,
+		getBackingPath: (f: string) => f,
+		stat: async () => ({} as any),
+		getTokens: async () => ({ tokens: 0, thinkingTokens: 0, actualTokens: 0 }),
+		countInteractions: async () => 0,
+		getModelUsage: async () => ({}),
+		getMeta: async () => ({ title: undefined, firstInteraction: null, lastInteraction: null }),
+		getEditorRoot: (f: string) => f,
+		discover: async (): Promise<DiscoveryResult> => {
+			await new Promise(resolve => setTimeout(resolve, delayMs));
+			return { sessionFiles: files, candidatePaths: [] };
+		},
+		getCandidatePaths: () => [],
+	} as unknown as IEcosystemAdapter;
+}
+
+test('SessionDiscovery streams fast adapter batches before a slow adapter resolves', async () => {
+	const batchTimestamps: { source: string; atMs: number }[] = [];
+	const start = Date.now();
+
+	const fastAdapter = makeFakeAdapter('fast', ['/fake/fast/session1.json'], 5);
+	const slowAdapter = makeFakeAdapter('slow-cursor', ['/fake/cursor/session2.json'], 150);
+
+	const discovery = new SessionDiscovery({
+		log: () => {},
+		warn: () => {},
+		error: () => {},
+		ecosystems: [fastAdapter, slowAdapter],
+	});
+
+	let sawFastBatchBeforeSlowResolved = false;
+	const files = await discovery.getCopilotSessionFilesStreaming((batch) => {
+		const atMs = Date.now() - start;
+		batchTimestamps.push({ source: batch[0], atMs });
+		if (batch[0].includes('fast') && atMs < 100) {
+			sawFastBatchBeforeSlowResolved = true;
+		}
+	});
+
+	assert.equal(files.length, 2);
+	assert.ok(sawFastBatchBeforeSlowResolved,
+		'fast adapter batch should stream in well before the slow adapter\'s 150ms delay elapses');
+	// The fast batch must be observed strictly before the slow one.
+	const fastEntry = batchTimestamps.find(b => b.source.includes('fast'));
+	const slowEntry = batchTimestamps.find(b => b.source.includes('cursor'));
+	assert.ok(fastEntry && slowEntry && fastEntry.atMs < slowEntry.atMs,
+		'fast adapter batch must arrive before slow adapter batch');
+});
+
+test('SessionDiscovery still reports adapter errors without blocking other batches', async () => {
+	const fastAdapter = makeFakeAdapter('fast', ['/fake/fast/session1.json'], 5);
+	const failingAdapter: IEcosystemAdapter = {
+		...makeFakeAdapter('broken', [], 0),
+		discover: async () => { throw new Error('boom'); },
+	} as IEcosystemAdapter;
+
+	const warnings: string[] = [];
+	const discovery = new SessionDiscovery({
+		log: () => {},
+		warn: (msg: string) => warnings.push(msg),
+		error: () => {},
+		ecosystems: [fastAdapter, failingAdapter],
+	});
+
+	const files = await discovery.getCopilotSessionFilesStreaming();
+	assert.deepEqual(files, ['/fake/fast/session1.json']);
+	assert.ok(warnings.some(w => w.includes('broken')));
+	assert.equal(discovery.lastDiscoveryHadError, true);
+});


### PR DESCRIPTION
## Why

Users reported the extension's first load feels slow, with editor discovery seemingly stalled. The root cause: Cursor support (`CursorAdapter`) lazily initializes a sql.js/WASM module and reads Cursor's entire global `state.vscdb` on first use, which is genuinely slow on a cold start.

## What changed

`SessionDiscovery.discoverFromAdapters()` in `src/sessionDiscovery.ts` already ran every discoverable editor adapter concurrently via `Promise.allSettled`, but it only invoked the `onBatch` streaming callback **once, after every single adapter had settled**. That defeated the purpose of the streaming pipeline in `_preloadSessionFiles` (`vscode-extension/src/extension.ts`): its worker pool waits on `onBatch` to receive files to parse, so it sat completely idle until the slowest adapter (Cursor) finished, even though fast adapters (Copilot Chat, Copilot CLI, etc.) had already found their files.

The fix awaits each adapter's `discover()` promise independently and pushes its files into the pipeline the instant *that* adapter resolves, instead of gating on `Promise.allSettled` across all of them. Error handling, dedup, and logging behavior are preserved per adapter.

## Testing

- Added `vscode-extension/test/unit/sessionDiscovery-streaming.test.ts`: a regression test with a fake fast adapter and a fake slow adapter, asserting the fast adapter's batch streams in well before the slow adapter's delay elapses, plus a test that adapter errors are reported without blocking other batches.
- `npm run validate` (type-check + lint + build): clean, only pre-existing unrelated warnings.
- `npm run test:node` targeted runs: new test passes (2/2), and `ecosystemAdapters.test.ts` still passes (73/73).