### PR TITLE
Fix Team Dashboard Azure fallback

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -325,6 +325,7 @@ import { ConfirmationMessages } from './backend/ui/messages';
 
 // --- Utilities ---
 import { getNonce, buildCspMeta, getCodiconStylesheetTag } from './utils/webviewUtils';
+import { getAzureTableStorageEndpoint } from './utils/azureEndpoints';
 import { isGuidMcpTool, isMcpFamilyResolvedTool, lookupKnownToolName } from '../../src/utils/toolUtils';
 import { toLocalDayKey } from '../../src/utils/dayKeys';
 import { buildRecentSessionBuckets as bucketRecentSessions } from '../../src/recentSessions';
@@ -9041,6 +9042,8 @@ private async shareTextToSocialPlatform(shareText: string, platform: 'linkedin' 
       if (await this.dispatchSharedCommand(message)) { return; }
       switch (message.command) {
         case "refresh": await this.dispatch('refresh:dashboard', () => this.refreshDashboardPanel()); break;
+        case "configureBackend": await this.dispatch('configureBackend:dashboard', () => vscode.commands.executeCommand("aiEngineeringFluency.configureBackend")); break;
+        case "configureTeamServer": await this.dispatch('configureTeamServer:dashboard', () => vscode.commands.executeCommand("aiEngineeringFluency.configureTeamServer")); break;
         case "deleteUserDataset": await this.dispatch('deleteUserDataset', () => this.handleDeleteUserDataset(message.userId, message.datasetId)); break;
         case "backfillHistoricalData": await this.dispatch('backfillHistoricalData', () => this.handleBackfillHistoricalData()); break;
         case "openExternal": if (typeof message.url === 'string') { await vscode.env.openExternal(vscode.Uri.parse(message.url)); } break;
@@ -9063,7 +9066,7 @@ private async shareTextToSocialPlatform(shareText: string, platform: 'linkedin' 
     } catch (error) {
       this.error("Failed to load dashboard data:", error);
       if (!this.lastDashboardData) {
-        this.dashboardPanel?.webview.postMessage({ command: "dashboardError", message: "Failed to load dashboard data. Please check backend configuration and try again." });
+        this.showDashboardFailure(this.getAzureDashboardFailureMessage("load dashboard data"));
       }
     }
   }
@@ -9091,10 +9094,7 @@ private async shareTextToSocialPlatform(shareText: string, platform: 'linkedin' 
       this.log("✅ Team Dashboard refreshed");
     } catch (error) {
       this.error("Failed to refresh dashboard:", error);
-      this.dashboardPanel?.webview.postMessage({
-        command: "dashboardError",
-        message: "Failed to refresh dashboard data.",
-      });
+      this.showDashboardFailure(this.getAzureDashboardFailureMessage("refresh dashboard data"));
     }
   }
 
@@ -9146,11 +9146,7 @@ private async shareTextToSocialPlatform(shareText: string, platform: 'linkedin' 
       await this.refreshDashboardPanel();
     } catch (error) {
       this.error("Failed to delete user dataset:", error);
-      this.dashboardPanel?.webview.postMessage({
-        command: "dashboardError",
-        message:
-          "Failed to delete data. Please check backend configuration and try again.",
-      });
+      this.showDashboardFailure(this.getAzureDashboardFailureMessage("delete Azure Storage data"));
     }
   }
 
@@ -9198,10 +9194,7 @@ private async shareTextToSocialPlatform(shareText: string, platform: 'linkedin' 
       await this.refreshDashboardPanel();
     } catch (error) {
       this.error('Backfill failed:', error);
-      this.dashboardPanel?.webview.postMessage({
-        command: 'dashboardError',
-        message: 'Backfill failed. Please check backend configuration and try again.',
-      });
+      this.showDashboardFailure(this.getAzureDashboardFailureMessage("backfill Azure Storage data"));
     }
   }
 
