### PR TITLE
Add per-repository cleanup for pushed worktrees

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -10720,15 +10720,8 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString(), startedAtMs)}
     }
   }
 
-  /**
-   * Bulk-deletes worktrees the caller believes are fully pushed, one at a time. Unlike the
-   * single-worktree delete flow, this NEVER force-deletes: if a worktree turns out to have
-   * uncommitted/untracked changes or unpushed commits (re-checked live, not trusted from the
-   * webview's possibly-stale list), it is skipped and the loop moves on to the next one. The
-   * OS-level directory-removal fallback (for git-for-windows junction/long-path failures) still
-   * applies, since that is not a safety bypass — the dirty-tree check already passed by then.
-   */
-  private async diagHandleCleanupPushedWorktrees(message: any): Promise<void> {
+  /** Parses the bulk-cleanup message into its candidate list and optional repo scope label. */
+  private _parseCleanupPushedWorktreesMessage(message: any): { candidates: Array<{ path: string; branch: string; repoLabel: string }>; scopeRepoLabel?: string } {
     const candidates: Array<{ path: string; branch: string; repoLabel: string }> = Array.isArray(message?.worktrees)
       ? message.worktrees
         .filter((w: any) => w && typeof w.path === "string" && w.path.trim())
@@ -10738,6 +10731,30 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString(), startedAtMs)}
           repoLabel: typeof w.repoLabel === "string" && w.repoLabel ? w.repoLabel : "",
         }))
       : [];
