### PR TITLE
Sync Copilot App / Claude (VS Code) editor labels to sharing server

### DIFF
--- a/.github/skills/visual-view-diff/lib/browser.js
+++ b/.github/skills/visual-view-diff/lib/browser.js
@@ -48,9 +48,21 @@ const INSTALL_HINT = [
 	'If a browser is already present elsewhere, point PLAYWRIGHT_BROWSERS_PATH at it.',
 ].join('\n');
 
+/**
+ * CI installs a pinned Playwright into its own package tree (see
+ * .github/workflows/dependencies/playwright) rather than globally, so a plain
+ * `require('playwright')` from this file never finds it via Node's normal
+ * upward node_modules search. Resolve that location explicitly.
+ */
+function pinnedWorkflowInstallRoot() {
+	return path.join(__dirname, '..', '..', '..', 'workflows', 'dependencies', 'playwright', 'node_modules');
+}
+
 /** Candidate module paths, cheapest first. */
 function candidatePaths() {
 	const paths = ['playwright', '@playwright/test', 'playwright-core'];
+	const pinnedRoot = pinnedWorkflowInstallRoot();
+	paths.push(`${pinnedRoot}/playwright`, `${pinnedRoot}/@playwright/test`, `${pinnedRoot}/playwright-core`);
 	// Global installs are not on a local script's resolution path, so ask npm
 	// where its global root is and look there too.
 	const globalRoot = globalNpmRoot();

--- a/src/workspaceHelpers.ts
+++ b/src/workspaceHelpers.ts
@@ -22,6 +22,7 @@ import {
 } from './utils/pathUtils';
 import { withErrorRecoverySync } from './utils/errors';
 import { isGuidMcpTool, lookupKnownToolName } from './utils/toolUtils';
+import { isCopilotAppClientName } from './copilotCliStore';
 
 export {
 	fileUriToPath,
@@ -1212,6 +1213,45 @@ export function getEditorTypeFromPath(filePath: string, isOpenCodeSessionFile?: 
 	return detectToolEditorFromPath(filePath, lowerPath, isOpenCodeSessionFile) ??
 		detectVSCodeVariantFromPath(lowerPath) ??
 		'Unknown';
+}
+
+/**
+ * Refines a `getEditorTypeFromPath` result with the same content-based signals the
+ * "Interaction Modes" usage view already applies per-session (see
+ * `usageAnalysis.ts::_asuApplyCopilotAppSplit` and `claudeCodeAdapter.ts::resolveModeBucket`),
+ * so consumers that sync a single per-file editor label (e.g. the sharing-server upload)
+ * can distinguish:
+ *  - 'Copilot App' — a Copilot CLI session launched via the Copilot desktop app
+ *    (`client_name: github/autopilot` in the session's sibling `workspace.yaml`).
+ *    Only covers file-based (worktree) session-state sessions; DB-backed Copilot CLI
+ *    sessions (session-store.db) still report 'Copilot CLI'.
+ *  - 'Claude (VS Code)' — a Claude Code session embedded in VS Code, i.e. the generic
+ *    'Claude Code' bucket `detectClaudeCodeEditorVariant` returns for any entrypoint other
+ *    than the standalone desktop app or the terminal CLI.
+ * Leaves every other editor label untouched.
+ */
+export function refineEditorLabelForInteractionModeSplit(filePath: string, baseLabel: string): string {
+	if (baseLabel === 'Claude Code') { return 'Claude (VS Code)'; }
+	if (baseLabel === 'Copilot CLI' && isCopilotAppSessionFile(filePath)) { return 'Copilot App'; }
+	return baseLabel;
+}
+
+/**
+ * Synchronously checks the sibling `workspace.yaml` of a Copilot CLI session-state file for
+ * `client_name: github/autopilot`, the marker the Copilot desktop app writes when it launches
+ * the CLI. Mirrors the async check in `usageAnalysis.ts::_asuApplyCopilotAppSplit`, but sync
+ * so it can be called from the otherwise-synchronous `getEditorTypeFromPath` family.
+ * @internal
+ */
+function isCopilotAppSessionFile(filePath: string): boolean {
+	try {
+		const yamlPath = path.join(path.dirname(filePath), 'workspace.yaml');
+		const content = fs.readFileSync(yamlPath, 'utf8');
+		const clientMatch = content.match(/^client_name:\s*(.+)$/m);
+		return !!clientMatch && isCopilotAppClientName(clientMatch[1].trim());
+	} catch {
+		return false;
+	}
 }
 
 // ── detectEditorSource helper ──────────────────────────────────────────

--- a/src/workspaceHelpers.ts
+++ b/src/workspaceHelpers.ts
@@ -1216,6 +1216,23 @@ export function getEditorTypeFromPath(filePath: string, isOpenCodeSessionFile?: 
 }
 
 /**
+ * Maps the content-classified `ModeUsage` keys (see `MODE_USAGE_CONTENT_CLASSIFIED_KEYS` in
+ * `vscode-extension/src/webview/shared/types.ts`) to the editor label
+ * `refineEditorLabelForInteractionModeSplit` produces for them when synced to the sharing
+ * server. `claudeDesktop` is intentionally absent: Claude Desktop already gets its own
+ * stable path-based label ('Claude Desktop') via `detectClaudeCodeEditorVariant`, so it
+ * needs no further refinement here.
+ *
+ * `workspaceHelpers.test.ts` asserts this map's keys plus `claudeDesktop` equal
+ * `MODE_USAGE_CONTENT_CLASSIFIED_KEYS` — add a new content-classified interaction mode to
+ * one and the test fails until the other side is updated too.
+ */
+export const SYNCED_INTERACTION_MODE_LABELS: Readonly<Record<string, string>> = {
+	cliApp: 'Copilot App',
+	claudeVsCode: 'Claude (VS Code)',
+};
+
+/**
  * Refines a `getEditorTypeFromPath` result with the same content-based signals the
  * "Interaction Modes" usage view already applies per-session (see
  * `usageAnalysis.ts::_asuApplyCopilotAppSplit` and `claudeCodeAdapter.ts::resolveModeBucket`),
@@ -1231,8 +1248,8 @@ export function getEditorTypeFromPath(filePath: string, isOpenCodeSessionFile?: 
  * Leaves every other editor label untouched.
  */
 export function refineEditorLabelForInteractionModeSplit(filePath: string, baseLabel: string): string {
-	if (baseLabel === 'Claude Code') { return 'Claude (VS Code)'; }
-	if (baseLabel === 'Copilot CLI' && isCopilotAppSessionFile(filePath)) { return 'Copilot App'; }
+	if (baseLabel === 'Claude Code') { return SYNCED_INTERACTION_MODE_LABELS.claudeVsCode; }
+	if (baseLabel === 'Copilot CLI' && isCopilotAppSessionFile(filePath)) { return SYNCED_INTERACTION_MODE_LABELS.cliApp; }
 	return baseLabel;
 }
 

--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to the VS Code extension will be documented in this file.
 ### Bug Fixes
 - Fix the "Efficiency" nav button in the Efficiency view doing nothing when clicked — the view passed no active view to the shared nav bar, so its own button rendered enabled with no click handler instead of being marked as the current page
 - Surface a warning when copying a path from the Usage Analysis view fails: the webview reported the failure but nothing on the extension side listened, so a failed copy was completely silent
+- Sharing-server sync now reports "Copilot App" and "Claude (VS Code)" as their own editor labels (matching the local Interaction Modes view) instead of lumping them into "Copilot CLI"/"Claude Code" — the team dashboard's "Editors Used" panel previously had no way to show these categories at all, since the synced `editor` field never carried the distinction
 
 ### Chores
 - New validation tooling: `npm run preflight` runs every check in one pass (see [docs/VALIDATION.md](../docs/VALIDATION.md)), `npm run check:contract` fails the build when a webview message has no handler on the other side, and `npm run check:interaction` clicks every control in every panel headlessly. CI now also renders before/after webview screenshots on pull requests

--- a/vscode-extension/src/backend/services/syncService.ts
+++ b/vscode-extension/src/backend/services/syncService.ts
@@ -24,7 +24,7 @@ import { SharingServerUploadService, type SharingServerEntry } from './sharingSe
 import { SyncLock } from './syncLock';
 import { type IBlobUploadService } from './blobUploadService';
 import { isJsonlContent } from '../../../../src/tokenEstimation';
-import { getEditorTypeFromPath } from '../../../../src/workspaceHelpers';
+import { getEditorTypeFromPath, refineEditorLabelForInteractionModeSplit } from '../../../../src/workspaceHelpers';
 
 /** Ecosystem session per-model usage entry (input, output, optional interactions). */
 type ModelUsageEntry = { inputTokens: number; outputTokens: number; interactions?: number };
@@ -1289,8 +1289,11 @@ return true;
 
 	private getEditorForFile(sessionFile: string, includeEditorDimension: boolean): string | undefined {
 		if (!includeEditorDimension) { return undefined; }
-		return this.deps.getEditorLabel?.(sessionFile) ??
+		const label = this.deps.getEditorLabel?.(sessionFile) ??
 			getEditorTypeFromPath(sessionFile, this.deps.editorHandlers?.isOpenCodeSession);
+		// Break out "Copilot App" and "Claude (VS Code)" from the coarser path-based label so
+		// the sharing-server "Editors Used" breakdown matches the local Interaction Modes view.
+		return refineEditorLabelForInteractionModeSplit(sessionFile, label);
 	}
 
 	private isVSSessionFileType(sessionFile: string): boolean {

--- a/vscode-extension/src/webview/shared/types.ts
+++ b/vscode-extension/src/webview/shared/types.ts
@@ -22,6 +22,19 @@ export type CategoryLevelData = {
 };
 
 export type ModeUsage = { ask: number; edit: number; agent: number; plan: number; customAgent: number; cli: number; cliApp?: number; claudeDesktop?: number; claudeVsCode?: number };
+
+/**
+ * ModeUsage keys computed from session *content* (not just path) that distinguish an
+ * interaction surface the coarse per-file editor label can't see on its own — e.g. a
+ * Copilot CLI session launched via the desktop app, or a Claude Code session embedded
+ * in VS Code vs. the standalone desktop app.
+ *
+ * If you add a new key here, also update `SYNCED_INTERACTION_MODE_LABELS` in
+ * `src/workspaceHelpers.ts` (repo root) so the sharing-server sync's per-file editor
+ * label picks it up too — `workspaceHelpers.test.ts` locks these two lists together
+ * and fails the build if they diverge.
+ */
+export const MODE_USAGE_CONTENT_CLASSIFIED_KEYS = ['cliApp', 'claudeDesktop', 'claudeVsCode'] as const;
 export type ToolCallUsage = { total: number; byTool: { [key: string]: number }; outputTokensByTool?: { [key: string]: number } };
 export type McpToolUsage = { total: number; byServer: { [key: string]: number }; byTool: { [key: string]: number } };
 

--- a/vscode-extension/test/unit/workspaceHelpers.test.ts
+++ b/vscode-extension/test/unit/workspaceHelpers.test.ts
@@ -349,8 +349,10 @@ import {
         getEditorTypeFromPath,
         detectEditorSource,
         detectClaudeCodeEditorVariant,
-        refineEditorLabelForInteractionModeSplit
+        refineEditorLabelForInteractionModeSplit,
+        SYNCED_INTERACTION_MODE_LABELS
 } from '../../../src/workspaceHelpers';
+import { MODE_USAGE_CONTENT_CLASSIFIED_KEYS } from '../../src/webview/shared/types';
 
 // ── extractWorkspaceIdFromSessionPath ───────────────────────────────────
 
@@ -514,6 +516,20 @@ test('refineEditorLabelForInteractionModeSplit: leaves Copilot CLI untouched whe
 
 test('refineEditorLabelForInteractionModeSplit: leaves unrelated editor labels untouched', () => {
         assert.equal(refineEditorLabelForInteractionModeSplit('/home/user/Code/User/workspaceStorage/abc/session.json', 'VS Code'), 'VS Code');
+});
+
+test('SYNCED_INTERACTION_MODE_LABELS stays in lockstep with MODE_USAGE_CONTENT_CLASSIFIED_KEYS (drift guard)', () => {
+        // 'claudeDesktop' needs no sync-side refinement: it already gets a stable path-based
+        // label ('Claude Desktop') straight from detectClaudeCodeEditorVariant.
+        const syncedKeys = Object.keys(SYNCED_INTERACTION_MODE_LABELS).concat('claudeDesktop').sort();
+        const webviewKeys = [...MODE_USAGE_CONTENT_CLASSIFIED_KEYS].sort();
+        assert.deepEqual(
+                syncedKeys,
+                webviewKeys,
+                'A new content-classified ModeUsage key was added on one side without updating the other — ' +
+                        'add it to SYNCED_INTERACTION_MODE_LABELS (workspaceHelpers.ts) or ' +
+                        'MODE_USAGE_CONTENT_CLASSIFIED_KEYS (webview/shared/types.ts) to match.'
+        );
 });
 
 test('getEditorTypeFromPath: detects Cursor', () => {

--- a/vscode-extension/test/unit/workspaceHelpers.test.ts
+++ b/vscode-extension/test/unit/workspaceHelpers.test.ts
@@ -348,7 +348,8 @@ import {
         globToRegExp,
         getEditorTypeFromPath,
         detectEditorSource,
-        detectClaudeCodeEditorVariant
+        detectClaudeCodeEditorVariant,
+        refineEditorLabelForInteractionModeSplit
 } from '../../../src/workspaceHelpers';
 
 // ── extractWorkspaceIdFromSessionPath ───────────────────────────────────
@@ -466,6 +467,53 @@ test('detectClaudeCodeEditorVariant: defaults to Claude Code when file is missin
         } finally {
                 fs.rmSync(dir, { recursive: true, force: true });
         }
+});
+
+// ── refineEditorLabelForInteractionModeSplit ─────────────────────────────
+
+test('refineEditorLabelForInteractionModeSplit: relabels Claude Code as Claude (VS Code)', () => {
+        assert.equal(refineEditorLabelForInteractionModeSplit('/home/user/.claude/projects/hash/session.jsonl', 'Claude Code'), 'Claude (VS Code)');
+});
+
+test('refineEditorLabelForInteractionModeSplit: leaves Claude Desktop and Claude Code CLI untouched', () => {
+        assert.equal(refineEditorLabelForInteractionModeSplit('/home/user/.claude/projects/hash/session.jsonl', 'Claude Desktop'), 'Claude Desktop');
+        assert.equal(refineEditorLabelForInteractionModeSplit('/home/user/.claude/projects/hash/session.jsonl', 'Claude Code CLI'), 'Claude Code CLI');
+});
+
+test('refineEditorLabelForInteractionModeSplit: relabels Copilot CLI as Copilot App when workspace.yaml marks the desktop app', () => {
+        const dir = fs.mkdtempSync(path.join(process.cwd(), 'copilot-app-'));
+        const sessionDir = path.join(dir, '.copilot', 'session-state', 'abc');
+        fs.mkdirSync(sessionDir, { recursive: true });
+        const file = path.join(sessionDir, 'events.jsonl');
+        fs.writeFileSync(file, '');
+        fs.writeFileSync(path.join(sessionDir, 'workspace.yaml'), 'cwd: /repo\nclient_name: github/autopilot\n');
+        try {
+                assert.equal(refineEditorLabelForInteractionModeSplit(file, 'Copilot CLI'), 'Copilot App');
+        } finally {
+                fs.rmSync(dir, { recursive: true, force: true });
+        }
+});
+
+test('refineEditorLabelForInteractionModeSplit: leaves Copilot CLI untouched for plain terminal CLI sessions', () => {
+        const dir = fs.mkdtempSync(path.join(process.cwd(), 'copilot-cli-'));
+        const sessionDir = path.join(dir, '.copilot', 'session-state', 'abc');
+        fs.mkdirSync(sessionDir, { recursive: true });
+        const file = path.join(sessionDir, 'events.jsonl');
+        fs.writeFileSync(file, '');
+        fs.writeFileSync(path.join(sessionDir, 'workspace.yaml'), 'cwd: /repo\nclient_name: github/cli\n');
+        try {
+                assert.equal(refineEditorLabelForInteractionModeSplit(file, 'Copilot CLI'), 'Copilot CLI');
+        } finally {
+                fs.rmSync(dir, { recursive: true, force: true });
+        }
+});
+
+test('refineEditorLabelForInteractionModeSplit: leaves Copilot CLI untouched when workspace.yaml is missing', () => {
+        assert.equal(refineEditorLabelForInteractionModeSplit('/nonexistent/path/session-state/abc/events.jsonl', 'Copilot CLI'), 'Copilot CLI');
+});
+
+test('refineEditorLabelForInteractionModeSplit: leaves unrelated editor labels untouched', () => {
+        assert.equal(refineEditorLabelForInteractionModeSplit('/home/user/Code/User/workspaceStorage/abc/session.json', 'VS Code'), 'VS Code');
 });
 
 test('getEditorTypeFromPath: detects Cursor', () => {


### PR DESCRIPTION
## Root cause

The team server's "Editors Used" dashboard panel and the local extension's "Interaction Modes" panel are computed by two completely different code paths:

- **Editors Used** (sharing-server dashboard) derives from `getEditorTypeFromPath()` — pure path-based detection (VS Code, Copilot CLI, Claude Code, Claude Desktop, ...).
- **Interaction Modes** (local extension webview) uses finer, content-based classification — e.g. it reads `workspace.yaml`'s `client_name` to split "Copilot App" out of Copilot CLI sessions, and the Claude Code `entrypoint` field to split "Claude (VS Code)" out of the generic Claude Code bucket.

Critically, `SharingServerEntry` (the payload synced to the sharing server) only has a single `editor?: string` field, populated purely from the path-based label. **The interaction-mode split was never synced to the server at all** — so this isn't a regression from the redeploy, it's a feature gap: the new "Copilot App" / "Claude (VS Code)" categories were added to the local view but never wired into the sync pipeline.

## Fix

Added `refineEditorLabelForInteractionModeSplit()` in `src/workspaceHelpers.ts`, reusing the exact same signals already used for local Interaction Modes classification:
- Reads the sibling `workspace.yaml` for `client_name: github/autopilot` to relabel `Copilot CLI` → `Copilot App`.
- Relabels the generic `Claude Code` bucket (VS Code-embedded entrypoint) → `Claude (VS Code)`.

Applied it in `syncService.ts::getEditorForFile()`, which builds the per-file editor label for the sharing-server upload rollups. `getEditorTypeFromPath()` itself is untouched, so all its existing consumers (CLI, local editor-usage stats, tests) are unaffected.

## Testing
- `npm run compile` — clean
- `npm run compile-tests && node --require ./out/vscode-extension/test/unit/vscode-shim-register.js --test out/vscode-extension/test/unit/workspaceHelpers.test.js` — 281/281 pass (including new tests)
- Same for `backend-syncService.test.js` — 76/76 pass

Once deployed, re-syncing will populate the new `Copilot App` / `Claude (VS Code)` rows in the team server's "Editors Used" panel going forward (historical uploads made before this fix keep their old coarse labels).