### PR TITLE
Efficiency tab: show date ranges, hide empty windows in Models picker

### DIFF
--- a/src/efficiencyAnalysis.ts
+++ b/src/efficiencyAnalysis.ts
@@ -1051,29 +1051,44 @@ export type ModelCompareWindowId = 'last30' | 'prev30' | 'last90' | 'thisMonth' 
 export interface ModelCompareWindow {
 	id: ModelCompareWindowId;
 	label: string;
+	/** Short, concrete date span (e.g. "Aug 8 – Sep 6") so windows with similar names are distinguishable. */
+	rangeLabel: string;
 	startKey: string;
 	endKey: string;
 }
 
-/** Resolves a window id into concrete day-key bounds relative to `now`. */
+/** Formats a short "Mon D – Mon D[, YYYY]" span; adds the year to the start when it differs from the end's year. */
+function formatDateRangeLabel(startKey: string, endKey: string): string {
+	const start = new Date(`${startKey}T00:00:00`);
+	const end = new Date(`${endKey}T00:00:00`);
+	const sameYear = start.getFullYear() === end.getFullYear();
+	const startOpts: Intl.DateTimeFormatOptions = { month: 'short', day: 'numeric', ...(sameYear ? {} : { year: 'numeric' }) };
+	const startFmt = start.toLocaleDateString('en-US', startOpts);
+	const endFmt = end.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+	return `${startFmt} – ${endFmt}`;
+}
+
+/** Resolves a window id into concrete date bounds relative to `now`. */
 export function resolveModelCompareWindow(id: ModelCompareWindowId, now: Date): ModelCompareWindow {
 	const monthLabel = (d: Date): string => d.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
 	const dayOffset = (days: number): Date => new Date(now.getFullYear(), now.getMonth(), now.getDate() - days);
+	const build = (label: string, startKey: string, endKey: string): ModelCompareWindow =>
+		({ id, label, rangeLabel: formatDateRangeLabel(startKey, endKey), startKey, endKey });
 	switch (id) {
 		case 'last30':
-			return { id, label: 'Last 30 days', startKey: fmtKey(dayOffset(29)), endKey: fmtKey(now) };
+			return build('Last 30 days', fmtKey(dayOffset(29)), fmtKey(now));
 		case 'prev30':
-			return { id, label: 'Previous 30 days', startKey: fmtKey(dayOffset(59)), endKey: fmtKey(dayOffset(30)) };
+			return build('Previous 30 days', fmtKey(dayOffset(59)), fmtKey(dayOffset(30)));
 		case 'last90':
-			return { id, label: 'Last 90 days', startKey: fmtKey(dayOffset(89)), endKey: fmtKey(now) };
+			return build('Last 90 days', fmtKey(dayOffset(89)), fmtKey(now));
 		case 'thisMonth': {
 			const start = new Date(now.getFullYear(), now.getMonth(), 1);
-			return { id, label: monthLabel(start), startKey: fmtKey(start), endKey: fmtKey(now) };
+			return build(monthLabel(start), fmtKey(start), fmtKey(now));
 		}
 		case 'lastMonth': {
 			const start = new Date(now.getFullYear(), now.getMonth() - 1, 1);
 			const end = new Date(now.getFullYear(), now.getMonth(), 0);
-			return { id, label: monthLabel(start), startKey: fmtKey(start), endKey: fmtKey(end) };
+			return build(monthLabel(start), fmtKey(start), fmtKey(end));
 		}
 	}
 }