+    const scopeRepoLabel: string | undefined = typeof message?.repoLabel === "string" && message.repoLabel ? message.repoLabel : undefined;
+    return { candidates, scopeRepoLabel };
+  }
+
+  /** Confirmation prompt title, naming the repository when the cleanup is scoped to one. */
+  private _buildCleanupConfirmTitle(count: number, scopeRepoLabel?: string): string {
+    const scopeText = scopeRepoLabel ? ` in "${scopeRepoLabel}"` : "";
+    return `Clean up ${count} pushed worktree${count === 1 ? "" : "s"}${scopeText}?`;
+  }
+
+  /**
+   * Bulk-deletes worktrees the caller believes are fully pushed, one at a time. Unlike the
+   * single-worktree delete flow, this NEVER force-deletes: if a worktree turns out to have
+   * uncommitted/untracked changes or unpushed commits (re-checked live, not trusted from the
+   * webview's possibly-stale list), it is skipped and the loop moves on to the next one. The
+   * OS-level directory-removal fallback (for git-for-windows junction/long-path failures) still
+   * applies, since that is not a safety bypass — the dirty-tree check already passed by then.
+   *
+   * `message.repoLabel` is optional: when present, the webview has already filtered `worktrees`
+   * down to a single repository's row (its own "Clean up" button), and this only changes the
+   * confirmation wording to name that repository — the deletion logic is identical either way.
+   */
+  private async diagHandleCleanupPushedWorktrees(message: any): Promise<void> {
+    const { candidates, scopeRepoLabel } = this._parseCleanupPushedWorktreesMessage(message);
 
     if (!this.analysisPanel || !this.isPanelOpen(this.analysisPanel)) { return; }
     const panel = this.analysisPanel;
@@ -10748,7 +10765,7 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString(), startedAtMs)}
     }
 
     const choice = await vscode.window.showWarningMessage(
-      `Clean up ${candidates.length} pushed worktree${candidates.length === 1 ? "" : "s"}?`,
+      this._buildCleanupConfirmTitle(candidates.length, scopeRepoLabel),
       {
         modal: true,
         detail: 'Removes worktrees whose commits are already pushed to a remote, using "git worktree remove". Any worktree found to have uncommitted, untracked, or unpushed changes is automatically skipped (never force-deleted) and the cleanup continues with the rest.',

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -119,6 +119,8 @@ import {
   shouldNotifyWorktreeFindings as _shouldNotifyWorktreeFindings,
   formatBytesForNotification as _formatBytesForNotification,
   sumWorktreeBytes as _sumWorktreeBytes,
+  parseCleanupPushedWorktreesMessage as _parseCleanupPushedWorktreesMessage,
+  buildCleanupConfirmTitle as _buildCleanupConfirmTitle,
   type WorktreeBackgroundScanResult,
 } from './worktreeBackgroundScan';
 import { scanWorktreeRootsWithTimeout as _scanWorktreeRootsWithTimeout } from './worktreeScan';
@@ -10721,33 +10723,6 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString(), startedAtMs)}
   }
 
   /**
-   * Parses the bulk-cleanup message into its candidate list and optional repo scope label.
-   * `scopeRepoLabel` is only trusted (and returned) when it matches every parsed candidate's
-   * `repoLabel` — a mismatched or mixed-repo list falls back to unscoped wording rather than
-   * letting the confirmation dialog claim a narrower scope than what will actually be deleted.
-   */
-  private _parseCleanupPushedWorktreesMessage(message: any): { candidates: Array<{ path: string; branch: string; repoLabel: string }>; scopeRepoLabel?: string } {
-    const candidates: Array<{ path: string; branch: string; repoLabel: string }> = Array.isArray(message?.worktrees)
-      ? message.worktrees
-        .filter((w: any) => w && typeof w.path === "string" && w.path.trim())
-        .map((w: any) => ({
-          path: String(w.path).trim(),
-          branch: typeof w.branch === "string" && w.branch ? w.branch : "?",
-          repoLabel: typeof w.repoLabel === "string" && w.repoLabel ? w.repoLabel : "",
-        }))
-      : [];
-    const requestedScope: string | undefined = typeof message?.repoLabel === "string" && message.repoLabel ? message.repoLabel : undefined;
-    const scopeRepoLabel = requestedScope && candidates.every((c) => c.repoLabel === requestedScope) ? requestedScope : undefined;
-    return { candidates, scopeRepoLabel };
-  }
-
-  /** Confirmation prompt title, naming the repository when the cleanup is scoped to one. */
-  private _buildCleanupConfirmTitle(count: number, scopeRepoLabel?: string): string {
-    const scopeText = scopeRepoLabel ? ` in "${scopeRepoLabel}"` : "";
-    return `Clean up ${count} pushed worktree${count === 1 ? "" : "s"}${scopeText}?`;
-  }
-
-  /**
    * Bulk-deletes worktrees the caller believes are fully pushed, one at a time. Unlike the
    * single-worktree delete flow, this NEVER force-deletes: if a worktree turns out to have
    * uncommitted/untracked changes or unpushed commits (re-checked live, not trusted from the
@@ -10760,7 +10735,7 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString(), startedAtMs)}
    * confirmation wording to name that repository — the deletion logic is identical either way.
    */
   private async diagHandleCleanupPushedWorktrees(message: any): Promise<void> {
-    const { candidates, scopeRepoLabel } = this._parseCleanupPushedWorktreesMessage(message);
+    const { candidates, scopeRepoLabel } = _parseCleanupPushedWorktreesMessage(message);
 
     if (!this.analysisPanel || !this.isPanelOpen(this.analysisPanel)) { return; }
     const panel = this.analysisPanel;
@@ -10771,7 +10746,7 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString(), startedAtMs)}
     }
 
     const choice = await vscode.window.showWarningMessage(
-      this._buildCleanupConfirmTitle(candidates.length, scopeRepoLabel),
+      _buildCleanupConfirmTitle(candidates.length, scopeRepoLabel),
       {
         modal: true,
         detail: 'Removes worktrees whose commits are already pushed to a remote, using "git worktree remove". Any worktree found to have uncommitted, untracked, or unpushed changes is automatically skipped (never force-deleted) and the cleanup continues with the rest.',

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -10720,7 +10720,12 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString(), startedAtMs)}
     }
   }
 
