### PR TITLE
Fix Claude Code interaction-mode misclassification as CLI

### DIFF
--- a/cli/src/commands/fluency.ts
+++ b/cli/src/commands/fluency.ts
@@ -117,7 +117,7 @@ export const fluencyCommand = new Command('fluency')
 		console.log(chalk.dim('─'.repeat(55)));
 		console.log(`  Sessions analyzed:       ${chalk.bold(fmt(p.sessions))}`);
 
-		const totalInteractions = p.modeUsage.ask + p.modeUsage.edit + p.modeUsage.agent + p.modeUsage.cli + (p.modeUsage.cliApp ?? 0);
+		const totalInteractions = p.modeUsage.ask + p.modeUsage.edit + p.modeUsage.agent + p.modeUsage.cli + (p.modeUsage.cliApp ?? 0) + (p.modeUsage.claudeDesktop ?? 0) + (p.modeUsage.claudeVsCode ?? 0);
 		console.log(`  Total interactions:      ${chalk.bold(fmt(totalInteractions))}`);
 
 		if (p.modeUsage.ask > 0) {
@@ -134,6 +134,12 @@ export const fluencyCommand = new Command('fluency')
 		}
 		if ((p.modeUsage.cliApp ?? 0) > 0) {
 			console.log(`    Copilot App (CLI):     ${fmt(p.modeUsage.cliApp!)}`);
+		}
+		if ((p.modeUsage.claudeDesktop ?? 0) > 0) {
+			console.log(`    Claude Desktop:        ${fmt(p.modeUsage.claudeDesktop!)}`);
+		}
+		if ((p.modeUsage.claudeVsCode ?? 0) > 0) {
+			console.log(`    Claude (VS Code):      ${fmt(p.modeUsage.claudeVsCode!)}`);
 		}
 		if (p.toolCalls.total > 0) {
 			console.log(`  Tool calls:              ${fmt(p.toolCalls.total)}`);

--- a/docs/USAGE-ANALYSIS.md
+++ b/docs/USAGE-ANALYSIS.md
@@ -28,8 +28,10 @@ The dashboard tracks these interaction modes:
 - **✏️ Edit Mode**: Interactions where Copilot directly edits your code inline using the edits agent (triggered via inline edit UI or commands)
 - **🤖 Agent Mode**: Autonomous task execution where Copilot operates as an independent agent in the chat panel
 - **📋 Plan Mode / ⚡ Custom Agent**: Plan-mode and custom-agent (.agent.md) interactions
-- **🖥️ CLI**: Interactions in terminal-based agent CLIs (Copilot CLI, Claude Code, OpenCode, etc.)
+- **🖥️ CLI**: Interactions in terminal-based agent CLIs (Copilot CLI, Claude Code CLI, OpenCode, Crush, Mistral Vibe, Hermes, Pi, etc.)
 - **✨ Copilot App**: Subset of Copilot CLI usage — sessions started via the Copilot desktop app (detected from `client_name: github/autopilot` in the session's `workspace.yaml`), broken out from terminal CLI usage
+- **🖥️ Claude Desktop**: Claude Code sessions launched from the standalone Claude Desktop app (detected via the session's `entrypoint` field), broken out from terminal CLI usage
+- **🧩 Claude (VS Code)**: Claude Code sessions running inside an IDE, e.g. the VS Code extension (also detected via `entrypoint`), broken out from terminal CLI usage
 
 **Data Source**: 
 - JSON files: 

--- a/src/adapters/claudeCodeAdapter.ts
+++ b/src/adapters/claudeCodeAdapter.ts
@@ -298,9 +298,13 @@ export class ClaudeCodeAdapter implements IEcosystemAdapter, IDiscoverableEcosys
 		const analysis = createEmptySessionUsageAnalysis();
 		const events = await readClaudeCodeEventsForAnalysis(sessionFile);
 		const models: string[] = [];
+		// Claude Code (terminal CLI), the standalone Claude Desktop app, and the Claude Code VS
+		// Code extension all write to the same ~/.claude/projects/ format, so user-turn interactions
+		// are bucketed into the matching modeUsage field instead of always landing in `cli`.
+		const modeBucket = this.resolveModeBucket(sessionFile);
 		for (const event of events) {
 			if (event.type === 'user' && event.message?.role === 'user' && !event.isSidechain) {
-				this.processUserEvent(event, analysis);
+				this.processUserEvent(event, analysis, modeBucket);
 			} else if (event.type === 'assistant') {
 				this.processAssistantEvent(event, analysis, ctx, models);
 			} else if (event.type === 'system' && event.subtype === 'compact_boundary') {
@@ -320,8 +324,26 @@ export class ClaudeCodeAdapter implements IEcosystemAdapter, IDiscoverableEcosys
 		}
 	}
 
-	private processUserEvent(event: any, analysis: import('../types').SessionUsageAnalysis): void {
-		analysis.modeUsage.cli++;
+	/**
+	 * Resolve which `modeUsage` field a session's user-turn interactions should be counted
+	 * under, based on the `entrypoint` variant `detectClaudeCodeEditorVariant` detects:
+	 * terminal CLI usage stays in the generic `cli` bucket, while the standalone Claude
+	 * Desktop app and IDE-embedded usage (e.g. the VS Code extension) get their own buckets
+	 * so terminal CLI counts aren't inflated by non-terminal Claude Code surfaces.
+	 */
+	private resolveModeBucket(sessionFile: string): 'cli' | 'claudeDesktop' | 'claudeVsCode' {
+		const variant = detectClaudeCodeEditorVariant(sessionFile);
+		if (variant === 'Claude Code CLI') { return 'cli'; }
+		if (variant === 'Claude Desktop') { return 'claudeDesktop'; }
+		return 'claudeVsCode';
+	}
+
+	private processUserEvent(event: any, analysis: import('../types').SessionUsageAnalysis, modeBucket: 'cli' | 'claudeDesktop' | 'claudeVsCode'): void {
+		if (modeBucket === 'cli') {
+			analysis.modeUsage.cli++;
+		} else {
+			analysis.modeUsage[modeBucket] = (analysis.modeUsage[modeBucket] ?? 0) + 1;
+		}
 		const cmd = extractClaudeSlashCommand(event.message?.content);
 		if (cmd) {
 			const key = `__slash__${cmd}`;

--- a/src/maturityScoring.ts
+++ b/src/maturityScoring.ts
@@ -22,9 +22,9 @@ function fmt(n: number): string {
 	return n.toLocaleString('en-US');
 }
 
-/** Total CLI-style interactions: terminal CLI plus Copilot desktop app sessions (broken out as `cliApp`). */
+/** Total CLI-style interactions: terminal CLI plus Copilot desktop app sessions (`cliApp`) and non-terminal Claude Code surfaces (`claudeDesktop`, `claudeVsCode`) — all still agentic, tool-calling sessions, just launched from a different surface than a plain terminal. */
 function cliTotal(m: UsageAnalysisPeriod['modeUsage']): number {
-	return (m.cli ?? 0) + (m.cliApp ?? 0);
+	return (m.cli ?? 0) + (m.cliApp ?? 0) + (m.claudeDesktop ?? 0) + (m.claudeVsCode ?? 0);
 }
 
 /** Fluency stage levels (1 = AI Skeptic through 4 = AI Strategist). */

--- a/src/types.ts
+++ b/src/types.ts
@@ -480,8 +480,10 @@ export interface ModeUsage {
   agent: number; // Agent mode interactions (standard agent mode)
   plan: number; // Plan mode interactions (built-in plan agent)
   customAgent: number; // Custom agent mode interactions (.agent.md files)
-  cli: number; // CLI tool interactions (Copilot CLI, Claude Code, OpenCode, Crush, Mistral Vibe)
+  cli: number; // CLI tool interactions (Copilot CLI, Claude Code CLI, OpenCode, Crush, Mistral Vibe, Hermes, Pi, …)
   cliApp?: number; // Subset of CLI interactions: Copilot CLI sessions started via the Copilot desktop app (client_name: github/autopilot), broken out from `cli`
+  claudeDesktop?: number; // Claude Code sessions launched from the standalone Claude Desktop app (entrypoint: 'claude-desktop'), broken out of `cli` so terminal usage isn't inflated by desktop-app usage
+  claudeVsCode?: number; // Claude Code sessions running inside an IDE, e.g. the VS Code extension (entrypoint: 'claude-vscode' or any non-CLI/non-desktop value), broken out of `cli` for the same reason
 }
 
 export interface ContextReferenceUsage {

--- a/src/usageAnalysis.ts
+++ b/src/usageAnalysis.ts
@@ -1295,7 +1295,7 @@ function _muaMergeModelEfficiency(period: UsageAnalysisPeriod, analysis: Session
 	mergeModelEfficiency(period.modelEfficiency, analysis.modelEfficiency);
 }
 
-/** Merge a session's mode usage counters (incl. the optional Copilot App cliApp split) into the period aggregate. */
+/** Merge a session's mode usage counters (incl. the optional cliApp/claudeDesktop/claudeVsCode splits) into the period aggregate. */
 function _muaMergeModeUsage(period: UsageAnalysisPeriod, analysis: SessionUsageAnalysis): void {
 	period.modeUsage.ask += analysis.modeUsage.ask;
 	period.modeUsage.edit += analysis.modeUsage.edit;
@@ -1304,6 +1304,8 @@ function _muaMergeModeUsage(period: UsageAnalysisPeriod, analysis: SessionUsageA
 	period.modeUsage.customAgent += analysis.modeUsage.customAgent;
 	period.modeUsage.cli += analysis.modeUsage.cli;
 	period.modeUsage.cliApp = (period.modeUsage.cliApp ?? 0) + (analysis.modeUsage.cliApp ?? 0);
+	period.modeUsage.claudeDesktop = (period.modeUsage.claudeDesktop ?? 0) + (analysis.modeUsage.claudeDesktop ?? 0);
+	period.modeUsage.claudeVsCode = (period.modeUsage.claudeVsCode ?? 0) + (analysis.modeUsage.claudeVsCode ?? 0);
 }
 
 /**

--- a/visualstudio-extension/src/AIEngineeringFluency/ToolWindow/TokenTrackerControl.xaml.cs
+++ b/visualstudio-extension/src/AIEngineeringFluency/ToolWindow/TokenTrackerControl.xaml.cs
@@ -453,6 +453,15 @@ namespace AIEngineeringFluency.ToolWindow
                             break;
                         }
 
+                        // Diagnostic/handshake-only messages posted by the shared VS Code webview bundles.
+                        // The VS Code host consumes these (readiness signalling, extension-point telemetry);
+                        // the Visual Studio host has no equivalent surface, so they are intentionally no-ops
+                        // here rather than falling through to the "unknown command" warning below.
+                        case "usageWebviewReady":
+                        case "usageWebviewTrace":
+                        case "extensionPointAction":
+                            break;
+
                         default:
                             Utilities.OutputLogger.LogWarning($"Unknown WebMessage command: {cmd}");
                             break;

--- a/visualstudio-extension/src/AIEngineeringFluency/webview/chart.js
+++ b/visualstudio-extension/src/AIEngineeringFluency/webview/chart.js
@@ -16341,25 +16341,79 @@ To suppress this warning, set window.${CONFIG_KEY} to true`);
     }).format(value);
   }
 
-  // src/webview/shared/extensionPoints.ts
-  function wireExtensionPointButtons(vscodeApi) {
-    const buttons = window.__EXTENSION_POINT_BUTTONS__ ?? [];
-    if (buttons.length === 0) {
-      return;
+  // src/webview/shared/messageHandler.ts
+  function collectOwnOrigins(currentWindow) {
+    const origins = [];
+    const origin = currentWindow.location?.origin;
+    if (origin && origin !== "null") {
+      origins.push(origin);
     }
+    const href = currentWindow.location?.href;
+    const derived = href ? /^[a-z][a-z0-9+.-]*:\/\/[^/?#]*/i.exec(href) : null;
+    if (derived && !origins.includes(derived[0])) {
+      origins.push(derived[0]);
+    }
+    return origins;
+  }
+  function isTrustedWebviewMessageSource(source, currentWindow, origin) {
+    if (source === null || source === void 0 || source === currentWindow) {
+      return true;
+    }
+    if (source === currentWindow.parent || source === currentWindow.top) {
+      return true;
+    }
+    return Boolean(origin) && collectOwnOrigins(currentWindow).includes(origin);
+  }
+  function registerMessageHandler(handler, onUntrustedMessage) {
+    window.addEventListener("message", (event) => {
+      if (!isTrustedWebviewMessageSource(event.source, window, event.origin)) {
+        onUntrustedMessage?.(event);
+        return;
+      }
+      handler(event.data);
+    });
+  }
+
+  // src/webview/shared/extensionPoints.ts
+  function buttonElementId(id) {
+    return `ext-point-${id}`;
+  }
+  function renderExtensionPointButtons(vscodeApi, buttons) {
     const buttonRow = document.querySelector(".button-row");
     if (!buttonRow) {
       return;
     }
+    const desiredIds = new Set(buttons.map((b3) => b3.id));
+    for (const existing of Array.from(buttonRow.querySelectorAll('[id^="ext-point-"]'))) {
+      const id = existing.id.slice("ext-point-".length);
+      if (!desiredIds.has(id)) {
+        existing.remove();
+      }
+    }
     for (const btn of buttons) {
+      if (document.getElementById(buttonElementId(btn.id))) {
+        continue;
+      }
       const el2 = document.createElement("vscode-button");
-      el2.id = `ext-point-${btn.id}`;
+      el2.id = buttonElementId(btn.id);
       el2.textContent = btn.label;
       el2.addEventListener("click", () => {
         vscodeApi.postMessage({ command: "extensionPointAction", buttonId: btn.id });
       });
       buttonRow.append(el2);
     }
+  }
+  function wireExtensionPointButtons(vscodeApi) {
+    renderExtensionPointButtons(vscodeApi, window.__EXTENSION_POINT_BUTTONS__ ?? []);
+    if (window.__extensionPointButtonsListenerRegistered__) {
+      return;
+    }
+    window.__extensionPointButtonsListenerRegistered__ = true;
+    registerMessageHandler((message) => {
+      if (message?.command === "extensionPointButtonsUpdated" && Array.isArray(message.buttons)) {
+        renderExtensionPointButtons(vscodeApi, message.buttons);
+      }
+    });
   }
 
   // src/webview/shared/periodSelector.ts
@@ -16374,7 +16428,7 @@ To suppress this warning, set window.${CONFIG_KEY} to true`);
     thisWeek: "This week",
     allTime: "All time"
   };
-  var CANONICAL_PERIODS = ["today", "last7", "last30", "currentMonth", "allTime"];
+  var CANONICAL_PERIODS = ["today", "last7", "last30", "last90", "currentMonth", "allTime"];
   function setOptionSelected(option, value, selected) {
     if (value === selected) {
       option.selected = true;
@@ -16479,6 +16533,41 @@ To suppress this warning, set window.${CONFIG_KEY} to true`);
         return next;
       }
     };
+  }
+
+  // ../src/timeWindows.ts
+  var ROLLING_WINDOW_DAYS = {
+    today: 1,
+    last7: 7,
+    last30: 30,
+    last90: 90
+  };
+  function getTimeWindowStartDate(timeWindow, now) {
+    if (timeWindow === "allTime") {
+      return null;
+    }
+    if (timeWindow === "currentMonth") {
+      return new Date(now.getFullYear(), now.getMonth(), 1);
+    }
+    const days = ROLLING_WINDOW_DAYS[timeWindow];
+    if (days === void 0) {
+      return null;
+    }
+    return new Date(now.getFullYear(), now.getMonth(), now.getDate() - days + 1);
+  }
+  function getTimeWindowStartDayKey(timeWindow, now) {
+    const start = getTimeWindowStartDate(timeWindow, now);
+    if (!start) {
+      return "0000-00-00";
+    }
+    return [
+      start.getFullYear(),
+      String(start.getMonth() + 1).padStart(2, "0"),
+      String(start.getDate()).padStart(2, "0")
+    ].join("-");
+  }
+  function getTimeWindowStartMonthKey(timeWindow, now) {
+    return timeWindow === "allTime" ? "0000-00" : getTimeWindowStartDayKey(timeWindow, now).slice(0, 7);
   }
 
   // src/webview/shared/theme.css
@@ -16817,19 +16906,6 @@ body[data-vscode-theme-kind="vscode-high-contrast-light"] .title {
   // src/webview/chart/styles.css
   var styles_default = "body {\n	margin: 0;\n	background: var(--bg-primary);\n	color: var(--text-primary);\n	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;\n}\n\n.container {\n	padding: 16px;\n	display: flex;\n	flex-direction: column;\n	gap: 32px;\n	max-width: 1200px;\n	margin: 0 auto;\n}\n\n.header {\n	display: flex;\n	justify-content: space-between;\n	align-items: center;\n	gap: 12px;\n	padding-bottom: 4px;\n}\n\n.header-left {\n	display: flex;\n	align-items: center;\n	gap: 8px;\n}\n\n.header-icon {\n	font-size: 20px;\n}\n\n.header-title {\n	font-size: 16px;\n	font-weight: 700;\n	color: var(--text-primary);\n	text-align: left;\n}\n\n\n\n.section {\n	background: var(--bg-secondary);\n	border: 1px solid var(--border-color);\n	border-radius: 10px;\n	padding: 16px;\n	box-shadow: 0 4px 10px var(--shadow-color);\n	text-align: center;\n}\n\n.section h3 {\n	margin: 0 0 10px;\n	font-size: 14px;\n	display: flex;\n	align-items: center;\n	gap: 6px;\n	color: var(--text-primary);\n	letter-spacing: 0.2px;\n	text-align: left;\n}\n\n.cards {\n	display: grid;\n	grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));\n	gap: 10px;\n	text-align: center;\n}\n\n.cards + .cards {\n	margin-top: 16px;\n}\n\n.editor-section {\n	margin-top: 16px;\n}\n\n.editor-section-header {\n	display: flex;\n	justify-content: flex-start;\n}\n\n.editor-list-toggle {\n	display: flex;\n	align-items: center;\n	gap: 6px;\n	background: none;\n	border: none;\n	cursor: pointer;\n	padding: 0 0 8px;\n	margin: 0;\n	font-size: 13px;\n	font-weight: 600;\n	color: var(--text-primary);\n}\n\n.editor-list-toggle:hover {\n	color: var(--text-secondary);\n}\n\n.editor-list-chevron {\n	font-size: 10px;\n	color: var(--text-secondary);\n}\n\n.card {\n	background: var(--bg-tertiary);\n	border: 1px solid var(--border-subtle);\n	border-radius: 8px;\n	padding: 12px;\n	box-shadow: 0 2px 6px var(--shadow-color);\n	text-align: center;\n}\n\n.card-label {\n	color: var(--text-secondary);\n	font-size: 11px;\n	margin-bottom: 6px;\n}\n\n.card-value {\n	color: var(--text-primary);\n	font-size: 18px;\n	font-weight: 700;\n}\n\n.card-sub {\n	color: var(--text-muted);\n	font-size: 11px;\n	margin-top: 2px;\n}\n\n.chart-section-header {\n	display: flex;\n	justify-content: space-between;\n	align-items: center;\n	margin-bottom: 10px;\n}\n\n.chart-section-header h3 {\n	margin: 0;\n}\n\n.chart-shell {	background: var(--bg-tertiary);\n	border: 1px solid var(--border-subtle);\n	border-radius: 10px;\n	padding: 12px;\n	box-shadow: 0 2px 8px var(--shadow-color);\n	text-align: center;\n}\n\n.chart-controls {\n	display: flex;\n	flex-direction: column;\n	gap: 10px;\n	margin-bottom: 12px;\n}\n\n.chart-controls-row {\n	display: flex;\n	flex-wrap: wrap;\n	align-items: center;\n	gap: 10px;\n	justify-content: flex-start;\n	padding-bottom: 10px;\n	border-bottom: 1px solid var(--border-subtle);\n}\n\n.chart-controls-row:last-child {\n	padding-bottom: 0;\n	border-bottom: none;\n}\n\n.control-group {\n	display: flex;\n	gap: 4px;\n	align-items: center;\n}\n\n.control-label {\n	font-size: 11px;\n	color: var(--text-secondary);\n}\n\n.loading-note {\n	font-size: 11px;\n	color: var(--text-secondary);\n	margin-left: 4px;\n	white-space: nowrap;\n}\n\n.control-group-separator {\n	width: 1px;\n	height: 20px;\n	background: var(--border-subtle);\n	margin: 0 4px;\n	flex-shrink: 0;\n}\n\n.period-controls {\n	display: flex;\n	gap: 4px;\n	align-items: center;\n}\n\n.period-controls-label {\n	font-size: 11px;\n	color: var(--text-secondary);\n	margin-right: 4px;\n}\n\n.period-controls .toggle {\n	padding: 6px 10px;\n}\n\n.toggle {\n	background: var(--button-secondary-bg);\n	border: 1px solid var(--border-subtle);\n	color: var(--text-primary);\n	padding: 6px 12px;\n	border-radius: 6px;\n	font-size: 12px;\n	cursor: pointer;\n	transition: all 0.15s ease;\n	min-height: 30px;\n	display: inline-flex;\n	align-items: center;\n	justify-content: center;\n}\n\n.toggle.active {\n	background: var(--button-bg);\n	border-color: var(--button-bg);\n	color: var(--button-fg);\n}\n\n.toggle:hover {\n	background: var(--button-secondary-hover-bg);\n}\n\n.toggle.active:hover {\n	background: var(--button-hover-bg);\n}\n\n.toggle:disabled {\n	opacity: 0.45;\n	cursor: not-allowed;\n}\n\n.toggle:disabled:hover {\n	background: var(--button-secondary-bg);\n}\n\n.canvas-wrap {\n	position: relative;\n	height: 420px;\n}\n\n.footer {\n	color: var(--text-muted);\n	font-size: 11px;\n	margin-top: 6px;\n	text-align: center;\n}\n\n.footer em {\n	color: var(--text-secondary);\n}\n\n.hidden {\n	display: none !important;\n}\n\n.toggle.dim {\n	opacity: 0.6;\n}\n\n.toggle.disabled {\n	opacity: 0.45;\n	cursor: not-allowed;\n}\n\n.toggle.disabled:hover {\n	background: var(--button-secondary-bg);\n}\n\n.time-window-select {\n	background: var(--button-secondary-bg);\n	border: 1px solid var(--border-subtle);\n	color: var(--text-primary);\n	border-radius: 6px;\n	padding: 6px 10px;\n	font-size: 12px;\n	cursor: pointer;\n	outline: none;\n	min-height: 30px;\n}\n\n.time-window-select:focus {\n	border-color: var(--button-bg);\n}\n\n.time-window-select option {\n	background: var(--bg-secondary);\n	color: var(--text-primary);\n}\n\n/* Language Heatmap */\n.heatmap-container {\n	position: relative;\n	min-height: 420px;\n	overflow: auto;\n}\n\n.heatmap-wrap {\n	width: 100%;\n	min-height: 380px;\n	display: flex;\n	flex-direction: column;\n	padding-top: 8px;\n}\n\n.heatmap-empty {\n	flex: 1;\n	display: flex;\n	align-items: center;\n	justify-content: center;\n	color: var(--text-muted);\n	font-size: 13px;\n	min-height: 380px;\n}\n\n.heatmap-table {\n	border-collapse: separate;\n	border-spacing: 3px;\n	width: 100%;\n	table-layout: fixed;\n}\n\n.heatmap-lang-header {\n	width: 72px;\n	min-width: 72px;\n}\n\n.heatmap-date-header {\n	height: 56px;\n	vertical-align: bottom;\n	padding: 0 0 2px 0;\n	text-align: center;\n}\n\n.heatmap-date-header span {\n	display: block;\n	writing-mode: vertical-lr;\n	transform: rotate(180deg);\n	white-space: nowrap;\n	font-size: 10px;\n	color: var(--text-primary);\n	font-weight: 500;\n	opacity: 0.85;\n	max-height: 54px;\n	overflow: hidden;\n	margin: 0 auto;\n}\n\n.heatmap-lang-label {\n	text-align: right;\n	padding-right: 8px;\n	font-size: 11px;\n	color: var(--text-secondary);\n	white-space: nowrap;\n	overflow: hidden;\n	text-overflow: ellipsis;\n	max-width: 72px;\n	height: 22px;\n}\n\n.heatmap-data-cell {\n	border-radius: 3px;\n	cursor: default;\n	height: 22px;\n	transition: opacity 0.1s ease;\n}\n\n.heatmap-data-cell:hover {\n	opacity: 0.75;\n	outline: 1px solid rgba(34, 197, 94, 0.7);\n	outline-offset: -1px;\n}\n";
 
-  // src/webview/shared/messageHandler.ts
-  function isTrustedWebviewMessageSource(source, currentWindow) {
-    return source === null || source === currentWindow;
-  }
-  function registerMessageHandler(handler) {
-    window.addEventListener("message", (event) => {
-      if (!isTrustedWebviewMessageSource(event.source, window)) {
-        return;
-      }
-      handler(event.data);
-    });
-  }
-
   // src/webview/chart/main.ts
   var vscode = acquireVsCodeApi();
   var initialData = getWindowData("__INITIAL_CHART__");
@@ -16867,39 +16943,6 @@ body[data-vscode-theme-kind="vscode-high-contrast-light"] .title {
   function saveWebviewState() {
     chartState.save({ period: currentPeriod, timeWindow: currentTimeWindow, metric: currentMetric, split: currentSplit, displayMode: currentDisplayMode, editorListCollapsed });
   }
-  function getWindowStartDate(timeWindow, now) {
-    const y3 = now.getFullYear();
-    const m2 = now.getMonth();
-    const d3 = now.getDate();
-    switch (timeWindow) {
-      case "today":
-        return `${y3}-${String(m2 + 1).padStart(2, "0")}-${String(d3).padStart(2, "0")}`;
-      case "last7": {
-        const start = new Date(y3, m2, d3 - 6);
-        return `${start.getFullYear()}-${String(start.getMonth() + 1).padStart(2, "0")}-${String(start.getDate()).padStart(2, "0")}`;
-      }
-      case "last30": {
-        const start = new Date(y3, m2, d3 - 29);
-        return `${start.getFullYear()}-${String(start.getMonth() + 1).padStart(2, "0")}-${String(start.getDate()).padStart(2, "0")}`;
-      }
-      case "currentMonth":
-        return `${y3}-${String(m2 + 1).padStart(2, "0")}-01`;
-      case "allTime":
-        return "0000-00-00";
-    }
-  }
-  function getWindowStartMonth(timeWindow, now) {
-    if (timeWindow === "allTime") {
-      return "0000-00";
-    }
-    const y3 = now.getFullYear();
-    const m2 = now.getMonth();
-    if (timeWindow === "currentMonth") {
-      return `${y3}-${String(m2 + 1).padStart(2, "0")}`;
-    }
-    const start = new Date(y3, m2, timeWindow === "today" ? 1 : timeWindow === "last7" ? -5 : -29);
-    return `${start.getFullYear()}-${String(start.getMonth() + 1).padStart(2, "0")}`;
-  }
   function sliceByIndices(arr, indices) {
     if (!arr) {
       return void 0;
@@ -16916,7 +16959,7 @@ body[data-vscode-theme-kind="vscode-high-contrast-light"] .title {
     });
   }
   function getFilterStartKey(timeWindow, periodType, now) {
-    return periodType === "month" ? getWindowStartMonth(timeWindow, now) : getWindowStartDate(timeWindow, now);
+    return periodType === "month" ? getTimeWindowStartMonthKey(timeWindow, now) : getTimeWindowStartDayKey(timeWindow, now);
   }
   function buildCoreFilteredPeriod(period, indices) {
     const totalTokens = indices.reduce((sum, i6) => sum + period.tokensData[i6], 0);
@@ -17059,6 +17102,9 @@ body[data-vscode-theme-kind="vscode-high-contrast-light"] .title {
     if (currentMetric === "output") {
       return periodMeta.outputTitle;
     }
+    if (currentMetric === "sessions") {
+      return periodMeta.sessionsTitle;
+    }
     let titleText = periodMeta.title;
     if (currentDisplayMode === "rolling" && currentSplit === "total") {
       titleText += ` (${getRollingLabel()})`;
@@ -17090,21 +17136,21 @@ body[data-vscode-theme-kind="vscode-high-contrast-light"] .title {
     return filterPeriodByTimeWindow(period, currentTimeWindow, currentPeriod);
   }
   var PERIOD_LABELS2 = {
-    day: { title: "Token Usage", footer: "Day-by-day token usage", countLabel: "Total Days", avgLabel: "Avg Tokens / Day", aggregationLabel: "Aggregated by Day", costTitle: "Est. Cost", avgCostLabel: "Avg Cost / Day", outputTitle: "Lines of Code", avgLocLabel: "Avg Lines / Day" },
-    week: { title: "Token Usage", footer: "Week-by-week token usage", countLabel: "Total Weeks", avgLabel: "Avg Tokens / Week", aggregationLabel: "Aggregated by Week", costTitle: "Est. Cost", avgCostLabel: "Avg Cost / Week", outputTitle: "Lines of Code", avgLocLabel: "Avg Lines / Week" },
-    month: { title: "Token Usage", footer: "Monthly token usage", countLabel: "Total Months", avgLabel: "Avg Tokens / Month", aggregationLabel: "Aggregated by Month", costTitle: "Est. Cost", avgCostLabel: "Avg Cost / Month", outputTitle: "Lines of Code", avgLocLabel: "Avg Lines / Month" }
+    day: { title: "Token Usage \u2013 Last 30 Days", footer: "Day-by-day token usage for the last 30 days", countLabel: "Total Days", avgLabel: "Avg Tokens / Day", aggregationLabel: "Aggregated by Day", costTitle: "Est. Cost \u2013 Last 30 Days", avgCostLabel: "Avg Cost / Day", outputTitle: "Lines of Code \u2013 Last 30 Days", avgLocLabel: "Avg Lines / Day", sessionsTitle: "Sessions \u2013 Last 30 Days", avgSessionsLabel: "Avg Sessions / Day" },
+    week: { title: "Token Usage \u2013 Last 6 Weeks", footer: "Week-by-week token usage for the last 6 weeks", countLabel: "Total Weeks", avgLabel: "Avg Tokens / Week", aggregationLabel: "Aggregated by Week", costTitle: "Est. Cost \u2013 Last 6 Weeks", avgCostLabel: "Avg Cost / Week", outputTitle: "Lines of Code \u2013 Last 6 Weeks", avgLocLabel: "Avg Lines / Week", sessionsTitle: "Sessions \u2013 Last 6 Weeks", avgSessionsLabel: "Avg Sessions / Week" },
+    month: { title: "Token Usage \u2013 Last 12 Months", footer: "Monthly token usage for the last 12 months", countLabel: "Total Months", avgLabel: "Avg Tokens / Month", aggregationLabel: "Aggregated by Month", costTitle: "Est. Cost \u2013 Last 12 Months", avgCostLabel: "Avg Cost / Month", outputTitle: "Lines of Code \u2013 Last 12 Months", avgLocLabel: "Avg Lines / Month", sessionsTitle: "Sessions \u2013 Last 12 Months", avgSessionsLabel: "Avg Sessions / Month" }
   };
   function isComboSupported(metric, split) {
     if (metric === "sessions") {
-      return split === "total" || split === "model" || split === "editor" || split === "provider";
+      return split === "total" || split === "model" || split === "editor" || split === "provider" || split === "task";
     }
     if (metric === "cost") {
-      return split === "total" || split === "model" || split === "editor" || split === "provider";
+      return split === "total" || split === "model" || split === "editor" || split === "provider" || split === "task";
     }
     if (metric === "output") {
-      return split !== "model" && split !== "provider" && split !== "taskCategory";
+      return split !== "model" && split !== "provider" && split !== "task" && split !== "taskCategory";
     }
-    return split !== "language";
+    return split !== "language" && split !== "provider";
   }
   function buildChartHeader(data) {
     const header = el("div", "header");
@@ -17117,39 +17163,36 @@ body[data-vscode-theme-kind="vscode-high-contrast-light"] .title {
     header.append(headerLeft, buttons);
     return header;
   }
-  function getSummaryTotal(periodData) {
-    switch (currentMetric) {
-      case "cost":
-        return { label: "Total Cost (est.)", value: `$${periodData.totalCost.toFixed(2)}` };
-      case "output":
-        return { label: "Total Lines (AI)", value: ((periodData.totalLinesAdded ?? 0) + (periodData.totalLinesRemoved ?? 0)).toLocaleString() };
-      case "sessions":
-        return { label: "Total Sessions", value: periodData.totalSessions.toLocaleString() };
-      default:
-        return { label: "Total Tokens", value: formatCompact(periodData.totalTokens) };
+  function getSummaryValues(periodData, periodMeta) {
+    if (currentMetric === "cost") {
+      return { totalLabel: "Total Cost (est.)", totalValue: `$${periodData.totalCost.toFixed(2)}`, avgLabel: periodMeta.avgCostLabel, avgValue: `$${periodData.avgCostPerPeriod.toFixed(2)}` };
     }
-  }
-  function getSummaryAverage(periodData, periodMeta) {
-    switch (currentMetric) {
-      case "cost":
-        return { label: periodMeta.avgCostLabel, value: `$${periodData.avgCostPerPeriod.toFixed(2)}` };
-      case "output":
-        return { label: periodMeta.avgLocLabel, value: Math.round(periodData.avgLocPerPeriod ?? 0).toLocaleString() };
-      case "sessions":
-        return { label: `Avg Sessions / ${periodMeta.countLabel.replace("Total ", "")}`, value: Math.round(periodData.totalSessions / (periodData.periodCount || 1)).toLocaleString() };
-      default:
-        return { label: periodMeta.avgLabel, value: formatCompact(periodData.avgPerPeriod) };
+    if (currentMetric === "output") {
+      return {
+        totalLabel: "Total Lines (AI)",
+        totalValue: ((periodData.totalLinesAdded ?? 0) + (periodData.totalLinesRemoved ?? 0)).toLocaleString(),
+        avgLabel: periodMeta.avgLocLabel,
+        avgValue: Math.round(periodData.avgLocPerPeriod ?? 0).toLocaleString()
+      };
     }
+    if (currentMetric === "sessions") {
+      return {
+        totalLabel: "Total Sessions",
+        totalValue: periodData.totalSessions.toLocaleString(),
+        avgLabel: periodMeta.avgSessionsLabel,
+        avgValue: Math.round(periodData.totalSessions / Math.max(1, periodData.periodCount)).toLocaleString()
+      };
+    }
+    return { totalLabel: "Total Tokens", totalValue: formatCompact(periodData.totalTokens), avgLabel: periodMeta.avgLabel, avgValue: formatCompact(periodData.avgPerPeriod) };
   }
   function buildSummaryCards(periodData, periodMeta) {
-    const total = getSummaryTotal(periodData);
-    const average = getSummaryAverage(periodData, periodMeta);
+    const { totalLabel, totalValue, avgLabel, avgValue } = getSummaryValues(periodData, periodMeta);
     const cards = el("div", "cards");
     cards.id = "summary-cards";
     cards.append(
       buildCard("card-period-count", periodMeta.countLabel, periodData.periodCount.toLocaleString()),
-      buildCard("card-total-tokens", total.label, total.value),
-      buildCard("card-avg-tokens", average.label, average.value),
+      buildCard("card-total-tokens", totalLabel, totalValue),
+      buildCard("card-avg-tokens", avgLabel, avgValue),
       buildCard("card-total-sessions", "Total Sessions", periodData.totalSessions.toLocaleString())
     );
     return cards;
@@ -17181,7 +17224,7 @@ body[data-vscode-theme-kind="vscode-high-contrast-light"] .title {
     const { wrapper } = createPeriodSelector({
       id: "time-window-select",
       selected: currentTimeWindow,
-      disabled: periodsReady ? [] : ["allTime"],
+      disabled: periodsReady ? [] : ["last90", "allTime"],
       disabledTitle: "Full history is still loading",
       label: "Time window:",
       onChange: (value) => {
@@ -17192,7 +17235,7 @@ body[data-vscode-theme-kind="vscode-high-contrast-light"] .title {
     group.append(wrapper);
     if (!periodsReady) {
       const loadingNote = el("span", "loading-note", "Loading history\u2026");
-      loadingNote.title = 'Full history is still loading. "All time" and weekly/monthly aggregation are not available yet.';
+      loadingNote.title = 'Full history is still loading. "Last 90 days", "All time", and weekly/monthly aggregation are not available yet.';
       group.append(loadingNote);
     }
     return group;
@@ -17217,24 +17260,26 @@ body[data-vscode-theme-kind="vscode-high-contrast-light"] .title {
   function buildSplitControl() {
     const group = el("div", "control-group");
     group.append(el("span", "control-label", "Split:"));
-    const mkSplit = (id, split, label) => {
+    const mkSplit = (id, split, label, tooltip) => {
       const supported = isComboSupported(currentMetric, split);
-      const btn = el("button", `toggle${currentSplit === split ? " active" : ""}${!supported ? " disabled" : ""}`, label);
+      const btn = el("button", `toggle${currentSplit === split || currentSplit === "taskCategory" && split === "task" ? " active" : ""}${!supported ? " disabled" : ""}`, label);
       btn.id = id;
       if (!supported) {
         btn.disabled = true;
         btn.title = `Not available for ${currentMetric} metric`;
+      } else if (tooltip) {
+        btn.title = tooltip;
       }
       return btn;
     };
     group.append(
       mkSplit("split-total", "total", "Total"),
-      mkSplit("split-model", "model", "By Model"),
-      mkSplit("split-editor", "editor", "By Editor"),
+      mkSplit("split-model", "model", "By Model", "Click a model name in the chart legend to hide its data; click it again to show it."),
+      mkSplit("split-editor", "editor", "By Editor", "Click an editor name in the chart legend to hide its data; click it again to show it."),
       mkSplit("split-provider", "provider", "\u{1F3F7}\uFE0F By Provider"),
       mkSplit("split-repository", "repository", "By Repository"),
       mkSplit("split-language", "language", "By Language"),
-      mkSplit("split-taskcategory", "taskCategory", "By Task")
+      mkSplit("split-task", "task", "By Task")
     );
     return group;
   }
@@ -17376,10 +17421,20 @@ Updates automatically every 5 minutes.`
       }
     };
     updateCard("card-period-count", periodMeta.countLabel, periodData.periodCount.toLocaleString());
-    const total = getSummaryTotal(periodData);
-    const average = getSummaryAverage(periodData, periodMeta);
-    updateCard("card-total-tokens", total.label, total.value);
-    updateCard("card-avg-tokens", average.label, average.value);
+    if (currentMetric === "cost") {
+      updateCard("card-total-tokens", "Total Cost (est.)", `$${periodData.totalCost.toFixed(2)}`);
+      updateCard("card-avg-tokens", periodMeta.avgCostLabel, `$${periodData.avgCostPerPeriod.toFixed(2)}`);
+    } else if (currentMetric === "output") {
+      const totalLines = (periodData.totalLinesAdded ?? 0) + (periodData.totalLinesRemoved ?? 0);
+      updateCard("card-total-tokens", "Total Lines (AI)", totalLines.toLocaleString());
+      updateCard("card-avg-tokens", periodMeta.avgLocLabel, Math.round(periodData.avgLocPerPeriod ?? 0).toLocaleString());
+    } else if (currentMetric === "sessions") {
+      updateCard("card-total-tokens", "Total Sessions", periodData.totalSessions.toLocaleString());
+      updateCard("card-avg-tokens", periodMeta.avgSessionsLabel, Math.round(periodData.totalSessions / Math.max(1, periodData.periodCount)).toLocaleString());
+    } else {
+      updateCard("card-total-tokens", "Total Tokens", formatCompact(periodData.totalTokens));
+      updateCard("card-avg-tokens", periodMeta.avgLabel, formatCompact(periodData.avgPerPeriod));
+    }
     updateCard("card-total-sessions", null, periodData.totalSessions.toLocaleString());
     const title = document.getElementById("chart-title");
     if (title) {
@@ -17459,7 +17514,7 @@ Updates automatically every 5 minutes.`;
       { id: "split-repository", split: "repository" },
       { id: "split-language", split: "language" },
       { id: "split-provider", split: "provider" },
-      { id: "split-taskcategory", split: "taskCategory" }
+      { id: "split-task", split: "task" }
     ];
     splitButtons.forEach(({ id, split }) => {
       const btn = document.getElementById(id);
@@ -17532,28 +17587,11 @@ Updates automatically every 5 minutes.`;
     }
     chart = new Chart2(ctx, createConfig(data));
   }
-  function clampSplitForMetric(metric) {
-    if (metric === "cost" && currentSplit !== "model" && currentSplit !== "editor" && currentSplit !== "provider") {
-      currentSplit = "total";
-      return;
-    }
-    if (metric === "output" && currentSplit === "model") {
-      currentSplit = "total";
-      return;
-    }
-    if (metric === "tokens" && currentSplit === "language") {
-      currentSplit = "total";
-      return;
-    }
-    if (metric === "sessions" && currentSplit !== "total" && currentSplit !== "model" && currentSplit !== "editor" && currentSplit !== "provider") {
-      currentSplit = "total";
-    }
-  }
   async function switchMetric(metric, data) {
     if (currentMetric === metric) {
       return;
     }
-    clampSplitForMetric(metric);
+    currentSplit = getPreferredSplitForMetric(metric, currentSplit);
     currentMetric = metric;
     const rollingApplicable = currentSplit === "total" && metric !== "output";
     if (!rollingApplicable) {
@@ -17582,11 +17620,34 @@ Updates automatically every 5 minutes.`;
     updateSummaryCards(data);
     await reinitChart(data);
   }
-  function isSplitSupported(metric, split) {
-    if (metric === "sessions") {
-      return split === "total" || split === "model" || split === "editor" || split === "provider";
+  function getPreferredSplitForMetric(metric, split) {
+    const normalized = split === "taskCategory" ? "task" : split;
+    if (metric === "cost") {
+      return normalized === "editor" || normalized === "provider" || normalized === "task" ? normalized : "total";
     }
-    return metric === "cost" && (split === "total" || split === "model" || split === "editor" || split === "provider") || metric === "output" && split !== "model" && split !== "provider" && split !== "taskCategory" || metric === "tokens" && split !== "language";
+    if (metric === "output") {
+      return normalized === "model" || normalized === "provider" || normalized === "task" ? "total" : normalized;
+    }
+    if (metric === "tokens") {
+      return normalized === "language" ? "total" : normalized;
+    }
+    if (metric === "sessions") {
+      return normalized === "total" || normalized === "model" || normalized === "editor" || normalized === "provider" || normalized === "task" ? normalized : "total";
+    }
+    return normalized;
+  }
+  function isSplitSupported(metric, split) {
+    const normalized = split === "taskCategory" ? "task" : split;
+    if (metric === "sessions") {
+      return normalized === "total" || normalized === "model" || normalized === "editor" || normalized === "provider" || normalized === "task";
+    }
+    if (metric === "cost") {
+      return normalized === "total" || normalized === "model" || normalized === "editor" || normalized === "provider" || normalized === "task";
+    }
+    if (metric === "output") {
+      return normalized !== "model" && normalized !== "provider" && normalized !== "task" && normalized !== "taskCategory";
+    }
+    return normalized !== "language" && normalized !== "provider";
   }
   async function reinitChart(data) {
     refreshHeatmapView(data);
@@ -17670,12 +17731,13 @@ Updates automatically every 5 minutes.`;
     });
   }
   function setActiveSplit(split) {
-    ["split-total", "split-model", "split-editor", "split-repository", "split-language", "split-provider", "split-taskcategory"].forEach((id) => {
+    const normalized = split === "taskCategory" ? "task" : split;
+    ["split-total", "split-model", "split-editor", "split-repository", "split-language", "split-provider", "split-task"].forEach((id) => {
       const btn = document.getElementById(id);
       if (!btn) {
         return;
       }
-      btn.classList.toggle("active", id === `split-${split}`);
+      btn.classList.toggle("active", id === `split-${normalized}`);
     });
   }
   function updateSplitButtonStates() {
@@ -17686,7 +17748,7 @@ Updates automatically every 5 minutes.`;
       { id: "split-repository", split: "repository" },
       { id: "split-language", split: "language" },
       { id: "split-provider", split: "provider" },
-      { id: "split-taskcategory", split: "taskCategory" }
+      { id: "split-task", split: "task" }
     ];
     splits.forEach(({ id, split }) => {
       const btn = document.getElementById(id);
@@ -17744,7 +17806,7 @@ Updates automatically every 5 minutes.`;
     };
   }
   function buildBaseOptions(c4, periodsReady) {
-    const title = !periodsReady && currentTimeWindow === "allTime" ? `${PERIOD_LABELS2[currentTimeWindow]} (loading history\u2026)` : PERIOD_LABELS2[currentTimeWindow];
+    const title = !periodsReady && (currentTimeWindow === "last90" || currentTimeWindow === "allTime") ? `${PERIOD_LABELS2[currentTimeWindow]} (loading history\u2026)` : PERIOD_LABELS2[currentTimeWindow];
     return {
       responsive: true,
       maintainAspectRatio: false,
@@ -18006,6 +18068,48 @@ Updates automatically every 5 minutes.`;
       }
     };
   }
+  function buildSessionsTotalViewConfig(period, baseOptions, c4) {
+    const isRolling = currentDisplayMode === "rolling";
+    const sessionsData = isRolling ? computeRollingAverage(period.sessionsData, ROLLING_WINDOW[currentPeriod]) : period.sessionsData;
+    const rollingLabel = getRollingLabel();
+    return {
+      type: "bar",
+      data: { labels: period.labels, datasets: [{ label: isRolling ? rollingLabel : "Sessions", data: sessionsData, backgroundColor: "rgba(255, 99, 132, 0.6)", borderColor: "rgba(255, 99, 132, 1)", borderWidth: 1, type: isRolling ? "line" : void 0, tension: isRolling ? 0.4 : void 0, fill: isRolling ? false : void 0 }] },
+      options: {
+        ...baseOptions,
+        scales: {
+          x: { stacked: true, grid: { color: c4.gridColor }, ticks: { color: c4.textColor, font: { size: 11 } } },
+          y: { stacked: true, type: "linear", display: true, position: "left", grid: { color: c4.gridColor }, ticks: { color: c4.textColor, font: { size: 11 }, callback: (value) => Number(value).toLocaleString() }, title: { display: true, text: "Sessions", color: c4.textColor, font: { size: 12, weight: "bold" } } }
+        }
+      }
+    };
+  }
+  function buildTaskCategoryViewConfig(period, baseOptions, c4, metric) {
+    const datasets = metric === "cost" ? period.taskCategoryCostDatasets ?? [] : metric === "sessions" ? period.taskCategorySessionDatasets ?? [] : period.taskCategoryTokenDatasets ?? [];
+    const yAxisTitle = metric === "cost" ? "Estimated Cost (USD)" : metric === "sessions" ? "Sessions" : "Tokens";
+    const valueFormatter = metric === "cost" ? (value) => `$${Number(value).toFixed(2)}` : (value) => Number(value).toLocaleString();
+    return {
+      type: "bar",
+      data: { labels: period.labels, datasets },
+      options: {
+        ...baseOptions,
+        plugins: {
+          ...baseOptions.plugins,
+          legend: { position: "top", labels: { color: c4.textColor, font: { size: 11 } } },
+          tooltip: {
+            ...baseOptions.plugins.tooltip,
+            callbacks: {
+              label: (ctx) => ` ${ctx.dataset.label}: ${metric === "cost" ? `$${Number(ctx.parsed.y).toFixed(4)}` : Number(ctx.parsed.y).toLocaleString()}`
+            }
+          }
+        },
+        scales: {
+          x: { stacked: true, grid: { color: c4.gridColor }, ticks: { color: c4.textColor, font: { size: 11 } } },
+          y: { stacked: true, type: "linear", display: true, position: "left", grid: { color: c4.gridColor }, ticks: { color: c4.textColor, font: { size: 11 }, callback: (value) => valueFormatter(Number(value)) }, title: { display: true, text: yAxisTitle, color: c4.textColor, font: { size: 12, weight: "bold" } } }
+        }
+      }
+    };
+  }
   function getHeatmapColor(value, maxValue) {
     if (maxValue === 0 || value === 0) {
       return "rgba(128, 128, 128, 0.06)";
@@ -18102,7 +18206,7 @@ Updates automatically every 5 minutes.`;
     }
   }
   function buildStackedViewConfig(view, period, baseOptions, c4) {
-    const datasets = view === "model" ? period.modelDatasets : view === "repository" ? period.repositoryDatasets : view === "taskCategory" ? period.taskCategoryDatasets ?? [] : view === "provider" ? period.providerTokensDatasets ?? [] : period.editorDatasets;
+    const datasets = view === "model" ? period.modelDatasets : view === "repository" ? period.repositoryDatasets : view === "task" || view === "taskCategory" ? period.taskCategoryDatasets ?? period.taskCategoryTokenDatasets ?? [] : view === "provider" ? period.providerTokensDatasets ?? [] : period.editorDatasets;
     const lastIdx = period.tokensData.length - 1;
     const projExtra = lastIdx >= 0 ? computeProjectionExtra(period.tokensData[lastIdx], getCurrentPeriodFraction(currentPeriod)) : null;
     const projDs = projExtra !== null ? [{ label: PROJECTION_LABELS[currentPeriod], data: period.tokensData.map((_2, i6) => i6 === lastIdx ? Math.round(projExtra) : 0), backgroundColor: "rgba(200, 200, 200, 0.25)", borderColor: "rgba(200, 200, 200, 0.5)", borderWidth: 1 }] : [];
@@ -18142,8 +18246,8 @@ Updates automatically every 5 minutes.`;
     if (split === "repository") {
       return "repository";
     }
-    if (split === "taskCategory") {
-      return "taskCategory";
+    if (split === "task" || split === "taskCategory") {
+      return "task";
     }
     if (split === "provider") {
       return "provider";
@@ -18160,6 +18264,9 @@ Updates automatically every 5 minutes.`;
     if (split === "provider") {
       return "cost-provider";
     }
+    if (split === "task" || split === "taskCategory") {
+      return "cost-task";
+    }
     return "cost";
   }
   function resolveSessionsView(split) {
@@ -18172,19 +18279,26 @@ Updates automatically every 5 minutes.`;
     if (split === "provider") {
       return "sessions-provider";
     }
+    if (split === "task" || split === "taskCategory") {
+      return "sessions-task";
+    }
     return "sessions";
   }
   function resolveChartView(metric, split) {
+    const normalized = split === "taskCategory" ? "task" : split;
+    if (metric === "output") {
+      return `output-${normalized}`;
+    }
     if (metric === "sessions") {
-      return resolveSessionsView(split);
+      return resolveSessionsView(normalized);
     }
     if (metric === "tokens") {
-      return resolveTokensView(split);
+      return resolveTokensView(normalized);
     }
     if (metric === "cost") {
-      return resolveCostView(split);
+      return resolveCostView(normalized);
     }
-    return `output-${split}`;
+    return `output-${normalized}`;
   }
   function createConfig(data) {
     const period = getActivePeriodData(data);
@@ -18210,8 +18324,20 @@ Updates automatically every 5 minutes.`;
     if (view === "cost-provider") {
       return buildCostProviderViewConfig(period, baseOptions, c4);
     }
+    if (view === "cost-task") {
+      return buildTaskCategoryViewConfig(period, baseOptions, c4, "cost");
+    }
+    if (view === "sessions-total") {
+      return buildSessionsTotalViewConfig(period, baseOptions, c4);
+    }
+    if (view === "sessions-task") {
+      return buildTaskCategoryViewConfig(period, baseOptions, c4, "sessions");
+    }
     if (view.startsWith("output-")) {
       return buildOutputViewConfig(view, period, baseOptions, c4);
+    }
+    if (view === "task") {
+      return buildTaskCategoryViewConfig(period, baseOptions, c4, "tokens");
     }
     return buildStackedViewConfig(view, period, baseOptions, c4);
   }
@@ -18221,7 +18347,9 @@ Updates automatically every 5 minutes.`;
       model: { metric: "tokens", split: "model" },
       editor: { metric: "tokens", split: "editor" },
       repository: { metric: "tokens", split: "repository" },
-      cost: { metric: "cost", split: "total" }
+      cost: { metric: "cost", split: "total" },
+      task: { metric: "tokens", split: "task" },
+      taskCategory: { metric: "tokens", split: "task" }
     };
     return map3[view] ?? { metric: "tokens", split: "total" };
   }
@@ -18238,7 +18366,7 @@ Updates automatically every 5 minutes.`;
         currentMetric = initialData2.initialMetric;
       }
       if (initialData2.initialSplit) {
-        currentSplit = initialData2.initialSplit;
+        currentSplit = initialData2.initialSplit === "taskCategory" ? "task" : initialData2.initialSplit;
       } else if (initialData2.initialView) {
         const m2 = migrateViewKey(initialData2.initialView);
         currentMetric = m2.metric;
@@ -18246,9 +18374,9 @@ Updates automatically every 5 minutes.`;
       }
       return;
     }
-    currentPeriod = saved.period;
+    currentPeriod = saved.period ?? "day";
     currentTimeWindow = saved.timeWindow ?? "last30";
-    currentDisplayMode = saved.displayMode;
+    currentDisplayMode = saved.displayMode ?? "actual";
     editorListCollapsed = saved.editorListCollapsed ?? false;
     if (saved.view && !saved.metric) {
       const m2 = migrateViewKey(saved.view);
@@ -18256,7 +18384,7 @@ Updates automatically every 5 minutes.`;
       currentSplit = m2.split;
     } else {
       currentMetric = saved.metric ?? "tokens";
-      currentSplit = saved.split ?? "total";
+      currentSplit = saved.split === "taskCategory" ? "task" : saved.split ?? "total";
     }
   }
   async function bootstrap() {

--- a/visualstudio-extension/src/AIEngineeringFluency/webview/details.js
+++ b/visualstudio-extension/src/AIEngineeringFluency/webview/details.js
@@ -2036,25 +2036,79 @@ To suppress this warning, set window.${CONFIG_KEY} to true`);
     return NAV_ORDER.filter((id) => id !== "btn-dashboard" || backendConfigured).map((id) => ({ ...BUTTONS[id], active: id === activeView }));
   }
 
-  // src/webview/shared/extensionPoints.ts
-  function wireExtensionPointButtons(vscodeApi) {
-    const buttons = window.__EXTENSION_POINT_BUTTONS__ ?? [];
-    if (buttons.length === 0) {
-      return;
+  // src/webview/shared/messageHandler.ts
+  function collectOwnOrigins(currentWindow) {
+    const origins = [];
+    const origin = currentWindow.location?.origin;
+    if (origin && origin !== "null") {
+      origins.push(origin);
     }
+    const href = currentWindow.location?.href;
+    const derived = href ? /^[a-z][a-z0-9+.-]*:\/\/[^/?#]*/i.exec(href) : null;
+    if (derived && !origins.includes(derived[0])) {
+      origins.push(derived[0]);
+    }
+    return origins;
+  }
+  function isTrustedWebviewMessageSource(source, currentWindow, origin) {
+    if (source === null || source === void 0 || source === currentWindow) {
+      return true;
+    }
+    if (source === currentWindow.parent || source === currentWindow.top) {
+      return true;
+    }
+    return Boolean(origin) && collectOwnOrigins(currentWindow).includes(origin);
+  }
+  function registerMessageHandler(handler, onUntrustedMessage) {
+    window.addEventListener("message", (event) => {
+      if (!isTrustedWebviewMessageSource(event.source, window, event.origin)) {
+        onUntrustedMessage?.(event);
+        return;
+      }
+      handler(event.data);
+    });
+  }
+
+  // src/webview/shared/extensionPoints.ts
+  function buttonElementId(id) {
+    return `ext-point-${id}`;
+  }
+  function renderExtensionPointButtons(vscodeApi, buttons) {
     const buttonRow = document.querySelector(".button-row");
     if (!buttonRow) {
       return;
     }
+    const desiredIds = new Set(buttons.map((b3) => b3.id));
+    for (const existing of Array.from(buttonRow.querySelectorAll('[id^="ext-point-"]'))) {
+      const id = existing.id.slice("ext-point-".length);
+      if (!desiredIds.has(id)) {
+        existing.remove();
+      }
+    }
     for (const btn of buttons) {
+      if (document.getElementById(buttonElementId(btn.id))) {
+        continue;
+      }
       const el2 = document.createElement("vscode-button");
-      el2.id = `ext-point-${btn.id}`;
+      el2.id = buttonElementId(btn.id);
       el2.textContent = btn.label;
       el2.addEventListener("click", () => {
         vscodeApi.postMessage({ command: "extensionPointAction", buttonId: btn.id });
       });
       buttonRow.append(el2);
     }
+  }
+  function wireExtensionPointButtons(vscodeApi) {
+    renderExtensionPointButtons(vscodeApi, window.__EXTENSION_POINT_BUTTONS__ ?? []);
+    if (window.__extensionPointButtonsListenerRegistered__) {
+      return;
+    }
+    window.__extensionPointButtonsListenerRegistered__ = true;
+    registerMessageHandler((message) => {
+      if (message?.command === "extensionPointButtonsUpdated" && Array.isArray(message.buttons)) {
+        renderExtensionPointButtons(vscodeApi, message.buttons);
+      }
+    });
   }
 
   // src/webview/shared/theme.css
@@ -2392,19 +2446,6 @@ body[data-vscode-theme-kind="vscode-high-contrast-light"] .title {
 
   // src/webview/details/styles.css
   var styles_default = "body {\n	margin: 0;\n	background: var(--bg-primary);\n	color: var(--text-primary);\n	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;\n}\n\n.container {\n	padding: 16px;\n	display: flex;\n	flex-direction: column;\n	gap: 14px;\n	max-width: 1200px;\n	margin: 0 auto;\n}\n\n.header {\n	display: flex;\n	justify-content: space-between;\n	align-items: center;\n	gap: 12px;\n	padding-bottom: 4px;\n}\n\n.header-left {\n	display: flex;\n	flex-direction: column;\n	gap: 4px;\n}\n\n.title {\n	display: flex;\n	align-items: center;\n	gap: 8px;\n	font-size: 16px;\n	font-weight: 700;\n	color: var(--text-primary);\n}\n\n.plan-badge {\n	display: inline-flex;\n	align-items: center;\n	gap: 4px;\n	align-self: flex-start;\n	background: var(--bg-tertiary);\n	border: 1px solid var(--border-subtle);\n	border-radius: 999px;\n	padding: 2px 10px;\n	font-size: 11px;\n	color: var(--text-secondary);\n	cursor: help;\n}\n\n.provider-panel-hint {\n	color: var(--text-secondary);\n	font-size: 11px;\n	margin: -4px 0 10px;\n}\n\n.provider-cards {\n	display: grid;\n	grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));\n	gap: 10px;\n	text-align: center;\n}\n\n.provider-card {\n	background: var(--bg-secondary);\n	border: 1px solid var(--border-color);\n	border-radius: 10px;\n	padding: 12px;\n	box-shadow: 0 4px 10px var(--shadow-color);\n	text-align: center;\n	cursor: pointer;\n	transition: background-color 0.1s ease, opacity 0.1s ease;\n}\n\n.provider-card:hover {\n	background: var(--list-hover-bg);\n}\n\n.provider-card-excluded {\n	opacity: 0.45;\n}\n\n.provider-card-total {\n	cursor: default;\n	border-style: dashed;\n}\n\n.provider-card-total:hover {\n	background: var(--bg-secondary);\n}\n\n.provider-card-label {\n	color: var(--text-secondary);\n	font-size: 11px;\n	margin-bottom: 6px;\n}\n\n.provider-card-value {\n	color: var(--text-primary);\n	font-size: 18px;\n	font-weight: 700;\n}\n\n.provider-card-sub {\n	color: var(--text-secondary);\n	font-size: 10px;\n	margin-top: 4px;\n}\n\n.no-data-row td {\n	text-align: center;\n	color: var(--text-secondary);\n	font-size: 12px;\n	padding: 14px;\n	font-style: italic;\n}\n\n.sections {\n	display: flex;\n	flex-direction: column;\n	gap: 16px;\n}\n\n.section {\n	background: var(--bg-secondary);\n	border: 1px solid var(--border-color);\n	border-radius: 10px;\n	padding: 12px;\n	box-shadow: 0 4px 10px var(--shadow-color);\n}\n\n.section h3 {\n	margin: 0 0 10px;\n	font-size: 14px;\n	display: flex;\n	align-items: center;\n	gap: 6px;\n	color: var(--text-primary);\n	letter-spacing: 0.2px;\n}\n\n.stats-table {\n	width: 100%;\n	border-collapse: collapse;\n	table-layout: fixed;\n	background: var(--bg-tertiary);\n	border: 1px solid var(--border-subtle);\n	border-radius: 8px;\n	overflow: hidden;\n}\n\n.stats-table thead {\n	background: var(--list-hover-bg);\n}\n\n.stats-table th,\n.stats-table td {\n	padding: 10px 12px;\n	border-bottom: 1px solid var(--border-subtle);\n	vertical-align: middle;\n}\n\n.stats-table th {\n	text-align: left;\n	color: var(--text-secondary);\n	font-weight: 700;\n	font-size: 12px;\n	letter-spacing: 0.1px;\n}\n\n.stats-table td {\n	color: var(--text-primary);\n	font-size: 12px;\n}\n\n.stats-table th.align-right,\n.stats-table td.align-right {\n	text-align: right;\n}\n\n.stats-table tr.group-row td {\n	background: var(--list-hover-bg);\n	color: var(--text-secondary);\n	font-size: 12px;\n	font-weight: 700;\n	text-transform: uppercase;\n	letter-spacing: 1px;\n	padding: 8px 12px;\n	border-top: 1px solid var(--border-color);\n	border-bottom: 1px solid var(--border-color);\n}\n\n/* First group sits right under the table header, no extra top rule needed */\n.stats-table tbody tr.group-row:first-child td {\n	border-top: none;\n}\n\n.metric-label {\n	display: inline-flex;\n	align-items: center;\n	gap: 6px;\n	font-weight: 600;\n}\n\n.period-header {\n	display: flex;\n	align-items: center;\n	gap: 4px;\n	color: var(--text-secondary);\n}\n\n.align-right .period-header {\n	justify-content: flex-end;\n}\n\n.value-right {\n	text-align: right;\n}\n\n.muted {\n	color: var(--text-muted);\n	font-size: 11px;\n	margin-top: 4px;\n}\n\n.notes {\n	margin: 4px 0 0;\n	padding-left: 16px;\n	color: var(--text-secondary);\n}\n\n.notes li {\n	margin: 4px 0;\n	line-height: 1.4;\n}\n\n.footer {\n	color: var(--text-muted);\n	font-size: 11px;\n	margin-top: 6px;\n}\n\n.empty-state {\n	display: flex;\n	flex-direction: column;\n	gap: 12px;\n	padding: 20px;\n}\n\n.empty-state-title {\n	font-size: 15px;\n	font-weight: 700;\n	color: var(--text-primary);\n}\n\n.empty-state-description {\n	color: var(--text-secondary);\n	font-size: 13px;\n	line-height: 1.5;\n	margin: 0;\n}\n\n.empty-state-steps {\n	margin: 0;\n	padding-left: 20px;\n	color: var(--text-secondary);\n	font-size: 13px;\n	line-height: 1.6;\n}\n\n.empty-state-steps li {\n	margin: 4px 0;\n}\n\n.empty-state-note {\n	background: var(--bg-tertiary);\n	border: 1px solid var(--border-subtle);\n	border-radius: 6px;\n	padding: 10px 14px;\n	color: var(--text-secondary);\n	font-size: 12px;\n	line-height: 1.5;\n}\n";
-
-  // src/webview/shared/messageHandler.ts
-  function isTrustedWebviewMessageSource(source, currentWindow) {
-    return source === null || source === currentWindow;
-  }
-  function registerMessageHandler(handler) {
-    window.addEventListener("message", (event) => {
-      if (!isTrustedWebviewMessageSource(event.source, window)) {
-        return;
-      }
-      handler(event.data);
-    });
-  }
 
   // ../src/statsHelpers.ts
   var COPILOT_EDITOR_NAMES = /* @__PURE__ */ new Set([

--- a/visualstudio-extension/src/AIEngineeringFluency/webview/diagnostics.js
+++ b/visualstudio-extension/src/AIEngineeringFluency/webview/diagnostics.js
@@ -1732,25 +1732,79 @@ To suppress this warning, set window.${CONFIG_KEY} to true`);
     return node;
   }
 
-  // src/webview/shared/extensionPoints.ts
-  function wireExtensionPointButtons(vscodeApi) {
-    const buttons = window.__EXTENSION_POINT_BUTTONS__ ?? [];
-    if (buttons.length === 0) {
-      return;
+  // src/webview/shared/messageHandler.ts
+  function collectOwnOrigins(currentWindow) {
+    const origins = [];
+    const origin = currentWindow.location?.origin;
+    if (origin && origin !== "null") {
+      origins.push(origin);
     }
+    const href = currentWindow.location?.href;
+    const derived = href ? /^[a-z][a-z0-9+.-]*:\/\/[^/?#]*/i.exec(href) : null;
+    if (derived && !origins.includes(derived[0])) {
+      origins.push(derived[0]);
+    }
+    return origins;
+  }
+  function isTrustedWebviewMessageSource(source, currentWindow, origin) {
+    if (source === null || source === void 0 || source === currentWindow) {
+      return true;
+    }
+    if (source === currentWindow.parent || source === currentWindow.top) {
+      return true;
+    }
+    return Boolean(origin) && collectOwnOrigins(currentWindow).includes(origin);
+  }
+  function registerMessageHandler(handler, onUntrustedMessage) {
+    window.addEventListener("message", (event) => {
+      if (!isTrustedWebviewMessageSource(event.source, window, event.origin)) {
+        onUntrustedMessage?.(event);
+        return;
+      }
+      handler(event.data);
+    });
+  }
+
+  // src/webview/shared/extensionPoints.ts
+  function buttonElementId(id) {
+    return `ext-point-${id}`;
+  }
+  function renderExtensionPointButtons(vscodeApi, buttons) {
     const buttonRow = document.querySelector(".button-row");
     if (!buttonRow) {
       return;
     }
+    const desiredIds = new Set(buttons.map((b3) => b3.id));
+    for (const existing of Array.from(buttonRow.querySelectorAll('[id^="ext-point-"]'))) {
+      const id = existing.id.slice("ext-point-".length);
+      if (!desiredIds.has(id)) {
+        existing.remove();
+      }
+    }
     for (const btn of buttons) {
+      if (document.getElementById(buttonElementId(btn.id))) {
+        continue;
+      }
       const el2 = document.createElement("vscode-button");
-      el2.id = `ext-point-${btn.id}`;
+      el2.id = buttonElementId(btn.id);
       el2.textContent = btn.label;
       el2.addEventListener("click", () => {
         vscodeApi.postMessage({ command: "extensionPointAction", buttonId: btn.id });
       });
       buttonRow.append(el2);
     }
+  }
+  function wireExtensionPointButtons(vscodeApi) {
+    renderExtensionPointButtons(vscodeApi, window.__EXTENSION_POINT_BUTTONS__ ?? []);
+    if (window.__extensionPointButtonsListenerRegistered__) {
+      return;
+    }
+    window.__extensionPointButtonsListenerRegistered__ = true;
+    registerMessageHandler((message) => {
+      if (message?.command === "extensionPointButtonsUpdated" && Array.isArray(message.buttons)) {
+        renderExtensionPointButtons(vscodeApi, message.buttons);
+      }
+    });
   }
 
   // src/editorIcons.ts
@@ -1868,7 +1922,7 @@ To suppress this warning, set window.${CONFIG_KEY} to true`);
     thisWeek: "This week",
     allTime: "All time"
   };
-  var CANONICAL_PERIODS = ["today", "last7", "last30", "currentMonth", "allTime"];
+  var CANONICAL_PERIODS = ["today", "last7", "last30", "last90", "currentMonth", "allTime"];
   function setOptionSelected(option, value, selected) {
     if (value === selected) {
       option.selected = true;
@@ -3406,19 +3460,143 @@ border: 1px solid #1f6feb;
 	to { transform: rotate(360deg); }
 }
 
+.ttft-chart-wrap {
+	margin-top: 16px;
+}
+
+.ttft-chart {
+	width: 100%;
+	height: auto;
+	display: block;
+}
+
+.ttft-gridline {
+	stroke: var(--border-color);
+	stroke-width: 1;
+	stroke-dasharray: 2 3;
+}
+
+.ttft-axis-label {
+	fill: var(--text-muted);
+	font-size: 10px;
+}
+
+.ttft-legend {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 12px;
+	margin-top: 8px;
+	font-size: 12px;
+	color: var(--text-secondary);
+}
+
+.ttft-legend-item {
+	display: inline-flex;
+	align-items: center;
+	gap: 5px;
+	cursor: pointer;
+	user-select: none;
+}
+
+.ttft-legend-item.ttft-hidden {
+	opacity: 0.4;
+	text-decoration: line-through;
+}
+
+.ttft-series.ttft-hidden {
+	display: none;
+}
+
+.ttft-legend-swatch {
+	width: 10px;
+	height: 10px;
+	border-radius: 2px;
+	display: inline-block;
+}
+
 `;
 
-  // src/webview/shared/messageHandler.ts
-  function isTrustedWebviewMessageSource(source, currentWindow) {
-    return source === null || source === currentWindow;
+  // ../src/webview/shared/modelUtils.ts
+  var _pricingData = getWindowData("__MODEL_PRICING__");
+  var _modelNames = {};
+  for (const [modelId, pricing] of Object.entries(_pricingData?.pricing ?? {})) {
+    if (pricing.displayNames && pricing.displayNames.length > 0) {
+      _modelNames[modelId] = pricing.displayNames[0];
+    }
   }
-  function registerMessageHandler(handler) {
-    window.addEventListener("message", (event) => {
-      if (!isTrustedWebviewMessageSource(event.source, window)) {
-        return;
+  function decodeSegment(segment) {
+    try {
+      return decodeURIComponent(segment);
+    } catch {
+      return segment;
+    }
+  }
+  function parseCustomProviderModel(model) {
+    const parts = model.split("/");
+    if (parts.length !== 3 || parts.some((part) => part.trim() === "")) {
+      return void 0;
+    }
+    return {
+      source: decodeSegment(parts[0]),
+      providerName: decodeSegment(parts[1]),
+      modelId: decodeSegment(parts[2])
+    };
+  }
+  var UUID_PREFIX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\//i;
+  function getModelLookupCandidates(model) {
+    const candidates = [];
+    const add = (id) => {
+      if (id && !candidates.includes(id)) {
+        candidates.push(id);
       }
-      handler(event.data);
-    });
+    };
+    const addWithVersionVariant = (id) => {
+      add(id);
+      add(id.replace(/(\d+)-(\d+)(?=-|$)/, "$1.$2"));
+    };
+    const base = model.replace(/^copilot\//, "");
+    addWithVersionVariant(base);
+    const custom = parseCustomProviderModel(base);
+    if (custom) {
+      addWithVersionVariant(custom.modelId);
+    }
+    if (UUID_PREFIX.test(base)) {
+      addWithVersionVariant(base.replace(UUID_PREFIX, ""));
+    }
+    return candidates;
+  }
+  function getModelDisplayName(model) {
+    for (const candidate of getModelLookupCandidates(model)) {
+      if (_modelNames[candidate]) {
+        return _modelNames[candidate];
+      }
+    }
+    const custom = parseCustomProviderModel(model);
+    if (custom) {
+      return custom.modelId;
+    }
+    if (UUID_PREFIX.test(model)) {
+      return model.replace(UUID_PREFIX, "");
+    }
+    return decodeSegment(model);
+  }
+
+  // ../src/tokenEstimation.ts
+  var NANO_AIU_TO_DOLLARS = 1 / 1e11;
+
+  // ../src/chartDataBuilder.ts
+  var MODEL_COLORS = [
+    { bg: "rgba(54, 162, 235, 0.6)", border: "rgba(54, 162, 235, 1)" },
+    { bg: "rgba(255, 99, 132, 0.6)", border: "rgba(255, 99, 132, 1)" },
+    { bg: "rgba(75, 192, 192, 0.6)", border: "rgba(75, 192, 192, 1)" },
+    { bg: "rgba(153, 102, 255, 0.6)", border: "rgba(153, 102, 255, 1)" },
+    { bg: "rgba(255, 159, 64, 0.6)", border: "rgba(255, 159, 64, 1)" },
+    { bg: "rgba(255, 205, 86, 0.6)", border: "rgba(255, 205, 86, 1)" },
+    { bg: "rgba(201, 203, 207, 0.6)", border: "rgba(201, 203, 207, 1)" },
+    { bg: "rgba(100, 181, 246, 0.6)", border: "rgba(100, 181, 246, 1)" }
+  ];
+  function getModelColor(index) {
+    return MODEL_COLORS[index % MODEL_COLORS.length];
   }
 
   // src/webview/shared/contextRefUtils.ts
@@ -3459,10 +3637,13 @@ border: 1px solid #1f6feb;
   // src/webview/diagnostics/main.ts
   var LOADING_PLACEHOLDER = "Loading...";
   var SESSION_FILES_SECTION_REGEX = /Session File Locations \(first 20\):[\s\S]*?(?=\n\s*\n|={70})/;
-  var LOADING_MESSAGE = `\u23F3 Loading diagnostic data...
-
-This may take a few moments depending on the number of session files.
-The view will automatically update when data is ready.`;
+  var LOADING_MESSAGE = `<div class="analyzer-loading" style="flex-direction:column;align-items:flex-start;gap:6px;">
+<div style="display:flex;align-items:center;gap:10px;">
+<span class="spinner" style="width:18px;height:18px;border:2px solid var(--link-color);border-top-color:transparent;border-radius:50%;display:inline-block;animation:spin 0.7s linear infinite;"></span>
+<span>\u23F3 Loading diagnostic data\u2026</span>
+</div>
+<div id="report-loading-subtext" style="font-size:12px;color:var(--text-muted);">Scanning session files\u2026</div>
+</div>`;
   var vscode = acquireVsCodeApi();
   var initialData = getWindowData("__INITIAL_DIAGNOSTICS__");
   if (initialData?.localization) {
@@ -3475,10 +3656,14 @@ The view will automatically update when data is ready.`;
     activeSubtab: void 0,
     otelDeltaPeriod: "all",
     shareCardPeriod: "last14",
-    skillUsageEditorFilter: "all"
+    skillUsageEditorFilter: "all",
+    ttftGranularity: "day",
+    ttftScanRange: "14d"
   });
   var currentOtelComparison;
   var currentOtelDeltaPeriod = diagState.restore().otelDeltaPeriod ?? "all";
+  var currentTtftGranularity = diagState.restore().ttftGranularity ?? "day";
+  var currentTtftScanRange = diagState.restore().ttftScanRange ?? "14d";
   var SHARE_CARD_PERIOD_ORDER = ["last7", "last14", "last30", "last90", "allTime"];
   var currentShareCardPeriod = diagState.restore().shareCardPeriod ?? "last14";
   var currentSortColumn = "lastInteraction";
@@ -4632,7 +4817,7 @@ ${authenticated ? `
   }
   var TAB_GROUPS = {
     diagnostics: ["report", "sessions", "cache", "path-analyzer"],
-    research: ["model-usage", "tool-analysis", "skill-usage", "otel-delta"],
+    research: ["model-usage", "tool-analysis", "skill-usage", "otel-delta", "ttft"],
     settings: ["display", "backend", "github", "debug"]
   };
   function groupOfTab(tabId) {
@@ -5003,6 +5188,11 @@ ${authenticated ? `
             const resultsDiv = document.getElementById("model-usage-results");
             if (resultsDiv && !resultsDiv.innerHTML.trim()) {
               triggerModelUsageAnalysis();
+            }
+          } else if (tabId === "ttft") {
+            const resultsDiv = document.getElementById("ttft-results");
+            if (resultsDiv && !resultsDiv.innerHTML.trim()) {
+              triggerTtftAnalysis();
             }
           }
         }
@@ -5502,6 +5692,14 @@ ${authenticated ? `
     if (shareSubtext) {
       shareSubtext.textContent = progressText;
     }
+    const reportSubtext = document.getElementById("report-loading-subtext");
+    if (reportSubtext) {
+      reportSubtext.textContent = progressText;
+    }
+    const ttftLoadingStatus = document.getElementById("ttft-loading-status");
+    if (ttftLoadingStatus) {
+      ttftLoadingStatus.textContent = progressText;
+    }
     const modelUsageStatus = document.getElementById("model-usage-status");
     if (modelUsageStatus) {
       modelUsageStatus.textContent = total > 0 ? `\u23F3 Loading sessions\u2026 (${processed}/${total})` : "\u23F3 Loading sessions\u2026";
@@ -5527,6 +5725,10 @@ ${authenticated ? `
       modelUsageStatus.textContent = "";
     }
     triggerModelUsageAnalysis();
+    const ttftResultsDiv = document.getElementById("ttft-results");
+    if (ttftResultsDiv && ttftResultsDiv.innerHTML.trim()) {
+      triggerTtftAnalysis();
+    }
     reRenderTable();
     reRenderShareCard();
   }
@@ -5645,6 +5847,8 @@ ${authenticated ? `
         handleFolderAnalysisResult(message);
       } else if (message.command === "modelUsageResult") {
         handleModelUsageResult(message);
+      } else if (message.command === "ttftResult") {
+        handleTtftResult(message);
       }
     });
   }
@@ -6144,6 +6348,235 @@ ${renderOtelDeltaSummaryCards(filtered)}
 ${tableOrEmpty}
 </div>`;
   }
+  var TTFT_GRANULARITY_LABELS = { day: "Day", week: "Week", month: "Month" };
+  var TTFT_SCAN_RANGE_LABELS = {
+    "14d": "Last 14 days",
+    "30d": "Last 30 days",
+    "90d": "Last 90 days",
+    "180d": "Last 6 months",
+    "365d": "Last year",
+    "all": "All time"
+  };
+  function formatTtftSeconds(seconds) {
+    return seconds >= 10 ? `${seconds.toFixed(1)}s` : `${Math.round(seconds * 1e3)}ms`;
+  }
+  function renderTtftGranularitySelector(granularity) {
+    const options = Object.keys(TTFT_GRANULARITY_LABELS).map((g2) => `<option value="${g2}"${g2 === granularity ? " selected" : ""}>${TTFT_GRANULARITY_LABELS[g2]}</option>`).join("");
+    return `<div class="otel-delta-period-row">
+<label for="ttft-granularity">Bucket by:</label>
+<select id="ttft-granularity" class="otel-delta-period-select">${options}</select>
+</div>`;
+  }
+  function renderTtftScanRangeSelector(range) {
+    const options = Object.keys(TTFT_SCAN_RANGE_LABELS).map((r6) => `<option value="${r6}"${r6 === range ? " selected" : ""}>${TTFT_SCAN_RANGE_LABELS[r6]}</option>`).join("");
+    return `<div class="otel-delta-period-row">
+<label for="ttft-scan-range">Scan session files from:</label>
+<select id="ttft-scan-range" class="otel-delta-period-select">${options}</select>
+</div>`;
+  }
+  var TTFT_CHART_WIDTH = 760;
+  var TTFT_CHART_HEIGHT = 220;
+  var TTFT_CHART_PAD_LEFT = 48;
+  var TTFT_CHART_PAD_RIGHT = 32;
+  var TTFT_CHART_PAD_TOP = 12;
+  var TTFT_CHART_PAD_BOTTOM = 28;
+  function renderTtftChartSvg(buckets, series) {
+    if (buckets.length === 0 || series.length === 0) {
+      return "";
+    }
+    const innerW = TTFT_CHART_WIDTH - TTFT_CHART_PAD_LEFT - TTFT_CHART_PAD_RIGHT;
+    const innerH = TTFT_CHART_HEIGHT - TTFT_CHART_PAD_TOP - TTFT_CHART_PAD_BOTTOM;
+    const allValues = series.flatMap((s4) => s4.data.filter((v2) => v2 !== null));
+    const maxValue = allValues.length > 0 ? Math.max(...allValues) : 1;
+    const yMax = (maxValue || 1) * 1.15;
+    const xStep = buckets.length > 1 ? innerW / (buckets.length - 1) : 0;
+    const xAt = (i6) => TTFT_CHART_PAD_LEFT + i6 * xStep;
+    const yAt = (v2) => TTFT_CHART_PAD_TOP + innerH - v2 / yMax * innerH;
+    const yTicks = [0, 0.25, 0.5, 0.75, 1].map((f3) => {
+      const value = yMax * f3;
+      const y3 = yAt(value);
+      return `<line x1="${TTFT_CHART_PAD_LEFT}" y1="${y3.toFixed(1)}" x2="${TTFT_CHART_WIDTH - TTFT_CHART_PAD_RIGHT}" y2="${y3.toFixed(1)}" class="ttft-gridline" />
+<text x="${TTFT_CHART_PAD_LEFT - 6}" y="${(y3 + 3).toFixed(1)}" class="ttft-axis-label" text-anchor="end">${escapeHtml(formatTtftSeconds(value))}</text>`;
+    }).join("");
+    const labelEvery = Math.max(1, Math.ceil(buckets.length / 8));
+    const xLabels = buckets.map((b3, i6) => {
+      if (i6 % labelEvery !== 0 && i6 !== buckets.length - 1) {
+        return "";
+      }
+      const anchor = i6 === buckets.length - 1 ? "end" : i6 === 0 ? "start" : "middle";
+      return `<text x="${xAt(i6).toFixed(1)}" y="${TTFT_CHART_HEIGHT - 8}" class="ttft-axis-label" text-anchor="${anchor}">${escapeHtml(b3.label)}</text>`;
+    }).join("");
+    const paths = series.map((s4, idx) => {
+      const color = getModelColor(idx);
+      let d3 = "";
+      let drawing = false;
+      s4.data.forEach((v2, i6) => {
+        if (v2 === null) {
+          drawing = false;
+          return;
+        }
+        const x2 = xAt(i6).toFixed(1);
+        const y3 = yAt(v2).toFixed(1);
+        d3 += drawing ? ` L ${x2} ${y3}` : `${d3 ? " " : ""}M ${x2} ${y3}`;
+        drawing = true;
+      });
+      const dots = s4.data.map((v2, i6) => v2 === null ? "" : `<circle cx="${xAt(i6).toFixed(1)}" cy="${yAt(v2).toFixed(1)}" r="2.5" fill="${color.border}" />`).join("");
+      return `<g class="ttft-series" data-model="${escapeHtml(s4.model)}"><path d="${d3}" fill="none" stroke="${color.border}" stroke-width="2" />${dots}</g>`;
+    }).join("");
+    const legend = series.map((s4, idx) => {
+      const color = getModelColor(idx);
+      const name = escapeHtml(getModelDisplayName(s4.model));
+      return `<span class="ttft-legend-item" data-model="${escapeHtml(s4.model)}" role="button" tabindex="0" aria-pressed="false" title="Click to hide/show ${name}"><span class="ttft-legend-swatch" style="background:${color.border}"></span>${name}</span>`;
+    }).join("");
+    return `<div class="ttft-chart-wrap">
+<svg viewBox="0 0 ${TTFT_CHART_WIDTH} ${TTFT_CHART_HEIGHT}" class="ttft-chart" role="img" aria-label="Average time to first token per model over time">
+${yTicks}
+${xLabels}
+${paths}
+</svg>
+<div class="ttft-legend">${legend}</div>
+</div>`;
+  }
+  function renderTtftBucketTableRows(buckets) {
+    return buckets.slice().reverse().map((b3) => `<tr>
+<td>${escapeHtml(b3.label)}</td>
+<td>${escapeHtml(formatTtftSeconds(b3.avgSeconds))}</td>
+<td>${b3.count.toLocaleString()}</td>
+</tr>`).join("");
+  }
+  function renderTtftResults(granularity, buckets, series, sampleCount, fileCount) {
+    if (sampleCount === 0) {
+      return `<div class="info-box">
+<div class="info-box-title">\u{1F4ED} No TTFT data found</div>
+<div>
+Checked ${fileCount.toLocaleString()} session file(s) in the selected range; none had a debug log
+with a populated <code>attrs.ttft</code>. Try widening "Scan session files from" above, but also
+check VS Code's <b>GitHub \u203A Copilot \u203A Chat \u203A Agent Debug Log \u203A File Logging: Enabled</b> setting
+(Experimental) \u2014 it's off by default, and this data only exists for sessions that ran while it
+was on (a window reload is needed after enabling it).
+</div>
+</div>`;
+    }
+    const overallAvg = buckets.reduce((sum, b3) => sum + b3.avgSeconds * b3.count, 0) / Math.max(1, sampleCount);
+    return `<div class="summary-cards">
+<div class="summary-card">
+<div class="summary-label">\u23F1\uFE0F Overall Avg TTFT</div>
+<div class="summary-value">${escapeHtml(formatTtftSeconds(overallAvg))}</div>
+</div>
+<div class="summary-card">
+<div class="summary-label">\u{1F9E9} Models Shown</div>
+<div class="summary-value">${series.length}</div>
+</div>
+<div class="summary-card">
+<div class="summary-label">\u{1F4CA} Samples</div>
+<div class="summary-value">${sampleCount.toLocaleString()}</div>
+</div>
+<div class="summary-card">
+<div class="summary-label">\u{1F4C4} Session Files Checked</div>
+<div class="summary-value">${fileCount.toLocaleString()}</div>
+</div>
+</div>
+${renderTtftChartSvg(buckets, series)}
+<div class="table-container" style="margin-top: 12px; max-height: 320px;">
+<table class="session-table">
+<thead><tr><th>${TTFT_GRANULARITY_LABELS[granularity]}</th><th>Avg TTFT</th><th>Samples</th></tr></thead>
+<tbody>${renderTtftBucketTableRows(buckets)}</tbody>
+</table>
+</div>`;
+  }
+  function renderTtftTab() {
+    return `<div id="tab-ttft" class="tab-content">
+<div class="info-box">
+<div class="info-box-title">\u23F1\uFE0F Time to First Token</div>
+<div>
+How long a chat model takes to start streaming a response, averaged per model over time.
+Read from VS Code Copilot Chat's own debug log (<code>attrs.ttft</code> on <code>llm_request</code>
+events) \u2014 the same file this extension already reads for exact per-session billing. This only
+exists for sessions that ran while VS Code's experimental <b>GitHub \u203A Copilot \u203A Chat \u203A Agent Debug
+Log \u203A File Logging: Enabled</b> setting was on (off by default, requires a window reload after
+enabling) \u2014 nothing in this extension's own settings. The unit isn't documented upstream, so
+values are auto-detected as seconds or milliseconds by magnitude.
+</div>
+</div>
+${renderTtftGranularitySelector(currentTtftGranularity)}
+${renderTtftScanRangeSelector(currentTtftScanRange)}
+<div id="ttft-results"></div>
+</div>`;
+  }
+  function triggerTtftAnalysis() {
+    const resultsDiv = document.getElementById("ttft-results");
+    if (resultsDiv) {
+      setHtml(resultsDiv, `
+        <div class="analyzer-loading">
+          <span class="spinner" style="width:18px;height:18px;border:2px solid var(--link-color);border-top-color:transparent;border-radius:50%;display:inline-block;animation:spin 0.7s linear infinite;"></span>
+          <span>Scanning debug logs for TTFT\u2026</span>
+        </div>`);
+    }
+    vscode.postMessage({ command: "analyzeTtft", granularity: currentTtftGranularity, scanRange: currentTtftScanRange });
+  }
+  function setupTtftHandlers() {
+    document.getElementById("ttft-granularity")?.addEventListener("change", (e7) => {
+      currentTtftGranularity = e7.target.value;
+      diagState.patch({ ttftGranularity: currentTtftGranularity });
+      triggerTtftAnalysis();
+    });
+    document.getElementById("ttft-scan-range")?.addEventListener("change", (e7) => {
+      currentTtftScanRange = e7.target.value;
+      diagState.patch({ ttftScanRange: currentTtftScanRange });
+      triggerTtftAnalysis();
+    });
+    const resultsDiv = document.getElementById("ttft-results");
+    const toggleTtftModel = (item) => {
+      const model = item.dataset.model;
+      if (!model) {
+        return;
+      }
+      const hidden = item.classList.toggle("ttft-hidden");
+      item.setAttribute("aria-pressed", String(hidden));
+      document.querySelectorAll(".ttft-series").forEach((el2) => {
+        if (el2.dataset.model === model) {
+          el2.classList.toggle("ttft-hidden", hidden);
+        }
+      });
+    };
+    resultsDiv?.addEventListener("click", (e7) => {
+      const item = e7.target?.closest(".ttft-legend-item");
+      if (item) {
+        toggleTtftModel(item);
+      }
+    });
+    resultsDiv?.addEventListener("keydown", (e7) => {
+      if (e7.key !== "Enter" && e7.key !== " ") {
+        return;
+      }
+      const item = e7.target?.closest(".ttft-legend-item");
+      if (item) {
+        e7.preventDefault();
+        toggleTtftModel(item);
+      }
+    });
+  }
+  function handleTtftResult(message) {
+    const resultsDiv = document.getElementById("ttft-results");
+    if (!resultsDiv) {
+      return;
+    }
+    if (message.stillLoading) {
+      setHtml(resultsDiv, `
+        <div class="analyzer-loading">
+          <span class="spinner" style="width:18px;height:18px;border:2px solid var(--link-color);border-top-color:transparent;border-radius:50%;display:inline-block;animation:spin 0.7s linear infinite;"></span>
+          <span id="ttft-loading-status">Waiting for session files to finish loading\u2026</span>
+        </div>`);
+      return;
+    }
+    setHtml(resultsDiv, renderTtftResults(
+      message.granularity || currentTtftGranularity,
+      message.buckets || [],
+      message.series || [],
+      Number(message.sampleCount || 0),
+      Number(message.fileCount || 0)
+    ));
+  }
   function buildDiagReportTabHtml(escapedReport) {
     return `<div id="tab-report" class="tab-content active">
 <div class="info-box">
@@ -6163,21 +6596,8 @@ code or conversation content. You can safely share this report when reporting is
 <div class="report-content">${escapedReport}</div>
 </div>`;
   }
-  function buildDiagRootHtml(data, detailedFiles, escapedReport) {
+  function renderTabBars(data, detailedFiles) {
     return `
-<style>${theme_default}</style>
-<style>${styles_default}</style>
-<div class="container">
-<div class="header">
-<div class="header-left">
-<span class="header-icon">\u{1F50D}</span>
-<span class="header-title">Diagnostic Report</span>
-</div>
-<div class="button-row">
-${navButtonsHtml("btn-diagnostics", !!data?.backendConfigured)}
-</div>
-</div>
-
 <div class="tabs group-tabs">
 <button class="group-tab active" data-group="diagnostics">\u{1FA7A} Diagnostics</button>
 <button class="group-tab" data-group="research">\u{1F52C} Research</button>
@@ -6197,6 +6617,7 @@ ${navButtonsHtml("btn-diagnostics", !!data?.backendConfigured)}
 <button class="tab" data-tab="tool-analysis">\u{1F527} Tool Analysis</button>
 <button class="tab" data-tab="skill-usage">\u{1F9E9} Skill Usage</button>
 <button class="tab" data-tab="otel-delta">\u{1F4E1} OTel Delta</button>
+<button class="tab" data-tab="ttft">\u23F1\uFE0F TTFT</button>
 </div>
 
 <div class="tabs leaf-tabs" data-group="settings" style="display: none;">
@@ -6204,7 +6625,24 @@ ${navButtonsHtml("btn-diagnostics", !!data?.backendConfigured)}
 <button class="tab" data-tab="backend">\u2601\uFE0F Backend Storage</button>
 <button class="tab" data-tab="github">\u{1F511} GitHub Auth</button>
 ${data.isDebugMode ? '<button class="tab" data-tab="debug">\u{1F41B} Debug</button>' : ""}
+</div>`;
+  }
+  function buildDiagRootHtml(data, detailedFiles, escapedReport) {
+    return `
+<style>${theme_default}</style>
+<style>${styles_default}</style>
+<div class="container">
+<div class="header">
+<div class="header-left">
+<span class="header-icon">\u{1F50D}</span>
+<span class="header-title">Diagnostic Report</span>
 </div>
+<div class="button-row">
+${navButtonsHtml("btn-diagnostics", !!data?.backendConfigured)}
+</div>
+</div>
+
+${renderTabBars(data, detailedFiles)}
 
 ${buildDiagReportTabHtml(escapedReport)}
 
@@ -6236,8 +6674,14 @@ ${renderModelUsageTab(detailedFiles, isLoading)}
 ${renderToolAnalysisTab(data.toolCallStats, data.toolFamilies)}
 ${renderSkillUsageTab(data.skillCallStats, data.skillCallsByEditor, data.skillDescriptions, skillUsageEditorFilter)}
 ${renderOtelDeltaTab(data.otelComparison)}
+${renderTtftTab()}
 </div>
 `;
+  }
+  function resolveEarlyBackendState(data) {
+    currentBackendInfo = currentBackendInfo ?? data.backendStorageInfo;
+    currentGithubAuth = currentGithubAuth ?? data.githubAuth;
+    return { backendStorageInfo: currentBackendInfo, githubAuth: currentGithubAuth };
   }
   function renderLayout(data) {
     const root = document.getElementById("root");
@@ -6247,8 +6691,7 @@ ${renderOtelDeltaTab(data.otelComparison)}
     const detailedFiles = data.detailedSessionFiles || [];
     storedDetailedFiles = detailedFiles;
     isLoading = detailedFiles.length === 0;
-    currentBackendInfo = data.backendStorageInfo;
-    currentGithubAuth = data.githubAuth;
+    const earlyBackendState = resolveEarlyBackendState(data);
     currentOtelComparison = data.otelComparison;
     if (data.toolFamilies) {
       storedToolFamilies = data.toolFamilies;
@@ -6258,7 +6701,7 @@ ${renderOtelDeltaTab(data.otelComparison)}
     currentSkillDescriptions = data.skillDescriptions;
     const reportIsLoading = data.report === LOADING_PLACEHOLDER;
     const escapedReport = reportIsLoading ? LOADING_MESSAGE.trim() : removeSessionFilesSection(escapeHtml(data.report));
-    setHtml(root, buildDiagRootHtml(data, detailedFiles, escapedReport));
+    setHtml(root, buildDiagRootHtml({ ...data, ...earlyBackendState }, detailedFiles, escapedReport));
     const sessionFolders = groupSessionFolders(data.sessionFolders || []);
     if (sessionFolders.length > 0) {
       const reportTab = document.getElementById("tab-report");
@@ -6267,7 +6710,6 @@ ${renderOtelDeltaTab(data.otelComparison)}
         reportContent.insertAdjacentElement("afterend", buildSessionFoldersElement(sessionFolders));
       }
     }
-    setupMessageHandlers();
     setupTabHandlers();
     setupGroupHandlers();
     setupSortHandlers();
@@ -6288,6 +6730,7 @@ ${renderOtelDeltaTab(data.otelComparison)}
     setupToolAnalysisSortHandlers();
     setupSkillUsageFilterHandler();
     setupOtelDeltaPeriodHandler();
+    setupTtftHandlers();
     const savedState = diagState.restore();
     let restoredTab = "report";
     if (savedState?.activeTab && activateTab(savedState.activeTab)) {
@@ -6311,6 +6754,7 @@ ${renderOtelDeltaTab(data.otelComparison)}
     }
     renderLayout(initialData);
   }
+  setupMessageHandlers();
   void bootstrap();
 })();
 /*! Bundled license information:

--- a/visualstudio-extension/src/AIEngineeringFluency/webview/environmental.js
+++ b/visualstudio-extension/src/AIEngineeringFluency/webview/environmental.js
@@ -1796,25 +1796,79 @@ To suppress this warning, set window.${CONFIG_KEY} to true`);
     }).format(value);
   }
 
-  // src/webview/shared/extensionPoints.ts
-  function wireExtensionPointButtons(vscodeApi) {
-    const buttons = window.__EXTENSION_POINT_BUTTONS__ ?? [];
-    if (buttons.length === 0) {
-      return;
+  // src/webview/shared/messageHandler.ts
+  function collectOwnOrigins(currentWindow) {
+    const origins = [];
+    const origin = currentWindow.location?.origin;
+    if (origin && origin !== "null") {
+      origins.push(origin);
     }
+    const href = currentWindow.location?.href;
+    const derived = href ? /^[a-z][a-z0-9+.-]*:\/\/[^/?#]*/i.exec(href) : null;
+    if (derived && !origins.includes(derived[0])) {
+      origins.push(derived[0]);
+    }
+    return origins;
+  }
+  function isTrustedWebviewMessageSource(source, currentWindow, origin) {
+    if (source === null || source === void 0 || source === currentWindow) {
+      return true;
+    }
+    if (source === currentWindow.parent || source === currentWindow.top) {
+      return true;
+    }
+    return Boolean(origin) && collectOwnOrigins(currentWindow).includes(origin);
+  }
+  function registerMessageHandler(handler, onUntrustedMessage) {
+    window.addEventListener("message", (event) => {
+      if (!isTrustedWebviewMessageSource(event.source, window, event.origin)) {
+        onUntrustedMessage?.(event);
+        return;
+      }
+      handler(event.data);
+    });
+  }
+
+  // src/webview/shared/extensionPoints.ts
+  function buttonElementId(id) {
+    return `ext-point-${id}`;
+  }
+  function renderExtensionPointButtons(vscodeApi, buttons) {
     const buttonRow = document.querySelector(".button-row");
     if (!buttonRow) {
       return;
     }
+    const desiredIds = new Set(buttons.map((b3) => b3.id));
+    for (const existing of Array.from(buttonRow.querySelectorAll('[id^="ext-point-"]'))) {
+      const id = existing.id.slice("ext-point-".length);
+      if (!desiredIds.has(id)) {
+        existing.remove();
+      }
+    }
     for (const btn of buttons) {
+      if (document.getElementById(buttonElementId(btn.id))) {
+        continue;
+      }
       const el2 = document.createElement("vscode-button");
-      el2.id = `ext-point-${btn.id}`;
+      el2.id = buttonElementId(btn.id);
       el2.textContent = btn.label;
       el2.addEventListener("click", () => {
         vscodeApi.postMessage({ command: "extensionPointAction", buttonId: btn.id });
       });
       buttonRow.append(el2);
     }
+  }
+  function wireExtensionPointButtons(vscodeApi) {
+    renderExtensionPointButtons(vscodeApi, window.__EXTENSION_POINT_BUTTONS__ ?? []);
+    if (window.__extensionPointButtonsListenerRegistered__) {
+      return;
+    }
+    window.__extensionPointButtonsListenerRegistered__ = true;
+    registerMessageHandler((message) => {
+      if (message?.command === "extensionPointButtonsUpdated" && Array.isArray(message.buttons)) {
+        renderExtensionPointButtons(vscodeApi, message.buttons);
+      }
+    });
   }
 
   // src/webview/shared/theme.css
@@ -2152,19 +2206,6 @@ body[data-vscode-theme-kind="vscode-high-contrast-light"] .title {
 
   // src/webview/environmental/styles.css
   var styles_default = "body {\n	margin: 0;\n	background: var(--bg-primary);\n	color: var(--text-primary);\n	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;\n}\n\n.container {\n	padding: 16px;\n	display: flex;\n	flex-direction: column;\n	gap: 14px;\n	max-width: 1200px;\n	margin: 0 auto;\n}\n\n.header {\n	display: flex;\n	justify-content: space-between;\n	align-items: center;\n	gap: 12px;\n	padding-bottom: 4px;\n}\n\n.title {\n	display: flex;\n	align-items: center;\n	gap: 8px;\n	font-size: 16px;\n	font-weight: 700;\n	color: var(--text-primary);\n}\n\n\n\n.sections {\n	display: flex;\n	flex-direction: column;\n	gap: 16px;\n}\n\n.section {\n	background: var(--bg-secondary);\n	border: 1px solid var(--border-color);\n	border-radius: 10px;\n	padding: 12px;\n	box-shadow: 0 4px 10px var(--shadow-color);\n}\n\n.section h3 {\n	margin: 0 0 10px;\n	font-size: 14px;\n	display: flex;\n	align-items: center;\n	gap: 6px;\n	color: var(--text-primary);\n	letter-spacing: 0.2px;\n}\n\n/* --- Metric cards --- */\n.metric-cards {\n	display: flex;\n	flex-direction: column;\n	gap: 16px;\n}\n\n.metric-card {\n	background: var(--bg-tertiary);\n	border: 1px solid var(--border-subtle);\n	border-radius: 8px;\n	padding: 14px 16px;\n}\n\n.metric-card-header {\n	display: flex;\n	align-items: center;\n	gap: 7px;\n	margin-bottom: 12px;\n}\n\n.metric-card-icon {\n	font-size: 16px;\n	line-height: 1;\n}\n\n.metric-card-label {\n	font-size: 13px;\n	font-weight: 700;\n	color: var(--text-primary);\n	text-transform: uppercase;\n	letter-spacing: 0.4px;\n}\n\n.metric-primary-value {\n	font-size: 16px;\n	font-weight: 700;\n	color: var(--text-primary);\n	padding: 6px 0 10px;\n	border-bottom: 1px solid var(--border-subtle);\n	margin-bottom: 8px;\n}\n\n.analogy-grid {\n	display: grid;\n	grid-template-columns: repeat(4, 1fr);\n	gap: 16px;\n}\n\n.analogy-col {\n	display: flex;\n	flex-direction: column;\n	gap: 6px;\n}\n\n.analogy-col-header {\n	font-size: 11px;\n	font-weight: 700;\n	color: var(--text-secondary);\n	text-transform: uppercase;\n	letter-spacing: 0.5px;\n	padding-bottom: 5px;\n	border-bottom: 1px solid var(--border-subtle);\n	margin-bottom: 2px;\n}\n\n.analogy-item {\n	display: flex;\n	align-items: baseline;\n	gap: 6px;\n	font-size: 12px;\n	color: var(--text-primary);\n	line-height: 1.5;\n}\n\n.analogy-icon {\n	flex-shrink: 0;\n	width: 20px;\n	text-align: center;\n	font-size: 13px;\n}\n\n.notes {\n	margin: 4px 0 0;\n	padding-left: 16px;\n	color: var(--text-secondary);\n}\n\n.notes li {\n	margin: 4px 0;\n	line-height: 1.4;\n}\n\n.footer {\n	color: var(--text-muted);\n	font-size: 11px;\n	margin-top: 6px;\n}\n\n.section-intro {\n	color: var(--text-secondary);\n	font-size: 12px;\n	margin: 0 0 10px;\n	line-height: 1.5;\n}\n";
-
-  // src/webview/shared/messageHandler.ts
-  function isTrustedWebviewMessageSource(source, currentWindow) {
-    return source === null || source === currentWindow;
-  }
-  function registerMessageHandler(handler) {
-    window.addEventListener("message", (event) => {
-      if (!isTrustedWebviewMessageSource(event.source, window)) {
-        return;
-      }
-      handler(event.data);
-    });
-  }
 
   // src/webview/environmental/main.ts
   var CO2_GRAMS_PER_CAR_KM = 120;

--- a/visualstudio-extension/src/AIEngineeringFluency/webview/maturity.js
+++ b/visualstudio-extension/src/AIEngineeringFluency/webview/maturity.js
@@ -9546,6 +9546,20 @@ To suppress this warning, set window.${CONFIG_KEY} to true`);
   function escapeHtml(text) {
     return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#039;");
   }
+  function safeSectionHtml(label, builder, onError = (m2) => console.error(m2)) {
+    try {
+      return builder();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      onError(`[usage-webview] Section "${label}" failed to render: ${message}`);
+      return `<div class="section" style="border-color: rgba(239, 68, 68, 0.3);">
+			<div class="section-title"><span>\u26A0\uFE0F</span><span>${escapeHtml(label)}</span></div>
+			<div style="color: var(--text-secondary); font-size: 12px; padding: 8px 0;">
+				This section couldn't be displayed due to an unexpected error. Other sections are unaffected \u2014 try refreshing the dashboard.
+			</div>
+		</div>`;
+    }
+  }
   function markdownToHtml(text) {
     let escaped = escapeHtml(text);
     escaped = escaped.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" target="_blank" rel="noopener noreferrer">$1</a>');
@@ -9564,25 +9578,508 @@ To suppress this warning, set window.${CONFIG_KEY} to true`);
     4: "Strategic, advanced use leveraging the full AI ecosystem"
   };
 
-  // src/webview/shared/extensionPoints.ts
-  function wireExtensionPointButtons(vscodeApi) {
-    const buttons = window.__EXTENSION_POINT_BUTTONS__ ?? [];
-    if (buttons.length === 0) {
-      return;
+  // src/webview/shared/messageHandler.ts
+  function collectOwnOrigins(currentWindow) {
+    const origins = [];
+    const origin = currentWindow.location?.origin;
+    if (origin && origin !== "null") {
+      origins.push(origin);
     }
+    const href = currentWindow.location?.href;
+    const derived = href ? /^[a-z][a-z0-9+.-]*:\/\/[^/?#]*/i.exec(href) : null;
+    if (derived && !origins.includes(derived[0])) {
+      origins.push(derived[0]);
+    }
+    return origins;
+  }
+  function isTrustedWebviewMessageSource(source, currentWindow, origin) {
+    if (source === null || source === void 0 || source === currentWindow) {
+      return true;
+    }
+    if (source === currentWindow.parent || source === currentWindow.top) {
+      return true;
+    }
+    return Boolean(origin) && collectOwnOrigins(currentWindow).includes(origin);
+  }
+  function registerMessageHandler(handler, onUntrustedMessage) {
+    window.addEventListener("message", (event) => {
+      if (!isTrustedWebviewMessageSource(event.source, window, event.origin)) {
+        onUntrustedMessage?.(event);
+        return;
+      }
+      handler(event.data);
+    });
+  }
+
+  // src/webview/shared/extensionPoints.ts
+  function buttonElementId(id) {
+    return `ext-point-${id}`;
+  }
+  function renderExtensionPointButtons(vscodeApi, buttons) {
     const buttonRow = document.querySelector(".button-row");
     if (!buttonRow) {
       return;
     }
+    const desiredIds = new Set(buttons.map((b3) => b3.id));
+    for (const existing of Array.from(buttonRow.querySelectorAll('[id^="ext-point-"]'))) {
+      const id = existing.id.slice("ext-point-".length);
+      if (!desiredIds.has(id)) {
+        existing.remove();
+      }
+    }
     for (const btn of buttons) {
+      if (document.getElementById(buttonElementId(btn.id))) {
+        continue;
+      }
       const el = document.createElement("vscode-button");
-      el.id = `ext-point-${btn.id}`;
+      el.id = buttonElementId(btn.id);
       el.textContent = btn.label;
       el.addEventListener("click", () => {
         vscodeApi.postMessage({ command: "extensionPointAction", buttonId: btn.id });
       });
       buttonRow.append(el);
     }
+  }
+  function wireExtensionPointButtons(vscodeApi) {
+    renderExtensionPointButtons(vscodeApi, window.__EXTENSION_POINT_BUTTONS__ ?? []);
+    if (window.__extensionPointButtonsListenerRegistered__) {
+      return;
+    }
+    window.__extensionPointButtonsListenerRegistered__ = true;
+    registerMessageHandler((message) => {
+      if (message?.command === "extensionPointButtonsUpdated" && Array.isArray(message.buttons)) {
+        renderExtensionPointButtons(vscodeApi, message.buttons);
+      }
+    });
+  }
+
+  // ../src/darkFactoryControls.json
+  var darkFactoryControls_default = {
+    description: "Dark Factory readiness control catalogue. Each control is one governance or evidence capability a repository either has, does not have, or that this scan cannot see. Stages follow the software-development dark factory maturity ladder and are assessed per repository (a product line), never per person and never for a whole enterprise.",
+    lastUpdated: "2026-09-01",
+    maxAssessableStage: 4,
+    stages: [
+      {
+        stage: 0,
+        name: "Manual / fragmented",
+        summary: "Human coding with inconsistent repositories and releases. The outcome sought here is visibility, not autonomy."
+      },
+      {
+        stage: 1,
+        name: "Standardized software delivery",
+        summary: "Trunk-oriented delivery, reliable tests, infrastructure as code, observability and service ownership. Nothing above this stage is trustworthy without it."
+      },
+      {
+        stage: 2,
+        name: "AI-assisted engineers",
+        summary: "Developers remain the authors. Repository-level instructions steer assistants; AI policy and telemetry boundaries are written down."
+      },
+      {
+        stage: 3,
+        name: "Agent-delegated, human-reviewed",
+        summary: "Small bounded work packages with strong review discipline. An agent may branch, implement, test and open a pull request, but cannot approve or merge its own work."
+      },
+      {
+        stage: 4,
+        name: "Spec-driven autonomous team",
+        summary: "Versioned specifications, acceptance scenarios, independent evaluators, risk classification and progressive delivery. Humans approve intent and outcomes, not every line."
+      },
+      {
+        stage: 5,
+        name: "Bounded dark factory",
+        summary: "Mature domain, executable intent, hidden holdouts, automated rollback and explicit legal accountability. A completely human-free merge path is not the current native GitHub model, and none of its defining evidence is machine-detectable \u2014 this scan never awards stage 5."
+      }
+    ],
+    controls: [
+      {
+        id: "ci-workflows",
+        stage: 1,
+        label: "CI workflows",
+        tier: "filesystem",
+        evidence: "direct",
+        why: "Automated delivery has to exist before anything can be delegated to an agent.",
+        remediation: "Add at least one GitHub Actions workflow under .github/workflows/."
+      },
+      {
+        id: "ci-test-execution",
+        stage: 1,
+        label: "Tests executed in CI",
+        tier: "filesystem",
+        evidence: "heuristic",
+        why: "A green build is only evidence when the build actually runs tests.",
+        remediation: "Run the test suite from a workflow step so every change is validated."
+      },
+      {
+        id: "reusable-workflows",
+        stage: 1,
+        label: "Reusable workflows",
+        tier: "filesystem",
+        evidence: "direct",
+        why: "Shared delivery definitions are what make a product line consistent rather than per-repository folklore.",
+        remediation: "Call a shared workflow with `uses: owner/repo/.github/workflows/file.yml@ref`."
+      },
+      {
+        id: "codeowners",
+        stage: 1,
+        label: "CODEOWNERS",
+        tier: "filesystem",
+        evidence: "direct",
+        why: "Service ownership has to be explicit before review can be held to anyone.",
+        remediation: "Add a CODEOWNERS file in .github/, the repository root, or docs/."
+      },
+      {
+        id: "dependabot",
+        stage: 1,
+        label: "Dependabot configuration",
+        tier: "filesystem",
+        evidence: "direct",
+        why: "Supply-chain currency is part of reliable delivery, not an AI feature.",
+        remediation: "Add .github/dependabot.yml."
+      },
+      {
+        id: "devcontainer",
+        stage: 1,
+        label: "Reproducible dev environment",
+        tier: "filesystem",
+        evidence: "direct",
+        why: "Agents and humans need the same reproducible environment for a result to transfer between them.",
+        remediation: "Add a .devcontainer/ configuration."
+      },
+      {
+        id: "infrastructure-as-code",
+        stage: 1,
+        label: "Infrastructure as code",
+        tier: "filesystem",
+        evidence: "heuristic",
+        why: "Environments that are clicked together by hand cannot be rebuilt or rolled back automatically.",
+        remediation: "Describe the environment in Terraform, Bicep, Pulumi, Helm or Kubernetes manifests."
+      },
+      {
+        id: "code-scanning",
+        stage: 1,
+        label: "Code scanning",
+        tier: "hybrid",
+        evidence: "direct",
+        why: "Static analysis is one of the few automated checks that keeps meaning when a machine wrote the code.",
+        remediation: "Enable CodeQL \u2014 either the default setup or a .github/workflows/codeql.yml workflow.",
+        unknownWhenAbsent: true,
+        unknownReason: "CodeQL default setup leaves no file in the repository, so a missing workflow does not mean scanning is off."
+      },
+      {
+        id: "branch-protection",
+        stage: 1,
+        label: "Branch protection or rulesets",
+        tier: "api",
+        evidence: "direct",
+        why: "Without an enforced target branch, every control above it is advisory.",
+        remediation: "Protect the default branch with a ruleset that requires status checks."
+      },
+      {
+        id: "artifact-attestations",
+        stage: 1,
+        label: "Artifact attestations",
+        tier: "hybrid",
+        evidence: "direct",
+        why: "Provenance is the evidence that the artefact you shipped is the artefact CI built.",
+        remediation: "Use actions/attest-build-provenance in the release workflow.",
+        unknownWhenAbsent: true,
+        unknownReason: "Attestations can be produced by workflows this scan cannot read, or by a shared reusable workflow."
+      },
+      {
+        id: "copilot-instructions",
+        stage: 2,
+        label: "Repository instructions",
+        tier: "filesystem",
+        evidence: "direct",
+        why: "Assistants need the repository's own conventions written down, not inferred.",
+        remediation: "Add .github/copilot-instructions.md."
+      },
+      {
+        id: "agent-instructions",
+        stage: 2,
+        label: "Agent instructions (AGENTS.md / CLAUDE.md)",
+        tier: "filesystem",
+        evidence: "direct",
+        why: "Cross-vendor agent instructions keep guidance in one place rather than per tool.",
+        remediation: "Add AGENTS.md (and mirror it for other agents where needed)."
+      },
+      {
+        id: "scoped-instructions",
+        stage: 2,
+        label: "Path-scoped instructions",
+        tier: "filesystem",
+        evidence: "direct",
+        why: "A monolithic instruction file stops scaling once a repository has distinct subsystems.",
+        remediation: "Add .github/instructions/*.instructions.md scoped with applyTo globs."
+      },
+      {
+        id: "ai-policy",
+        stage: 2,
+        label: "AI usage policy and telemetry boundaries",
+        tier: "governance",
+        evidence: "not-scannable",
+        why: "The paper is explicit that AI adoption needs a stated policy and telemetry boundaries, and that individual performance scoring is out of bounds.",
+        remediation: "Write down the AI usage policy, what telemetry is collected, and that it is never used to score individuals."
+      },
+      {
+        id: "custom-agents",
+        stage: 3,
+        label: "Custom agents",
+        tier: "filesystem",
+        evidence: "direct",
+        why: "Bounded work packages need agents with a defined remit, not one general-purpose agent.",
+        remediation: "Define agents under .github/agents/."
+      },
+      {
+        id: "agent-skills",
+        stage: 3,
+        label: "Agent skills",
+        tier: "filesystem",
+        evidence: "direct",
+        why: "Repeatable procedures belong in a skill so every run does the same thing.",
+        remediation: "Add .github/skills/<name>/SKILL.md for the procedures agents keep repeating."
+      },
+      {
+        id: "mcp-configuration",
+        stage: 3,
+        label: "Declared MCP servers",
+        tier: "filesystem",
+        evidence: "direct",
+        why: "Tool access an agent is given has to be declared in the repository to be reviewable.",
+        remediation: "Declare the MCP servers the repository's agents may use in .vscode/mcp.json or .mcp.json."
+      },
+      {
+        id: "agent-authored-pull-requests",
+        stage: 3,
+        label: "Agent-authored pull requests",
+        tier: "api",
+        evidence: "direct",
+        why: "Delegation is only real once agents are actually opening pull requests in this repository.",
+        remediation: "Delegate a bounded work package to a coding agent and let it open a draft pull request."
+      },
+      {
+        id: "human-review-enforced",
+        stage: 3,
+        label: "Human review enforced on merge",
+        tier: "api",
+        evidence: "direct",
+        why: "The stage-3 boundary is that an agent can propose but cannot approve or merge its own work.",
+        remediation: "Require pull request reviews from someone other than the author on the protected branch."
+      },
+      {
+        id: "issue-forms",
+        stage: 4,
+        label: "Issue Forms as an intent queue",
+        tier: "filesystem",
+        evidence: "direct",
+        why: "Structured intent is what makes a work package specifiable rather than a paragraph of prose.",
+        remediation: "Add .github/ISSUE_TEMPLATE/*.yml Issue Forms capturing intent, constraints and acceptance criteria."
+      },
+      {
+        id: "versioned-specifications",
+        stage: 4,
+        label: "Versioned specifications",
+        tier: "filesystem",
+        evidence: "heuristic",
+        why: "Spec-driven work needs specifications that are reviewed and versioned like code.",
+        remediation: "Keep specifications under specs/ or docs/specs/ in the repository."
+      },
+      {
+        id: "executable-acceptance",
+        stage: 4,
+        label: "Executable acceptance scenarios",
+        tier: "filesystem",
+        evidence: "heuristic",
+        why: "Acceptance has to be executable for an evaluator to be independent of the implementer.",
+        remediation: "Express acceptance scenarios as executable tests (for example .feature files or an acceptance test suite)."
+      },
+      {
+        id: "independent-evaluator-agent",
+        stage: 4,
+        label: "Independent evaluator agents",
+        tier: "filesystem",
+        evidence: "heuristic",
+        why: "The implementation agent must not own the acceptance oracle it is judged by.",
+        remediation: "Define separate review, test or security agents under .github/agents/, distinct from the implementation agent."
+      },
+      {
+        id: "agentic-workflows",
+        stage: 4,
+        label: "Agentic workflows",
+        tier: "filesystem",
+        evidence: "direct",
+        why: "Autonomy that runs on a schedule or an event has to be defined in the repository to be governed.",
+        remediation: "Define agentic workflows in .github/workflows/ so their triggers and permissions are reviewable."
+      },
+      {
+        id: "deployment-environments",
+        stage: 4,
+        label: "Deployment environments declared",
+        tier: "hybrid",
+        evidence: "direct",
+        why: "Progressive delivery needs named environments before it can have gates.",
+        remediation: "Declare `environment:` on the deploying job.",
+        unknownWhenAbsent: true,
+        unknownReason: "Environments can be deployed to from a reusable workflow this scan cannot read."
+      },
+      {
+        id: "environment-protection-rules",
+        stage: 4,
+        label: "Environment protection rules",
+        tier: "api",
+        evidence: "direct",
+        why: "A named environment without required reviewers or wait timers gates nothing.",
+        remediation: "Add required reviewers or a wait timer to the production environment."
+      },
+      {
+        id: "risk-classification",
+        stage: 4,
+        label: "Documented risk classification",
+        tier: "governance",
+        evidence: "not-scannable",
+        why: "Autonomy is permitted per risk class, so the risk classes have to exist and be written down.",
+        remediation: "Classify the repository's change types by risk and state which classes may be handled autonomously."
+      }
+    ]
+  };
+
+  // ../src/darkFactoryReadiness.ts
+  var CATALOGUE = darkFactoryControls_default;
+  var DARK_FACTORY_CONTROLS = CATALOGUE.controls;
+  var DARK_FACTORY_STAGES = CATALOGUE.stages;
+  var MAX_ASSESSABLE_STAGE = CATALOGUE.maxAssessableStage;
+  var DARK_FACTORY_DISCLAIMER = "This scan reports the controls a repository has, per repository and never per person. It does not certify that anything is ready to run without human review.";
+  function nextStageToClose(report) {
+    return report.stages.find((s4) => s4.stage > report.confirmedStage);
+  }
+
+  // src/webview/maturity/darkFactorySection.ts
+  var VERDICT_PRESENTATION = {
+    attained: { label: "Attained", modifier: "df-verdict-attained" },
+    blocked: { label: "Blocked", modifier: "df-verdict-blocked" },
+    indeterminate: { label: "Unverified", modifier: "df-verdict-unverified" }
+  };
+  var SEVERITY_ICONS = {
+    high: "\u{1F534}",
+    medium: "\u{1F7E1}",
+    low: "\u{1F7E2}"
+  };
+  function controlsById(controls, ids) {
+    return ids.map((id) => controls.find((control) => control.id === id)).filter((control) => control !== void 0);
+  }
+  function buildBandHtml(repo) {
+    if (repo.fullyEvidenced) {
+      return `<div class="df-band df-band-complete">
+			<span class="df-band-stage">Stage ${repo.confirmedStage}</span>
+			<span class="df-band-note">every control observed</span>
+		</div>`;
+    }
+    const ceiling = repo.ceilingStage > repo.confirmedStage ? `<span class="df-band-note">up to Stage ${repo.ceilingStage} unverified &middot; ${repo.unknownCount} control(s) not checked</span>` : `<span class="df-band-note">${repo.unknownCount} control(s) not checked</span>`;
+    return `<div class="df-band">
+		<span class="df-band-stage">Stage ${repo.confirmedStage} confirmed</span>
+		${ceiling}
+	</div>`;
+  }
+  function buildControlItemHtml(control, secondLine) {
+    const heuristic = control.evidence === "heuristic" ? ' <span class="df-heuristic" title="Detected by pattern matching \u2014 a candidate, not a verdict">heuristic</span>' : "";
+    return `<li>
+		<span class="df-control-label">${escapeHtml(control.label)}</span>${heuristic}
+		<span class="df-control-detail">${escapeHtml(secondLine)}</span>
+	</li>`;
+  }
+  function buildBlockersHtml(stage, controls) {
+    if (stage.missing.length === 0) {
+      return "";
+    }
+    const items = controlsById(controls, stage.missing).map((control) => buildControlItemHtml(control, control.remediation)).join("");
+    return `<div class="df-block">
+		<div class="df-block-title">Missing for Stage ${stage.stage} &mdash; ${escapeHtml(stage.name)}</div>
+		<ul class="df-control-list">${items}</ul>
+	</div>`;
+  }
+  function buildUnknownsHtml(stage, controls) {
+    if (stage.unknown.length === 0) {
+      return "";
+    }
+    const items = controlsById(controls, stage.unknown).map((control) => buildControlItemHtml(control, control.detail ?? "State could not be determined.")).join("");
+    return `<div class="df-block df-block-unknown">
+		<div class="df-block-title">Could not check for Stage ${stage.stage}</div>
+		<ul class="df-control-list">${items}</ul>
+	</div>`;
+  }
+  function buildStageChipsHtml(repo) {
+    const chips = repo.stages.map((stage) => {
+      const presentation = VERDICT_PRESENTATION[stage.verdict];
+      const title = `${stage.name} \u2014 ${stage.summary}`;
+      return `<span class="df-chip ${presentation.modifier}" title="${escapeHtml(title)}">
+			<span class="df-chip-stage">${stage.stage}</span>${escapeHtml(presentation.label)}
+		</span>`;
+    }).join("");
+    return `<div class="df-chips">${chips}</div>`;
+  }
+  function buildFindingsHtml(findings) {
+    if (findings.length === 0) {
+      return "";
+    }
+    const items = findings.map((finding) => `<li>
+		<span class="df-finding-title">${SEVERITY_ICONS[finding.severity]} ${escapeHtml(finding.title)}</span>
+		<span class="df-control-detail">${escapeHtml(finding.detail)}</span>
+	</li>`).join("");
+    return `<div class="df-block df-block-findings">
+		<div class="df-block-title">Anti-patterns detected</div>
+		<ul class="df-control-list">${items}</ul>
+	</div>`;
+  }
+  function buildRepoCardHtml(repo) {
+    const nextStage = nextStageToClose(repo);
+    const identity = repo.nameWithOwner ? `<span class="df-repo-owner">${escapeHtml(repo.nameWithOwner)}</span>` : `<span class="df-repo-owner df-repo-owner-unknown">local repository &mdash; no GitHub remote resolved</span>`;
+    return `<div class="df-repo-card">
+		<div class="df-repo-head">
+			<span class="df-repo-name">${escapeHtml(repo.name)}</span>
+			${identity}
+		</div>
+		${buildBandHtml(repo)}
+		${buildStageChipsHtml(repo)}
+		${nextStage ? buildBlockersHtml(nextStage, repo.controls) : ""}
+		${nextStage ? buildUnknownsHtml(nextStage, repo.controls) : ""}
+		${buildFindingsHtml(repo.findings)}
+	</div>`;
+  }
+  function buildEvidenceNoticeHtml(report) {
+    const apiNote = report.apiSignalsIncluded ? "Pull-request evidence from the Usage Analysis view is included." : "No GitHub API evidence was available, so rulesets, required reviews, environment protection and scanning enablement are all reported as unchecked rather than missing.";
+    const skippedCount = report.skippedRepoCount;
+    const skipped = skippedCount > 0 ? ` ${skippedCount} further ${skippedCount === 1 ? "repository was" : "repositories were"} found but not scanned in this run.` : "";
+    return `<div class="df-notice">${apiNote}${skipped}</div>`;
+  }
+  function buildDarkFactorySectionHtml(report) {
+    if (!report) {
+      return "";
+    }
+    const body = report.repos.length === 0 ? `<div class="df-empty">No git repositories were found in this workspace, so there is nothing to assess. This scan reads repositories, never people.</div>` : report.repos.map(buildRepoCardHtml).join("");
+    return `
+		<div class="df-section">
+			<div class="df-section-head">
+				<span class="df-section-icon">\u{1F3ED}</span>
+				<span class="df-section-title">Dark Factory Readiness</span>
+				<span class="df-section-badge">per repository</span>
+			</div>
+			<div class="info-box">
+				<div class="info-box-title">\u{1F4CB} What this measures</div>
+				<div>
+					A dark factory is a governed, observable production system &mdash; humans specify intent, constraints, risk and
+					evidence of success while agents implement and validate. This section reports which of those governance and
+					evidence controls each repository in your workspace actually has, and the specific ones blocking the next stage.
+					<br><br>
+					<strong>It never tells you that you are ready to go dark.</strong> A green build from an unbounded agent is weak
+					evidence. ${escapeHtml(DARK_FACTORY_DISCLAIMER)} Stage 5 (a bounded dark factory) is never awarded: its
+					defining evidence is not machine-detectable.
+				</div>
+			</div>
+			${buildEvidenceNoticeHtml(report)}
+			${body}
+			<div class="df-footer">Scanned ${escapeHtml(new Date(report.scannedAt).toLocaleString())} &middot; Stages 1&ndash;${report.maxAssessableStage} are assessable; Stage 5 is not.</div>
+		</div>
+	`;
   }
 
   // src/webview/shared/theme.css
@@ -10860,6 +11357,225 @@ body[data-vscode-theme-kind="vscode-high-contrast-light"] .demo-step-active.demo
 	margin-bottom: 6px;
 }
 
+
+/* \u2500\u2500 Dark Factory readiness section \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
+   Rendered as its own block, visually separate from the personal fluency
+   cards above it: this ladder scores repositories, not people. */
+
+.df-section {
+	margin-top: 32px;
+	padding-top: 24px;
+	border-top: 2px solid var(--border-color);
+}
+
+.df-section-head {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	margin-bottom: 12px;
+}
+
+.df-section-icon {
+	font-size: 22px;
+}
+
+.df-section-title {
+	font-size: 18px;
+	font-weight: 700;
+	color: var(--text-primary);
+}
+
+.df-section-badge {
+	font-size: 11px;
+	font-weight: 600;
+	padding: 2px 8px;
+	border-radius: 10px;
+	background: var(--badge-bg);
+	color: var(--badge-fg);
+}
+
+.df-notice {
+	font-size: 12px;
+	color: var(--text-secondary);
+	margin-bottom: 16px;
+	padding: 8px 12px;
+	border-left: 3px solid var(--border-color);
+	background: var(--bg-tertiary);
+}
+
+.df-empty {
+	font-size: 13px;
+	color: var(--text-secondary);
+	padding: 16px;
+	background: var(--bg-tertiary);
+	border-radius: 6px;
+}
+
+.df-repo-card {
+	background: var(--bg-tertiary);
+	border: 1px solid var(--border-color);
+	border-radius: 8px;
+	padding: 16px;
+	margin-bottom: 14px;
+}
+
+.df-repo-head {
+	display: flex;
+	align-items: baseline;
+	flex-wrap: wrap;
+	gap: 10px;
+	margin-bottom: 10px;
+}
+
+.df-repo-name {
+	font-size: 15px;
+	font-weight: 700;
+	color: var(--text-primary);
+}
+
+.df-repo-owner {
+	font-size: 12px;
+	color: var(--text-secondary);
+}
+
+.df-repo-owner-unknown {
+	font-style: italic;
+	color: var(--text-muted);
+}
+
+.df-band {
+	display: flex;
+	align-items: baseline;
+	flex-wrap: wrap;
+	gap: 10px;
+	margin-bottom: 12px;
+}
+
+.df-band-stage {
+	font-size: 20px;
+	font-weight: 800;
+	color: var(--text-primary);
+}
+
+.df-band-note {
+	font-size: 12px;
+	color: var(--text-secondary);
+}
+
+.df-band-complete .df-band-note {
+	color: var(--success-fg);
+}
+
+.df-chips {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 6px;
+	margin-bottom: 14px;
+}
+
+.df-chip {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	font-size: 11px;
+	font-weight: 600;
+	padding: 3px 10px;
+	border-radius: 12px;
+	border: 1px solid var(--border-color);
+	color: var(--text-secondary);
+	background: var(--bg-secondary);
+}
+
+.df-chip-stage {
+	font-weight: 800;
+	color: var(--text-primary);
+}
+
+.df-verdict-attained {
+	border-color: var(--success-fg);
+	color: var(--success-fg);
+}
+
+.df-verdict-blocked {
+	border-color: var(--error-fg);
+	color: var(--error-fg);
+}
+
+.df-verdict-unverified {
+	border-color: var(--warning-fg);
+	color: var(--warning-fg);
+}
+
+.df-block {
+	margin-top: 12px;
+	padding: 10px 12px;
+	border-radius: 6px;
+	background: var(--bg-secondary);
+	border-left: 3px solid var(--error-fg);
+}
+
+.df-block-unknown {
+	border-left-color: var(--warning-fg);
+}
+
+.df-block-findings {
+	border-left-color: var(--error-fg);
+}
+
+.df-block-title {
+	font-size: 12px;
+	font-weight: 700;
+	color: var(--text-primary);
+	margin-bottom: 8px;
+}
+
+.df-control-list {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+}
+
+.df-control-list li {
+	margin-bottom: 8px;
+}
+
+.df-control-list li:last-child {
+	margin-bottom: 0;
+}
+
+.df-control-label {
+	font-size: 12px;
+	font-weight: 600;
+	color: var(--text-primary);
+}
+
+.df-finding-title {
+	font-size: 12px;
+	font-weight: 700;
+	color: var(--text-primary);
+}
+
+.df-control-detail {
+	display: block;
+	font-size: 11px;
+	color: var(--text-secondary);
+	margin-top: 2px;
+}
+
+.df-heuristic {
+	font-size: 10px;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.4px;
+	color: var(--text-muted);
+	margin-left: 6px;
+}
+
+.df-footer {
+	font-size: 11px;
+	color: var(--text-muted);
+	margin-top: 8px;
+}
 `;
 
   // src/webview/maturity/main.ts
@@ -11217,6 +11933,7 @@ body[data-vscode-theme-kind="vscode-high-contrast-light"] .demo-step-active.demo
         </div>
       </div>
       <div class="category-grid">${categoryCards}</div>
+      ${safeSectionHtml("Dark Factory Readiness", () => buildDarkFactorySectionHtml(data.darkFactory))}
       <div class="footer">
         <span class="footer-info">Based on last 30 days of activity &middot; Last updated: ${new Date(data.lastUpdated).toLocaleString()} &middot; Updates every 5 minutes</span>
         ${dismissedTips.length > 0 ? `<button id="btn-reset-tips" class="reset-tips-btn" title="Show all dismissed improvement suggestions again">\u{1F504} Reset Dismissed Tips</button>` : ""}

--- a/visualstudio-extension/src/AIEngineeringFluency/webview/modelPricing.json
+++ b/visualstudio-extension/src/AIEngineeringFluency/webview/modelPricing.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "description": "Model pricing data - costs per million tokens. Each model has direct provider/API pricing at the top level (used as a reference); models billed through GitHub Copilot AI Credits also include a `copilotPricing` block reflecting GitHub's published per-token rates (1 AI credit = $0.01).",
   "metadata": {
-    "lastUpdated": "2026-08-30",
+    "lastUpdated": "2026-09-05",
     "sources": [
       {
         "name": "OpenAI API Pricing",
@@ -1136,14 +1136,14 @@
       "cacheCreationCostPerMillion": 0.25
     },
     "gpt-5.6-sol": {
-      "inputCostPerMillion": 2.0,
-      "outputCostPerMillion": 10.0,
+      "inputCostPerMillion": 4.0,
+      "outputCostPerMillion": 20.0,
       "category": "GPT-5 models",
       "tier": "standard",
       "displayNames": [
         "GPT-5.6 Sol"
       ],
-      "cachedInputCostPerMillion": 0.2,
+      "cachedInputCostPerMillion": 0.4,
       "copilotPricing": {
         "inputCostPerMillion": 5.0,
         "cachedInputCostPerMillion": 0.5,
@@ -1157,7 +1157,7 @@
           "threshold": "> 272K"
         }
       },
-      "cacheCreationCostPerMillion": 2.5
+      "cacheCreationCostPerMillion": 5.0
     },
     "gpt-5.6-terra": {
       "inputCostPerMillion": 2.0,
@@ -1253,6 +1253,38 @@
         "Kimi K3"
       ],
       "cachedInputCostPerMillion": 0.3
+    },
+    "claude-fable-5.1": {
+      "inputCostPerMillion": 10.0,
+      "outputCostPerMillion": 50.0,
+      "category": "Claude models (Anthropic)",
+      "tier": "standard",
+      "displayNames": [
+        "Claude Fable 5.1"
+      ],
+      "cachedInputCostPerMillion": 0.25,
+      "cacheCreationCostPerMillion": 12.5
+    },
+    "gpt-6-astra": {
+      "inputCostPerMillion": 10.0,
+      "outputCostPerMillion": 50.0,
+      "category": "OpenAI models",
+      "tier": "standard",
+      "displayNames": [
+        "GPT-6 Astra"
+      ],
+      "cachedInputCostPerMillion": 1.0,
+      "cacheCreationCostPerMillion": 12.5
+    },
+    "gemini-3.8-flash": {
+      "inputCostPerMillion": 0.75,
+      "outputCostPerMillion": 3.75,
+      "category": "Google Gemini models",
+      "tier": "standard",
+      "displayNames": [
+        "Gemini 3.8 Flash"
+      ],
+      "cachedInputCostPerMillion": 0.075
     }
   }
 }

--- a/visualstudio-extension/src/AIEngineeringFluency/webview/tokenEstimators.json
+++ b/visualstudio-extension/src/AIEngineeringFluency/webview/tokenEstimators.json
@@ -91,6 +91,9 @@
     "gemini-3.7-flash": 0.25,
     "grok-4.6": 0.25,
     "mai-code-1.1-flash": 0.25,
-    "kimi-k3": 0.25
+    "kimi-k3": 0.25,
+    "claude-fable-5.1": 0.24,
+    "gpt-6-astra": 0.25,
+    "gemini-3.8-flash": 0.25
   }
 }

--- a/visualstudio-extension/src/AIEngineeringFluency/webview/toolNames.json
+++ b/visualstudio-extension/src/AIEngineeringFluency/webview/toolNames.json
@@ -1258,4 +1258,6 @@
   ,"archive_session": "Archive Session"
   ,"reply_and_resolve_review_thread": "Reply And Resolve Review Thread"
   ,"save_session_automation": "Save Session Automation"
+  ,"MCP": "MCP"
+  ,"run_workflow": "Run Workflow"
 }

--- a/visualstudio-extension/src/AIEngineeringFluency/webview/usage.js
+++ b/visualstudio-extension/src/AIEngineeringFluency/webview/usage.js
@@ -7511,7 +7511,7 @@ ${_renderMultiModelMixedCostSessions(switching)}
     const modeUsageHtml = safeSectionHtml("Interaction Modes", () => `
 			<div class="section" id="section-interaction-modes">
 				<div class="section-title"><span>\u{1F3AF}</span><span>Interaction Modes</span></div>
-				<div class="section-subtitle">How you're using Copilot: Ask (chat), Edit (code edits), Agent (autonomous tasks), Plan, Custom Agent, CLI (terminal), Copilot App (desktop-app CLI sessions), Claude Desktop, or Claude (VS Code)</div>
+				<div class="section-subtitle">How you're using AI assistants: Ask (chat), Edit (code edits), Agent (autonomous tasks), Plan, Custom Agent, CLI (terminal), Copilot App (desktop-app CLI sessions), Claude Desktop, or Claude (VS Code)</div>
 				<div class="two-column">
 					${renderModeBarChart(stats.today.modeUsage, "\u{1F4C5} Today")}
 					${renderModeBarChart(stats.last30Days.modeUsage, "\u{1F4CA} Last 30 Days")}

--- a/visualstudio-extension/src/AIEngineeringFluency/webview/usage.js
+++ b/visualstudio-extension/src/AIEngineeringFluency/webview/usage.js
@@ -1938,25 +1938,79 @@ To suppress this warning, set window.${CONFIG_KEY} to true`);
     }
   }
 
-  // src/webview/shared/extensionPoints.ts
-  function wireExtensionPointButtons(vscodeApi) {
-    const buttons = window.__EXTENSION_POINT_BUTTONS__ ?? [];
-    if (buttons.length === 0) {
-      return;
+  // src/webview/shared/messageHandler.ts
+  function collectOwnOrigins(currentWindow) {
+    const origins = [];
+    const origin = currentWindow.location?.origin;
+    if (origin && origin !== "null") {
+      origins.push(origin);
     }
+    const href = currentWindow.location?.href;
+    const derived = href ? /^[a-z][a-z0-9+.-]*:\/\/[^/?#]*/i.exec(href) : null;
+    if (derived && !origins.includes(derived[0])) {
+      origins.push(derived[0]);
+    }
+    return origins;
+  }
+  function isTrustedWebviewMessageSource(source, currentWindow, origin) {
+    if (source === null || source === void 0 || source === currentWindow) {
+      return true;
+    }
+    if (source === currentWindow.parent || source === currentWindow.top) {
+      return true;
+    }
+    return Boolean(origin) && collectOwnOrigins(currentWindow).includes(origin);
+  }
+  function registerMessageHandler(handler, onUntrustedMessage) {
+    window.addEventListener("message", (event) => {
+      if (!isTrustedWebviewMessageSource(event.source, window, event.origin)) {
+        onUntrustedMessage?.(event);
+        return;
+      }
+      handler(event.data);
+    });
+  }
+
+  // src/webview/shared/extensionPoints.ts
+  function buttonElementId(id) {
+    return `ext-point-${id}`;
+  }
+  function renderExtensionPointButtons(vscodeApi, buttons) {
     const buttonRow = document.querySelector(".button-row");
     if (!buttonRow) {
       return;
     }
+    const desiredIds = new Set(buttons.map((b3) => b3.id));
+    for (const existing of Array.from(buttonRow.querySelectorAll('[id^="ext-point-"]'))) {
+      const id = existing.id.slice("ext-point-".length);
+      if (!desiredIds.has(id)) {
+        existing.remove();
+      }
+    }
     for (const btn of buttons) {
+      if (document.getElementById(buttonElementId(btn.id))) {
+        continue;
+      }
       const el2 = document.createElement("vscode-button");
-      el2.id = `ext-point-${btn.id}`;
+      el2.id = buttonElementId(btn.id);
       el2.textContent = btn.label;
       el2.addEventListener("click", () => {
         vscodeApi.postMessage({ command: "extensionPointAction", buttonId: btn.id });
       });
       buttonRow.append(el2);
     }
+  }
+  function wireExtensionPointButtons(vscodeApi) {
+    renderExtensionPointButtons(vscodeApi, window.__EXTENSION_POINT_BUTTONS__ ?? []);
+    if (window.__extensionPointButtonsListenerRegistered__) {
+      return;
+    }
+    window.__extensionPointButtonsListenerRegistered__ = true;
+    registerMessageHandler((message) => {
+      if (message?.command === "extensionPointButtonsUpdated" && Array.isArray(message.buttons)) {
+        renderExtensionPointButtons(vscodeApi, message.buttons);
+      }
+    });
   }
 
   // src/webview/usage/recentSessionsSanitizer.ts
@@ -2862,6 +2916,26 @@ body {
 	background: var(--model-color);
 }
 
+.model-leaderboard-other {
+	margin-top: 8px;
+}
+
+.model-leaderboard-other > summary {
+	cursor: pointer;
+	user-select: none;
+	font-size: 12px;
+	color: var(--text-secondary);
+	padding: 4px 0;
+}
+
+.model-leaderboard-other > summary:hover {
+	color: var(--link-color);
+}
+
+.model-leaderboard-other[open] > summary {
+	margin-bottom: 6px;
+}
+
 .model-use-cell {
 	display: grid;
 	grid-template-columns: 82px 42px auto;
@@ -3453,19 +3527,6 @@ background: var(--bg-tertiary);
 }
 `;
 
-  // src/webview/shared/messageHandler.ts
-  function isTrustedWebviewMessageSource(source, currentWindow) {
-    return source === null || source === currentWindow;
-  }
-  function registerMessageHandler(handler) {
-    window.addEventListener("message", (event) => {
-      if (!isTrustedWebviewMessageSource(event.source, window)) {
-        return;
-      }
-      handler(event.data);
-    });
-  }
-
   // ../src/webview/shared/modelUtils.ts
   var _pricingData = getWindowData("__MODEL_PRICING__");
   var _modelNames = {};
@@ -3608,6 +3669,27 @@ background: var(--bg-tertiary);
       return null;
     }
     return calls[Math.floor((calls.length - 1) * 0.25)];
+  }
+  function computeLongTailModels(usage) {
+    const ranked = Object.entries(usage).map(([model, counters]) => ({ model, calls: counters.calls })).sort((a3, b3) => b3.calls - a3.calls);
+    let cutoffIndex = -1;
+    let smallestRatio = 1;
+    for (let i6 = 1; i6 < ranked.length; i6++) {
+      const previousCalls = ranked[i6 - 1].calls;
+      if (previousCalls <= 0) {
+        continue;
+      }
+      const ratio = ranked[i6].calls / previousCalls;
+      if (ratio < smallestRatio) {
+        smallestRatio = ratio;
+        cutoffIndex = i6;
+      }
+    }
+    const tailLength = cutoffIndex === -1 ? 0 : ranked.length - cutoffIndex;
+    if (cutoffIndex === -1 || smallestRatio >= 0.5 || tailLength < 2) {
+      return /* @__PURE__ */ new Set();
+    }
+    return new Set(ranked.slice(cutoffIndex).map((entry) => entry.model));
   }
 
   // ../src/chartDataBuilder.ts
@@ -3866,17 +3948,27 @@ background: var(--bg-tertiary);
       bounds: { left, right: left + width, top: y3 - 10, bottom: y3 - 10 + LABEL_HEIGHT }
     };
   }
+  var STACK_SLOTS = 5;
+  var STACK_STEP = LABEL_HEIGHT + 3;
+  function getStackedSideOffsets(input, bounds) {
+    const preferBelowFirst = input.y < (bounds.top + bounds.bottom) / 2;
+    const offsets = [];
+    for (let step = 0; step < STACK_SLOTS; step++) {
+      const below = input.y + 18 + step * STACK_STEP;
+      const above = input.y - 10 - step * STACK_STEP;
+      offsets.push(...preferBelowFirst ? [below, above] : [above, below]);
+    }
+    return offsets;
+  }
   function getLabelCandidates(input, bounds) {
     const right = input.x + input.radius + LABEL_GAP;
     const left = input.x - input.radius - LABEL_GAP;
     const above = input.y - input.radius - 6;
     const below = input.y + input.radius + LABEL_HEIGHT;
-    const sideY = input.y < bounds.top + 22 ? [input.y + 18, input.y - 10] : [input.y - 10, input.y + 18];
+    const stackedOffsets = getStackedSideOffsets(input, bounds);
     return [
-      createLabelPlacement(input, right, sideY[0], "start"),
-      createLabelPlacement(input, right, sideY[1], "start"),
-      createLabelPlacement(input, left, sideY[0], "end"),
-      createLabelPlacement(input, left, sideY[1], "end"),
+      ...stackedOffsets.map((y3) => createLabelPlacement(input, right, y3, "start")),
+      ...stackedOffsets.map((y3) => createLabelPlacement(input, left, y3, "end")),
       createLabelPlacement(input, input.x, above, "middle"),
       createLabelPlacement(input, input.x, below, "middle")
     ];
@@ -3908,6 +4000,31 @@ background: var(--bg-tertiary);
       placed.push(best);
     }
     return placed;
+  }
+
+  // src/webview/usage/readiness.ts
+  function createUsageWebviewReadyNotifier(postMessage, hasContainers = defaultHasGitHubActivityContainers) {
+    return (reason) => {
+      postMessage({
+        command: "usageWebviewReady",
+        reason,
+        hasGitHubActivityContainers: hasContainers()
+      });
+    };
+  }
+  function defaultHasGitHubActivityContainers() {
+    if (typeof document === "undefined") {
+      return false;
+    }
+    return Boolean(document.querySelector("#repos-pr-content") && document.querySelector("#agent-sessions-content"));
+  }
+  function restoreGitHubActivityPanels(repoData, agentData, renderRepo, renderAgent) {
+    if (repoData) {
+      renderRepo(repoData);
+    }
+    if (agentData) {
+      renderAgent(agentData);
+    }
   }
 
   // ../src/utils/toolUtils.ts
@@ -4059,6 +4176,28 @@ background: var(--bg-tertiary);
   function isMcpFamilyResolvedTool(id) {
     return resolveMcpFamilyToolName(id) !== void 0;
   }
+  function camelToSnake(value) {
+    return value.replace(/(?<=[a-z0-9])(?=[A-Z])/g, "_").replace(/(?<=[A-Z])(?=[A-Z][a-z])/g, "_");
+  }
+  function canonicalizeToolId(id) {
+    return camelToSnake(id).toLowerCase().replace(/[.-]/g, "_");
+  }
+  function lookupKnownToolName(id, toolNameMap) {
+    if (toolNameMap[id]) {
+      return toolNameMap[id];
+    }
+    const lower = id.toLowerCase();
+    if (toolNameMap[lower]) {
+      return toolNameMap[lower];
+    }
+    const canonicalId = canonicalizeToolId(id);
+    for (const key of Object.keys(toolNameMap)) {
+      if (canonicalizeToolId(key) === canonicalId) {
+        return toolNameMap[key];
+      }
+    }
+    return void 0;
+  }
 
   // src/webview/usage/main.ts
   function statusBadgeHtml(status, label) {
@@ -4073,6 +4212,9 @@ background: var(--bg-tertiary);
     }
   }
   var vscode = acquireVsCodeApi();
+  var notifyUsageWebviewReady = createUsageWebviewReadyNotifier(
+    (message) => vscode.postMessage(message)
+  );
   var curationTraceOnceKeys = /* @__PURE__ */ new Set();
   var aboutCollapsed = vscode.getState()?.aboutCollapsed ?? false;
   function traceCuration(stage, details) {
@@ -4375,7 +4517,7 @@ background: var(--bg-tertiary);
     if (!TOOL_NAME_MAP) {
       return id;
     }
-    return TOOL_NAME_MAP[id] ?? TOOL_NAME_MAP[id.toLowerCase()] ?? resolveGuidMcpToolName(id) ?? resolveMcpFamilyToolName(id) ?? id;
+    return lookupKnownToolName(id, TOOL_NAME_MAP) ?? resolveGuidMcpToolName(id) ?? resolveMcpFamilyToolName(id) ?? id;
   }
   function lookupMcpToolName(id) {
     const full = lookupToolName(id);
@@ -4397,7 +4539,7 @@ background: var(--bg-tertiary);
     Object.entries(stats.last30Days.toolCalls.byTool).forEach(([tool]) => allTools.add(tool));
     Object.entries(stats.month.toolCalls.byTool).forEach(([tool]) => allTools.add(tool));
     const suppressed = new Set(stats.suppressedUnknownTools ?? []);
-    return Array.from(allTools).filter((tool) => !TOOL_NAME_MAP?.[tool] && !TOOL_NAME_MAP?.[tool.toLowerCase()] && !isGuidMcpTool(tool) && !isMcpFamilyResolvedTool(tool) && !suppressed.has(tool)).sort();
+    return Array.from(allTools).filter((tool) => !(TOOL_NAME_MAP && lookupKnownToolName(tool, TOOL_NAME_MAP)) && !isGuidMcpTool(tool) && !isMcpFamilyResolvedTool(tool) && !suppressed.has(tool)).sort();
   }
   function createMcpToolIssueUrl(unknownTools) {
     const repoUrl = "https://github.com/rajbos/ai-engineering-fluency";
@@ -4422,7 +4564,9 @@ Please add friendly names for these tools to improve the user experience.`
     { label: "\u{1F4CB} Plan Mode", key: "plan", gradient: "linear-gradient(90deg, #f59e0b, #fbbf24)" },
     { label: "\u26A1 Custom Agent", key: "customAgent", gradient: "linear-gradient(90deg, #ec4899, #f472b6)" },
     { label: "\u{1F5A5}\uFE0F CLI", key: "cli", gradient: "linear-gradient(90deg, #06b6d4, #22d3ee)" },
-    { label: "\u2728 Copilot App", key: "cliApp", gradient: "linear-gradient(90deg, #6366f1, #818cf8)" }
+    { label: "\u2728 Copilot App", key: "cliApp", gradient: "linear-gradient(90deg, #6366f1, #818cf8)" },
+    { label: "\u{1F5A5}\uFE0F Claude Desktop", key: "claudeDesktop", gradient: "linear-gradient(90deg, #d97706, #f59e0b)" },
+    { label: "\u{1F9E9} Claude (VS Code)", key: "claudeVsCode", gradient: "linear-gradient(90deg, #ea580c, #fb923c)" }
   ];
   function renderModeBarItem(label, count, total, gradient) {
     const pct = total > 0 ? count / total * 100 : 0;
@@ -4433,7 +4577,7 @@ Please add friendly names for these tools to improve the user experience.`
 </div>`;
   }
   function renderModeBarChart(modeUsage, title) {
-    const total = modeUsage.ask + modeUsage.edit + modeUsage.agent + modeUsage.plan + modeUsage.customAgent + modeUsage.cli + (modeUsage.cliApp ?? 0);
+    const total = modeUsage.ask + modeUsage.edit + modeUsage.agent + modeUsage.plan + modeUsage.customAgent + modeUsage.cli + (modeUsage.cliApp ?? 0) + (modeUsage.claudeDesktop ?? 0) + (modeUsage.claudeVsCode ?? 0);
     const bars = MODE_BAR_CONFIGS.map(({ label, key, gradient }) => renderModeBarItem(label, modeUsage[key] ?? 0, total, gradient)).join("");
     return `
 <div>
@@ -4963,7 +5107,9 @@ ${_renderMultiModelMixedCostSessions(switching)}
       plan: coerceNumber2(m2.plan),
       customAgent: coerceNumber2(m2.customAgent),
       cli: coerceNumber2(m2.cli),
-      cliApp: coerceNumber2(m2.cliApp)
+      cliApp: coerceNumber2(m2.cliApp),
+      claudeDesktop: coerceNumber2(m2.claudeDesktop),
+      claudeVsCode: coerceNumber2(m2.claudeVsCode)
     };
   }
   function sanitizeContextRefs(refs) {
@@ -5822,7 +5968,7 @@ ${_renderMultiModelMixedCostSessions(switching)}
   function updateReposPrPanel(data) {
     const container = document.querySelector("#repos-pr-content");
     if (!container) {
-      return;
+      return false;
     }
     setHtml(container, `
 		<div class="section-title"><span>\u{1F916}</span><span>AI Activity in Repository PRs</span></div>
@@ -5833,6 +5979,7 @@ ${_renderMultiModelMixedCostSessions(switching)}
 		</div>
 		${renderReposPrContent(data)}
 	`);
+    return true;
   }
   function agentRepoLabelHtml(r6) {
     const mono = "font-family:'Courier New',monospace; font-size:12px;";
@@ -5951,7 +6098,7 @@ ${_renderMultiModelMixedCostSessions(switching)}
   function updateAgentSessionsPanel(data) {
     const container = document.querySelector("#agent-sessions-content");
     if (!container) {
-      return;
+      return false;
     }
     setHtml(container, `
 		<div class="section-title"><span>\u{1F916}</span><span>Copilot Cloud Agent Sessions</span></div>
@@ -5962,6 +6109,7 @@ ${_renderMultiModelMixedCostSessions(switching)}
 		</div>
 		${renderAgentSessionsContent(data)}
 	`);
+    return true;
   }
   function buildCustomizationSectionHtml(matrix) {
     if (!matrix || !matrix.workspaces || matrix.workspaces.length === 0) {
@@ -6562,19 +6710,21 @@ ${_renderMultiModelMixedCostSessions(switching)}
     }
   }
   function buildReposAndAgentTabPanelsHtml() {
+    const repoLoadingMessage = repoPrStatsLoaded ? "Fetching repository PRs\u2026" : "Loading\u2026 (sign in with GitHub to see data)";
+    const agentLoadingMessage = agentSessionsLoaded ? "Loading cloud agent snapshot\u2026" : "Loading\u2026 (sign in with GitHub to see data)";
     return `
 		<div id="tab-panel-repos" class="tab-panel"${activeTab !== "repos" ? ' style="display:none"' : ""}>
 			<div class="section" id="repos-pr-content">
 				<div class="section-title"><span>\u{1F916}</span><span>AI Activity in Repository PRs</span></div>
 				<div class="section-subtitle">PRs from the last 30 days across your known repositories \u2014 authored or reviewed by AI agents.</div>
-				<div style="margin-top:12px; color: var(--text-secondary); font-size:12px;">Loading\u2026 (sign in with GitHub to see data)</div>
+				<div style="margin-top:12px; color: var(--text-secondary); font-size:12px;">${repoLoadingMessage}</div>
 			</div>
 		</div>
 		<div id="tab-panel-agent" class="tab-panel"${activeTab !== "agent" ? ' style="display:none"' : ""}>
 			<div class="section" id="agent-sessions-content">
 				<div class="section-title"><span>\u{1F916}</span><span>Copilot Cloud Agent Sessions</span></div>
 				<div class="section-subtitle">Cloud agent tasks and sessions from the last 30 days, fetched from the GitHub API.</div>
-				<div style="margin-top:12px; color: var(--text-secondary); font-size:12px;">Loading\u2026 (sign in with GitHub to see data)</div>
+				<div style="margin-top:12px; color: var(--text-secondary); font-size:12px;">${agentLoadingMessage}</div>
 			</div>
 		</div>`;
   }
@@ -7361,7 +7511,7 @@ ${_renderMultiModelMixedCostSessions(switching)}
     const modeUsageHtml = safeSectionHtml("Interaction Modes", () => `
 			<div class="section" id="section-interaction-modes">
 				<div class="section-title"><span>\u{1F3AF}</span><span>Interaction Modes</span></div>
-				<div class="section-subtitle">How you're using Copilot: Ask (chat), Edit (code edits), Agent (autonomous tasks), Plan, Custom Agent, CLI (terminal), or Copilot App (desktop-app CLI sessions)</div>
+				<div class="section-subtitle">How you're using Copilot: Ask (chat), Edit (code edits), Agent (autonomous tasks), Plan, Custom Agent, CLI (terminal), Copilot App (desktop-app CLI sessions), Claude Desktop, or Claude (VS Code)</div>
 				<div class="two-column">
 					${renderModeBarChart(stats.today.modeUsage, "\u{1F4C5} Today")}
 					${renderModeBarChart(stats.last30Days.modeUsage, "\u{1F4CA} Last 30 Days")}
@@ -7672,6 +7822,7 @@ ${_renderMultiModelMixedCostSessions(switching)}
   var efficiencySortDirection = "desc";
   var cachedModelEfficiency = {};
   var efficiencyFilterLowUsage = true;
+  var efficiencyOtherModelsOpen = false;
   function formatUnitCost(value) {
     if (value === null) {
       return "\u2014";
@@ -7875,15 +8026,32 @@ ${_renderMultiModelMixedCostSessions(switching)}
 		<label class="efficiency-control"><span>Color by</span><select id="eff-color-mode">${colorOptions}</select></label>
 	</div>`;
   }
-  function buildEfficiencyTableHtml(rows, totalCalls) {
-    const tableRows = rows.map((row) => {
+  function buildEfficiencyTableRowsHtml(rows, totalCalls) {
+    return rows.map((row) => {
       const cells = EFFICIENCY_COLUMN_DEFS.map((column) => `<td>${column.render(row, totalCalls)}</td>`).join("");
       return `<tr style="--model-color:${getEfficiencyColor(row.model)}">${cells}</tr>`;
     }).join("");
-    const headers = EFFICIENCY_COLUMN_DEFS.map(
+  }
+  function buildEfficiencyTableHeadersHtml() {
+    return EFFICIENCY_COLUMN_DEFS.map(
       (column) => `<th class="sortable" data-eff-sort="${column.sortKey}" title="${column.title}">${column.label}${getEfficiencySortIndicator(column.sortKey)}</th>`
     ).join("");
-    return `<div class="model-leaderboard-table-wrap"><table class="model-leaderboard-table"><thead><tr>${headers}</tr></thead><tbody>${tableRows}</tbody></table></div>`;
+  }
+  function buildEfficiencyTableHtml(rows, totalCalls, longTailModels) {
+    const mainRows = longTailModels.size > 0 ? rows.filter((row) => !longTailModels.has(row.model)) : rows;
+    const otherRows = longTailModels.size > 0 ? rows.filter((row) => longTailModels.has(row.model)) : [];
+    const headers = buildEfficiencyTableHeadersHtml();
+    const table = `<div class="model-leaderboard-table-wrap"><table class="model-leaderboard-table"><thead><tr>${headers}</tr></thead><tbody>${buildEfficiencyTableRowsHtml(mainRows, totalCalls)}</tbody></table></div>`;
+    if (otherRows.length === 0) {
+      return table;
+    }
+    const otherCalls = otherRows.reduce((sum, row) => sum + row.counters.calls, 0);
+    const otherShare = totalCalls > 0 ? otherCalls / totalCalls : 0;
+    const otherTable = `<div class="model-leaderboard-table-wrap"><table class="model-leaderboard-table"><thead><tr>${headers}</tr></thead><tbody>${buildEfficiencyTableRowsHtml(otherRows, totalCalls)}</tbody></table></div>`;
+    return `${table}<details class="model-leaderboard-other" id="model-leaderboard-other"${efficiencyOtherModelsOpen ? " open" : ""}>
+		<summary>Other models (${otherRows.length}, ${formatRatePercent(otherShare)} of turns)</summary>
+		${otherTable}
+	</details>`;
   }
   function buildModelEfficiencyContentHtml() {
     const usage = cachedModelEfficiency[efficiencyPeriod];
@@ -7894,10 +8062,12 @@ ${_renderMultiModelMixedCostSessions(switching)}
     const totalCalls = allRows.reduce((sum, row) => sum + row.counters.calls, 0);
     const filtered = filterLowUsageRows(allRows, usage);
     const note = filtered.hiddenNote ? `<span class="model-leaderboard-filter-note">${filtered.hiddenNote}</span>` : "";
+    const filteredUsage = Object.fromEntries(filtered.rows.map((row) => [row.model, row.counters]));
+    const longTailModels = computeLongTailModels(filteredUsage);
     return `<div class="efficiency-chart-header"><div><strong>Efficiency frontier</strong><span>One-shot edit rate is a local quality proxy, not a benchmark pass rate.</span></div>${buildChartControlsHtml()}</div>
 		${buildEfficiencyChartHtml(filtered.rows)}
 		<div class="model-leaderboard-heading"><div><strong>Most used models locally</strong><span>Ranked by your local turns; all averages use the same selected period.</span></div>${note}</div>
-		${buildEfficiencyTableHtml(filtered.rows, totalCalls)}`;
+		${buildEfficiencyTableHtml(filtered.rows, totalCalls, longTailModels)}`;
   }
   function buildModelEfficiencySectionHtml(stats) {
     cachedModelEfficiency = { today: stats.today.modelEfficiency, last30Days: stats.last30Days.modelEfficiency, month: stats.month.modelEfficiency };
@@ -7961,6 +8131,12 @@ ${_renderMultiModelMixedCostSessions(switching)}
     if (!section) {
       return;
     }
+    section.addEventListener("toggle", (event) => {
+      const target = event.target;
+      if (target.id === "model-leaderboard-other") {
+        efficiencyOtherModelsOpen = target.open;
+      }
+    }, true);
     section.addEventListener("click", (event) => {
       const target = event.target;
       const header = target.closest("th[data-eff-sort]");
@@ -8124,6 +8300,8 @@ ${_renderMultiModelMixedCostSessions(switching)}
     currentInsights = stats.insights ?? [];
     wireInsightCardButtons();
     scrollToPendingTabAnchor();
+    restoreGitHubActivityPanels(repoPrStatsData, agentSessionsData, updateReposPrPanel, updateAgentSessionsPanel);
+    notifyUsageWebviewReady("layout-rendered");
   }
   function wireAboutInfoToggle() {
     const toggle = document.getElementById("about-info-toggle");
@@ -8273,12 +8451,6 @@ ${_renderMultiModelMixedCostSessions(switching)}
       renderLayout(sanitized);
       setupSessionsTableSort();
       renderRepositoryHygienePanels();
-      if (repoPrStatsData) {
-        updateReposPrPanel(repoPrStatsData);
-      }
-      if (agentSessionsData) {
-        updateAgentSessionsPanel(agentSessionsData);
-      }
     } else {
       traceCurationOnce("update-invalid-sanitized", "handleUpdateStats.sanitizeReturnedNull");
       showLoadError("Received invalid data from the extension. Try refreshing.");
@@ -8328,7 +8500,12 @@ ${_renderMultiModelMixedCostSessions(switching)}
     if (!repoPrStatsData.authenticated) {
       repoPrStatsLoaded = false;
     }
-    updateReposPrPanel(repoPrStatsData);
+    if (!updateReposPrPanel(repoPrStatsData)) {
+      traceToHost("repoPrStatsLoaded.notRendered", {
+        repos: repoPrStatsData.repos.length,
+        authenticated: repoPrStatsData.authenticated
+      });
+    }
   }
   function handleAgentSessionsLoaded(data) {
     if (!data || typeof data !== "object") {
@@ -8338,7 +8515,9 @@ ${_renderMultiModelMixedCostSessions(switching)}
     if (!agentSessionsData.authenticated) {
       agentSessionsLoaded = false;
     }
-    updateAgentSessionsPanel(agentSessionsData);
+    if (!updateAgentSessionsPanel(agentSessionsData)) {
+      traceToHost("agentSessionsLoaded.notRendered", { authenticated: agentSessionsData.authenticated });
+    }
   }
   function handleUpdateInsights(rawInsights) {
     if (!Array.isArray(rawInsights)) {
@@ -8447,10 +8626,38 @@ ${_renderMultiModelMixedCostSessions(switching)}
       setTimeout(() => anchor.scrollIntoView({ behavior: "smooth", block: "start" }), 50);
     }
   }
+  var _traceBudget = 20;
+  function traceToHost(stage, details) {
+    if (_traceBudget <= 0) {
+      return;
+    }
+    _traceBudget--;
+    vscode.postMessage({ command: "usageWebviewTrace", stage, details });
+  }
   registerMessageHandler((message) => {
-    handleExtensionMessage(message);
+    try {
+      handleExtensionMessage(message);
+    } catch (err) {
+      traceToHost("handleExtensionMessage.threw", {
+        command: String(message?.command ?? ""),
+        error: err instanceof Error ? err.message : String(err)
+      });
+    }
+  }, (event) => {
+    traceToHost("message-rejected-untrusted", {
+      command: String(event?.data?.command ?? "(none)"),
+      origin: event.origin,
+      ownOrigin: location.origin,
+      href: String(location.href).slice(0, 120)
+    });
   });
-  vscode.postMessage({ command: "usageWebviewReady" });
+  window.addEventListener("error", (event) => {
+    traceToHost("window.error", { message: String(event.message).slice(0, 200) });
+  });
+  window.addEventListener("unhandledrejection", (event) => {
+    traceToHost("unhandledRejection", { reason: String(event?.reason).slice(0, 200) });
+  });
+  notifyUsageWebviewReady("listener-registered");
   function getWorkspaceName(workspacePath) {
     const workspace = hygieneMatrixState?.workspaces.find((ws) => ws.workspacePath === workspacePath);
     return workspace?.workspaceName || workspacePath;

--- a/vscode-extension/src/backend/services/syncService.ts
+++ b/vscode-extension/src/backend/services/syncService.ts
@@ -780,7 +780,7 @@ return this.buildDayModelInteractionsFromJson(content, fileMtimeMs, startMs, ses
 			agentModeCount: Math.round((analysis.modeUsage.agent || 0) * ratio),
 			planModeCount: Math.round((analysis.modeUsage.plan || 0) * ratio),
 			customAgentModeCount: Math.round((analysis.modeUsage.customAgent || 0) * ratio),
-			cliModeCount: Math.round(((analysis.modeUsage.cli || 0) + (analysis.modeUsage.cliApp || 0)) * ratio)
+			cliModeCount: Math.round(((analysis.modeUsage.cli || 0) + (analysis.modeUsage.cliApp || 0) + (analysis.modeUsage.claudeDesktop || 0) + (analysis.modeUsage.claudeVsCode || 0)) * ratio)
 		};
 	}
 

--- a/vscode-extension/src/webview/shared/types.ts
+++ b/vscode-extension/src/webview/shared/types.ts
@@ -21,7 +21,7 @@ export type CategoryLevelData = {
 	levels: LevelInfo[];
 };
 
-export type ModeUsage = { ask: number; edit: number; agent: number; plan: number; customAgent: number; cli: number; cliApp?: number };
+export type ModeUsage = { ask: number; edit: number; agent: number; plan: number; customAgent: number; cli: number; cliApp?: number; claudeDesktop?: number; claudeVsCode?: number };
 export type ToolCallUsage = { total: number; byTool: { [key: string]: number }; outputTokensByTool?: { [key: string]: number } };
 export type McpToolUsage = { total: number; byServer: { [key: string]: number }; byTool: { [key: string]: number } };
 

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -802,6 +802,8 @@ const MODE_BAR_CONFIGS: readonly ModeBarConfig[] = [
 { label: '\u26A1 Custom Agent',   key: 'customAgent', gradient: 'linear-gradient(90deg, #ec4899, #f472b6)' },
 { label: '\u{1F5A5}\uFE0F CLI',   key: 'cli',         gradient: 'linear-gradient(90deg, #06b6d4, #22d3ee)' },
 { label: '\u2728 Copilot App',    key: 'cliApp',      gradient: 'linear-gradient(90deg, #6366f1, #818cf8)' },
+{ label: '\u{1F5A5}\uFE0F Claude Desktop', key: 'claudeDesktop', gradient: 'linear-gradient(90deg, #d97706, #f59e0b)' },
+{ label: '\u{1F9E9} Claude (VS Code)', key: 'claudeVsCode', gradient: 'linear-gradient(90deg, #ea580c, #fb923c)' },
 ];
 
 /** Renders a single horizontal bar item for the mode usage chart. */
@@ -816,7 +818,7 @@ return `
 
 /** Renders the full bar-chart column for a single time period's mode usage. */
 function renderModeBarChart(modeUsage: ModeUsage, title: string): string {
-const total = modeUsage.ask + modeUsage.edit + modeUsage.agent + modeUsage.plan + modeUsage.customAgent + modeUsage.cli + (modeUsage.cliApp ?? 0);
+const total = modeUsage.ask + modeUsage.edit + modeUsage.agent + modeUsage.plan + modeUsage.customAgent + modeUsage.cli + (modeUsage.cliApp ?? 0) + (modeUsage.claudeDesktop ?? 0) + (modeUsage.claudeVsCode ?? 0);
 const bars = MODE_BAR_CONFIGS
 .map(({ label, key, gradient }) => renderModeBarItem(label, modeUsage[key] ?? 0, total, gradient))
 .join('');
@@ -1417,6 +1419,8 @@ function sanitizeModeUsage(mode: any): ModeUsage {
 		customAgent: coerceNumber(m.customAgent),
 		cli: coerceNumber(m.cli),
 		cliApp: coerceNumber(m.cliApp),
+		claudeDesktop: coerceNumber(m.claudeDesktop),
+		claudeVsCode: coerceNumber(m.claudeVsCode),
 	};
 }
 
@@ -4043,7 +4047,7 @@ function buildActivityTabPanelHtml(
 	const modeUsageHtml = safeSectionHtml('Interaction Modes', () => `
 			<div class="section" id="section-interaction-modes">
 				<div class="section-title"><span>🎯</span><span>Interaction Modes</span></div>
-				<div class="section-subtitle">How you're using Copilot: Ask (chat), Edit (code edits), Agent (autonomous tasks), Plan, Custom Agent, CLI (terminal), or Copilot App (desktop-app CLI sessions)</div>
+				<div class="section-subtitle">How you're using Copilot: Ask (chat), Edit (code edits), Agent (autonomous tasks), Plan, Custom Agent, CLI (terminal), Copilot App (desktop-app CLI sessions), Claude Desktop, or Claude (VS Code)</div>
 				<div class="two-column">
 					${renderModeBarChart(stats.today.modeUsage, '📅 Today')}
 					${renderModeBarChart(stats.last30Days.modeUsage, '📊 Last 30 Days')}

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -4047,7 +4047,7 @@ function buildActivityTabPanelHtml(
 	const modeUsageHtml = safeSectionHtml('Interaction Modes', () => `
 			<div class="section" id="section-interaction-modes">
 				<div class="section-title"><span>🎯</span><span>Interaction Modes</span></div>
-				<div class="section-subtitle">How you're using Copilot: Ask (chat), Edit (code edits), Agent (autonomous tasks), Plan, Custom Agent, CLI (terminal), Copilot App (desktop-app CLI sessions), Claude Desktop, or Claude (VS Code)</div>
+				<div class="section-subtitle">How you're using AI assistants: Ask (chat), Edit (code edits), Agent (autonomous tasks), Plan, Custom Agent, CLI (terminal), Copilot App (desktop-app CLI sessions), Claude Desktop, or Claude (VS Code)</div>
 				<div class="two-column">
 					${renderModeBarChart(stats.today.modeUsage, '📅 Today')}
 					${renderModeBarChart(stats.last30Days.modeUsage, '📊 Last 30 Days')}

--- a/vscode-extension/test/unit/claudecode.test.ts
+++ b/vscode-extension/test/unit/claudecode.test.ts
@@ -983,6 +983,69 @@ test('ClaudeCodeAdapter.analyzeUsage: a user-typed slash invocation (<command-na
 	}
 });
 
+// ----- ClaudeCodeAdapter.analyzeUsage: modeUsage bucketing by entrypoint variant -----
+
+test('ClaudeCodeAdapter.analyzeUsage: entrypoint "cli" counts toward modeUsage.cli', async () => {
+	const events = [
+		{ type: 'user', isSidechain: false, entrypoint: 'cli', message: { role: 'user', content: 'hello' } },
+	];
+	const filePath = createTempSession(events);
+	try {
+		const result = await claudeCodeAdapter.analyzeUsage(filePath, adapterCtx);
+		assert.equal(result.modeUsage.cli, 1);
+		assert.equal(result.modeUsage.claudeDesktop ?? 0, 0);
+		assert.equal(result.modeUsage.claudeVsCode ?? 0, 0);
+	} finally {
+		cleanup(filePath);
+	}
+});
+
+test('ClaudeCodeAdapter.analyzeUsage: entrypoint "claude-desktop" counts toward modeUsage.claudeDesktop, not cli', async () => {
+	const events = [
+		{ type: 'user', isSidechain: false, entrypoint: 'claude-desktop', message: { role: 'user', content: 'hello' } },
+	];
+	const filePath = createTempSession(events);
+	try {
+		const result = await claudeCodeAdapter.analyzeUsage(filePath, adapterCtx);
+		assert.equal(result.modeUsage.claudeDesktop, 1);
+		assert.equal(result.modeUsage.cli, 0);
+		assert.equal(result.modeUsage.claudeVsCode ?? 0, 0);
+	} finally {
+		cleanup(filePath);
+	}
+});
+
+test('ClaudeCodeAdapter.analyzeUsage: entrypoint "claude-vscode" counts toward modeUsage.claudeVsCode, not cli', async () => {
+	const events = [
+		{ type: 'user', isSidechain: false, entrypoint: 'claude-vscode', message: { role: 'user', content: 'hello' } },
+	];
+	const filePath = createTempSession(events);
+	try {
+		const result = await claudeCodeAdapter.analyzeUsage(filePath, adapterCtx);
+		assert.equal(result.modeUsage.claudeVsCode, 1);
+		assert.equal(result.modeUsage.cli, 0);
+		assert.equal(result.modeUsage.claudeDesktop ?? 0, 0);
+	} finally {
+		cleanup(filePath);
+	}
+});
+
+test('ClaudeCodeAdapter.analyzeUsage: multiple user turns in a claude-desktop session all count under claudeDesktop', async () => {
+	const events = [
+		{ type: 'user', isSidechain: false, entrypoint: 'claude-desktop', message: { role: 'user', content: 'first' } },
+		{ type: 'assistant', message: { id: 'm1', model: 'claude-sonnet-4-6', role: 'assistant', stop_reason: 'end_turn', content: [{ type: 'text', text: 'ok' }] } },
+		{ type: 'user', isSidechain: false, message: { role: 'user', content: 'second' } },
+	];
+	const filePath = createTempSession(events);
+	try {
+		const result = await claudeCodeAdapter.analyzeUsage(filePath, adapterCtx);
+		assert.equal(result.modeUsage.claudeDesktop, 2);
+		assert.equal(result.modeUsage.cli, 0);
+	} finally {
+		cleanup(filePath);
+	}
+});
+
 // ----- getClaudeCodeDailyFractions (issue #1608, root cause A) -----
 
 test('getClaudeCodeDailyFractions: splits usage by each assistant event day, weighted by tokens', async () => {


### PR DESCRIPTION
## Problem

The "Interaction Modes" panel in the Usage Analysis dashboard showed an implausibly high "CLI" percentage. Root cause: `ClaudeCodeAdapter` unconditionally counted every Claude session under `~/.claude/projects/` as `modeUsage.cli++`, regardless of whether it came from the terminal CLI, the Claude Code VS Code extension, or the standalone Claude Desktop app — even though a working `entrypoint`-based detector (`detectClaudeCodeEditorVariant`) already existed to tell them apart.

## Fix

Added two Claude-specific `ModeUsage` buckets — `claudeDesktop` and `claudeVsCode` — and routed adapter counts into the correct bucket via the existing entrypoint detector. Terminal-only tools (OpenCode, Crush, Pi, Hermes) remain unchanged in the `cli` bucket, as does Claude Code's actual terminal CLI usage.

### Changes
- `src/types.ts` — new `claudeDesktop?`/`claudeVsCode?` fields on `ModeUsage`
- `src/adapters/claudeCodeAdapter.ts` — routes each session to the right bucket instead of always `cli`
- `src/usageAnalysis.ts` — merges new fields into period aggregates
- `src/maturityScoring.ts` — includes new fields in the fluency/maturity CLI total (same agentic capability, different launch surface)
- `vscode-extension/src/webview/usage/main.ts` + `shared/types.ts` — new bars ("Claude Desktop", "Claude (VS Code)"), sanitization, totals, subtitle text
- `vscode-extension/src/backend/services/syncService.ts` — folds new fields into the existing `cliModeCount` cloud-sync column (no schema migration needed)
- `cli/src/commands/fluency.ts` — reports the two new buckets
- `docs/USAGE-ANALYSIS.md` — documents the new buckets
- `vscode-extension/test/unit/claudecode.test.ts` — new tests covering entrypoint → bucket routing
- Visual Studio webview bundles (`visualstudio-extension/.../webview/*.js`) — refreshed via the `sync-host-views` skill (unminified dev build, matching repo convention) to pick up the usage-panel changes

## Testing
- `npm run validate` (type-check + lint + build) in `vscode-extension/` — passed, no new warnings/errors
- Full `npm run test:node` suite in `vscode-extension/` — all 79 test files pass
- `npm run check:contract` — webview message contract intact
- `cli/` build (`npm run build`) — passed

## Scope notes
- Antigravity has the same class of bug (GUI IDE sessions counted as `cli`) but was explicitly left out of scope per user request — can be addressed separately if desired.
- The two new fields are Claude-specific by design (not a generic "desktop app" bucket), per user's explicit preference.