### PR TITLE
Add editor/vendor/model/HydraFusion pill filters to Recent Sessions table

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -4729,7 +4729,11 @@ class CopilotTokenTracker implements vscode.Disposable {
 		// Wall-clock duration (includes idle gaps between turns) — kept for reference/future use.
 		const durationMs = computeSessionDurationMs(sessionData.firstInteraction, sessionData.lastInteraction);
 		// Net/active duration (excludes idle gaps between turns) — this is what's shown as "Duration".
-		const activeDurationMs = analysis.sessionDuration?.activeDurationMs;
+		// Only meaningful for formats with per-request timing data (e.g. VS Code Chat); other
+		// formats (e.g. Copilot CLI JSONL) report 0 here, which must not shadow the wall-clock
+		// duration below, or every such session would misleadingly show up as "<1m".
+		const rawActiveDurationMs = analysis.sessionDuration?.activeDurationMs;
+		const activeDurationMs = rawActiveDurationMs !== undefined && rawActiveDurationMs > 0 ? rawActiveDurationMs : undefined;
 		const workspace = this.resolveSessionWorkspaceName(sessionData, sessionFile);
 		return {
 			title: sessionData.title || null, filePath: sessionFile, interactions,

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -1158,7 +1158,10 @@ const SESSION_COLUMN_DEFS: SessionColumnDef[] = [
 	{ id: 'workspace', label: 'Workspace', sortKey: 'workspace', align: 'left', cellStyle: 'max-width:140px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;', render: s => { const workspace = escapeHtml(s.workspace || '—'); return { html: workspace, title: workspace }; } },
 	{ id: 'models', label: 'Models', align: 'left', cellStyle: 'font-size:11px; max-width:180px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;', render: s => { const models = s.models.map(m => escapeHtml(getModelDisplayName(m))).join(', ') || '—'; return { html: models, title: models }; } },
 	{ id: 'durationMs', label: 'Duration', sortKey: 'durationMs', align: 'right', cellStyle: 'white-space:nowrap;', render: s => {
-		const net = s.activeDurationMs ?? s.durationMs;
+		// A zero (but defined) activeDurationMs means no per-request timing data was available
+		// for this session format (e.g. Copilot CLI JSONL) — fall back to wall-clock duration
+		// instead of showing a misleading "<1m".
+		const net = s.activeDurationMs ? s.activeDurationMs : s.durationMs;
 		const wallLabel = s.durationMs !== undefined ? `Wall time: ${formatDurationShort(s.durationMs)}` : undefined;
 		return { html: formatDurationShort(net), ...(wallLabel ? { title: wallLabel } : {}) };
 	} },
@@ -1323,7 +1326,7 @@ const _todaySessionColumnComparators: Partial<Record<SessionSortColumn, (a: Toda
 	title: (a, b) => (a.title || '').localeCompare(b.title || ''),
 	editor: (a, b) => (a.editor || '').localeCompare(b.editor || ''),
 	workspace: (a, b) => (a.workspace || '').localeCompare(b.workspace || ''),
-	durationMs: (a, b) => (a.activeDurationMs ?? a.durationMs ?? -1) - (b.activeDurationMs ?? b.durationMs ?? -1),
+	durationMs: (a, b) => (a.activeDurationMs || a.durationMs || -1) - (b.activeDurationMs || b.durationMs || -1),
 	subAgentCalls: (a, b) => (a.subAgentCalls ?? 0) - (b.subAgentCalls ?? 0),
 	lastActivity: (a, b) => (a.lastActivity || '').localeCompare(b.lastActivity || ''),
 };

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -1140,6 +1140,16 @@ function isHydraFusionModel(model: string): boolean {
 	return getModelLookupCandidates(model).some(candidate => candidate.toLowerCase() === 'hydrafusion');
 }
 
+/**
+ * Returns the duration to display/sort by for a session: the active (non-idle) duration when
+ * available, falling back to the wall-clock duration for session formats that don't provide
+ * per-request timing data (e.g. Copilot CLI JSONL, where `activeDurationMs` is always 0).
+ * Single source of truth for this fallback so the cell renderer and sort comparator can't drift.
+ */
+function getEffectiveSessionDurationMs(s: TodaySessionSummary): number | undefined {
+	return s.activeDurationMs ? s.activeDurationMs : s.durationMs;
+}
+
 const SESSION_COLUMN_DEFS: SessionColumnDef[] = [
 	{ id: 'interactions', label: 'Turns', sortKey: 'interactions', align: 'right', render: s => formatCompactSessionNumber(s.interactions) },
 	{ id: 'toolCalls', label: 'Tools', sortKey: 'toolCalls', align: 'right', render: s => formatCompactSessionNumber(s.toolCalls) },
@@ -1158,10 +1168,7 @@ const SESSION_COLUMN_DEFS: SessionColumnDef[] = [
 	{ id: 'workspace', label: 'Workspace', sortKey: 'workspace', align: 'left', cellStyle: 'max-width:140px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;', render: s => { const workspace = escapeHtml(s.workspace || '—'); return { html: workspace, title: workspace }; } },
 	{ id: 'models', label: 'Models', align: 'left', cellStyle: 'font-size:11px; max-width:180px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;', render: s => { const models = s.models.map(m => escapeHtml(getModelDisplayName(m))).join(', ') || '—'; return { html: models, title: models }; } },
 	{ id: 'durationMs', label: 'Duration', sortKey: 'durationMs', align: 'right', cellStyle: 'white-space:nowrap;', render: s => {
-		// A zero (but defined) activeDurationMs means no per-request timing data was available
-		// for this session format (e.g. Copilot CLI JSONL) — fall back to wall-clock duration
-		// instead of showing a misleading "<1m".
-		const net = s.activeDurationMs ? s.activeDurationMs : s.durationMs;
+		const net = getEffectiveSessionDurationMs(s);
 		const wallLabel = s.durationMs !== undefined ? `Wall time: ${formatDurationShort(s.durationMs)}` : undefined;
 		return { html: formatDurationShort(net), ...(wallLabel ? { title: wallLabel } : {}) };
 	} },
@@ -1326,7 +1333,7 @@ const _todaySessionColumnComparators: Partial<Record<SessionSortColumn, (a: Toda
 	title: (a, b) => (a.title || '').localeCompare(b.title || ''),
 	editor: (a, b) => (a.editor || '').localeCompare(b.editor || ''),
 	workspace: (a, b) => (a.workspace || '').localeCompare(b.workspace || ''),
-	durationMs: (a, b) => (a.activeDurationMs || a.durationMs || -1) - (b.activeDurationMs || b.durationMs || -1),
+	durationMs: (a, b) => (getEffectiveSessionDurationMs(a) ?? -1) - (getEffectiveSessionDurationMs(b) ?? -1),
 	subAgentCalls: (a, b) => (a.subAgentCalls ?? 0) - (b.subAgentCalls ?? 0),
 	lastActivity: (a, b) => (a.lastActivity || '').localeCompare(b.lastActivity || ''),
 };

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -1265,7 +1265,7 @@ function buildFilterPillGroupHtml(groupLabel: string, filterType: string, items:
 	const pills = items.map(({ value, label, count }) => {
 		const isActive = activeSet.has(value);
 		const safeLabel = escapeHtml(label);
-		return `<button type="button" class="session-filter-pill${isActive ? ' active' : ''}" data-filter-type="${filterType}" data-filter-value="${escapeHtml(value)}" title="${safeLabel}: ${count} session${count === 1 ? '' : 's'}">${safeLabel} <span class="session-filter-pill-count">${count}</span></button>`;
+		return `<button type="button" class="session-filter-pill${isActive ? ' active' : ''}" data-filter-type="${filterType}" data-filter-value="${escapeHtml(value)}" aria-pressed="${isActive}" title="${safeLabel}: ${count} session${count === 1 ? '' : 's'}">${safeLabel} <span class="session-filter-pill-count">${count}</span></button>`;
 	}).join('');
 	return `<div class="session-filter-group"><span class="session-filter-group-label">${escapeHtml(groupLabel)}:</span>${pills}</div>`;
 }
@@ -1278,7 +1278,7 @@ function buildSessionFilterBarHtml(sessions: TodaySessionSummary[]): string {
 	const groups: string[] = [];
 	if (opts.hydraFusionCount > 0) {
 		const isActive = sessionFilterHydraFusionOnly;
-		groups.push(`<div class="session-filter-group"><button type="button" class="session-filter-pill session-filter-pill-hydrafusion${isActive ? ' active' : ''}" data-filter-type="hydrafusion" data-filter-value="true" title="Show only sessions that used HydraFusion">⚡ HydraFusion <span class="session-filter-pill-count">${opts.hydraFusionCount}</span></button></div>`);
+		groups.push(`<div class="session-filter-group"><button type="button" class="session-filter-pill session-filter-pill-hydrafusion${isActive ? ' active' : ''}" data-filter-type="hydrafusion" data-filter-value="true" aria-pressed="${isActive}" title="Show only sessions that used HydraFusion">⚡ HydraFusion <span class="session-filter-pill-count">${opts.hydraFusionCount}</span></button></div>`);
 	}
 	groups.push(buildFilterPillGroupHtml('Editor', 'editor', opts.editors, sessionFilterEditors));
 	groups.push(buildFilterPillGroupHtml('Vendor', 'vendor', opts.vendors, sessionFilterVendors));

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -1190,8 +1190,128 @@ const recentSessionsCache: { [period: string]: TodaySessionSummary[] } = {};
 /** Which optional columns are currently visible. Title (and the row number) are always shown. */
 let enabledSessionColumns: Set<SessionColumnId> = new Set(ALL_SESSION_COLUMN_IDS);
 
+// --- Recent Sessions pill filters (Editor / Model / Model vendor / HydraFusion) ---
+/** Active editor pill filters. Empty set means "no filter" (show all editors). */
+let sessionFilterEditors: Set<string> = new Set();
+/** Active model-vendor pill filters (e.g. "Anthropic", "OpenAI"). Empty set means "no filter". */
+let sessionFilterVendors: Set<string> = new Set();
+/** Active model pill filters. Empty set means "no filter". */
+let sessionFilterModels: Set<string> = new Set();
+/** Quick toggle: when true, only show sessions that used a HydraFusion model. */
+let sessionFilterHydraFusionOnly = false;
+
 function saveSessionColumnSettings(): void {
 	vscode.postMessage({ command: 'saveSessionColumnSettings', settings: { enabledColumns: Array.from(enabledSessionColumns) } });
+}
+
+/** Returns true when a session passes all currently active pill filters. */
+function sessionMatchesFilters(s: TodaySessionSummary): boolean {
+	if (sessionFilterHydraFusionOnly && !s.models.some(isHydraFusionModel)) { return false; }
+	if (sessionFilterEditors.size > 0 && !sessionFilterEditors.has(s.editor || 'unknown')) { return false; }
+	if (sessionFilterModels.size > 0 && !s.models.some(m => sessionFilterModels.has(m))) { return false; }
+	if (sessionFilterVendors.size > 0 && !s.models.some(m => sessionFilterVendors.has(getModelBillingProvider(m)))) { return false; }
+	return true;
+}
+
+/** Whether any Recent Sessions pill filter is currently active. */
+function hasActiveSessionFilters(): boolean {
+	return sessionFilterHydraFusionOnly || sessionFilterEditors.size > 0 || sessionFilterVendors.size > 0 || sessionFilterModels.size > 0;
+}
+
+type SessionFilterOption = { value: string; label: string; count: number };
+
+/** Computes the distinct editor/vendor/model values (with counts) present across the given sessions, used to render filter pills. */
+function computeSessionFilterOptions(sessions: TodaySessionSummary[]): {
+	editors: SessionFilterOption[];
+	vendors: SessionFilterOption[];
+	models: SessionFilterOption[];
+	hydraFusionCount: number;
+} {
+	const editorCounts = new Map<string, number>();
+	const vendorCounts = new Map<string, number>();
+	const modelCounts = new Map<string, number>();
+	let hydraFusionCount = 0;
+	for (const s of sessions) {
+		const editor = s.editor || 'unknown';
+		editorCounts.set(editor, (editorCounts.get(editor) || 0) + 1);
+		const vendorsInSession = new Set<string>();
+		let hasHydra = false;
+		for (const m of s.models) {
+			modelCounts.set(m, (modelCounts.get(m) || 0) + 1);
+			vendorsInSession.add(getModelBillingProvider(m));
+			if (isHydraFusionModel(m)) { hasHydra = true; }
+		}
+		for (const v of vendorsInSession) { vendorCounts.set(v, (vendorCounts.get(v) || 0) + 1); }
+		if (hasHydra) { hydraFusionCount++; }
+	}
+	const toSortedOptions = (counts: Map<string, number>, labelFn: (value: string) => string): SessionFilterOption[] =>
+		Array.from(counts.entries())
+			.map(([value, count]) => ({ value, label: labelFn(value), count }))
+			.sort((a, b) => b.count - a.count || a.label.localeCompare(b.label));
+	return {
+		editors: toSortedOptions(editorCounts, v => v),
+		vendors: toSortedOptions(vendorCounts, v => v),
+		models: toSortedOptions(modelCounts, getModelDisplayName),
+		hydraFusionCount,
+	};
+}
+
+/** Renders one labeled group of toggle pills (e.g. "Editor: VS Code (12) JetBrains (3)"). */
+function buildFilterPillGroupHtml(groupLabel: string, filterType: string, items: SessionFilterOption[], activeSet: Set<string>): string {
+	if (items.length === 0) { return ''; }
+	const pills = items.map(({ value, label, count }) => {
+		const isActive = activeSet.has(value);
+		const safeLabel = escapeHtml(label);
+		return `<button type="button" class="session-filter-pill${isActive ? ' active' : ''}" data-filter-type="${filterType}" data-filter-value="${escapeHtml(value)}" title="${safeLabel}: ${count} session${count === 1 ? '' : 's'}">${safeLabel} <span class="session-filter-pill-count">${count}</span></button>`;
+	}).join('');
+	return `<div class="session-filter-group"><span class="session-filter-group-label">${escapeHtml(groupLabel)}:</span>${pills}</div>`;
+}
+
+/** Renders the pill filter bar above the Recent Sessions table (Editor / Vendor / Model / HydraFusion). */
+function buildSessionFilterBarHtml(sessions: TodaySessionSummary[]): string {
+	if (!sessions || sessions.length === 0) { return ''; }
+	const opts = computeSessionFilterOptions(sessions);
+	if (opts.editors.length === 0 && opts.vendors.length === 0 && opts.models.length === 0) { return ''; }
+	const groups: string[] = [];
+	if (opts.hydraFusionCount > 0) {
+		const isActive = sessionFilterHydraFusionOnly;
+		groups.push(`<div class="session-filter-group"><button type="button" class="session-filter-pill session-filter-pill-hydrafusion${isActive ? ' active' : ''}" data-filter-type="hydrafusion" data-filter-value="true" title="Show only sessions that used HydraFusion">⚡ HydraFusion <span class="session-filter-pill-count">${opts.hydraFusionCount}</span></button></div>`);
+	}
+	groups.push(buildFilterPillGroupHtml('Editor', 'editor', opts.editors, sessionFilterEditors));
+	groups.push(buildFilterPillGroupHtml('Vendor', 'vendor', opts.vendors, sessionFilterVendors));
+	groups.push(buildFilterPillGroupHtml('Model', 'model', opts.models, sessionFilterModels));
+	const clearButton = hasActiveSessionFilters()
+		? `<button type="button" id="sessions-filter-clear" class="session-filter-pill session-filter-pill-clear">✕ Clear filters</button>`
+		: '';
+	return `<div class="session-filter-bar">${groups.filter(Boolean).join('')}${clearButton}</div>`;
+}
+
+/** Handles a click on a filter pill or the "Clear filters" button; returns true if it was handled. */
+function handleSessionFilterPillClick(target: HTMLElement): boolean {
+	const clearButton = target.closest<HTMLElement>('#sessions-filter-clear');
+	if (clearButton) {
+		sessionFilterEditors.clear();
+		sessionFilterVendors.clear();
+		sessionFilterModels.clear();
+		sessionFilterHydraFusionOnly = false;
+		return true;
+	}
+	const pill = target.closest<HTMLElement>('.session-filter-pill');
+	if (!pill) { return false; }
+	const filterType = pill.getAttribute('data-filter-type');
+	const value = pill.getAttribute('data-filter-value');
+	if (filterType === 'hydrafusion') {
+		sessionFilterHydraFusionOnly = !sessionFilterHydraFusionOnly;
+		return true;
+	}
+	if (!value) { return false; }
+	const targetSet = filterType === 'editor' ? sessionFilterEditors
+		: filterType === 'vendor' ? sessionFilterVendors
+		: filterType === 'model' ? sessionFilterModels
+		: undefined;
+	if (!targetSet) { return false; }
+	if (targetSet.has(value)) { targetSet.delete(value); } else { targetSet.add(value); }
+	return true;
 }
 
 function getSessionSortIndicator(column: SessionSortColumn): string {
@@ -1231,8 +1351,14 @@ function renderTodaySessionsTable(sessions: TodaySessionSummary[]): string {
 }
 
 function buildSessionsTableHtml(sessions: TodaySessionSummary[]): string {
-	const sorted = sortTodaySessions(sessions);
+	const filterBarHtml = buildSessionFilterBarHtml(sessions);
+	const filtered = sessions.filter(sessionMatchesFilters);
+	const sorted = sortTodaySessions(filtered);
 	const visibleColumns = SESSION_COLUMN_DEFS.filter(c => enabledSessionColumns.has(c.id));
+
+	if (sorted.length === 0) {
+		return `${filterBarHtml}<div style="color: var(--text-secondary); font-size: 13px; padding: 16px;">No sessions match the selected filters.</div>`;
+	}
 
 	const rows = sorted.map((s, idx) => {
 		const title = escapeHtml(s.title || 'Untitled session');
@@ -1260,6 +1386,7 @@ function buildSessionsTableHtml(sessions: TodaySessionSummary[]): string {
 	}).join('');
 
 	return `
+		${filterBarHtml}
 		<div style="overflow-x:auto;">
 		<table class="sessions-table" style="width:100%; border-collapse:collapse; min-width:1050px;">
 			<thead>
@@ -1306,6 +1433,12 @@ function setupSessionsTableSort(): void {
 			if (file) {
 				vscode.postMessage({ command: 'openSessionFile', file });
 			}
+			return;
+		}
+		// Handle filter pill / clear-filters clicks
+		if (handleSessionFilterPillClick(e.target as HTMLElement)) {
+			const container = document.getElementById('sessions-table-container');
+			if (container) { setHtml(container, buildSessionsTableHtml(cachedTodaySessions)); }
 			return;
 		}
 		// Handle sortable column header clicks

--- a/vscode-extension/src/webview/usage/styles.css
+++ b/vscode-extension/src/webview/usage/styles.css
@@ -886,6 +886,7 @@ background: var(--bg-tertiary);
 	display: inline-flex;
 	align-items: center;
 	gap: 4px;
+	font-family: inherit;
 	font-size: 11px;
 	padding: 3px 10px;
 	border-radius: 999px;

--- a/vscode-extension/src/webview/usage/styles.css
+++ b/vscode-extension/src/webview/usage/styles.css
@@ -859,6 +859,65 @@ background: var(--bg-tertiary);
 	background: var(--list-hover-bg);
 }
 
+/* Recent Sessions pill filter bar (Editor / Vendor / Model / HydraFusion) */
+.session-filter-bar {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 8px 12px;
+	margin-bottom: 10px;
+}
+
+.session-filter-group {
+	display: flex;
+	align-items: center;
+	flex-wrap: wrap;
+	gap: 6px;
+}
+
+.session-filter-group-label {
+	font-size: 11px;
+	font-weight: 600;
+	color: var(--text-secondary);
+	margin-right: 2px;
+}
+
+.session-filter-pill {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	font-size: 11px;
+	padding: 3px 10px;
+	border-radius: 999px;
+	border: 1px solid var(--border-subtle);
+	background: var(--bg-tertiary);
+	color: var(--text-primary);
+	cursor: pointer;
+	transition: background 0.1s ease, border-color 0.1s ease;
+}
+
+.session-filter-pill:hover {
+	background: var(--list-hover-bg);
+	border-color: var(--link-color);
+}
+
+.session-filter-pill.active {
+	background: var(--vscode-badge-background, var(--accent-color));
+	border-color: var(--vscode-badge-background, var(--accent-color));
+	color: var(--vscode-badge-foreground, var(--bg-primary));
+}
+
+.session-filter-pill-count {
+	opacity: 0.75;
+	font-size: 10px;
+}
+
+.session-filter-pill-clear {
+	background: transparent;
+	border-style: dashed;
+	color: var(--text-secondary);
+}
+
 /* Worktrees tab */
 .summary-cards {
 	display: grid;

--- a/vscode-extension/test/unit/usageWebviewMessageFlow.test.ts
+++ b/vscode-extension/test/unit/usageWebviewMessageFlow.test.ts
@@ -353,6 +353,69 @@ test('marks HydraFusion sessions in the recent sessions list', async () => {
 	assert.equal(costCell?.title, '$12.3450');
 });
 
+test('Recent Sessions Duration column falls back to wall-clock time when activeDurationMs is zero', async () => {
+	// Regression test for a bug where session formats without per-request timing data (e.g.
+	// Copilot CLI JSONL) always reported activeDurationMs === 0, and the Duration column's old
+	// `??` fallback treated that defined zero as "no fallback needed", showing a misleading "<1m"
+	// for sessions that actually ran much longer.
+	const stats = buildStats();
+	const cliSession = {
+		title: 'Long CLI session', filePath: 'cli-session.jsonl', interactions: 40, toolCalls: 53,
+		inputTokens: 3700000, outputTokens: 14300, thinkingTokens: 0, cachedTokens: 3600000, totalTokens: 3800000,
+		estimatedCost: 1.13, editor: 'Copilot CLI (App)', models: ['gpt-5.6-terra'],
+		lastActivity: '2026-09-06T11:00:00.000Z',
+		durationMs: 125 * 60_000, // 125 minutes of wall-clock time
+		activeDurationMs: 0, // no per-request timing available for this format
+	};
+	stats.todaySessions = [cliSession];
+	const harness = await bootWebview(stats);
+
+	const row = harness.window.document.querySelector('.sessions-table tbody tr');
+	assert.ok(row, 'expects a rendered session row');
+	assert.match(row.textContent, /2h 05m/, 'Duration should fall back to the 125-minute wall-clock time, not "<1m"');
+	assert.doesNotMatch(row.textContent, /<1m/, 'a zero-but-defined activeDurationMs must not be shown as "<1m"');
+});
+
+test('Recent Sessions pill filters narrow the table by editor, vendor, model, and HydraFusion', async () => {
+	const stats = buildStats();
+	const baseSession = {
+		interactions: 10, toolCalls: 5, inputTokens: 1000, outputTokens: 500, thinkingTokens: 0,
+		cachedTokens: 0, totalTokens: 1500, estimatedCost: 0.5, lastActivity: '2026-09-06T11:00:00.000Z',
+	};
+	stats.todaySessions = [
+		{ ...baseSession, title: 'CLI session', filePath: 'a.jsonl', editor: 'Copilot CLI (App)', models: ['claude-opus-5'] },
+		{ ...baseSession, title: 'VS Code session', filePath: 'b.jsonl', editor: 'VS Code', models: ['gpt-5.6-terra'] },
+		{ ...baseSession, title: 'HydraFusion session', filePath: 'c.jsonl', editor: 'VS Code', models: ['hydrafusion'] },
+	];
+	const harness = await bootWebview(stats);
+	const doc = harness.window.document;
+	const titles = () => [...doc.querySelectorAll('.sessions-table tbody tr .session-title-link')].map(a => a.textContent.replace(/^HydraFusion/, ''));
+
+	assert.deepEqual(titles(), ['CLI session', 'VS Code session', 'HydraFusion session'], 'all three sessions render before any filter is applied');
+
+	// Filter by editor: only the two VS Code sessions should remain.
+	const editorPill = [...doc.querySelectorAll('.session-filter-pill[data-filter-type="editor"]')].find(p => p.getAttribute('data-filter-value') === 'VS Code');
+	assert.ok(editorPill, 'expects a VS Code editor filter pill');
+	editorPill.click();
+	assert.deepEqual(titles(), ['VS Code session', 'HydraFusion session']);
+	// The click replaces the whole table container's HTML, so re-query for the live pill.
+	const editorPillAfterClick = [...doc.querySelectorAll('.session-filter-pill[data-filter-type="editor"]')].find(p => p.getAttribute('data-filter-value') === 'VS Code');
+	assert.equal(editorPillAfterClick?.getAttribute('aria-pressed'), 'true', 'an active pill should expose aria-pressed="true"');
+
+	// Combine with the HydraFusion quick filter: only the HydraFusion session should remain.
+	const hydraPill = doc.querySelector('.session-filter-pill-hydrafusion');
+	assert.ok(hydraPill, 'expects a HydraFusion quick-filter pill');
+	hydraPill.click();
+	assert.deepEqual(titles(), ['HydraFusion session']);
+
+	// Clearing filters restores every session.
+	const clearButton = doc.getElementById('sessions-filter-clear');
+	assert.ok(clearButton, 'expects a "Clear filters" button once a filter is active');
+	clearButton.click();
+	assert.deepEqual(titles(), ['CLI session', 'VS Code session', 'HydraFusion session']);
+	assert.equal(doc.getElementById('sessions-filter-clear'), null, 'the clear button disappears once no filters are active');
+});
+
 test('renders cloud agent session results', async () => {
 	const harness = await bootWebview(buildStats());
 


### PR DESCRIPTION
## Summary
Adds a filter bar above the "Recent Sessions" table (Usage Analysis → Recent Sessions tab) with toggleable pills to quickly narrow down sessions:

- **Editor** — pills for each editor present in the current lookback (e.g. Copilot CLI (App), VS Code)
- **Vendor** — pills for each model vendor (Anthropic, OpenAI, Google, xAI, Mistral AI, Microsoft, …) derived via the existing `getModelBillingProvider()`
- **Model** — pills for each individual model, using friendly display names
- **HydraFusion** — a quick toggle pill (shown only when at least one session used HydraFusion) to instantly isolate HydraFusion sessions

Each pill shows a count of matching sessions and can be combined with pills from other groups (AND across groups, OR within a group). A "Clear filters" pill appears once any filter is active. When no sessions match the active filters, the table shows a "No sessions match the selected filters." message instead of an empty table.

## Implementation
- Filter state lives as webview-local module state (`sessionFilterEditors`, `sessionFilterVendors`, `sessionFilterModels`, `sessionFilterHydraFusionOnly`), reset only if the user clears them.
- Pill options are computed from the full (unfiltered) session set for the current lookback so filters remain visible/toggleable even when combined.
- Filtering/click handling is wired into the existing delegated click listener on `#sessions-panel-body`, so it survives lookback and sort re-renders the same way the existing sort/column-toggle handling does.
- New `.session-filter-*` CSS classes added to `styles.css`, matching the existing theme variables used elsewhere in the panel.

## Validation
- `npx tsc --noEmit` — no type errors
- `npm run compile` — builds cleanly
- `npm run check:contract` — postMessage contract intact (no new messages needed; filters are pure client-side state)
- `npm run check:interaction` — headless click-crawl passes for all views, including `usage`
- `npm run test:node` (usage webview test file) — all existing tests pass, including the HydraFusion badge test