@@ -9549,7 +9542,7 @@ private async shareTextToSocialPlatform(shareText: string, platform: 'linkedin' 
    * Azure is considered configured when all required Azure Storage fields are filled.
    * Team Server is configured when enabled with a valid http/https URL.
    */
-  private getDashboardBackendConfig(): { azureConfigured: boolean; teamServerConfigured: boolean; teamServerUrl: string } {
+  private getDashboardBackendConfig(): { azureConfigured: boolean; azureStorageUrl: string; teamServerConfigured: boolean; teamServerUrl: string } {
     const settings = this.backend?.getSettings();
     const azureConfigured = !!(
       settings?.subscriptionId &&
@@ -9557,8 +9550,26 @@ private async shareTextToSocialPlatform(shareText: string, platform: 'linkedin' 
       settings?.storageAccount &&
       settings?.aggTable
     );
+    const azureStorageUrl = azureConfigured
+      ? getAzureTableStorageEndpoint(settings.storageAccount)
+      : '';
     const teamServerUrl = this.buildTeamServerUrl(settings);
-    return { azureConfigured, teamServerConfigured: !!teamServerUrl, teamServerUrl };
+    return { azureConfigured, azureStorageUrl, teamServerConfigured: !!teamServerUrl, teamServerUrl };
+  }
+
+  private getAzureDashboardFailureMessage(action: string): string {
+    const { azureStorageUrl } = this.getDashboardBackendConfig();
+    const source = azureStorageUrl ? ` from ${azureStorageUrl}` : '';
+    return `Unable to ${action}${source}. Review the Azure Storage configuration and try again.`;
+  }
+
+  private showDashboardFailure(message: string): void {
+    const { teamServerConfigured, teamServerUrl } = this.getDashboardBackendConfig();
+    this.dashboardPanel?.webview.postMessage(
+      teamServerConfigured
+        ? { command: 'dashboardTeamServerFallback', message, url: teamServerUrl }
+        : { command: 'dashboardError', message },
+    );
   }
 
   private buildTeamServerUrl(settings: any): string {

--- a/vscode-extension/src/webview/dashboard/main.ts
+++ b/vscode-extension/src/webview/dashboard/main.ts
@@ -68,6 +68,7 @@ type VSCodeApi = ReturnType<typeof acquireVsCodeApi>;
 
 interface DashboardConfig {
   azureConfigured: boolean;
+  azureStorageUrl: string;
   teamServerConfigured: boolean;
   teamServerUrl: string;
 }
@@ -117,7 +118,12 @@ function showLoading(): void {
 
   const loading = el("div", "loading-indicator");
   const spinner = el("div", "spinner");
-  const loadingText = el("div", "loading-text", "Loading dashboard data...");
+  const serverUrl = currentConfig?.azureStorageUrl;
+  const loadingText = el(
+    "div",
+    "loading-text",
+    serverUrl ? `Loading dashboard data from ${serverUrl}...` : "Loading dashboard data...",
+  );
   loadingTextEl = loadingText;
   loading.append(spinner, loadingText);
 
@@ -147,11 +153,21 @@ function showError(message: string): void {
   buttonRow.append(createButton(BUTTONS["btn-refresh"]));
   header.append(title, buttonRow);
 
-  const errorEl = el("div", "error-message", message);
-
-  container.append(header, errorEl);
+  container.append(header, buildDashboardFailure(message));
   root.append(themeStyle, style, container);
   wireButtons();
+}
+
+function buildDashboardFailure(message: string): HTMLElement {
+  const failure = el("div", "dashboard-failure");
+  const errorEl = el("div", "error-message", message);
+  const configureButton = createButton(
+    "btn-configure-backend",
+    "Configure Azure Storage",
+    "secondary",
+  );
+  failure.append(errorEl, configureButton);
+  return failure;
 }
 
 function render(stats: DashboardStats): void {
@@ -582,8 +598,8 @@ function buildTeamServerPanel(url: string): HTMLElement {
   return panel;
 }
 
-/** Shows the team-server-only full view (when Azure is not configured). */
-function showTeamServerView(url: string): void {
+/** Shows the team-server view, optionally retaining an Azure Storage failure message. */
+function showTeamServerView(url: string, failureMessage?: string): void {
   loadingTextEl = null;
   const root = document.getElementById("root");
   if (!root) { return; }
@@ -612,7 +628,11 @@ function showTeamServerView(url: string): void {
 
   const panel = buildTeamServerPanel(url);
 
-  container.append(header, panel);
+  container.append(header);
+  if (failureMessage) {
+    container.append(buildDashboardFailure(failureMessage));
+  }
+  container.append(panel);
   root.append(themeStyle, style, container);
   wireButtons();
 }
@@ -621,6 +641,12 @@ function wireButtons(): void {
   document.getElementById("btn-refresh")?.addEventListener("click", () => {
     vscode.postMessage({ command: "refresh" });
   });
+
+  document
+    .getElementById("btn-configure-backend")
+    ?.addEventListener("click", () => {
+      vscode.postMessage({ command: "configureBackend" });
+    });
 
   document.getElementById("btn-details")?.addEventListener("click", () => {
     vscode.postMessage({ command: "showDetails" });
@@ -668,8 +694,8 @@ registerMessageHandler((message: any) => {
     case "dashboardError":
       showError(message.message);
       break;
-    case "dashboardTeamServerReload": {
-      // No-op: team server is now a launch card, not an iframe
+    case "dashboardTeamServerFallback": {
+      showTeamServerView(message.url, message.message);
       break;
     }
     case "backfillProgress": {

--- a/vscode-extension/src/webview/dashboard/styles.css
+++ b/vscode-extension/src/webview/dashboard/styles.css
@@ -294,6 +294,14 @@
         text-transform: uppercase;
 }
 
+.dashboard-failure {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 12px;
+        margin-bottom: 24px;
+}
+
 /* Fluency score badges */
 .fluency-cell {
         text-align: center;


### PR DESCRIPTION
A stale Azure Storage configuration could replace the Team Dashboard with an ambiguous load failure even when the Team Server remained available.

This change shows the Azure Table endpoint during loading and in Azure-specific failure messages. When a Team Server is configured, Azure load, refresh, delete, and backfill failures preserve the Team Server launch card, while the new Configure Azure Storage action opens the relevant configuration flow.