@@ -1081,6 +1096,11 @@ export function resolveModelCompareWindow(id: ModelCompareWindowId, now: Date): 
 /** Filters `days` down to the resolved window (inclusive on both ends). */
 export function selectDaysInWindow(days: ModelDailyInput[], window: ModelCompareWindow): ModelDailyInput[] {
 	return days.filter(d => d.date >= window.startKey && d.date <= window.endKey);
+}
+
+/** Whether any per-model efficiency data exists inside the resolved window — used to hide/disable empty windows in the picker. */
+export function windowHasModelData(days: ModelDailyInput[], window: ModelCompareWindow): boolean {
+	return selectDaysInWindow(days, window).some(d => d.modelEfficiency && Object.keys(d.modelEfficiency).length > 0);
 }
 
 export type ModelComparisonMetricId =	| 'cost-per-edit-turn' | 'cost-per-session' | 'cost-per-kloc' | 'dollars-per-mtokens'

--- a/vscode-extension/src/webview/efficiency/main.ts
+++ b/vscode-extension/src/webview/efficiency/main.ts
@@ -27,6 +27,7 @@ import {
 	listComparableModels,
 	resolveModelCompareWindow,
 	selectDaysInWindow,
+	windowHasModelData,
 } from '../../../../src/efficiencyAnalysis';
 import { initializeWebviewLocalization, setCurrentLanguage } from '../shared/localization';
 
@@ -505,7 +506,14 @@ function payloadNow(d: EfficiencyViewData): Date {
 	return Number.isNaN(parsed.getTime()) ? new Date() : parsed;
 }
 
-/** Picks sensible defaults on first render: the two most-used comparable models. */
+/** Which window ids currently have per-model data, in `WINDOW_OPTIONS` order. */
+function availableWindowIds(d: EfficiencyViewData, now: Date): ModelCompareWindowId[] {
+	return WINDOW_OPTIONS
+		.map(w => w.id)
+		.filter(id => windowHasModelData(d.modelDaily, resolveModelCompareWindow(id, now)));
+}
+
+/** Picks sensible defaults on first render: the two most-used comparable models, and windows that actually have data. */
 function initModelState(d: EfficiencyViewData): void {
 	if (modelState.initialized) { return; }
 	modelState.initialized = true;
@@ -514,6 +522,13 @@ function initModelState(d: EfficiencyViewData): void {
 	const pool = preferred.length >= 2 ? preferred : models;
 	modelState.modelA = pool[0]?.model ?? '';
 	modelState.modelB = pool[1]?.model ?? pool[0]?.model ?? '';
+
+	const available = availableWindowIds(d, payloadNow(d));
+	if (available.length > 0) {
+		modelState.window = available.includes('last30') ? 'last30' : available[0];
+		modelState.windowA = available[0];
+		modelState.windowB = available.length > 1 ? available[1] : available[0];
+	}
 }
 
 /** Resolves the current selection into a comparison, or null when a side has no data. */
@@ -547,13 +562,19 @@ function modelOptions(d: EfficiencyViewData): { value: string; label: string }[]
 	}));
 }
 
