### PR TITLE
Improve dashboard config card UI (Azure Storage / Team Server)

### DIFF
--- a/vscode-extension/src/webview/dashboard/main.ts
+++ b/vscode-extension/src/webview/dashboard/main.ts
@@ -160,13 +160,19 @@ function showError(message: string): void {
 
 function buildDashboardFailure(message: string): HTMLElement {
   const failure = el("div", "dashboard-failure");
+
+  const header = el("div", "config-card-header");
+  const icon = el("span", "config-card-icon", "☁️");
+  const heading = el("span", "config-card-heading", "Azure Storage");
+  header.append(icon, heading);
+
   const errorEl = el("div", "error-message", message);
   const configureButton = createButton(
     "btn-configure-backend",
     "Configure Azure Storage",
     "secondary",
   );
-  failure.append(errorEl, configureButton);
+  failure.append(header, errorEl, configureButton);
   return failure;
 }
 
@@ -576,11 +582,14 @@ function buildTeamServerPanel(url: string): HTMLElement {
 
   const card = el("div", "team-server-card");
 
-  const icon = el("div", "team-server-card-icon", "🖥️");
-  const heading = el("div", "team-server-card-heading", "Team Server Dashboard");
+  const header = el("div", "config-card-header");
+  const icon = el("span", "config-card-icon", "🖥️");
+  const heading = el("span", "config-card-heading", "Team Server Dashboard");
+  header.append(icon, heading);
+
   const urlEl = el("div", "team-server-card-url", url);
 
-  const openBtn = el("button", "team-server-open-btn", "↗ Open Team Server in Browser") as HTMLButtonElement;
+  const openBtn = createButton("btn-open-team-server", "↗ Open Team Server in Browser", "secondary") as HTMLButtonElement;
   openBtn.addEventListener("click", () => {
     vscode.postMessage({ command: "openExternal", url });
   });
@@ -593,7 +602,7 @@ function buildTeamServerPanel(url: string): HTMLElement {
     "so the dashboard opens in your default browser instead.",
   );
 
-  card.append(icon, heading, urlEl, openBtn, note);
+  card.append(header, urlEl, openBtn, note);
   panel.append(card);
   return panel;
 }

--- a/vscode-extension/src/webview/dashboard/styles.css
+++ b/vscode-extension/src/webview/dashboard/styles.css
@@ -300,6 +300,52 @@
         align-items: flex-start;
         gap: 12px;
         margin-bottom: 24px;
+        border: 2px solid var(--vscode-foreground);
+        padding: 20px;
+}
+
+.config-card-header {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+}
+
+.config-card-icon {
+        font-size: 22px;
+        line-height: 1;
+}
+
+.config-card-heading {
+        font-size: 15px;
+        font-weight: 900;
+        text-transform: uppercase;
+        letter-spacing: 1.5px;
+        color: var(--vscode-foreground);
+}
+
+.team-server-panel {
+        margin-top: 20px;
+}
+
+.team-server-card {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 12px;
+        border: 2px solid var(--vscode-foreground);
+        padding: 20px;
+}
+
+.team-server-card-url {
+        font-size: 13px;
+        color: var(--vscode-descriptionForeground);
+        word-break: break-all;
+}
+
+.team-server-card-note {
+        font-size: 12px;
+        color: var(--vscode-descriptionForeground);
+        margin: 0;
 }
 
 /* Fluency score badges */


### PR DESCRIPTION
## Why
When the dashboard falls back to showing the Azure Storage error and/or the Team Server launch card, the two config sections looked inconsistent: the Team Server icon and heading were stacked on separate lines instead of side by side, there was no clear label distinguishing "this is the Azure Storage config" from "this is the Team Server config," and the "Open Team Server in Browser" button was a plain unstyled `<button>` while "Configure Azure Storage" was a proper `vscode-button`.

## What changed
- `vscode-extension/src/webview/dashboard/main.ts`: both cards now build a `config-card-header` row with the icon and heading rendered inline, and each card gets an explicit label ("☁️ Azure Storage" / "🖥️ Team Server Dashboard") so it's obvious these are two separate configurations. The "Open Team Server in Browser" button now uses `createButton(..., "secondary")`, the same `vscode-button` component used for "Configure Azure Storage," so both buttons render identically.
- `vscode-extension/src/webview/dashboard/styles.css`: added bordered card styling (`.dashboard-failure`, `.team-server-card`) plus the shared `.config-card-header/-icon/-heading` classes used by both sections.

## Verification
- `npm run compile`
- `npm run check:contract`
- `npm run check:interaction`