### PR TITLE
Improve recent session readability

### DIFF
--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -1119,18 +1119,22 @@ type SessionColumnDef = {
 	render: (s: TodaySessionSummary) => { html: string; title?: string };
 };
 
+function formatCompactSessionNumber(value: number): { html: string; title: string } {
+	return { html: formatCompact(value), title: formatNumber(value) };
+}
+
 const SESSION_COLUMN_DEFS: SessionColumnDef[] = [
-	{ id: 'interactions', label: 'Turns', sortKey: 'interactions', align: 'right', render: s => ({ html: formatNumber(s.interactions) }) },
-	{ id: 'toolCalls', label: 'Tools', sortKey: 'toolCalls', align: 'right', render: s => ({ html: formatNumber(s.toolCalls) }) },
+	{ id: 'interactions', label: 'Turns', sortKey: 'interactions', align: 'right', render: s => formatCompactSessionNumber(s.interactions) },
+	{ id: 'toolCalls', label: 'Tools', sortKey: 'toolCalls', align: 'right', render: s => formatCompactSessionNumber(s.toolCalls) },
 	{ id: 'subAgentCalls', label: 'Sub-Agents', sortKey: 'subAgentCalls', align: 'right', render: s => s.subAgentCalls
-		? { html: formatNumber(s.subAgentCalls), title: `${s.subAgentCalls} sub-agent tool call${s.subAgentCalls === 1 ? '' : 's'} detected in this session` }
+		? { ...formatCompactSessionNumber(s.subAgentCalls), title: `${formatNumber(s.subAgentCalls)} sub-agent tool call${s.subAgentCalls === 1 ? '' : 's'} detected in this session` }
 		: { html: '—', title: 'No sub-agent calls detected in this session' } },
-	{ id: 'inputTokens', label: 'Input', sortKey: 'inputTokens', align: 'right', render: s => ({ html: formatNumber(s.inputTokens) }) },
-	{ id: 'outputTokens', label: 'Output', sortKey: 'outputTokens', align: 'right', render: s => ({ html: formatNumber(s.outputTokens) }) },
-	{ id: 'thinkingTokens', label: 'Thinking', sortKey: 'thinkingTokens', align: 'right', render: s => ({ html: formatNumber(s.thinkingTokens) }) },
-	{ id: 'cachedTokens', label: 'Cached', sortKey: 'cachedTokens', align: 'right', render: s => ({ html: formatNumber(s.cachedTokens) }) },
-	{ id: 'totalTokens', label: 'Total', sortKey: 'totalTokens', align: 'right', render: s => ({ html: formatNumber(s.totalTokens) }) },
-	{ id: 'estimatedCost', label: 'Cost', sortKey: 'estimatedCost', align: 'right', render: s => ({ html: s.estimatedCost > 0 ? `$${s.estimatedCost.toFixed(4)}` : '—' }) },
+	{ id: 'inputTokens', label: 'Input', sortKey: 'inputTokens', align: 'right', render: s => formatCompactSessionNumber(s.inputTokens) },
+	{ id: 'outputTokens', label: 'Output', sortKey: 'outputTokens', align: 'right', render: s => formatCompactSessionNumber(s.outputTokens) },
+	{ id: 'thinkingTokens', label: 'Thinking', sortKey: 'thinkingTokens', align: 'right', render: s => formatCompactSessionNumber(s.thinkingTokens) },
+	{ id: 'cachedTokens', label: 'Cached', sortKey: 'cachedTokens', align: 'right', render: s => formatCompactSessionNumber(s.cachedTokens) },
+	{ id: 'totalTokens', label: 'Total', sortKey: 'totalTokens', align: 'right', render: s => formatCompactSessionNumber(s.totalTokens) },
+	{ id: 'estimatedCost', label: 'Cost', sortKey: 'estimatedCost', align: 'right', render: s => ({ html: s.estimatedCost > 0 ? formatCost(s.estimatedCost) : '—' }) },
 	{ id: 'editor', label: 'Editor', sortKey: 'editor', align: 'left', render: s => ({ html: escapeHtml(s.editor || 'unknown') }) },
 	{ id: 'workspace', label: 'Workspace', sortKey: 'workspace', align: 'left', cellStyle: 'max-width:140px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;', render: s => { const workspace = escapeHtml(s.workspace || '—'); return { html: workspace, title: workspace }; } },
 	{ id: 'models', label: 'Models', align: 'left', cellStyle: 'font-size:11px; max-width:180px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;', render: s => { const models = s.models.map(m => escapeHtml(getModelDisplayName(m))).join(', ') || '—'; return { html: models, title: models }; } },
@@ -1214,6 +1218,9 @@ function buildSessionsTableHtml(sessions: TodaySessionSummary[]): string {
 	const rows = sorted.map((s, idx) => {
 		const title = escapeHtml(s.title || 'Untitled session');
 		const filePath = escapeHtml(s.filePath || '');
+		const hydraFusionBadge = s.models.some(model => model.toLowerCase().includes('hydrafusion'))
+			? '<span class="hydrafusion-session-badge" title="This session used HydraFusion" style="display:inline-block; margin-right:4px; padding:1px 5px; border:1px solid var(--vscode-badge-background, var(--accent-color)); border-radius:999px; background:var(--vscode-badge-background, var(--accent-color)); color:var(--vscode-badge-foreground, var(--bg-primary)); font-size:10px; font-weight:600; line-height:14px; vertical-align:middle;">HydraFusion</span>'
+			: '';
 		const optionalCells = visibleColumns.map(col => {
 			const { html, title: cellTitle } = col.render(s);
 			const alignStyle = col.align === 'right' ? 'text-align:right;' : '';
@@ -1222,7 +1229,7 @@ function buildSessionsTableHtml(sessions: TodaySessionSummary[]): string {
 		}).join('');
 		return `<tr>
 			<td style="padding:6px 8px; border-bottom:1px solid var(--border-subtle); font-size:12px; color:var(--text-secondary);">${idx + 1}</td>
-			<td style="padding:6px 8px; border-bottom:1px solid var(--border-subtle); font-size:12px; max-width:200px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;" title="Open viewer for session &quot;${title}&quot;"><a href="#" class="session-title-link" data-file="${filePath}" style="color:var(--link-color, #4fc1ff); text-decoration:none; cursor:pointer;">${title}</a></td>
+			<td style="padding:6px 8px; border-bottom:1px solid var(--border-subtle); font-size:12px; max-width:200px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;" title="Open viewer for session &quot;${title}&quot;"><a href="#" class="session-title-link" data-file="${filePath}" style="color:var(--link-color, #4fc1ff); text-decoration:none; cursor:pointer;">${hydraFusionBadge}${title}</a></td>
 			${optionalCells}
 		</tr>`;
 	}).join('');

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -1138,7 +1138,9 @@ const SESSION_COLUMN_DEFS: SessionColumnDef[] = [
 	{ id: 'thinkingTokens', label: 'Thinking', sortKey: 'thinkingTokens', align: 'right', render: s => formatCompactSessionNumber(s.thinkingTokens) },
 	{ id: 'cachedTokens', label: 'Cached', sortKey: 'cachedTokens', align: 'right', render: s => formatCompactSessionNumber(s.cachedTokens) },
 	{ id: 'totalTokens', label: 'Total', sortKey: 'totalTokens', align: 'right', render: s => formatCompactSessionNumber(s.totalTokens) },
-	{ id: 'estimatedCost', label: 'Cost', sortKey: 'estimatedCost', align: 'right', render: s => ({ html: s.estimatedCost > 0 ? formatCost(s.estimatedCost) : '—' }) },
+	{ id: 'estimatedCost', label: 'Cost', sortKey: 'estimatedCost', align: 'right', render: s => s.estimatedCost > 0
+		? { html: formatCost(s.estimatedCost), title: `$${s.estimatedCost.toFixed(4)}` }
+		: { html: '—' } },
 	{ id: 'editor', label: 'Editor', sortKey: 'editor', align: 'left', render: s => ({ html: escapeHtml(s.editor || 'unknown') }) },
 	{ id: 'workspace', label: 'Workspace', sortKey: 'workspace', align: 'left', cellStyle: 'max-width:140px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;', render: s => { const workspace = escapeHtml(s.workspace || '—'); return { html: workspace, title: workspace }; } },
 	{ id: 'models', label: 'Models', align: 'left', cellStyle: 'font-size:11px; max-width:180px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;', render: s => { const models = s.models.map(m => escapeHtml(getModelDisplayName(m))).join(', ') || '—'; return { html: models, title: models }; } },

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -13,7 +13,7 @@ import themeStyles from '../shared/theme.css';
 import styles from './styles.css';
 import { getWindowData } from '../../../../src/webview/shared/dataLoader';
 import { registerMessageHandler } from '../shared/messageHandler';
-import { getModelDisplayName } from '../../../../src/webview/shared/modelUtils';
+import { getModelDisplayName, getModelLookupCandidates } from '../../../../src/webview/shared/modelUtils';
 import { getModelBillingProvider } from '../../../../src/chartDataBuilder';
 import { getLongContextInfo } from '../../../../src/tokenEstimation';
 import { deriveModelEfficiencyRates, computeEfficiencyLowUsageThreshold, computeLongTailModels } from '../../../../src/modelEfficiency';
@@ -1123,6 +1123,10 @@ function formatCompactSessionNumber(value: number): { html: string; title: strin
 	return { html: formatCompact(value), title: formatNumber(value) };
 }
 
+function isHydraFusionModel(model: string): boolean {
+	return getModelLookupCandidates(model).some(candidate => candidate.toLowerCase() === 'hydrafusion');
+}
+
 const SESSION_COLUMN_DEFS: SessionColumnDef[] = [
 	{ id: 'interactions', label: 'Turns', sortKey: 'interactions', align: 'right', render: s => formatCompactSessionNumber(s.interactions) },
 	{ id: 'toolCalls', label: 'Tools', sortKey: 'toolCalls', align: 'right', render: s => formatCompactSessionNumber(s.toolCalls) },
@@ -1218,7 +1222,7 @@ function buildSessionsTableHtml(sessions: TodaySessionSummary[]): string {
 	const rows = sorted.map((s, idx) => {
 		const title = escapeHtml(s.title || 'Untitled session');
 		const filePath = escapeHtml(s.filePath || '');
-		const hydraFusionBadge = s.models.some(model => model.toLowerCase().includes('hydrafusion'))
+		const hydraFusionBadge = s.models.some(isHydraFusionModel)
 			? '<span class="hydrafusion-session-badge" title="This session used HydraFusion" style="display:inline-block; margin-right:4px; padding:1px 5px; border:1px solid var(--vscode-badge-background, var(--accent-color)); border-radius:999px; background:var(--vscode-badge-background, var(--accent-color)); color:var(--vscode-badge-foreground, var(--bg-primary)); font-size:10px; font-weight:600; line-height:14px; vertical-align:middle;">HydraFusion</span>'
 			: '';
 		const optionalCells = visibleColumns.map(col => {

--- a/vscode-extension/test/unit/usageWebviewMessageFlow.test.ts
+++ b/vscode-extension/test/unit/usageWebviewMessageFlow.test.ts
@@ -289,7 +289,7 @@ test('accepts payloads relayed the way VS Code actually delivers them', async ()
 
 test('marks HydraFusion sessions in the recent sessions list', async () => {
 	const stats = buildStats();
-	stats.todaySessions = [{
+	const hydraFusionSession = {
 		title: 'HydraFusion task',
 		filePath: 'session.jsonl',
 		interactions: 12500,
@@ -303,10 +303,16 @@ test('marks HydraFusion sessions in the recent sessions list', async () => {
 		editor: 'VS Code',
 		models: ['hydrafusion'],
 		lastActivity: '2026-08-31T12:00:00.000Z',
-	}];
+	};
+	stats.todaySessions = [
+		hydraFusionSession,
+		{ ...hydraFusionSession, title: 'Unrelated task', models: ['unrelated-hydrafusion'] },
+	];
 	const harness = await bootWebview(stats);
 
-	const badge = harness.window.document.querySelector('.hydrafusion-session-badge');
+	const badges = harness.window.document.querySelectorAll('.hydrafusion-session-badge');
+	assert.equal(badges.length, 1, 'only the HydraFusion model identifier should be marked');
+	const badge = badges[0];
 	assert.ok(badge, 'expects a marker for HydraFusion sessions');
 	assert.equal(badge.textContent, 'HydraFusion');
 	const row = harness.window.document.querySelector('.sessions-table tbody tr');

--- a/vscode-extension/test/unit/usageWebviewMessageFlow.test.ts
+++ b/vscode-extension/test/unit/usageWebviewMessageFlow.test.ts
@@ -287,6 +287,34 @@ test('accepts payloads relayed the way VS Code actually delivers them', async ()
 	assert.ok(rendered?.includes('ai-engineering-fluency'), `expected the repo table, got: ${rendered}`);
 });
 
+test('marks HydraFusion sessions in the recent sessions list', async () => {
+	const stats = buildStats();
+	stats.todaySessions = [{
+		title: 'HydraFusion task',
+		filePath: 'session.jsonl',
+		interactions: 12500,
+		toolCalls: 1500,
+		inputTokens: 1500000,
+		outputTokens: 12000,
+		thinkingTokens: 2000,
+		cachedTokens: 30000,
+		totalTokens: 1544000,
+		estimatedCost: 12.345,
+		editor: 'VS Code',
+		models: ['hydrafusion'],
+		lastActivity: '2026-08-31T12:00:00.000Z',
+	}];
+	const harness = await bootWebview(stats);
+
+	const badge = harness.window.document.querySelector('.hydrafusion-session-badge');
+	assert.ok(badge, 'expects a marker for HydraFusion sessions');
+	assert.equal(badge.textContent, 'HydraFusion');
+	const row = harness.window.document.querySelector('.sessions-table tbody tr');
+	assert.match(row.textContent, /12\.5K/);
+	assert.match(row.textContent, /1\.5M/);
+	assert.match(row.textContent, /\$12\.35/);
+});
+
 test('renders cloud agent session results', async () => {
 	const harness = await bootWebview(buildStats());
 

--- a/vscode-extension/test/unit/usageWebviewMessageFlow.test.ts
+++ b/vscode-extension/test/unit/usageWebviewMessageFlow.test.ts
@@ -319,6 +319,8 @@ test('marks HydraFusion sessions in the recent sessions list', async () => {
 	assert.match(row.textContent, /12\.5K/);
 	assert.match(row.textContent, /1\.5M/);
 	assert.match(row.textContent, /\$12\.35/);
+	const costCell = [...row.cells].find(cell => cell.textContent === '$12.35');
+	assert.equal(costCell?.title, '$12.3450');
 });
 
 test('renders cloud agent session results', async () => {


### PR DESCRIPTION
Recent sessions using HydraFusion were difficult to spot, and full token counts made the table harder to scan.

- Add a HydraFusion pill before matching session titles.
- Use compact K/M formatting for Recent Sessions numeric columns while preserving exact values on hover.
- Round displayed session costs to two decimal places.