### PR TITLE
Group low-activity workspaces into "Other" on Workspace Health tab

### DIFF
--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -392,6 +392,8 @@ const repoAnalysisState = new Map<string, RepoAnalysisRecord>();
 const repoAnalysisInFlight = new Set<string>();
 let selectedRepoPath: string | null = null;
 let isSwitchingRepository = false;
+/** When true, the Workspace Health repo list shows every workspace instead of grouping low-activity ones into "Other". */
+let showAllWorkspacesInHealth = false;
 let isBatchAnalysisInProgress = false;
 /** True while the single "Analyze Repo for Best Practices" analysis (no workspace matrix) runs. */
 let isSingleRepoAnalysisInProgress = false;
@@ -5177,6 +5179,16 @@ function wireRepositoryButtons(): void {
 
 	document.getElementById('repo-list-pane')?.addEventListener('click', (e: MouseEvent) => {
 		const target = e.target as HTMLElement;
+		if (target.closest('#btn-show-other-workspaces')) {
+			showAllWorkspacesInHealth = true;
+			renderRepositoryHygienePanels();
+			return;
+		}
+		if (target.closest('#btn-collapse-other-workspaces')) {
+			showAllWorkspacesInHealth = false;
+			renderRepositoryHygienePanels();
+			return;
+		}
 		const actionButton = target.closest<HTMLElement>('.btn-repo-action');
 		if (!actionButton) { return; }
 		const workspacePath = actionButton.getAttribute('data-workspace-path');
@@ -5718,7 +5730,38 @@ function buildRepoAnalysisBodyElement(data: RepoAnalysisData, workspacePath?: st
 	return container;
 }
 
-function renderRepoListPane(listPane: HTMLElement, visibleWorkspaces: any[], hasSelectedRepository: boolean): void {
+/**
+ * Splits workspaces into a "major" group and a long-tail "other" group based on session count,
+ * so a handful of heavily-used workspaces aren't buried in a long list of one/two-session workspaces.
+ * The split point is found dynamically: the biggest proportional drop in session count between
+ * consecutive workspaces (sorted descending), as long as the drop is at least 2x and leaves a
+ * tail of 3+ workspaces (otherwise there's no meaningful "long tail" to group).
+ */
+function computeWorkspaceHealthGrouping(workspaces: WorkspaceCustomizationRow[]): { visible: WorkspaceCustomizationRow[]; otherWorkspaces: WorkspaceCustomizationRow[] } {
+	if (workspaces.length <= 6) {
+		return { visible: workspaces, otherWorkspaces: [] };
+	}
+	const sorted = [...workspaces].sort((a, b) => (Number(b.sessionCount) || 0) - (Number(a.sessionCount) || 0));
+	let splitIdx = sorted.length;
+	let bestRatio = 1;
+	for (let i = 1; i < sorted.length; i++) {
+		const prev = Number(sorted[i - 1].sessionCount) || 0;
+		const curr = Number(sorted[i].sessionCount) || 0;
+		if (prev <= 0) { continue; }
+		const ratio = prev / Math.max(curr, 1);
+		if (ratio > bestRatio) {
+			bestRatio = ratio;
+			splitIdx = i;
+		}
+	}
+	const tailSize = sorted.length - splitIdx;
+	if (bestRatio < 2 || splitIdx < 1 || tailSize < 3) {
+		return { visible: sorted, otherWorkspaces: [] };
+	}
+	return { visible: sorted.slice(0, splitIdx), otherWorkspaces: sorted.slice(splitIdx) };
+}
+
+function renderRepoListPane(listPane: HTMLElement, visibleWorkspaces: any[], hasSelectedRepository: boolean, otherWorkspaces: WorkspaceCustomizationRow[] = [], canCollapse: boolean = false): void {
 	const colStyles = {
 		sessions: 'width: 60px; text-align: right; flex-shrink: 0; font-size: 11px; color: var(--text-primary);',
 		interactions: 'width: 80px; text-align: right; flex-shrink: 0; font-size: 11px; color: var(--text-primary);',
@@ -5760,7 +5803,21 @@ function renderRepoListPane(listPane: HTMLElement, visibleWorkspaces: any[], has
 				</vscode-button>
 			</div>
 		`;
-	}).join(''));
+	}).join('') + (otherWorkspaces.length > 0 ? `
+		<div class="repo-item repo-item-other" style="padding: 6px 12px; border-top: 1px solid var(--border-color); display: flex; align-items: center; gap: 10px; background: var(--bg-secondary);">
+			<div style="flex: 1; min-width: 0; font-size: 12px; font-style: italic; color: var(--text-secondary);">
+				Other (${otherWorkspaces.length} repositor${otherWorkspaces.length === 1 ? 'y' : 'ies'} with low activity)
+			</div>
+			<div style="${colStyles.sessions}">${otherWorkspaces.reduce((sum, ws) => sum + (Number(ws.sessionCount) || 0), 0)}</div>
+			<div style="${colStyles.interactions}">${otherWorkspaces.reduce((sum, ws) => sum + (Number(ws.interactionCount) || 0), 0)}</div>
+			<div style="${colStyles.score}">—</div>
+			<vscode-button id="btn-show-other-workspaces" appearance="secondary" style="width: 110px; flex-shrink: 0;">Show all</vscode-button>
+		</div>
+	` : showAllWorkspacesInHealth && !hasSelectedRepository && canCollapse ? `
+		<div class="repo-item repo-item-other" style="padding: 6px 12px; border-top: 1px solid var(--border-color); display: flex; align-items: center; justify-content: flex-end;">
+			<vscode-button id="btn-collapse-other-workspaces" appearance="secondary" style="width: 110px; flex-shrink: 0;">Show less</vscode-button>
+		</div>
+	` : ''));
 }
 
 function renderRepoDetailSuccess(detailsPane: HTMLElement, record: any, workspaceName: string): void {
@@ -5795,13 +5852,22 @@ function renderRepositoryHygienePanels(): void {
 	}
 
 	const hasSelectedRepository = !!selectedRepoPath && !isSwitchingRepository;
-	const visibleWorkspaces = hasSelectedRepository
-		? hygieneMatrixState.workspaces.filter((ws) => ws.workspacePath === selectedRepoPath)
-		: hygieneMatrixState.workspaces;
+	const grouping = computeWorkspaceHealthGrouping(hygieneMatrixState.workspaces);
+	const canCollapse = grouping.otherWorkspaces.length > 0;
+	let visibleWorkspaces: WorkspaceCustomizationRow[];
+	let otherWorkspaces: WorkspaceCustomizationRow[] = [];
+	if (hasSelectedRepository) {
+		visibleWorkspaces = hygieneMatrixState.workspaces.filter((ws) => ws.workspacePath === selectedRepoPath);
+	} else if (showAllWorkspacesInHealth || !canCollapse) {
+		visibleWorkspaces = grouping.visible.concat(grouping.otherWorkspaces);
+	} else {
+		visibleWorkspaces = grouping.visible;
+		otherWorkspaces = grouping.otherWorkspaces;
+	}
 
 	listContainer.classList.remove('repo-hygiene-pane-collapsed');
 	detailsContainer.classList.toggle('repo-hygiene-pane-collapsed', !hasSelectedRepository);
-	renderRepoListPane(listPane, visibleWorkspaces, hasSelectedRepository);
+	renderRepoListPane(listPane, visibleWorkspaces, hasSelectedRepository, otherWorkspaces, canCollapse);
 
 	if (!hasSelectedRepository || !selectedRepoPath) {
 		detailsPane.replaceChildren();

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -5742,9 +5742,11 @@ function computeWorkspaceHealthGrouping(workspaces: WorkspaceCustomizationRow[])
 		return { visible: workspaces, otherWorkspaces: [] };
 	}
 	const sorted = [...workspaces].sort((a, b) => (Number(b.sessionCount) || 0) - (Number(a.sessionCount) || 0));
-	let splitIdx = sorted.length;
+	let splitIdx = -1;
 	let bestRatio = 1;
-	for (let i = 1; i < sorted.length; i++) {
+	// Only consider split points that would leave a tail of 3+ workspaces — a later, larger
+	// ratio near the very end of the list isn't a valid candidate since it wouldn't group anything.
+	for (let i = 1; i <= sorted.length - 3; i++) {
 		const prev = Number(sorted[i - 1].sessionCount) || 0;
 		const curr = Number(sorted[i].sessionCount) || 0;
 		if (prev <= 0) { continue; }
@@ -5754,14 +5756,13 @@ function computeWorkspaceHealthGrouping(workspaces: WorkspaceCustomizationRow[])
 			splitIdx = i;
 		}
 	}
-	const tailSize = sorted.length - splitIdx;
-	if (bestRatio < 2 || splitIdx < 1 || tailSize < 3) {
+	if (splitIdx < 1 || bestRatio < 2) {
 		return { visible: sorted, otherWorkspaces: [] };
 	}
 	return { visible: sorted.slice(0, splitIdx), otherWorkspaces: sorted.slice(splitIdx) };
 }
 
-function renderRepoListPane(listPane: HTMLElement, visibleWorkspaces: any[], hasSelectedRepository: boolean, otherWorkspaces: WorkspaceCustomizationRow[] = [], canCollapse: boolean = false): void {
+function renderRepoListPane(listPane: HTMLElement, visibleWorkspaces: WorkspaceCustomizationRow[], hasSelectedRepository: boolean, otherWorkspaces: WorkspaceCustomizationRow[] = [], canCollapse: boolean = false): void {
 	const colStyles = {
 		sessions: 'width: 60px; text-align: right; flex-shrink: 0; font-size: 11px; color: var(--text-primary);',
 		interactions: 'width: 80px; text-align: right; flex-shrink: 0; font-size: 11px; color: var(--text-primary);',

--- a/vscode-extension/test/unit/usageWebviewMessageFlow.test.ts
+++ b/vscode-extension/test/unit/usageWebviewMessageFlow.test.ts
@@ -92,6 +92,31 @@ function buildStatsWithLongTailModelEfficiency(): Record<string, unknown> {
 	return stats;
 }
 
+/**
+ * `buildStats()` with a Workspace Health customization matrix mirroring a real long-tail
+ * distribution: 5 heavily-used workspaces (110-60 sessions) followed by 5 workspaces with
+ * only 1-2 sessions each — the "clear cliff" `computeWorkspaceHealthGrouping()` should detect.
+ */
+function buildStatsWithLongTailWorkspaces(): Record<string, unknown> {
+	const stats = buildStats();
+	const majorSessionCounts = [110, 90, 80, 70, 60];
+	const tailSessionCounts = [2, 2, 1, 1, 1];
+	const workspaces = [...majorSessionCounts, ...tailSessionCounts].map((sessionCount, index) => ({
+		workspacePath: `/repos/repo-${index + 1}`,
+		workspaceName: `repo-${index + 1}`,
+		sessionCount,
+		interactionCount: sessionCount * 10,
+		typeStatuses: {},
+	}));
+	stats.customizationMatrix = {
+		customizationTypes: [],
+		workspaces,
+		totalWorkspaces: workspaces.length,
+		workspacesWithIssues: 0,
+	};
+	return stats;
+}
+
 function buildStatsWithCorrections(): Record<string, unknown> {
 	return {
 		...buildStats(),
@@ -424,6 +449,62 @@ test('remembers the "Other models" open state across a leaderboard re-render', a
 	const detailsAfterSort = harness.window.document.getElementById('model-leaderboard-other');
 	assert.ok(detailsAfterSort, 'expects the "Other models" group to still exist after sorting');
 	assert.equal(detailsAfterSort.open, true, 'the open state must survive the re-render');
+});
+
+test('collapses the long tail of low-activity workspaces into an "Other" row on Workspace Health', async () => {
+	const harness = await bootWebview(buildStatsWithLongTailWorkspaces());
+
+	const majorRows = harness.window.document.querySelectorAll('#repo-list-pane .repo-name');
+	assert.equal(majorRows.length, 5, 'only the 5 high-activity workspaces should render as individual rows');
+
+	const rendered = harness.text('#repo-list-pane');
+	assert.match(rendered ?? '', /Other \(5 repositories with low activity\)/);
+
+	const showAllButton = harness.window.document.getElementById('btn-show-other-workspaces');
+	assert.ok(showAllButton, 'expects a "Show all" toggle for the collapsed tail');
+
+	showAllButton.click();
+	await harness.settle();
+
+	const allRows = harness.window.document.querySelectorAll('#repo-list-pane .repo-name');
+	assert.equal(allRows.length, 10, '"Show all" must reveal every workspace, including the low-activity tail');
+	assert.equal(
+		harness.window.document.getElementById('btn-show-other-workspaces'), null,
+		'the "Other" row must disappear once expanded',
+	);
+	const collapseButton = harness.window.document.getElementById('btn-collapse-other-workspaces');
+	assert.ok(collapseButton, 'expects a "Show less" toggle once expanded');
+
+	collapseButton.click();
+	await harness.settle();
+
+	const collapsedAgainRows = harness.window.document.querySelectorAll('#repo-list-pane .repo-name');
+	assert.equal(collapsedAgainRows.length, 5, '"Show less" must collapse back to just the major group');
+});
+
+test('does not group workspaces on Workspace Health when there is no long tail', async () => {
+	const stats = buildStats();
+	// A gentle, non-cliff distribution with too few workspaces to bother grouping.
+	stats.customizationMatrix = {
+		customizationTypes: [],
+		workspaces: [10, 8, 6, 4].map((sessionCount, index) => ({
+			workspacePath: `/repos/repo-${index + 1}`,
+			workspaceName: `repo-${index + 1}`,
+			sessionCount,
+			interactionCount: sessionCount * 10,
+			typeStatuses: {},
+		})),
+		totalWorkspaces: 4,
+		workspacesWithIssues: 0,
+	};
+	const harness = await bootWebview(stats);
+
+	const rows = harness.window.document.querySelectorAll('#repo-list-pane .repo-name');
+	assert.equal(rows.length, 4, 'all workspaces should render individually when there is no meaningful drop-off');
+	assert.equal(
+		harness.window.document.getElementById('btn-show-other-workspaces'), null,
+		'no "Other" row should appear for a small, non-cliff workspace list',
+	);
 });
 
 test('filters corrections by type and opens the selected session turn', async () => {


### PR DESCRIPTION
## Why

The Workspace Health tab's repo list shows every workspace with Copilot activity in the last 30 days, sorted by activity. In practice this often means a handful of heavily-used workspaces (dozens to 100+ sessions) followed by a long tail of workspaces with only 1-2 sessions each, which pushes the workspaces that matter further down and adds a lot of visual noise.

## Approach

Added `computeWorkspaceHealthGrouping()` in `vscode-extension/src/webview/usage/main.ts`, which finds a dynamic split point in the (session-count-sorted) workspace list: the position with the biggest proportional drop in session count between consecutive workspaces. A split is only applied when:
- the drop is at least 2x, and
- the resulting tail has 3+ workspaces (otherwise there's no meaningful "long tail" to hide).

The "major" workspaces render as before; anything past the split collapses into a single "Other (N repositories with low activity)" summary row showing aggregated session/interaction totals, with a "Show all" button to expand back to the full list (and "Show less" to re-collapse). Selecting a specific repository for detailed analysis is unaffected.

## Notes

- No new webview message types were introduced (`check:contract` and `check:interaction` both pass) — the toggle is purely local UI state (`showAllWorkspacesInHealth`), not persisted across data refreshes.
- Grouping is skipped entirely for 6 or fewer workspaces, or when there's no meaningful drop-off, so small setups see no behavior change.