-  /** Parses the bulk-cleanup message into its candidate list and optional repo scope label. */
+  /**
+   * Parses the bulk-cleanup message into its candidate list and optional repo scope label.
+   * `scopeRepoLabel` is only trusted (and returned) when it matches every parsed candidate's
+   * `repoLabel` — a mismatched or mixed-repo list falls back to unscoped wording rather than
+   * letting the confirmation dialog claim a narrower scope than what will actually be deleted.
+   */
   private _parseCleanupPushedWorktreesMessage(message: any): { candidates: Array<{ path: string; branch: string; repoLabel: string }>; scopeRepoLabel?: string } {
     const candidates: Array<{ path: string; branch: string; repoLabel: string }> = Array.isArray(message?.worktrees)
       ? message.worktrees
@@ -10731,7 +10736,8 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString(), startedAtMs)}
           repoLabel: typeof w.repoLabel === "string" && w.repoLabel ? w.repoLabel : "",
         }))
       : [];
-    const scopeRepoLabel: string | undefined = typeof message?.repoLabel === "string" && message.repoLabel ? message.repoLabel : undefined;
+    const requestedScope: string | undefined = typeof message?.repoLabel === "string" && message.repoLabel ? message.repoLabel : undefined;
+    const scopeRepoLabel = requestedScope && candidates.every((c) => c.repoLabel === requestedScope) ? requestedScope : undefined;
     return { candidates, scopeRepoLabel };
   }
 

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -3739,18 +3739,24 @@ function worktreeSizeText(worktrees: WorktreeResult[]): string {
 }
 
 /**
- * A repository's summary row (Repository | Worktrees | Size) plus a details row that holds the
- * per-worktree table. The details row is hidden unless the repo is in worktreeExpandedRepos.
+ * Repo-scoped "Clean up (N)" button shown in each repository's summary row. Takes the repo's
+ * already-sliced worktree list (the caller already has it) rather than re-filtering the entire
+ * `worktreeResults` array per repo row — that would be an O(repoCount × worktreeCount) rescan on
+ * every render.
  */
