### PR TITLE
Preserve Copilot App labels in sharing uploads

### DIFF
--- a/docs/sharing-server/README.md
+++ b/docs/sharing-server/README.md
@@ -153,6 +153,9 @@ members of that GitHub organization.
   `shareWorkspaceMachineNames` setting (off by default).
 - **Rollups only** — The extension sends daily aggregates (tokens, interactions, model
   names), not raw prompts or completions.
+- **Editor attribution** — Each rollup includes the session's editor label. This preserves
+  session-specific sources such as `Copilot CLI (App)` separately from terminal
+  `Copilot CLI` usage in the team dashboard.
 
 ---
 

--- a/sharing-server/README.md
+++ b/sharing-server/README.md
@@ -186,6 +186,7 @@ Content-Type: application/json
     "workspaceName": "My Project",
     "machineId": "laptop-abc123",
     "machineName": "My Laptop",
+    "editor": "Copilot CLI (App)",
     "inputTokens": 15000,
     "outputTokens": 8000,
     "interactions": 42,
@@ -195,7 +196,7 @@ Content-Type: application/json
 ```
 
 Accepts up to **500 entries per request**. The server upserts by
-`(user_id, dataset_id, day, model, workspace_id, machine_id)` so repeated
+`(user_id, dataset_id, day, model, workspace_id, machine_id, editor)` so repeated
 uploads are safe and idempotent.
 
 ### Other endpoints
@@ -312,11 +313,11 @@ users (
 
 usage_uploads (
   id, user_id, dataset_id, day, model,
-  workspace_id, workspace_name, machine_id, machine_name,
+  workspace_id, workspace_name, machine_id, machine_name, editor,
   input_tokens, output_tokens, interactions, schema_version,
   uploaded_at
 )
--- UNIQUE(user_id, dataset_id, day, model, workspace_id, machine_id)
+-- UNIQUE(user_id, dataset_id, day, model, workspace_id, machine_id, editor)
 ```
 
 ## Backup

--- a/vscode-extension/src/backend/facade.ts
+++ b/vscode-extension/src/backend/facade.ts
@@ -85,6 +85,8 @@ export interface BackendFacadeDeps {
   }>;
   // Visual Studio session detection (binary MessagePack — cannot be parsed as JSON)
   isVSSessionFile?: (sessionFile: string) => boolean;
+  /** Resolves session-specific labels such as Copilot CLI (App). */
+  getEditorLabel?: (sessionFile: string) => string;
   /** Returns the current GitHub OAuth access token, or undefined if not authenticated. */
   getGithubToken?: () => string | undefined;
 }
@@ -150,6 +152,7 @@ export class BackendFacade {
         },
         updateTokenStats: deps.updateTokenStats,
         getGithubToken: deps.getGithubToken,
+        getEditorLabel: deps.getEditorLabel,
       },
       this.credentialService,
       this.dataPlaneService,
@@ -1096,7 +1099,6 @@ export class BackendFacade {
     return true;
   }
 }
-
 
 
 

--- a/vscode-extension/src/backend/services/syncService.ts
+++ b/vscode-extension/src/backend/services/syncService.ts
@@ -109,6 +109,8 @@ export interface SyncServiceDeps {
 	updateTokenStats?: () => Promise<void>;
 	/** Returns the current GitHub OAuth access token, or undefined if not authenticated. */
 	getGithubToken?: () => string | undefined;
+	/** Resolves the session-specific editor label supplied by an ecosystem adapter. */
+	getEditorLabel?: (sessionFile: string) => string;
 }
 
 /**
@@ -1287,7 +1289,8 @@ return true;
 
 	private getEditorForFile(sessionFile: string, includeEditorDimension: boolean): string | undefined {
 		if (!includeEditorDimension) { return undefined; }
-		return getEditorTypeFromPath(sessionFile, this.deps.editorHandlers?.isOpenCodeSession);
+		return this.deps.getEditorLabel?.(sessionFile) ??
+			getEditorTypeFromPath(sessionFile, this.deps.editorHandlers?.isOpenCodeSession);
 	}
 
 	private isVSSessionFileType(sessionFile: string): boolean {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -749,7 +749,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 	 * Extract custom agent name from a file:// URI pointing to a .agent.md file.
 	 * Returns the filename without the .agent.md extension.
 	 */
