### PR TITLE
Add automatic compaction insights

### DIFF
--- a/.github/skills/visual-view-diff/fixtures/usage.json
+++ b/.github/skills/visual-view-diff/fixtures/usage.json
@@ -831,6 +831,13 @@
     "multiAgentParentSessions": 27,
     "delegationSessions": 45
   },
+  "autoCompactionsLast7Days": {
+    "total": 6,
+    "bySource": {
+      "copilotCli": 4,
+      "claude": 2
+    }
+  },
   "locale": "en-US",
   "lastUpdated": "2026-03-14T09:30:00.000Z",
   "agenticDailyTrend": [

--- a/src/types.ts
+++ b/src/types.ts
@@ -823,6 +823,8 @@ todaySessions?: TodaySessionSummary[];
 recentSessions?: { last7: TodaySessionSummary[]; last30: TodaySessionSummary[]; currentMonth: TodaySessionSummary[] };
 /** Optional tool curation analysis (VS Code only; absent in CLI/VS/JetBrains). */
 curationAnalysis?: ToolCurationAnalysis | null;
+/** Automatic context compactions observed across recent Copilot CLI and Claude sessions. */
+autoCompactionsLast7Days?: AutomaticCompactionStats;
 /**
  * Daily-bucketed multi-agent/delegation usage over the trailing ~30 days, for the
  * "Multi-Agent Usage" sparkline on the Fluency dashboard. Absent when no sessions
@@ -1008,6 +1010,15 @@ export interface DarkFactoryReport {
   repos: DarkFactoryRepoReport[];
   /** Repositories found but not scanned because the per-scan cap was reached. */
   skippedRepoCount: number;
+}
+
+/** Automatic context compactions grouped by the session format that recorded them. */
+export interface AutomaticCompactionStats {
+  total: number;
+  bySource: {
+    copilotCli: number;
+    claude: number;
+  };
 }
 
 export interface UsageAnalysisPeriod {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -3346,6 +3346,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			last30Days: stats.last30Days,
 			month: stats.month,
 			lastMonth: stats.lastMonth,
+			autoCompactionsLast7Days: stats.autoCompactionsLast7Days,
 			missedPotential: stats.missedPotential ?? [],
 			customizationMatrix: stats.customizationMatrix,
 		};
@@ -3406,6 +3407,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			last30Days: stats.last30Days,
 			month: stats.month,
 			lastMonth: stats.lastMonth,
+			autoCompactionsLast7Days: stats.autoCompactionsLast7Days,
 			missedPotential: stats.missedPotential ?? [],
 			customizationMatrix: stats.customizationMatrix,
 			todaySessions: stats.todaySessions,