-/** Repo-scoped "Clean up (N)" button shown in each repository's summary row. */
-function buildWorktreeRepoCleanupButtonHtml(repoLabel: string): string {
-	const pushedCount = getCleanupCandidates(repoLabel).length;
+function buildWorktreeRepoCleanupButtonHtml(repoLabel: string, worktrees: WorktreeResult[]): string {
+	const pushedCount = worktrees.filter((w) => w.pushed === "yes" && !isWorktreePending(w)).length;
 	const disabled = worktreeCleanupInProgress || worktreeCleanupConfirmPending || worktreeScanInProgress || pushedCount === 0;
 	return `<button type="button" class="button secondary worktree-repo-cleanup-btn" data-repo="${encodeURIComponent(repoLabel)}"
     title="Remove this repository's pushed worktrees via git worktree remove (asks for confirmation)" ${disabled ? "disabled" : ""}
     >🧹 Clean up (${pushedCount})</button>`;
 }
 
+/**
+ * A repository's summary row (Repository | Worktrees | Size | Actions) plus a details row that
+ * holds the per-worktree table. The details row is hidden unless the repo is in
+ * worktreeExpandedRepos.
+ */
 function buildWorktreeRepoRowsHtml(repoLabel: string, worktrees: WorktreeResult[]): string {
 	const expanded = worktreeExpandedRepos.has(repoLabel);
 	const caret = expanded ? "▼" : "▶";
@@ -3759,7 +3765,7 @@ function buildWorktreeRepoRowsHtml(repoLabel: string, worktrees: WorktreeResult[
     <td><span class="worktree-caret">${caret}</span> ${escapeHtml(repoLabel)}</td>
     <td>${worktrees.length}</td>
     <td>${worktreeSizeText(worktrees)}</td>
-    <td class="worktree-repo-actions">${buildWorktreeRepoCleanupButtonHtml(repoLabel)}</td>
+    <td class="worktree-repo-actions">${buildWorktreeRepoCleanupButtonHtml(repoLabel, worktrees)}</td>
   </tr>`;
 	const detailsRow = `<tr class="worktree-repo-details" data-repo="${repoAttr}"${expanded ? "" : ' style="display: none;"'}>
     <td colspan="4">${buildWorktreeDetailsTableHtml(worktrees)}</td>

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -1773,19 +1773,21 @@ function startWorktreeScan(): void {
 }
 
 /**
- * Kicks off the bulk "clean up pushed worktrees" flow. The actual confirmation is a native
- * VS Code modal shown by the extension (see diagHandleCleanupPushedWorktrees) — this only sends
- * the candidate list and waits for cleanupStarted/cleanupDeclined to know the outcome.
+ * Kicks off the "clean up pushed worktrees" flow. The actual confirmation is a native VS Code
+ * modal shown by the extension (see diagHandleCleanupPushedWorktrees) — this only sends the
+ * candidate list and waits for cleanupStarted/cleanupDeclined to know the outcome. Pass
+ * `repoLabel` to scope the cleanup to one repository's row; omit it for the global card.
  */
-function startWorktreeCleanup(): void {
+function startWorktreeCleanup(repoLabel?: string): void {
 	if (worktreeCleanupInProgress || worktreeCleanupConfirmPending || worktreeScanInProgress) { return; }
-	const targets = getCleanupCandidates();
+	const targets = getCleanupCandidates(repoLabel);
 	if (targets.length === 0) { return; }
 	worktreeCleanupConfirmPending = true;
 	updateWorktreeResults();
 	vscode.postMessage({
 		command: "cleanupPushedWorktrees",
 		worktrees: targets.map((w) => ({ path: w.path, branch: w.branch, repoLabel: w.repoLabel })),
+		repoLabel,
 	});
 }
 
@@ -1812,6 +1814,12 @@ function _handleWorktreeActionButtonClick(target: HTMLElement): boolean {
 	}
 	if (target.id === "btn-cancel-cleanup") {
 		vscode.postMessage({ command: "cancelCleanupPushedWorktrees" });
+		return true;
+	}
+	const repoCleanupBtn = target.closest(".worktree-repo-cleanup-btn") as HTMLElement | null;
+	if (repoCleanupBtn) {
+		const repo = decodeURIComponent(repoCleanupBtn.getAttribute("data-repo") || "");
+		if (repo) { startWorktreeCleanup(repo); }
 		return true;
 	}
 	return false;
@@ -3734,6 +3742,15 @@ function worktreeSizeText(worktrees: WorktreeResult[]): string {
  * A repository's summary row (Repository | Worktrees | Size) plus a details row that holds the
  * per-worktree table. The details row is hidden unless the repo is in worktreeExpandedRepos.
  */
+/** Repo-scoped "Clean up (N)" button shown in each repository's summary row. */
+function buildWorktreeRepoCleanupButtonHtml(repoLabel: string): string {
+	const pushedCount = getCleanupCandidates(repoLabel).length;
+	const disabled = worktreeCleanupInProgress || worktreeCleanupConfirmPending || worktreeScanInProgress || pushedCount === 0;
+	return `<button type="button" class="button secondary worktree-repo-cleanup-btn" data-repo="${encodeURIComponent(repoLabel)}"
+    title="Remove this repository's pushed worktrees via git worktree remove (asks for confirmation)" ${disabled ? "disabled" : ""}
+    >🧹 Clean up (${pushedCount})</button>`;
+}
+
 function buildWorktreeRepoRowsHtml(repoLabel: string, worktrees: WorktreeResult[]): string {
 	const expanded = worktreeExpandedRepos.has(repoLabel);
 	const caret = expanded ? "▼" : "▶";
@@ -3742,9 +3759,10 @@ function buildWorktreeRepoRowsHtml(repoLabel: string, worktrees: WorktreeResult[
     <td><span class="worktree-caret">${caret}</span> ${escapeHtml(repoLabel)}</td>
     <td>${worktrees.length}</td>
     <td>${worktreeSizeText(worktrees)}</td>
+    <td class="worktree-repo-actions">${buildWorktreeRepoCleanupButtonHtml(repoLabel)}</td>
   </tr>`;
 	const detailsRow = `<tr class="worktree-repo-details" data-repo="${repoAttr}"${expanded ? "" : ' style="display: none;"'}>
-    <td colspan="3">${buildWorktreeDetailsTableHtml(worktrees)}</td>
+    <td colspan="4">${buildWorktreeDetailsTableHtml(worktrees)}</td>
   </tr>`;
 	return summaryRow + detailsRow;
 }
@@ -3771,9 +3789,14 @@ function compareWorktreeGroups(a: [string, WorktreeResult[]], b: [string, Worktr
 	return diff !== 0 ? dir * diff : a[0].localeCompare(b[0]);
 }
 
-/** Worktrees eligible for the bulk cleanup: known to be pushed and already enriched. */
-function getCleanupCandidates(): WorktreeResult[] {
-	return worktreeResults.filter((w) => w.pushed === "yes" && !isWorktreePending(w));
+/**
+ * Worktrees eligible for a cleanup: known to be pushed and already enriched. Pass `repoLabel`
+ * to scope the candidates to a single repository (used by each repo row's own "Clean up"
+ * button); omit it for the global "Clean Up" card that spans every repository.
+ */
+function getCleanupCandidates(repoLabel?: string): WorktreeResult[] {
+	return worktreeResults.filter((w) =>
+		w.pushed === "yes" && !isWorktreePending(w) && (repoLabel === undefined || w.repoLabel === repoLabel));
 }
 
 /** The cleanup trigger, rendered as its own card inside the hero summary-cards row (to the right of Worktrees/Repositories/Total Size). */
@@ -3849,6 +3872,7 @@ function renderWorktreeResults(): string {
         <th class="sortable" data-wt-sort="repo">Repository${getWorktreeSortIndicator("repo")}</th>
         <th class="sortable" data-wt-sort="count">Worktrees${getWorktreeSortIndicator("count")}</th>
         <th class="sortable" data-wt-sort="size">Size${getWorktreeSortIndicator("size")}</th>
+        <th>Actions</th>
       </tr></thead>
       <tbody>${repoRows}</tbody>
     </table>

--- a/vscode-extension/src/webview/usage/styles.css
+++ b/vscode-extension/src/webview/usage/styles.css
@@ -1113,3 +1113,13 @@ background: var(--bg-tertiary);
 	color: var(--text-muted);
 	flex: 1;
 }
+
+.worktree-repo-actions {
+	white-space: nowrap;
+}
+
+.worktree-repo-cleanup-btn {
+	font-size: 12px;
+	padding: 4px 10px;
+	font-weight: normal;
+}

--- a/vscode-extension/src/worktreeBackgroundScan.ts
+++ b/vscode-extension/src/worktreeBackgroundScan.ts
@@ -97,3 +97,47 @@ export function formatBytesForNotification(bytes: number): string {
 export function sumWorktreeBytes(worktrees: { bytes: number }[]): number {
 	return worktrees.reduce((sum, w) => sum + (w.bytes > 0 ? w.bytes : 0), 0);
 }
+
+/** One candidate worktree parsed out of a `cleanupPushedWorktrees` webview message. */
+export interface CleanupWorktreeCandidate {
+	path: string;
+	branch: string;
+	repoLabel: string;
+}
+
+/** Result of parsing a `cleanupPushedWorktrees` webview message. */
+export interface ParsedCleanupPushedWorktreesMessage {
+	candidates: CleanupWorktreeCandidate[];
+	scopeRepoLabel?: string;
+}
+
+/**
+ * Parses the bulk-cleanup message into its candidate list and optional repo scope label.
+ * `scopeRepoLabel` is only trusted (and returned) when it matches every parsed candidate's
+ * `repoLabel` — a mismatched or mixed-repo list falls back to unscoped (`undefined`) rather than
+ * letting the confirmation dialog claim a narrower scope than what will actually be deleted.
+ *
+ * Pulled out of `CopilotTokenTracker.diagHandleCleanupPushedWorktrees` in `extension.ts` so this
+ * parsing/validation logic is unit-testable without needing a full extension host instance,
+ * following the same pattern as the rest of this module.
+ */
+export function parseCleanupPushedWorktreesMessage(message: any): ParsedCleanupPushedWorktreesMessage {
+	const candidates: CleanupWorktreeCandidate[] = Array.isArray(message?.worktrees)
+		? message.worktrees
+			.filter((w: any) => w && typeof w.path === "string" && w.path.trim())
+			.map((w: any) => ({
+				path: String(w.path).trim(),
+				branch: typeof w.branch === "string" && w.branch ? w.branch : "?",
+				repoLabel: typeof w.repoLabel === "string" && w.repoLabel ? w.repoLabel : "",
+			}))
+		: [];
+	const requestedScope: string | undefined = typeof message?.repoLabel === "string" && message.repoLabel ? message.repoLabel : undefined;
+	const scopeRepoLabel = requestedScope && candidates.every((c) => c.repoLabel === requestedScope) ? requestedScope : undefined;
+	return { candidates, scopeRepoLabel };
+}
+
+/** Confirmation prompt title, naming the repository when the cleanup is scoped to one. */
+export function buildCleanupConfirmTitle(count: number, scopeRepoLabel?: string): string {
+	const scopeText = scopeRepoLabel ? ` in "${scopeRepoLabel}"` : "";
+	return `Clean up ${count} pushed worktree${count === 1 ? "" : "s"}${scopeText}?`;
+}

--- a/vscode-extension/test/unit/worktreeBackgroundScan.test.ts
+++ b/vscode-extension/test/unit/worktreeBackgroundScan.test.ts
@@ -5,6 +5,8 @@ import {
 	shouldNotifyWorktreeFindings,
 	formatBytesForNotification,
 	sumWorktreeBytes,
+	parseCleanupPushedWorktreesMessage,
+	buildCleanupConfirmTitle,
 	WORKTREE_BACKGROUND_SCAN_INTERVAL_MS,
 	WORKTREE_SCAN_NOTIFY_MIN_BYTES,
 } from '../../src/worktreeBackgroundScan';
@@ -154,4 +156,86 @@ test('scanWorktreeRootsWithTimeout: invalidates a timed-out root callback', asyn
 	});
 
 	assert.equal(isBlockedRootActive?.(), false);
+});
+
+// ---------------------------------------------------------------------------
+// parseCleanupPushedWorktreesMessage
+// ---------------------------------------------------------------------------
+
+test('parseCleanupPushedWorktreesMessage: parses candidates and an unscoped message', () => {
+	const result = parseCleanupPushedWorktreesMessage({
+		worktrees: [
+			{ path: '/repo-a/wt1', branch: 'feature-1', repoLabel: 'repo-a' },
+			{ path: '/repo-b/wt1', branch: 'feature-2', repoLabel: 'repo-b' },
+		],
+	});
+	assert.deepEqual(result.candidates, [
+		{ path: '/repo-a/wt1', branch: 'feature-1', repoLabel: 'repo-a' },
+		{ path: '/repo-b/wt1', branch: 'feature-2', repoLabel: 'repo-b' },
+	]);
+	assert.equal(result.scopeRepoLabel, undefined);
+});
+
+test('parseCleanupPushedWorktreesMessage: trusts repoLabel scope when every candidate matches', () => {
+	const result = parseCleanupPushedWorktreesMessage({
+		repoLabel: 'repo-a',
+		worktrees: [
+			{ path: '/repo-a/wt1', branch: 'feature-1', repoLabel: 'repo-a' },
+			{ path: '/repo-a/wt2', branch: 'feature-2', repoLabel: 'repo-a' },
+		],
+	});
+	assert.equal(result.scopeRepoLabel, 'repo-a');
+	assert.equal(result.candidates.length, 2);
+});
+
+test('parseCleanupPushedWorktreesMessage: falls back to unscoped when the candidate list is mixed-repo', () => {
+	// A stale/mismatched webview state could send a repoLabel scope alongside worktrees from a
+	// different (or multiple) repos; the confirmation dialog must not claim a narrower scope
+	// than what is actually about to be deleted.
+	const result = parseCleanupPushedWorktreesMessage({
+		repoLabel: 'repo-a',
+		worktrees: [
+			{ path: '/repo-a/wt1', branch: 'feature-1', repoLabel: 'repo-a' },
+			{ path: '/repo-b/wt1', branch: 'feature-2', repoLabel: 'repo-b' },
+		],
+	});
+	assert.equal(result.scopeRepoLabel, undefined);
+	assert.equal(result.candidates.length, 2);
+});
+
+test('parseCleanupPushedWorktreesMessage: falls back to unscoped when no candidate matches the requested repoLabel', () => {
+	const result = parseCleanupPushedWorktreesMessage({
+		repoLabel: 'repo-a',
+		worktrees: [{ path: '/repo-b/wt1', branch: 'feature-2', repoLabel: 'repo-b' }],
+	});
+	assert.equal(result.scopeRepoLabel, undefined);
+});
+
+test('parseCleanupPushedWorktreesMessage: filters out entries with a missing/blank path', () => {
+	const result = parseCleanupPushedWorktreesMessage({
+		worktrees: [
+			{ path: '  ', branch: 'x', repoLabel: 'repo-a' },
+			{ branch: 'x', repoLabel: 'repo-a' },
+			{ path: '/repo-a/wt1', branch: 'feature-1', repoLabel: 'repo-a' },
+		],
+	});
+	assert.deepEqual(result.candidates, [{ path: '/repo-a/wt1', branch: 'feature-1', repoLabel: 'repo-a' }]);
+});
+
+test('parseCleanupPushedWorktreesMessage: a non-array/missing worktrees list yields no candidates', () => {
+	assert.deepEqual(parseCleanupPushedWorktreesMessage({}).candidates, []);
+	assert.deepEqual(parseCleanupPushedWorktreesMessage({ worktrees: 'not-an-array' }).candidates, []);
+});
+
+// ---------------------------------------------------------------------------
+// buildCleanupConfirmTitle
+// ---------------------------------------------------------------------------
+
+test('buildCleanupConfirmTitle: unscoped, singular vs. plural count', () => {
+	assert.equal(buildCleanupConfirmTitle(1, undefined), 'Clean up 1 pushed worktree?');
+	assert.equal(buildCleanupConfirmTitle(3, undefined), 'Clean up 3 pushed worktrees?');
+});
+
+test('buildCleanupConfirmTitle: names the repository when scoped', () => {
+	assert.equal(buildCleanupConfirmTitle(2, 'repo-a'), 'Clean up 2 pushed worktrees in "repo-a"?');
 });


### PR DESCRIPTION
## Summary
The Worktree Discovery tab (Usage Analysis → Worktrees) already grouped discovered worktrees by repository, but only offered:
- a per-worktree **Delete** link, and
- a single global **Clean Up (N)** button that removed every pushed worktree across *all* repositories at once.

This adds a **Clean up (N)** button to each repository's own summary row, so you can clean up just one repo's safely-pushed worktrees without touching any others.

## Changes
- `getCleanupCandidates()` (webview) now accepts an optional `repoLabel` filter — shared by both the global summary card and each repo row's button, so there's a single source of truth for "which worktrees are eligible."
- `startWorktreeCleanup()` accepts an optional `repoLabel`, forwarded to the extension host as `message.repoLabel`.
- `diagHandleCleanupPushedWorktrees` (extension host) names the repository in the confirmation dialog when the cleanup is scoped to one; the actual deletion logic (never force-deletes, live re-checks push status per worktree, skips anything dirty/unpushed) is unchanged and shared with the global cleanup.
- New `.worktree-repo-cleanup-btn` styling and an `Actions` column in the repo summary table.

## Validation
- `npm run validate` (type-check + lint + build) — 0 errors, warning count unchanged from baseline (15).
- `npm run test:node` — all suites pass.
- `npm run check:contract` — every posted webview message has a handler.
- `npm run check:interaction` — every control still does something when clicked.

Note: `sync-host-views` reports the Visual Studio committed bundles (`chart`, `details`, `diagnostics`, `environmental`, `maturity`, `usage`) as stale vs. `dist/webview` — this pre-dates this change (confirmed via `git stash`) and is left out of scope here to keep the diff focused.