-	private getEditorTypeFromPath(filePath: string): string {
+	public getEditorTypeFromPath(filePath: string): string {
 		return this._resolveEditorLabel(filePath) ??
 			_getEditorTypeFromPath(filePath, (p) => this.findEcosystem(p)?.id === 'opencode');
 	}
@@ -12037,6 +12037,8 @@ function createBackendFacade(context: vscode.ExtensionContext, tokenTracker: Cop
     isVSSessionFile: (sessionFile: string) =>
       tokenTracker.visualStudio.isVSSessionFile(sessionFile),
     getGithubToken: () => tokenTracker.githubSession?.accessToken,
+    getEditorLabel: (sessionFile: string) =>
+      tokenTracker.getEditorTypeFromPath(sessionFile),
   });
 }
 

--- a/vscode-extension/test/unit/backend-syncService.test.ts
+++ b/vscode-extension/test/unit/backend-syncService.test.ts
@@ -31,6 +31,7 @@ interface FlatDepsOverrides {
 	getCrushSessionData?: (sessionFile: string) => Promise<any>;
 	isVSSessionFile?: (sessionFile: string) => boolean;
 	getGithubToken?: () => string | undefined;
+	getEditorLabel?: (sessionFile: string) => string;
 }
 
 function makeDeps(overrides?: FlatDepsOverrides): SyncServiceDeps {
@@ -56,6 +57,7 @@ function makeDeps(overrides?: FlatDepsOverrides): SyncServiceDeps {
 		},
 		updateTokenStats: overrides?.updateTokenStats,
 		getGithubToken: overrides?.getGithubToken,
+		getEditorLabel: overrides?.getEditorLabel,
 	};
 }
 
@@ -700,6 +702,52 @@ test('computeDailyRollupsFromLocalSessions processes JSONL files in fallback pat
 	} finally {
 		tmpFile.cleanup();
 	}
+});
+
+test('syncToSharingServer preserves the Copilot App editor label in uploaded rollups', async () => {
+	const dayKey = new Date().toISOString().slice(0, 10);
+	const sessionFile = '/home/user/.copilot/session-state/app-session/events.jsonl';
+	const uploadedEntries: Array<{ editor?: string }> = [];
+	const svc = new SyncService(
+		makeDeps({
+			getGithubToken: () => 'github-token',
+			getCopilotSessionFiles: async () => [sessionFile],
+			getEditorLabel: () => 'Copilot CLI (App)',
+			statSessionFile: async () => ({ mtimeMs: Date.now(), size: 100 } as any),
+			getSessionFileDataCached: async () => ({
+				tokens: 300,
+				mtime: Date.now(),
+				interactions: 1,
+				modelUsage: { 'gpt-4o': { inputTokens: 100, outputTokens: 200 } },
+				dailyRollups: {
+					[dayKey]: {
+						tokens: 300,
+						actualTokens: 300,
+						thinkingTokens: 0,
+						interactions: 1,
+						modelUsage: { 'gpt-4o': { inputTokens: 100, outputTokens: 200 } },
+					},
+				},
+			}),
+		}),
+		{} as any,
+		{} as any,
+		undefined,
+		BackendUtility,
+		{
+			uploadRollups: async (_endpoint: string, _token: string, entries: Array<{ editor?: string }>) => {
+				uploadedEntries.push(...entries);
+				return { success: true, entriesUploaded: entries.length, message: 'Uploaded' };
+			},
+		} as any,
+	);
+
+	await (svc as any).syncToSharingServer(
+		{ lookbackDays: 7, datasetId: 'default', sharingServerEndpointUrl: 'https://sharing.example.com' },
+		{ allowCloudSync: true, includeUserDimension: false, includeNames: false },
+	);
+
+	assert.deepEqual(uploadedEntries.map(entry => entry.editor), ['Copilot CLI (App)']);
 });
 
 test('computeDailyRollupsFromLocalSessions skips files older than lookback', async () => {


### PR DESCRIPTION
Copilot App sessions are shown separately in the extension but were collapsed into generic Copilot CLI usage when uploaded to the team sharing server.

The backend facade now forwards the session-aware adapter label into sharing rollups, preserving `Copilot CLI (App)` as its own editor dimension. A regression test verifies the uploaded payload, and the sharing-server documentation defines the `editor` field and its role in the idempotency key.