### PR TITLE
chore: upgrade fast-uri to 4.1.4

### DIFF
--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -6732,9 +6732,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.2.tgz",
-      "integrity": "sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.4.tgz",
+      "integrity": "sha512-dODXrIxlS9JSdgAnhIUKOosKV1oMtU2VtVw87QRaHzyl5jxO290Ii5tEZfCfzfWNHi3jKWwBSdQj0qIyshdZdQ==",
       "dev": true,
       "funding": [
         {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -588,7 +588,7 @@
     "brace-expansion": ">=5.0.8",
     "diff": ">=8.0.3",
     "dompurify": ">=3.4.13",
-    "fast-uri": ">=4.1.2",
+    "fast-uri": ">=4.1.4",
     "qs": ">=6.15.2",
     "serialize-javascript": ">=7.0.3",
     "cheerio": {


### PR DESCRIPTION
## Summary

Update the VS Code extension override for ast-uri from >=4.1.2 to >=4.1.4 so the lockfile resolves a fixed, non-vulnerable version.

## Changes

- bump the ast-uri override in scode-extension/package.json
- refresh scode-extension/package-lock.json to ast-uri 4.1.4

## Validation

- cd vscode-extension && npm ci
- cd vscode-extension && npm run validate

This remediation addresses Dependabot alerts #178-#181 for the fast-uri advisory in scode-extension/package-lock.json.