### PR TITLE
Remove redundant efficiency waterfall

### DIFF
--- a/vscode-extension/src/webview/efficiency/main.ts
+++ b/vscode-extension/src/webview/efficiency/main.ts
@@ -263,8 +263,6 @@ function renderAttributionTab(d: EfficiencyViewData): string {
 		return `<p class="eff-section-note">Not enough data to decompose the cost change — both compared windows need at least one session with token data.</p>`;
 	}
 	const maxAbs = Math.max(Math.abs(a.volumeEffect), Math.abs(a.efficiencyEffect), Math.abs(a.mixEffect), 0.01);
-	const afterVolume = a.prev.cost + a.volumeEffect;
-	const afterEfficiency = afterVolume + a.efficiencyEffect;
 	const shifts = a.modelShifts.length === 0 ? '' : `
 		<h3>Model mix movement</h3>
 		<table class="attr-shift-table">
@@ -286,7 +284,6 @@ function renderAttributionTab(d: EfficiencyViewData): string {
 			<div class="attr-stat"><div class="stat-label">${escapeHtml(capitalizeFirst(d.attributionWindows.cur))}</div><div class="stat-value">$${a.cur.cost.toFixed(2)}</div><div class="stat-sub">${escapeHtml(d.attributionWindows.curRange)} · ${a.cur.sessions} sessions · ${formatCompact(a.cur.tokens)} tokens</div></div>
 			<div class="attr-stat"><div class="stat-label">Change</div><div class="stat-value">${fmtMoney(a.deltaCost)}</div><div class="stat-sub">blended rate ${a.prev.dollarsPerMTokens.toFixed(2)} → ${a.cur.dollarsPerMTokens.toFixed(2)} $/M tokens</div></div>
 		</div>
-		<div class="attr-waterfall"><span>Starting cost <b>$${a.prev.cost.toFixed(2)}</b></span><span>After session count <b>$${afterVolume.toFixed(2)}</b></span><span>After session size <b>$${afterEfficiency.toFixed(2)}</b></span><span>After model mix <b>$${a.cur.cost.toFixed(2)}</b></span></div>
 		<div class="attr-bars">
 			${attrBar('Volume (session count)', `${a.prev.sessions.toLocaleString()} → ${a.cur.sessions.toLocaleString()} sessions`, a.volumeEffect, maxAbs, `Session count went from ${a.prev.sessions} to ${a.cur.sessions}.`)}
 			${attrBar('Session size (tokens/session)', `${formatCompact(a.prev.tokensPerSession)} → ${formatCompact(a.cur.tokensPerSession)} tokens/session`, a.efficiencyEffect, maxAbs, `Tokens per session went from ${Math.round(a.prev.tokensPerSession)} to ${Math.round(a.cur.tokensPerSession)}.`)}

--- a/vscode-extension/src/webview/efficiency/styles.css
+++ b/vscode-extension/src/webview/efficiency/styles.css
@@ -200,22 +200,6 @@
 .attr-bar-fill.pos { background: var(--vscode-charts-red, #fb7185); }
 .attr-bar-fill.neg { background: var(--vscode-charts-green, #4ade80); }
 .attr-bar-value { font-size: 0.88em; font-variant-numeric: tabular-nums; }
-.attr-waterfall {
-	display: flex;
-	flex-wrap: wrap;
-	gap: 4px 18px;
-	margin: -8px 0 14px;
-	color: var(--vscode-descriptionForeground);
-	font-size: 0.82em;
-}
-.attr-waterfall span:not(:last-child)::after {
-	content: '→';
-	margin-left: 18px;
-}
-.attr-waterfall b {
-	color: var(--vscode-foreground);
-	font-variant-numeric: tabular-nums;
-}
 
 .attr-shift-table { width: 100%; border-collapse: collapse; font-size: 0.88em; }
 .attr-shift-table th, .attr-shift-table td {


### PR DESCRIPTION
This trims a confusing duplicate summary from the Efficiency > Cost Attribution tab. The waterfall line repeated the same cost decomposition that the bars already explain, so removing it makes the view easier to read without changing the underlying analysis.

## What changed
- Removed the waterfall row that showed Starting cost / After session count / After session size / After model mix.
- Dropped the unused CSS for that row.

## Notes
- The cost attribution bars and explanatory copy remain in place, so the tab still shows the full decomposition.
- No template was present in the repo, so this PR uses a freeform description.