### PR TITLE
Remove compaction highlight border

### DIFF
--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -4290,7 +4290,7 @@ function renderAutomaticCompactions(stats: AutomaticCompactionStats | undefined)
 		? entries.join(', ')
 		: 'No automatic compactions detected';
 	return `
-		<div class="automatic-compactions-card${stats.total > 0 ? ' automatic-compactions-card--active' : ''}"
+		<div class="automatic-compactions-card"
 			title="Automatic compactions remove earlier messages to fit the context window and can affect response quality.">
 			<div>
 				<div class="automatic-compactions-label">↩ Automatic compactions (last 7 days)</div>

--- a/vscode-extension/src/webview/usage/styles.css
+++ b/vscode-extension/src/webview/usage/styles.css
@@ -89,10 +89,6 @@ body {
 	background: var(--list-hover-bg);
 }
 
-.automatic-compactions-card--active {
-	border-color: var(--warning-color, #cca700);
-}
-
 .automatic-compactions-label {
 	font-size: 13px;
 	font-weight: 700;


### PR DESCRIPTION
This removes the yellow highlight border from the automatic compactions card in the AI usage analysis view. The card now uses the standard neutral styling regardless of compaction count, since the border was drawing attention without adding useful signal.

## What changed
- Always render the automatic compactions card without the active border variant
- Remove the unused active border rule from the webview stylesheet

## Notes
- No functional behavior changes; this is a presentation-only cleanup.