@@ -4037,12 +4039,14 @@ class CopilotTokenTracker implements vscode.Disposable {
 		let recentSessions: { last7: TodaySessionSummary[]; last30: TodaySessionSummary[]; currentMonth: TodaySessionSummary[] } | undefined;
 		let correctionReport: CorrectionReport | undefined;
 		let repeatedTasks: RepeatedTaskReport | undefined;
+		let autoCompactionsLast7Days: UsageAnalysisStats['autoCompactionsLast7Days'];
 		try {
 			const { results: usageResults, totalFiles } = await this.loadUsageSessionFiles(preloaded, cutoffMs);
 			const periods = { todayStats, last30DaysStats, monthStats, lastMonthStats, todayUtcKey, last30DaysUtcStartKey, monthUtcStartKey, lastMonthUtcStartKey, lastMonthUtcEndKey };
 			const wsMaps = { workspaceSessionCounts, workspaceInteractionCounts, unresolvedWorkspaceIds, unresolvedWorkspaceInteractionCounts };
 			this.aggregateUsageFileResults(usageResults, periods, wsMaps, todaySessionsList, totalFiles);
 			recentSessions = this.buildRecentSessionBuckets(usageResults, now);
+			autoCompactionsLast7Days = this.buildAutoCompactionStats(usageResults, now);
 			correctionReport = this.buildCorrectionReport(usageResults);
 			repeatedTasks = this.buildRepeatedTaskReport(usageResults);
 			this._lastSkillCallsByEditor = {};
@@ -4073,6 +4077,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			repeatedTasks,
 			curationAnalysis: this.computeCurationAnalysis(last30DaysStats),
 			agenticDailyTrend,
+			autoCompactionsLast7Days,
 		};
 		this.lastUsageAnalysisStats = stats;
 		return stats;
@@ -4558,6 +4563,24 @@ class CopilotTokenTracker implements vscode.Disposable {
 		return this.buildRecentSessionItems(results)
 			.filter(it => it.activityKey >= startKey)
 			.map(it => it.value);
+	}
+
+	/**
+	 * Aggregate the two explicit automatic-compaction signals emitted by supported
+	 * session formats without exposing them as regular tool calls.
+	 */
+	private buildAutoCompactionStats(
+		results: ({ sessionFile: string; sessionData: SessionFileCache; mtime: number } | null | undefined)[],
+		now: Date,
+	): NonNullable<UsageAnalysisStats['autoCompactionsLast7Days']> {
+		const startKey = getTimeWindowStartDayKey('last7', now);
+		const bySource = { copilotCli: 0, claude: 0 };
+		for (const result of results) {
+			if (!result || this.computeLastActivityKey(result.sessionData, result.mtime) < startKey) { continue; }
+			bySource.copilotCli += result.sessionData.truncationCount ?? 0;
+			bySource.claude += result.sessionData.usageAnalysis?.toolCalls.byTool['__auto_compact__'] ?? 0;
+		}
+		return { total: bySource.copilotCli + bySource.claude, bySource };
 	}
 
 	private buildRecentSessionItems(
@@ -7494,6 +7517,7 @@ private computeFallbackDailyRollup(
 		return {
 			today: analysisStats.today, last30Days: analysisStats.last30Days,
 			month: analysisStats.month, lastMonth: analysisStats.lastMonth,
+			autoCompactionsLast7Days: analysisStats.autoCompactionsLast7Days,
 			locale: analysisStats.locale,
 			customizationMatrix: analysisStats.customizationMatrix || null,
 			missedPotential: analysisStats.missedPotential || [],
@@ -11721,6 +11745,7 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString(), startedAtMs)}
       last30Days: stats.last30Days,
       month: stats.month,
       lastMonth: stats.lastMonth,
+      autoCompactionsLast7Days: stats.autoCompactionsLast7Days,
       locale: detectedLocale,
       customizationMatrix: stats.customizationMatrix || null,
       missedPotential: stats.missedPotential || [],

--- a/vscode-extension/src/insightsEngine.ts
+++ b/vscode-extension/src/insightsEngine.ts
@@ -6,6 +6,7 @@
  */
 import type {
 	UsageAnalysisPeriod,
+	AutomaticCompactionStats,
 	MissedPotentialWorkspace,
 	WorkspaceCustomizationMatrix,
 	TodaySessionSummary,
@@ -279,6 +280,8 @@ export interface InsightContext {
 	month?: UsageAnalysisPeriod;
 	/** Previous full calendar month — enables month-over-month trend insights. */
 	lastMonth?: UsageAnalysisPeriod;
+	/** Automatic context compactions recorded during the trailing seven days. */
+	autoCompactionsLast7Days?: AutomaticCompactionStats;
 	missedPotential: MissedPotentialWorkspace[];
 	customizationMatrix?: WorkspaceCustomizationMatrix | null;
 	todaySessions?: TodaySessionSummary[];
@@ -332,9 +335,19 @@ interface InsightDefinition {
 }
 
 // ---------------------------------------------------------------------------
-/** Count of auto-compaction events in a period (Claude Code / Desktop only). */
-function autoCompactCount(p: UsageAnalysisPeriod): number {
-	return p.toolCalls.byTool['__auto_compact__'] ?? 0;
+/** Count of automatic compactions across all supported session formats in the trailing week. */
+function autoCompactCount(ctx: InsightContext): number {
+	return ctx.autoCompactionsLast7Days?.total ?? 0;
+}
+
+function autoCompactBreakdown(stats: AutomaticCompactionStats): string {
+	const sources: Array<[string, number]> = [
+		['GitHub Copilot CLI', stats.bySource.copilotCli],
+		['Claude', stats.bySource.claude],
+	];
+	return sources.filter(([, count]) => count > 0)
+		.map(([source, count]) => `${source}: ${count}`)
+		.join('; ');
 }
 
 // Starter catalog
@@ -906,14 +919,15 @@ export const INSIGHT_CATALOG: InsightDefinition[] = [
 		id: 'auto-compaction-pattern',
 		category: 'consistency',
 		severity: 'opportunity',
-		title: '⚠️ Claude Code is auto-compacting your sessions',
+		title: '⚠️ Your sessions are auto-compacting frequently',
 		buildBody: (ctx) => {
-			const n = autoCompactCount(ctx.last30Days);
-			return `Claude Code hit the context window limit and auto-compacted ${n} session${n !== 1 ? 's' : ''} in the last 30 days. ` +
+			const stats = ctx.autoCompactionsLast7Days!;
+			const n = autoCompactCount(ctx);
+			return `Your sessions automatically compacted ${n} time${n !== 1 ? 's' : ''} in the last 7 days (${autoCompactBreakdown(stats)}). ` +
 				`Auto-compaction means earlier context was lost without your control — you may have noticed replies suddenly lacking earlier detail. ` +
-				`To avoid this: start a fresh chat (\`/new\`) when switching tasks, and use \`/compact\` yourself before the window fills.`;
+				`To avoid this: start a fresh chat (\`/new\`) when switching tasks, and use \`/compact\` yourself in Claude before the window fills.`;
 		},
-		appliesTo: (ctx) => autoCompactCount(ctx.last30Days) >= 2,
+		appliesTo: (ctx) => autoCompactCount(ctx) > 5,
 		weight: 65,
 		allowToast: true,
 	},

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -45,6 +45,14 @@ type ContextWindowStats = {
 	maxReachedWindowLimit?: number;
 };
 
+type AutomaticCompactionStats = {
+	total: number;
+	bySource: {
+		copilotCli: number;
+		claude: number;
+	};
+};
+
 type UsageAnalysisPeriod = {
 	sessions: number;
 	toolCalls: ToolCallUsage;
@@ -178,6 +186,7 @@ type UsageAnalysisStats = {
 	last30Days: UsageAnalysisPeriod;
 	month: UsageAnalysisPeriod;
 	lastMonth: UsageAnalysisPeriod;
+	autoCompactionsLast7Days?: AutomaticCompactionStats;
 	locale?: string;
 	lastUpdated: string;
 	customizationMatrix?: WorkspaceCustomizationMatrix | null;
@@ -4158,6 +4167,28 @@ function renderContextWindowPeriodHtml(cw: ContextWindowStats | undefined): stri
 	return _cwLargestRequestRow(cw!) + _cwFullestWindowRow(cw!) + tierRow;
 }
 
+function renderAutomaticCompactions(stats: AutomaticCompactionStats | undefined): string {
+	if (!stats) { return ''; }
+	const sources: Array<[string, number]> = [
+		['GitHub Copilot CLI', stats.bySource.copilotCli],
+		['Claude', stats.bySource.claude],
+	];
+	const entries = sources.filter(([, count]) => count > 0)
+		.map(([source, count]) => `${escapeHtml(source)} ×${formatNumber(count)}`);
+	const breakdown = entries.length > 0
+		? entries.join(', ')
+		: 'No automatic compactions detected';
+	return `
+		<div class="automatic-compactions-card${stats.total > 0 ? ' automatic-compactions-card--active' : ''}"
+			title="Automatic compactions remove earlier messages to fit the context window and can affect response quality.">
+			<div>
+				<div class="automatic-compactions-label">↩ Automatic compactions (last 7 days)</div>
+				<div class="automatic-compactions-detail">${breakdown}</div>
+			</div>
+			<div class="automatic-compactions-value">${formatNumber(stats.total)}</div>
+		</div>`;
+}
+
 /**
  * Bottom-of-tab section: largest request per period vs the long-context
  * pricing threshold, fullest CLI window, and context tiers used.
@@ -4184,6 +4215,7 @@ function buildContextWindowSectionHtml(stats: UsageAnalysisStats): string {
 					${renderContextWindowPeriodHtml(stats.lastMonth.contextWindow)}
 				</div>
 			</div>
+			${renderAutomaticCompactions(stats.autoCompactionsLast7Days)}
 			${bar}
 		</div>`;
 }

--- a/vscode-extension/src/webview/usage/styles.css
+++ b/vscode-extension/src/webview/usage/styles.css
@@ -77,6 +77,41 @@ body {
 	margin-bottom: 12px;
 }
 
+.automatic-compactions-card {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px;
+	margin: 0 0 14px;
+	padding: 10px 12px;
+	border: 1px solid var(--border-color);
+	border-radius: 6px;
+	background: var(--list-hover-bg);
+}
+
+.automatic-compactions-card--active {
+	border-color: var(--warning-color, #cca700);
+}
+
+.automatic-compactions-label {
+	font-size: 13px;
+	font-weight: 700;
+	color: var(--text-primary);
+}
+
+.automatic-compactions-detail {
+	margin-top: 2px;
+	font-size: 11px;
+	color: var(--text-secondary);
+}
+
+.automatic-compactions-value {
+	font-size: 24px;
+	font-weight: 700;
+	color: var(--text-primary);
+	font-variant-numeric: tabular-nums;
+}
+
 .stats-grid {
 	display: grid;
 	grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));

--- a/vscode-extension/test/unit/insightsEngine.test.ts
+++ b/vscode-extension/test/unit/insightsEngine.test.ts
@@ -42,15 +42,18 @@ function emptyPeriod(): UsageAnalysisPeriod {
 function makeCtx(overrides?: { autoCompact?: number; manualCompact?: number }): InsightContext {
 	const last30Days = emptyPeriod();
 	last30Days.sessions = 20;
-	if (overrides?.autoCompact) {
-		last30Days.toolCalls.byTool['__auto_compact__'] = overrides.autoCompact;
-	}
 	if (overrides?.manualCompact) {
 		last30Days.toolCalls.byTool['__slash__compact'] = overrides.manualCompact;
 	}
 	return {
 		today: emptyPeriod(),
 		last30Days,
+		...(overrides?.autoCompact !== undefined ? {
+			autoCompactionsLast7Days: {
+				total: overrides.autoCompact,
+				bySource: { copilotCli: overrides.autoCompact, claude: 0 },
+			},
+		} : {}),
 		missedPotential: [],
 	};
 }
@@ -66,28 +69,28 @@ test('auto-compaction-pattern: insight exists in INSIGHT_CATALOG', () => {
 	assert.ok(def, 'auto-compaction-pattern should be in INSIGHT_CATALOG');
 });
 
-test('auto-compaction-pattern: does NOT fire when __auto_compact__ is absent', () => {
+test('auto-compaction-pattern: does NOT fire when seven-day data is absent', () => {
 	const ctx = makeCtx();
 	const results = evaluateInsights(ctx, {}, 7, null);
 	const insight = results.find(i => i.id === AUTO_COMPACT_ID);
 	assert.equal(insight, undefined);
 });
 
-test('auto-compaction-pattern: does NOT fire when __auto_compact__ = 1 (below threshold)', () => {
-	const ctx = makeCtx({ autoCompact: 1 });
+test('auto-compaction-pattern: does NOT fire at five weekly compactions', () => {
+	const ctx = makeCtx({ autoCompact: 5 });
 	const results = evaluateInsights(ctx, {}, 7, null);
 	const insight = results.find(i => i.id === AUTO_COMPACT_ID);
 	assert.equal(insight, undefined);
 });
 
-test('auto-compaction-pattern: fires when __auto_compact__ = 2 (threshold)', () => {
-	const ctx = makeCtx({ autoCompact: 2 });
+test('auto-compaction-pattern: fires at six weekly compactions', () => {
+	const ctx = makeCtx({ autoCompact: 6 });
 	const results = evaluateInsights(ctx, {}, 7, null);
 	const insight = results.find(i => i.id === AUTO_COMPACT_ID);
-	assert.ok(insight, 'insight should fire at count = 2');
+	assert.ok(insight, 'insight should fire at count = 6');
 });
 
-test('auto-compaction-pattern: fires when __auto_compact__ > 2', () => {
+test('auto-compaction-pattern: fires above the weekly threshold', () => {
 	const ctx = makeCtx({ autoCompact: 7 });
 	const results = evaluateInsights(ctx, {}, 7, null);
 	const insight = results.find(i => i.id === AUTO_COMPACT_ID);
@@ -95,11 +98,23 @@ test('auto-compaction-pattern: fires when __auto_compact__ > 2', () => {
 });
 
 test('auto-compaction-pattern: body includes auto-compact count', () => {
-	const ctx = makeCtx({ autoCompact: 3 });
+	const ctx = makeCtx({ autoCompact: 6 });
 	const results = evaluateInsights(ctx, {}, 7, null);
 	const insight = results.find(i => i.id === AUTO_COMPACT_ID);
 	assert.ok(insight);
-	assert.ok(insight!.body.includes('3'), 'body should mention the count (3)');
+	assert.ok(insight!.body.includes('6'), 'body should mention the count (6)');
+});
+
+test('auto-compaction-pattern: names all contributing session formats', () => {
+	const ctx = makeCtx();
+	ctx.autoCompactionsLast7Days = {
+		total: 6,
+		bySource: { copilotCli: 4, claude: 2 },
+	};
+	const insight = evaluateInsights(ctx, {}, 7, null).find(i => i.id === AUTO_COMPACT_ID);
+	assert.ok(insight);
+	assert.match(insight.body, /GitHub Copilot CLI: 4/);
+	assert.match(insight.body, /Claude: 2/);
 });
 
 test('auto-compaction-pattern: has severity=opportunity', () => {
@@ -118,7 +133,7 @@ test('auto-compaction-pattern: has category=consistency', () => {
 });
 
 test('auto-compaction-pattern: body mentions /compact and /new', () => {
-	const ctx = makeCtx({ autoCompact: 2 });
+	const ctx = makeCtx({ autoCompact: 6 });
 	const results = evaluateInsights(ctx, {}, 7, null);
 	const insight = results.find(i => i.id === AUTO_COMPACT_ID);
 	assert.ok(insight);


### PR DESCRIPTION
Automatic session compactions were tracked only in provider-specific paths and were easy to miss in Usage Analysis. This makes their frequency visible across GitHub Copilot CLI and Claude, and warns when frequent compactions may indicate context pressure.

- Aggregates explicit GitHub Copilot CLI truncation events and Claude auto-compaction events over the last seven days.
- Displays a prominent Context Window card with the total and provider breakdown.
- Surfaces an insight only when more than five automatic compactions occur in a week.
- Updates insight coverage and the Usage Analysis visual fixture.