-function windowOptions(): { value: string; label: string }[] {
-	return WINDOW_OPTIONS.map(w => ({ value: w.id, label: w.label }));
+/** Dropdown options for the window picker: each label carries its concrete date span, and windows with no per-model data yet are disabled so they can't silently be picked. */
+function windowOptions(d: EfficiencyViewData, now: Date): { value: string; label: string; disabled?: boolean }[] {
+	return WINDOW_OPTIONS.map(w => {
+		const resolved = resolveModelCompareWindow(w.id, now);
+		const hasData = windowHasModelData(d.modelDaily, resolved);
+		const label = `${w.label} (${resolved.rangeLabel})${hasData ? '' : ' — no data'}`;
+		return { value: w.id, label, disabled: !hasData };
+	});
 }
 
 function renderModelControls(d: EfficiencyViewData): string {
 	const models = modelOptions(d);
-	const windows = windowOptions();
+	const windows = windowOptions(d, payloadNow(d));
 	const modeSelect = selectHtml('model-mode', [
 		{ value: 'models', label: 'Compare two models' },
 		{ value: 'periods', label: 'One model, two periods' },

--- a/vscode-extension/test/unit/efficiencyAnalysis.test.ts
+++ b/vscode-extension/test/unit/efficiencyAnalysis.test.ts
@@ -16,6 +16,7 @@ import {
 	buildModelWeeklySeries,
 	resolveModelCompareWindow,
 	selectDaysInWindow,
+	windowHasModelData,
 	type EfficiencyDeps,
 	type EfficiencySessionInput,
 } from '../../../src/efficiencyAnalysis';
@@ -749,4 +750,32 @@ test('selectDaysInWindow: keeps only days inside the window, bounds included', (
 test('selectDaysInWindow: returns nothing when no day falls inside the window', () => {
 	const days = [modelDay('2026-01-05', {}), modelDay('2026-02-05', {})];
 	assert.equal(selectDaysInWindow(days, resolveModelCompareWindow('last30', NOW)).length, 0);
+});
+
+test('resolveModelCompareWindow: rangeLabel is a concrete date span distinguishing same-length windows', () => {
+	const last = resolveModelCompareWindow('last30', NOW);
+	const prev = resolveModelCompareWindow('prev30', NOW);
+	assert.equal(last.rangeLabel, 'Jun 16 – Jul 15, 2026');
+	assert.equal(prev.rangeLabel, 'May 17 – Jun 15, 2026');
+	assert.notEqual(last.rangeLabel, prev.rangeLabel);
+});
+
+test('resolveModelCompareWindow: rangeLabel includes both years when the span crosses a year boundary', () => {
+	const w = resolveModelCompareWindow('lastMonth', new Date(2026, 0, 9, 12, 0, 0));
+	assert.equal(w.rangeLabel, 'Dec 1 – Dec 31, 2025');
+});
+
+test('windowHasModelData: false when no day in the window has per-model efficiency data', () => {
+	const days = [modelDay('2026-07-01', {}), modelDay('2026-07-10', {})];
+	assert.equal(windowHasModelData(days, resolveModelCompareWindow('thisMonth', NOW)), false);
+});
+
+test('windowHasModelData: true when at least one day in the window has per-model efficiency data', () => {
+	const days = [modelDay('2026-07-10', { 'gpt-4o': {} })];
+	assert.equal(windowHasModelData(days, resolveModelCompareWindow('thisMonth', NOW)), true);
+});
+
+test('windowHasModelData: ignores data outside the window bounds', () => {
+	const days = [modelDay('2026-06-01', { 'gpt-4o': {} })];
+	assert.equal(windowHasModelData(days, resolveModelCompareWindow('thisMonth', NOW)), false);
 });


### PR DESCRIPTION
## Why

On the Efficiency tab's Models comparison, the window picker (Last 30 days, Previous 30 days, This month, Last month, Last 90 days) had two problems:

- Names like "Last 30 days" vs "Previous 30 days" didn't say which actual dates they covered, so it was hard to tell them apart at a glance.
- Windows with zero per-model data (e.g. This month, Last month, when there simply weren't sessions logged yet) were offered anyway, leading to a confusing "no data" comparison after picking them.

## What changed

- `resolveModelCompareWindow()` in `src/efficiencyAnalysis.ts` now also returns a concrete `rangeLabel` (e.g. `Aug 8 - Sep 6, 2026`) alongside its existing short label.
- New `windowHasModelData()` reports whether a resolved window has any per-model efficiency data, shared between the extension and its tests.
- The dropdown in `vscode-extension/src/webview/efficiency/main.ts` now renders `<label> (<range>)`, appends `- no data` and disables the option when the window is empty.
- Default window selections (`window`, `windowA`, `windowB`) now pick from windows that actually have data instead of the previous hardcoded `lastMonth`/`thisMonth` pair.

## Testing

- Added unit tests for `rangeLabel` (including a year-boundary case) and `windowHasModelData` in `vscode-extension/test/unit/efficiencyAnalysis.test.ts`.
- `npm run compile` (vscode-extension) - clean.
- `npm run test:node` (vscode-extension) - 58/58 pass.
- `npm run check:contract` (vscode-extension) - clean.