### PR TITLE
Pin workflow tool dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,11 +260,12 @@ jobs:
       run: npm ci --ignore-scripts
 
     # Playwright is deliberately not a dependency of the extension - it is
-    # tooling, not shipped code - so the harness looks for a global install.
+    # tooling, not shipped code - so the harness uses a dedicated locked install.
     - name: Install Playwright Chromium
+      working-directory: .github/workflows/dependencies/playwright
       run: |
-        npm install -g playwright@1.56.0
-        npx --yes playwright@1.56.0 install --with-deps chromium
+        npm ci --ignore-scripts --no-audit --no-fund
+        npx --no-install playwright install --with-deps chromium
 
     - name: Compile webview bundles
       working-directory: vscode-extension

--- a/.github/workflows/dependencies/agent-skills-eval/package-lock.json
+++ b/.github/workflows/dependencies/agent-skills-eval/package-lock.json
@@ -1,0 +1,72 @@
+{
+  "name": "workflow-agent-skills-eval",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "workflow-agent-skills-eval",
+      "version": "1.0.0",
+      "dependencies": {
+        "agent-skills-eval": "0.1.1"
+      }
+    },
+    "node_modules/agent-skills-eval": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/agent-skills-eval/-/agent-skills-eval-0.1.1.tgz",
+      "integrity": "sha512-BfCCps2hUw79GUU0fo+04XX1/swCgNSGCY8kEWUeNqzppXX/Z03UiMl5BQzW9ZHdYggr7sRbM0+Y+eqDHcGZzg==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^12.1.0",
+        "js-yaml": "^4.1.1"
+      },
+      "bin": {
+        "agent-skills-eval": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/darkrishabh"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    }
+  }
+}

--- a/.github/workflows/dependencies/agent-skills-eval/package.json
+++ b/.github/workflows/dependencies/agent-skills-eval/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "workflow-agent-skills-eval",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Pinned dependencies for the Agent Skills Eval workflow.",
+  "dependencies": {
+    "agent-skills-eval": "0.1.1"
+  }
+}

--- a/.github/workflows/dependencies/playwright/package-lock.json
+++ b/.github/workflows/dependencies/playwright/package-lock.json
@@ -1,0 +1,42 @@
+{
+  "name": "workflow-playwright",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "workflow-playwright",
+      "version": "1.0.0",
+      "dependencies": {
+        "playwright": "1.63.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.63.0.tgz",
+      "integrity": "sha512-+7ziBLidS4NaNCdt57SUDT+wYmmd5fmiQejUic/kb+YsYSCPyOOE9sebzMjNmQrsnNpDJqd4WHvV/8lfKfUDUg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.63.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.63.0.tgz",
+      "integrity": "sha512-rYCsBF/M5HjUch52bbtVONEFjv6Xu8sm8h72dNlR5bzIE1fvC/bxgspzkjSfU+MweEMmPM8KJebG6nnyxo5mCg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    }
+  }
+}

--- a/.github/workflows/dependencies/playwright/package.json
+++ b/.github/workflows/dependencies/playwright/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "workflow-playwright",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Pinned dependencies for the Webview UI checks workflow.",
+  "dependencies": {
+    "playwright": "1.63.0"
+  }
+}

--- a/.github/workflows/skills-eval.yml
+++ b/.github/workflows/skills-eval.yml
@@ -60,19 +60,17 @@ jobs:
           npx --yes @github/copilot --version
 
       - name: Install agent-skills-eval
+        working-directory: .github/workflows/dependencies/agent-skills-eval
         run: |
           set -euo pipefail
-          mkdir -p /tmp/skills-eval
-          cd /tmp/skills-eval
-          npm init -y > /dev/null
-          npm install --ignore-scripts --no-audit --no-fund agent-skills-eval@0.1.1
+          npm ci --ignore-scripts --no-audit --no-fund
 
       - name: Run agent-skills-eval via the Copilot CLI
         id: eval
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
           COPILOT_GITHUB_TOKEN: ${{ secrets.GH_PAT }}
-          EVAL_PKG_DIR: /tmp/skills-eval
+          EVAL_PKG_DIR: .github/workflows/dependencies/agent-skills-eval
           COPILOT_MODEL: ${{ inputs.model || '' }}
           SKILLS_ROOT: .github/skills
           EVAL_WORKSPACE: ./agent-skills-workspace


### PR DESCRIPTION
## Summary
- replace ad-hoc workflow npm installs with committed, integrity-checked lockfiles
- update the workflow-only Playwright dependency to upstream v1.63.0
- retain agent-skills-eval at its latest available v0.1.1 release

## Validation
- 
pm ci --ignore-scripts --no-audit --no-fund for each workflow lockfile
- 
px --no-install playwright --version reports 1.63.0