### PR TITLE
Explain Team Server data sharing in the config panel

### DIFF
--- a/vscode-extension/src/backend/teamServerConfigPanel.ts
+++ b/vscode-extension/src/backend/teamServerConfigPanel.ts
@@ -138,9 +138,17 @@ function renderTeamPanelBaseStyles(): string {
       color: var(--vscode-foreground);
       background-color: var(--vscode-editor-background);
       padding: 24px;
-      max-width: 560px;
+      max-width: 1040px;
     }
     h1 { font-size: 1.2em; margin-bottom: 24px; font-weight: 600; }
+    h2 { font-size: 1.05em; margin: 0 0 10px; font-weight: 600; }
+    h3 { font-size: 0.95em; margin: 18px 0 8px; font-weight: 600; }
+    .layout { display: flex; gap: 32px; align-items: flex-start; }
+    .form-col { flex: 0 0 360px; min-width: 300px; }
+    .info-col {
+      flex: 1; min-width: 320px; padding-left: 28px;
+      border-left: 1px solid var(--vscode-panel-border, #454545);
+    }
     .field { margin-bottom: 20px; }
     .field label { display: block; margin-bottom: 6px; font-weight: 500; }
     .field input[type="text"] {
@@ -178,43 +186,144 @@ function renderTeamPanelInteractiveStyles(): string {
       border: 1px solid var(--vscode-input-border, #ccc); border-radius: 2px;
       font-size: inherit; font-family: inherit;
     }
-    .field select:focus { outline: 1px solid var(--vscode-focusBorder); border-color: var(--vscode-focusBorder); }`;
+    .field select:focus { outline: 1px solid var(--vscode-focusBorder); border-color: var(--vscode-focusBorder); }
+    .info-lead { color: var(--vscode-descriptionForeground); margin: 0 0 14px; line-height: 1.5; }
+    .info-card {
+      background: var(--vscode-textCodeBlock-background, #2d2d30);
+      border: 1px solid var(--vscode-panel-border, #454545);
+      border-radius: 4px; padding: 10px 12px; margin-bottom: 10px; font-size: 0.92em; line-height: 1.5;
+    }
+    .info-card .row { margin-bottom: 4px; }
+    .info-card .row strong { font-weight: 600; }
+    .fields-table { width: 100%; border-collapse: collapse; font-size: 0.88em; margin-bottom: 12px; }
+    .fields-table th, .fields-table td {
+      text-align: left; padding: 4px 8px; border-bottom: 1px solid var(--vscode-panel-border, #454545);
+    }
+    .fields-table th { font-weight: 600; color: var(--vscode-descriptionForeground); }
+    .callout {
+      background: var(--vscode-inputValidation-infoBackground, #063b49);
+      border: 1px solid var(--vscode-inputValidation-infoBorder, #007acc);
+      border-radius: 2px; padding: 8px 10px; font-size: 0.88em; margin-bottom: 8px;
+    }
+    .dashboard-preview {
+      border: 1px solid var(--vscode-panel-border, #454545); border-radius: 4px;
+      padding: 14px; background: var(--vscode-editorWidget-background, #252526);
+    }
+    .dashboard-preview .dp-note { font-size: 0.85em; color: var(--vscode-descriptionForeground); margin-bottom: 10px; }
+    .dp-summary { display: flex; gap: 8px; margin-bottom: 12px; flex-wrap: wrap; }
+    .dp-tile {
+      flex: 1 1 90px; background: var(--vscode-textCodeBlock-background, #2d2d30);
+      border-radius: 3px; padding: 8px 10px;
+    }
+    .dp-tile .dp-label { font-size: 0.78em; color: var(--vscode-descriptionForeground); }
+    .dp-tile .dp-value { font-size: 1.1em; font-weight: 700; color: var(--vscode-charts-blue, #3794ff); }
+    .dp-bar-row { display: flex; align-items: center; gap: 8px; margin-bottom: 6px; font-size: 0.82em; }
+    .dp-bar-label { flex: 0 0 90px; color: var(--vscode-descriptionForeground); }
+    .dp-bar-track { flex: 1; background: var(--vscode-editorWidget-background, #333); border-radius: 3px; height: 10px; overflow: hidden; }
+    .dp-bar-fill { height: 100%; background: var(--vscode-charts-blue, #3794ff); border-radius: 3px; }
+    .dp-bar-pct { flex: 0 0 36px; text-align: right; color: var(--vscode-descriptionForeground); }
+    .dp-trend { display: flex; align-items: flex-end; gap: 4px; height: 60px; margin-top: 12px; }
+    .dp-trend-bar { flex: 1; background: var(--vscode-charts-purple, #c586c0); border-radius: 2px 2px 0 0; }`;
 }
 
 function renderTeamPanelBody(nonce: string, enabledChecked: string, safeEndpoint: string, profileOptions: string): string {
 	return `<body>
   <h1>Configure Team Server</h1>
-  <div class="field">
-    <div class="toggle-row">
-      <input type="checkbox" id="chk-enabled" ${enabledChecked}>
-      <label for="chk-enabled">Enable Team Server backend</label>
+  <div class="layout">
+    <div class="form-col">
+      <div class="field">
+        <div class="toggle-row">
+          <input type="checkbox" id="chk-enabled" ${enabledChecked}>
+          <label for="chk-enabled">Enable Team Server backend</label>
+        </div>
+        <p class="field-hint">When enabled, session data is pushed to your self-hosted sharing server.</p>
+      </div>
+      <div class="field">
+        <label for="txt-endpoint">Server endpoint URL</label>
+        <input type="text" id="txt-endpoint" placeholder="https://your-server.example.com" value="${safeEndpoint}">
+        <div class="error-msg" id="err-endpoint"></div>
+        <p class="field-hint">The base URL of your team sharing server (no trailing slash required).</p>
+      </div>
+      <div class="field">
+        <label for="sel-profile">Sharing profile</label>
+        <select id="sel-profile">
+					${profileOptions}
+        </select>
+        <p class="field-hint">See "What data is shared" on the right for what each profile sends.</p>
+      </div>
+      <div class="actions">
+        <button class="primary" id="btn-save">Save</button>
+        <button class="secondary" id="btn-cancel">Cancel</button>
+      </div>
     </div>
-    <p class="field-hint">When enabled, session data is pushed to your self-hosted sharing server.</p>
-  </div>
-  <div class="field">
-    <label for="txt-endpoint">Server endpoint URL</label>
-    <input type="text" id="txt-endpoint" placeholder="https://your-server.example.com" value="${safeEndpoint}">
-    <div class="error-msg" id="err-endpoint"></div>
-    <p class="field-hint">The base URL of your team sharing server (no trailing slash required).</p>
-  </div>
-  <div class="field">
-    <label for="sel-profile">Sharing profile</label>
-    <select id="sel-profile">
-				${profileOptions}
-    </select>
-    <p class="field-hint">Controls what user-level data is included in each sync. <strong>Off</strong> sends only aggregate counts — no user identifiers. Team profiles add per-user keys at increasing fidelity.</p>
-  </div>
-  <div class="actions">
-    <button class="primary" id="btn-save">Save</button>
-    <button class="secondary" id="btn-cancel">Cancel</button>
+    ${renderTeamInfoColumn()}
   </div>
   ${renderTeamPanelScript(nonce)}
 </body>`;
 }
 
+function renderTeamInfoColumn(): string {
+	return `<div class="info-col">
+      <h2>What data is shared</h2>
+      <p class="info-lead">The extension reuses your existing GitHub sign-in — no new credentials are created. Once a day it sends aggregated usage rollups (never raw prompts or completions) to the server URL above.</p>
+      <div class="info-card">
+        <div class="row"><strong>Your identity:</strong> every upload is authenticated with your GitHub token, so the server always knows which GitHub account sent it. Unlike the Azure Storage backend, the Team Server has no anonymous mode — the sharing profile below only controls whether readable workspace/machine <em>names</em> are included.</div>
+      </div>
+      <div class="info-card" id="profile-explainer"></div>
+      <h3>Fields sent per upload</h3>
+      <table class="fields-table">
+        <tr><th>Field</th><th>Example</th></tr>
+        <tr><td>day, model</td><td>2026-09-07, claude-sonnet-5</td></tr>
+        <tr><td>inputTokens, outputTokens, interactions</td><td>8123456, 55400, 6</td></tr>
+        <tr><td>workspaceId, machineId</td><td>opaque IDs — always included, not raw file paths</td></tr>
+        <tr><td>workspaceName, machineName</td><td>optional, only when the profile enables names</td></tr>
+        <tr><td>editor</td><td>Copilot CLI, VS Code, Claude Desktop, ...</td></tr>
+        <tr><td>datasetId, fluencyMetrics</td><td>your configured dataset tag; fluency score breakdown</td></tr>
+      </table>
+      <div class="callout">Prompt and response content is never uploaded — only the aggregate counts above.</div>
+      <h2>What you'll get</h2>
+      <div class="dashboard-preview">
+        <p class="dp-note">Illustrative preview of the team dashboard members sign into with GitHub — not live data.</p>
+        <div class="dp-summary">
+          <div class="dp-tile"><div class="dp-label">Input Tokens</div><div class="dp-value">8.1M</div></div>
+          <div class="dp-tile"><div class="dp-label">Output Tokens</div><div class="dp-value">55.4K</div></div>
+          <div class="dp-tile"><div class="dp-label">Interactions</div><div class="dp-value">6</div></div>
+          <div class="dp-tile"><div class="dp-label">Days Active</div><div class="dp-value">1</div></div>
+        </div>
+        <div class="dp-bar-row"><span class="dp-bar-label">Copilot CLI</span><div class="dp-bar-track"><div class="dp-bar-fill" data-width="89"></div></div><span class="dp-bar-pct">89%</span></div>
+        <div class="dp-bar-row"><span class="dp-bar-label">Claude Desktop</span><div class="dp-bar-track"><div class="dp-bar-fill" data-width="10"></div></div><span class="dp-bar-pct">10%</span></div>
+        <div class="dp-bar-row"><span class="dp-bar-label">VS Code</span><div class="dp-bar-track"><div class="dp-bar-fill" data-width="1"></div></div><span class="dp-bar-pct">1%</span></div>
+        <div class="dp-trend">
+          <div class="dp-trend-bar" data-height="20"></div>
+          <div class="dp-trend-bar" data-height="35"></div>
+          <div class="dp-trend-bar" data-height="15"></div>
+          <div class="dp-trend-bar" data-height="55"></div>
+          <div class="dp-trend-bar" data-height="70"></div>
+          <div class="dp-trend-bar" data-height="40"></div>
+          <div class="dp-trend-bar" data-height="90"></div>
+        </div>
+      </div>
+    </div>`;
+}
+
 function renderTeamPanelScript(nonce: string): string {
 	return `<script nonce="${nonce}">
     const vscode = acquireVsCodeApi();
+    const PROFILE_EXPLAINERS = {
+      off: '<div class="row"><strong>Off</strong> — sync is disabled entirely. Nothing is sent to the Team Server for this profile.</div>',
+      soloFull: '<div class="row"><strong>Solo Full</strong> — readable workspace and machine names are always included, since only you see this data.</div>',
+      teamAnonymized: '<div class="row"><strong>Team Anonymized</strong> — workspace/machine <em>names</em> are withheld; only the opaque IDs are sent. Note this does not hide who uploaded it — see "Your identity" above.</div>',
+      teamPseudonymous: '<div class="row"><strong>Team Pseudonymous</strong> — workspace/machine names follow the "share readable names" setting below (off by default).</div>',
+      teamIdentified: '<div class="row"><strong>Team Identified</strong> — workspace/machine names follow the "share readable names" setting below (off by default). Combined with your always-on GitHub identity, this is the most transparent profile.</div>',
+    };
+    function updateProfileExplainer() {
+      const profile = document.getElementById('sel-profile').value;
+      document.getElementById('profile-explainer').innerHTML = PROFILE_EXPLAINERS[profile] || PROFILE_EXPLAINERS.teamAnonymized;
+    }
+    document.getElementById('sel-profile').addEventListener('change', updateProfileExplainer);
+    updateProfileExplainer();
+    document.querySelectorAll('.dp-bar-fill[data-width]').forEach((el) => { el.style.width = el.getAttribute('data-width') + '%'; });
+    document.querySelectorAll('.dp-trend-bar[data-height]').forEach((el) => { el.style.height = el.getAttribute('data-height') + '%'; });
     document.getElementById('btn-save').addEventListener('click', () => {
       const enabled = document.getElementById('chk-enabled').checked;
       const endpointUrl = document.getElementById('txt-endpoint').value.trim();

--- a/vscode-extension/src/backend/teamServerConfigPanel.ts
+++ b/vscode-extension/src/backend/teamServerConfigPanel.ts
@@ -143,11 +143,14 @@ function renderTeamPanelBaseStyles(): string {
     h1 { font-size: 1.2em; margin-bottom: 24px; font-weight: 600; }
     h2 { font-size: 1.05em; margin: 0 0 10px; font-weight: 600; }
     h3 { font-size: 0.95em; margin: 18px 0 8px; font-weight: 600; }
-    .layout { display: flex; gap: 32px; align-items: flex-start; }
-    .form-col { flex: 0 0 360px; min-width: 300px; }
+    .layout { display: flex; flex-wrap: wrap; gap: 32px; align-items: flex-start; }
+    .form-col { flex: 1 1 360px; min-width: 280px; }
     .info-col {
-      flex: 1; min-width: 320px; padding-left: 28px;
+      flex: 2 1 320px; min-width: 280px; padding-left: 28px;
       border-left: 1px solid var(--vscode-panel-border, #454545);
+    }
+    @media (max-width: 720px) {
+      .info-col { padding-left: 0; border-left: none; border-top: 1px solid var(--vscode-panel-border, #454545); padding-top: 20px; }
     }
     .field { margin-bottom: 20px; }
     .field label { display: block; margin-bottom: 6px; font-weight: 500; }
@@ -265,9 +268,9 @@ function renderTeamPanelBody(nonce: string, enabledChecked: string, safeEndpoint
 function renderTeamInfoColumn(): string {
 	return `<div class="info-col">
       <h2>What data is shared</h2>
-      <p class="info-lead">The extension reuses your existing GitHub sign-in — no new credentials are created. Once a day it sends aggregated usage rollups (never raw prompts or completions) to the server URL above.</p>
+      <p class="info-lead">The extension reuses your existing GitHub sign-in — no new credentials are created. On a periodic timer (at most every 5 minutes) it sends aggregated usage rollups (never raw prompts or completions) to the server URL above.</p>
       <div class="info-card">
-        <div class="row"><strong>Your identity:</strong> every upload is authenticated with your GitHub token, so the server always knows which GitHub account sent it. Unlike the Azure Storage backend, the Team Server has no anonymous mode — the sharing profile below only controls whether readable workspace/machine <em>names</em> are included.</div>
+        <div class="row"><strong>Your identity:</strong> every upload is authenticated with your GitHub token, so the server always knows which GitHub account sent it. Unlike the Azure Storage backend, the Team Server has no anonymous mode — the sharing profile below controls whether readable workspace/machine <em>names</em> are included (together with the "share readable names" setting) and whether a per-user dimension is added, not whether you're identifiable.</div>
       </div>
       <div class="info-card" id="profile-explainer"></div>
       <h3>Fields sent per upload</h3>
@@ -311,10 +314,10 @@ function renderTeamPanelScript(nonce: string): string {
     const vscode = acquireVsCodeApi();
     const PROFILE_EXPLAINERS = {
       off: '<div class="row"><strong>Off</strong> — sync is disabled entirely. Nothing is sent to the Team Server for this profile.</div>',
-      soloFull: '<div class="row"><strong>Solo Full</strong> — readable workspace and machine names are always included, since only you see this data.</div>',
-      teamAnonymized: '<div class="row"><strong>Team Anonymized</strong> — workspace/machine <em>names</em> are withheld; only the opaque IDs are sent. Note this does not hide who uploaded it — see "Your identity" above.</div>',
-      teamPseudonymous: '<div class="row"><strong>Team Pseudonymous</strong> — workspace/machine names follow the "share readable names" setting below (off by default).</div>',
-      teamIdentified: '<div class="row"><strong>Team Identified</strong> — workspace/machine names follow the "share readable names" setting below (off by default). Combined with your always-on GitHub identity, this is the most transparent profile.</div>',
+      soloFull: '<div class="row"><strong>Solo Full</strong> — readable workspace and machine names are always included, since only you see this data. No separate per-user dimension is added (you are the only user).</div>',
+      teamAnonymized: '<div class="row"><strong>Team Anonymized</strong> — workspace/machine <em>names</em> are withheld; only the opaque IDs are sent, and no per-user dimension is added. Note this does not hide who uploaded it — see "Your identity" above.</div>',
+      teamPseudonymous: '<div class="row"><strong>Team Pseudonymous</strong> — adds a per-user dimension to the rollups. Workspace/machine names follow the "share readable names" setting below (off by default).</div>',
+      teamIdentified: '<div class="row"><strong>Team Identified</strong> — adds a per-user dimension to the rollups. Workspace/machine names follow the "share readable names" setting below (off by default). Combined with your always-on GitHub identity, this is the most transparent profile.</div>',
     };
     function updateProfileExplainer() {
       const profile = document.getElementById('sel-profile').value;

--- a/vscode-extension/test/unit/backend-teamServerConfigPanel.test.ts
+++ b/vscode-extension/test/unit/backend-teamServerConfigPanel.test.ts
@@ -463,3 +463,40 @@ test('TeamServerConfigPanel - renderHtml generates valid HTML', async () => {
 	assert.ok(html.includes('teamAnonymized'), 'Should include sharing profile');
 	assert.ok(html.includes('nonce='), 'Should include nonce for CSP');
 });
+
+test('TeamServerConfigPanel - renderHtml includes the data-sharing info column', async () => {
+	(vscode as any).__mock.reset();
+
+	const context = {
+		extensionUri: vscode.Uri.parse('file:///extension'),
+		subscriptions: []
+	} as any;
+
+	const { TeamServerConfigPanel } = require('../../src/backend/teamServerConfigPanel');
+	TeamServerConfigPanel.current = undefined;
+
+	const panel = new TeamServerConfigPanel(context.extensionUri);
+	const mockWebview = { postMessage: () => {} } as any;
+	const html = (panel as any).renderHtml(mockWebview, false, '', 'off');
+
+	// Info column explaining what data is shared and why
+	assert.ok(html.includes('What data is shared'), 'Should include the info column heading');
+	assert.ok(html.includes('id="profile-explainer"'), 'Should include the per-profile explainer container');
+	assert.ok(html.includes('Your identity'), 'Should explain the always-on GitHub identity model');
+	assert.ok(html.includes('PROFILE_EXPLAINERS'), 'Should include the per-profile explainer script map');
+	assert.ok(html.includes('teamAnonymized:'), 'Explainer map should cover the teamAnonymized profile');
+	assert.ok(html.includes('teamPseudonymous:'), 'Explainer map should cover the teamPseudonymous profile');
+	assert.ok(html.includes('teamIdentified:'), 'Explainer map should cover the teamIdentified profile');
+
+	// Fields table listing the exact SharingServerEntry payload
+	assert.ok(html.includes('Fields sent per upload'), 'Should include the fields table heading');
+	assert.ok(html.includes('workspaceId, machineId'), 'Should list workspace/machine IDs');
+	assert.ok(html.includes('workspaceName, machineName'), 'Should list optional workspace/machine names');
+	assert.ok(html.includes('datasetId, fluencyMetrics'), 'Should list dataset ID and fluency metrics');
+	assert.ok(html.includes('Prompt and response content is never uploaded'), 'Should include the no-content callout');
+
+	// Illustrative dashboard preview
+	assert.ok(html.includes("What you'll get"), 'Should include the dashboard preview heading');
+	assert.ok(html.includes('dashboard-preview'), 'Should include the dashboard preview mockup');
+	assert.ok(html.includes('not live data'), 'Should label the mockup as illustrative, not live data');
+});


### PR DESCRIPTION
## What
Adds a right-hand "What data is shared" info column to the **Configure Team Server** webview panel (`vscode-extension/src/backend/teamServerConfigPanel.ts`).

## Why
When configuring the self-hosted Team Server backend, users had no visibility into what data actually gets uploaded and why. This makes the sharing transparent before they enable it.

## What's shown
- **Identity note**: uploads are always authenticated with the user's GitHub token, so the Team Server always knows which account sent the data — unlike the Azure Storage backend, there is no anonymous mode. The sharing profile only controls whether readable workspace/machine *names* are included.
- **Per-profile explainer** that updates live when the sharing profile dropdown changes.
- **Fields table** listing the exact `SharingServerEntry` fields sent per upload (day, model, token counts, workspace/machine IDs, optional names, editor, dataset ID, fluency metrics).
- **Callout** confirming prompt/response content is never uploaded.
- **Illustrative dashboard preview** (static CSS mockup, not a live image) showing the kind of "My Dashboard" view team members get after signing in with GitHub.

## Validation
- `npm run compile` — passes
- `npm run compile-tests` + targeted unit test run — all 9 existing `backend-teamServerConfigPanel.test.ts` tests pass unchanged
- `npx eslint src/backend/teamServerConfigPanel.ts` — clean