### PR TITLE
Clarify cost attribution periods and effects

### DIFF
--- a/src/efficiencyAnalysis.ts
+++ b/src/efficiencyAnalysis.ts
@@ -333,13 +333,23 @@ export function computeCostAttribution(
 	};
 }
 
+/** Inclusive calendar-day boundaries for the two adjacent 30-day attribution windows. */
+export function getTrailingWindowBoundaries(now: Date): { prevStart: Date; prevEnd: Date; curStart: Date; curEnd: Date } {
+	const dayAtOffset = (offset: number): Date => new Date(now.getFullYear(), now.getMonth(), now.getDate() - offset);
+	return {
+		prevStart: dayAtOffset(59),
+		prevEnd: dayAtOffset(30),
+		curStart: dayAtOffset(29),
+		curEnd: dayAtOffset(0),
+	};
+}
+
 /** Splits daily stats into [previous 30 days, trailing 30 days] windows relative to `now`. */
 export function splitTrailingWindows(dailyStats: DailyTokenStats[], now: Date): { prevDays: DailyTokenStats[]; curDays: DailyTokenStats[] } {
-	const curStart = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 29);
-	const prevStart = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 59);
-	const curStartKey = fmtKey(curStart);
-	const prevStartKey = fmtKey(prevStart);
-	const nowKey = fmtKey(now);
+	const boundaries = getTrailingWindowBoundaries(now);
+	const curStartKey = fmtKey(boundaries.curStart);
+	const prevStartKey = fmtKey(boundaries.prevStart);
+	const nowKey = fmtKey(boundaries.curEnd);
 	const prevDays: DailyTokenStats[] = [];
 	const curDays: DailyTokenStats[] = [];
 	for (const day of dailyStats) {
@@ -1243,8 +1253,8 @@ export interface EfficiencyViewData {
 	/** True when any week has apply-rate data. */
 	hasApply: boolean;
 	attribution: CostAttribution | null;
-	/** Human labels for the compared attribution windows. */
-	attributionWindows: { prev: string; cur: string };
+	/** Human labels and inclusive calendar-date ranges for the compared attribution windows. */
+	attributionWindows: { prev: string; cur: string; prevRange: string; curRange: string };
 	deltas: EfficiencyDelta[];
 	/** Human labels for the delta card periods. */
 	deltaWindows: { prev: string; cur: string };

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -205,6 +205,7 @@ import {
   computeSkillImpact as _computeSkillImpact,
   listComparableModels as _listComparableModels,
   computeValueSignals as _computeValueSignals,
+  getTrailingWindowBoundaries as _getTrailingWindowBoundaries,
   splitTrailingWindows as _splitTrailingWindows,
   type EfficiencySessionInput,
   type EfficiencyViewData,
@@ -8902,6 +8903,10 @@ private async shareTextToSocialPlatform(shareText: string, platform: 'linkedin' 
 		const skillTrends = _buildSkillUsageTrends(sessionInputs, deps);
 		const skillImpact = _computeSkillImpact(sessionInputs);
 		const { prevDays, curDays } = _splitTrailingWindows(dailyStats, now);
+		const attributionBoundaries = _getTrailingWindowBoundaries(now);
+		const formatAttributionDate = (date: Date): string => date.toLocaleDateString('en-US', {
+			month: 'short', day: 'numeric', year: 'numeric',
+		});
 		const attribution = _computeCostAttribution(prevDays, curDays, deps);
 		const monthKey = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
 		const lastMonthDate = new Date(now.getFullYear(), now.getMonth() - 1, 1);
@@ -8933,7 +8938,12 @@ private async shareTextToSocialPlatform(shareText: string, platform: 'linkedin' 
 			hasRetry: weekly.some(w => w.retryRate !== null),
 			hasApply: weekly.some(w => w.applyRate !== null),
 			attribution,
-			attributionWindows: { prev: 'previous 30 days', cur: 'last 30 days' },
+			attributionWindows: {
+				prev: 'previous 30 days',
+				cur: 'last 30 days',
+				prevRange: `${formatAttributionDate(attributionBoundaries.prevStart)}–${formatAttributionDate(attributionBoundaries.prevEnd)}`,
+				curRange: `${formatAttributionDate(attributionBoundaries.curStart)}–${formatAttributionDate(attributionBoundaries.curEnd)}`,
+			},
 			deltas,
 			deltaWindows: {
 				prev: lastMonthDate.toLocaleDateString('en-US', { month: 'long', year: 'numeric' }),

--- a/vscode-extension/src/webview/efficiency/main.ts
+++ b/vscode-extension/src/webview/efficiency/main.ts
@@ -245,15 +245,15 @@ function renderDeltasTab(d: EfficiencyViewData): string {
 		<div class="delta-grid">${cards}</div>`;
 }
 
-function attrBar(label: string, value: number, maxAbs: number, explain: string): string {
+function attrBar(label: string, detail: string, value: number, maxAbs: number, explain: string): string {
 	const widthPct = maxAbs > 0 ? Math.min(50, (Math.abs(value) / maxAbs) * 50) : 0;
 	const side = value >= 0 ? `left: 50%; width: ${widthPct}%;` : `right: 50%; width: ${widthPct}%;`;
 	const cls = value >= 0 ? 'pos' : 'neg';
 	return `
 		<div class="attr-bar-row" title="${escapeHtml(explain)}">
-			<div class="attr-bar-label">${escapeHtml(label)}</div>
+			<div class="attr-bar-label">${escapeHtml(label)}<div class="attr-bar-detail">${escapeHtml(detail)}</div></div>
 			<div class="attr-bar-track"><div class="attr-bar-mid"></div><div class="attr-bar-fill ${cls}" style="${side}"></div></div>
-			<div class="attr-bar-value">${fmtMoney(value)}</div>
+			<div class="attr-bar-value">${fmtMoney(value)}<div class="attr-bar-effect">estimated cost effect</div></div>
 		</div>`;
 }
 
@@ -263,10 +263,12 @@ function renderAttributionTab(d: EfficiencyViewData): string {
 		return `<p class="eff-section-note">Not enough data to decompose the cost change — both compared windows need at least one session with token data.</p>`;
 	}
 	const maxAbs = Math.max(Math.abs(a.volumeEffect), Math.abs(a.efficiencyEffect), Math.abs(a.mixEffect), 0.01);
+	const afterVolume = a.prev.cost + a.volumeEffect;
+	const afterEfficiency = afterVolume + a.efficiencyEffect;
 	const shifts = a.modelShifts.length === 0 ? '' : `
 		<h3>Model mix movement</h3>
 		<table class="attr-shift-table">
-			<thead><tr><th>Model</th><th class="num">${escapeHtml(capitalizeFirst(d.attributionWindows.prev))}</th><th class="num">${escapeHtml(capitalizeFirst(d.attributionWindows.cur))}</th><th class="num">Shift</th></tr></thead>
+			<thead><tr><th>Model</th><th class="num">${escapeHtml(d.attributionWindows.prevRange)}</th><th class="num">${escapeHtml(d.attributionWindows.curRange)}</th><th class="num">Shift</th></tr></thead>
 			<tbody>
 				${a.modelShifts.map(s => `
 					<tr>
@@ -278,16 +280,17 @@ function renderAttributionTab(d: EfficiencyViewData): string {
 			</tbody>
 		</table>`;
 	return `
-		<p class="eff-section-note">Why did your estimated cost change from ${escapeHtml(d.attributionWindows.prev)} to ${escapeHtml(d.attributionWindows.cur)}? The change decomposes exactly into three effects: <b>volume</b> (you used AI more or less), <b>session efficiency</b> (each session consumed more or fewer tokens), and <b>model mix</b> (your blended price per token changed by switching models). Green bars reduce cost; red bars increase it.</p>
+		<p class="eff-section-note">The periods are adjacent, not overlapping: ${escapeHtml(capitalizeFirst(d.attributionWindows.prev))} is <b>${escapeHtml(d.attributionWindows.prevRange)}</b>; ${escapeHtml(d.attributionWindows.cur)} is <b>${escapeHtml(d.attributionWindows.curRange)}</b>. Each bar is a <b>what-if dollar amount</b>, not a session count: starting from the earlier cost, the factors are applied in order. Green reduces estimated cost; red increases it.</p>
 		<div class="attr-summary">
-			<div class="attr-stat"><div class="stat-label">${escapeHtml(capitalizeFirst(d.attributionWindows.prev))}</div><div class="stat-value">$${a.prev.cost.toFixed(2)}</div><div class="stat-sub">${a.prev.sessions} sessions · ${formatCompact(a.prev.tokens)} tokens</div></div>
-			<div class="attr-stat"><div class="stat-label">${escapeHtml(capitalizeFirst(d.attributionWindows.cur))}</div><div class="stat-value">$${a.cur.cost.toFixed(2)}</div><div class="stat-sub">${a.cur.sessions} sessions · ${formatCompact(a.cur.tokens)} tokens</div></div>
+			<div class="attr-stat"><div class="stat-label">${escapeHtml(capitalizeFirst(d.attributionWindows.prev))}</div><div class="stat-value">$${a.prev.cost.toFixed(2)}</div><div class="stat-sub">${escapeHtml(d.attributionWindows.prevRange)} · ${a.prev.sessions} sessions · ${formatCompact(a.prev.tokens)} tokens</div></div>
+			<div class="attr-stat"><div class="stat-label">${escapeHtml(capitalizeFirst(d.attributionWindows.cur))}</div><div class="stat-value">$${a.cur.cost.toFixed(2)}</div><div class="stat-sub">${escapeHtml(d.attributionWindows.curRange)} · ${a.cur.sessions} sessions · ${formatCompact(a.cur.tokens)} tokens</div></div>
 			<div class="attr-stat"><div class="stat-label">Change</div><div class="stat-value">${fmtMoney(a.deltaCost)}</div><div class="stat-sub">blended rate ${a.prev.dollarsPerMTokens.toFixed(2)} → ${a.cur.dollarsPerMTokens.toFixed(2)} $/M tokens</div></div>
 		</div>
+		<div class="attr-waterfall"><span>Starting cost <b>$${a.prev.cost.toFixed(2)}</b></span><span>After session count <b>$${afterVolume.toFixed(2)}</b></span><span>After session size <b>$${afterEfficiency.toFixed(2)}</b></span><span>After model mix <b>$${a.cur.cost.toFixed(2)}</b></span></div>
 		<div class="attr-bars">
-			${attrBar('Volume (session count)', a.volumeEffect, maxAbs, `Session count went from ${a.prev.sessions} to ${a.cur.sessions}.`)}
-			${attrBar('Session efficiency (tokens/session)', a.efficiencyEffect, maxAbs, `Tokens per session went from ${Math.round(a.prev.tokensPerSession)} to ${Math.round(a.cur.tokensPerSession)}.`)}
-			${attrBar('Model mix ($/token)', a.mixEffect, maxAbs, `Blended price went from ${a.prev.dollarsPerMTokens.toFixed(2)} to ${a.cur.dollarsPerMTokens.toFixed(2)} $/M tokens.`)}
+			${attrBar('Volume (session count)', `${a.prev.sessions.toLocaleString()} → ${a.cur.sessions.toLocaleString()} sessions`, a.volumeEffect, maxAbs, `Session count went from ${a.prev.sessions} to ${a.cur.sessions}.`)}
+			${attrBar('Session size (tokens/session)', `${formatCompact(a.prev.tokensPerSession)} → ${formatCompact(a.cur.tokensPerSession)} tokens/session`, a.efficiencyEffect, maxAbs, `Tokens per session went from ${Math.round(a.prev.tokensPerSession)} to ${Math.round(a.cur.tokensPerSession)}.`)}
+			${attrBar('Model mix ($/token)', `$${a.prev.dollarsPerMTokens.toFixed(2)} → $${a.cur.dollarsPerMTokens.toFixed(2)} /M tokens`, a.mixEffect, maxAbs, `Blended price went from ${a.prev.dollarsPerMTokens.toFixed(2)} to ${a.cur.dollarsPerMTokens.toFixed(2)} $/M tokens.`)}
 		</div>
 		${shifts}`;
 }

--- a/vscode-extension/src/webview/efficiency/styles.css
+++ b/vscode-extension/src/webview/efficiency/styles.css
@@ -168,12 +168,18 @@
 .attr-bars { margin: 8px 0 18px 0; }
 .attr-bar-row {
 	display: grid;
-	grid-template-columns: 190px 1fr 90px;
+	grid-template-columns: 230px 1fr 120px;
 	align-items: center;
 	gap: 10px;
 	margin-bottom: 8px;
 }
 .attr-bar-label { font-size: 0.88em; text-align: right; }
+.attr-bar-detail,
+.attr-bar-effect {
+	color: var(--vscode-descriptionForeground);
+	font-size: 0.78em;
+	margin-top: 2px;
+}
 .attr-bar-track {
 	position: relative;
 	height: 20px;
@@ -194,6 +200,22 @@
 .attr-bar-fill.pos { background: var(--vscode-charts-red, #fb7185); }
 .attr-bar-fill.neg { background: var(--vscode-charts-green, #4ade80); }
 .attr-bar-value { font-size: 0.88em; font-variant-numeric: tabular-nums; }
+.attr-waterfall {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 4px 18px;
+	margin: -8px 0 14px;
+	color: var(--vscode-descriptionForeground);
+	font-size: 0.82em;
+}
+.attr-waterfall span:not(:last-child)::after {
+	content: '→';
+	margin-left: 18px;
+}
+.attr-waterfall b {
+	color: var(--vscode-foreground);
+	font-variant-numeric: tabular-nums;
+}
 
 .attr-shift-table { width: 100%; border-collapse: collapse; font-size: 0.88em; }
 .attr-shift-table th, .attr-shift-table td {

--- a/vscode-extension/test/unit/efficiencyAnalysis.test.ts
+++ b/vscode-extension/test/unit/efficiencyAnalysis.test.ts
@@ -8,6 +8,7 @@ import {
 	computeSkillImpact,
 	computeEfficiencyDeltas,
 	computeValueSignals,
+	getTrailingWindowBoundaries,
 	splitTrailingWindows,
 	computeModelPeriodMetrics,
 	listComparableModels,
@@ -247,6 +248,19 @@ test('splitTrailingWindows: partitions days into trailing and previous 30-day wi
 	const { prevDays, curDays } = splitTrailingWindows(days, NOW);
 	assert.deepEqual(curDays.map(d => d.date).sort(), ['2026-06-16', '2026-07-15']);
 	assert.deepEqual(prevDays.map(d => d.date).sort(), ['2026-05-17', '2026-06-15']);
+});
+
+test('getTrailingWindowBoundaries: returns adjacent inclusive 30-day ranges', () => {
+	const boundaries = getTrailingWindowBoundaries(NOW);
+	assert.deepEqual(
+		[
+			boundaries.prevStart,
+			boundaries.prevEnd,
+			boundaries.curStart,
+			boundaries.curEnd,
+			].map(d => `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`),
+		['2026-05-17', '2026-06-15', '2026-06-16', '2026-07-15'],
+	);
 });
 
 // ── computeEfficiencyDeltas ──────────────────────────────────────────────────


### PR DESCRIPTION
## Why

Cost attribution made adjacent 30-day periods and driver dollar effects easy to misread as overlapping data or session counts expressed in currency.

## What changed

- Display each inclusive calendar-date range and state that the two periods are adjacent, not overlapping.
- Explain that each bar is a sequential what-if estimated cost effect, and show the intermediate cost waterfall from the earlier period to the later one.
- Show each driver's before/after measure alongside its dollar effect, and rename the user-facing session driver to "Session size (tokens/session)".
- Centralize the trailing-window boundaries and cover their adjacent inclusive ranges with a unit test.