### PR TITLE
Improve worktree cleanup validation

### DIFF
--- a/src/utils/pathUtils.ts
+++ b/src/utils/pathUtils.ts
@@ -52,6 +52,7 @@ export function normalizePathForDedup(
 /**
  * Normalize a session workspace path up to its parent repository root by stripping a trailing
  * agent-worktree segment created by Copilot CLI, Claude Code, or the Copilot App:
+ *   "<home>/.copilot/copilot-worktrees/<repo>[/...]" -> "<home>/.copilot/copilot-worktrees/<repo>"
  *   "<repo>/copilot-worktrees/<name>[/...]"      -> "<repo>"
  *   "<repo>/.claude/worktrees/<name>[/...]"       -> "<repo>"
  *   "<parent>/<repo>.worktrees/<name>[/...]"      -> "<parent>/<repo>"
@@ -64,6 +65,8 @@ export function normalizePathForDedup(
  * and the input's separator style is preserved.
  */
 export function normalizeToRepoRoot(p: string): string {
+	const appStore = p.match(/^(.+?[\\/]\.copilot[\\/]copilot-worktrees[\\/][^\\/]+)(?:[\\/].*)?$/i);
+	if (appStore) { return appStore[1]; }
 	const copilot = p.match(/^(.+?)[\\/]copilot-worktrees[\\/][^\\/]+(?:[\\/].*)?$/i);
 	if (copilot) { return copilot[1]; }
 	const claude = p.match(/^(.+?)[\\/]\.claude[\\/]worktrees[\\/][^\\/]+(?:[\\/].*)?$/i);

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -121,6 +121,7 @@ import {
   sumWorktreeBytes as _sumWorktreeBytes,
   parseCleanupPushedWorktreesMessage as _parseCleanupPushedWorktreesMessage,
   buildCleanupConfirmTitle as _buildCleanupConfirmTitle,
+  validateWorktreeRepoRootFromSessionPaths as _validateWorktreeRepoRootFromSessionPaths,
   type WorktreeBackgroundScanResult,
 } from './worktreeBackgroundScan';
 import { scanWorktreeRootsWithTimeout as _scanWorktreeRootsWithTimeout } from './worktreeScan';
@@ -10848,30 +10849,66 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString(), startedAtMs)}
    * worktree is reported as "skipped", not force-removed.
    */
   private async cleanupSinglePushedWorktree(worktreePath: string): Promise<{ status: "deleted" | "skipped" | "error"; reason?: string }> {
+    const sessionEvidence = await this.findSessionRepoEvidenceForWorktree(worktreePath);
     const mainRepoRoot = await this.resolveMainRepoRoot(worktreePath);
-    if (!mainRepoRoot || path.resolve(mainRepoRoot).toLowerCase() === path.resolve(worktreePath).toLowerCase()) {
-      return { status: "error", reason: "Could not safely locate the main repository." };
+    const validatedMainRepoRoot = mainRepoRoot ?? sessionEvidence?.repoRoot;
+    if (!validatedMainRepoRoot || _normalizePathForDedup(path.resolve(validatedMainRepoRoot)) === _normalizePathForDedup(path.resolve(worktreePath))) {
+      return { status: "error", reason: `Could not safely locate the main repository for "${worktreePath}".` };
+    }
+    if (mainRepoRoot && sessionEvidence && _normalizePathForDedup(path.resolve(mainRepoRoot)) !== _normalizePathForDedup(path.resolve(sessionEvidence.repoRoot))) {
+      return {
+        status: "error",
+        reason: `Repo validation failed for "${worktreePath}": git resolved "${mainRepoRoot}" but session "${sessionEvidence.sessionWorkspacePath}" points to "${sessionEvidence.repoRoot}".`,
+      };
     }
 
     const pushed = await this.getWorktreePushedStatus(worktreePath);
     if (pushed !== "yes") {
       return {
         status: "skipped",
-        reason: pushed === "no" ? "Has commits not pushed to any remote." : "Push status could not be confirmed.",
+        reason: pushed === "no"
+          ? `Worktree at "${worktreePath}" has commits not pushed to any remote.`
+          : `Could not confirm push status for worktree at "${worktreePath}".`,
       };
     }
 
-    let result = await this.removeGitWorktree(mainRepoRoot, worktreePath, false);
+    let result = await this.removeGitWorktree(validatedMainRepoRoot, worktreePath, false);
     if (!result.ok && /modified or untracked/i.test(result.stderr)) {
       return { status: "skipped", reason: "Has uncommitted or untracked changes." };
     }
     if (!result.ok && this.isWorktreeDirectoryRemovalFailure(result.stderr)) {
-      result = await this.removeWorktreeDirectoryFallback(mainRepoRoot, worktreePath);
+      result = await this.removeWorktreeDirectoryFallback(validatedMainRepoRoot, worktreePath);
     }
     if (!result.ok) {
-      return { status: "error", reason: result.stderr || "unknown error" };
+      return { status: "error", reason: `Could not delete worktree at "${worktreePath}": ${result.stderr || "unknown error"}` };
     }
     return { status: "deleted" };
+  }
+
+  private getKnownSessionWorkspacePaths(): string[] {
+    return this.diagnosticsCachedFiles
+      .map((details) => typeof details.workspacePath === "string" ? details.workspacePath.trim() : "")
+      .filter((value): value is string => value.length > 0);
+  }
+
+  private async findSessionRepoEvidenceForWorktree(worktreePath: string): Promise<{ sessionWorkspacePath: string; repoRoot: string } | undefined> {
+    const cachedMatch = _validateWorktreeRepoRootFromSessionPaths(worktreePath, this.getKnownSessionWorkspacePaths());
+    if (cachedMatch) { return cachedMatch; }
+
+    const sessionFiles = await this.sessionDiscovery.getCopilotSessionFiles();
+    const maxFilesToInspect = 25;
+    for (const sessionFile of sessionFiles.slice(0, maxFilesToInspect)) {
+      try {
+        const details = await this.getSessionFileDetails(sessionFile);
+        if (!details.workspacePath) { continue; }
+        const match = _validateWorktreeRepoRootFromSessionPaths(worktreePath, [details.workspacePath]);
+        if (match) { return match; }
+      } catch {
+        // Ignore individual session parse failures; this is only a best-effort validation path.
+      }
+    }
+
+    return undefined;
   }
 
   private async confirmDeleteWorktree(worktreePath: string, branch: string, repoLabel: string, pushed: "yes" | "no" | "?"): Promise<boolean> {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -10852,10 +10852,10 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString(), startedAtMs)}
     const sessionEvidence = await this.findSessionRepoEvidenceForWorktree(worktreePath);
     const mainRepoRoot = await this.resolveMainRepoRoot(worktreePath);
     const validatedMainRepoRoot = mainRepoRoot ?? sessionEvidence?.repoRoot;
-    if (!validatedMainRepoRoot || _normalizePathForDedup(path.resolve(validatedMainRepoRoot)) === _normalizePathForDedup(path.resolve(worktreePath))) {
+    if (!validatedMainRepoRoot || _normalizePathForDedup(validatedMainRepoRoot) === _normalizePathForDedup(_normalizeToRepoRoot(worktreePath))) {
       return { status: "error", reason: `Could not safely locate the main repository for "${worktreePath}".` };
     }
-    if (mainRepoRoot && sessionEvidence && _normalizePathForDedup(path.resolve(mainRepoRoot)) !== _normalizePathForDedup(path.resolve(sessionEvidence.repoRoot))) {
+    if (mainRepoRoot && sessionEvidence && _normalizePathForDedup(mainRepoRoot) !== _normalizePathForDedup(sessionEvidence.repoRoot)) {
       return {
         status: "error",
         reason: `Repo validation failed for "${worktreePath}": git resolved "${mainRepoRoot}" but session "${sessionEvidence.sessionWorkspacePath}" points to "${sessionEvidence.repoRoot}".`,

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -3917,9 +3917,14 @@ function renderWorktreeCleanupLog(): string {
 		const icon = e.status === "skipped" ? "⏭️" : "❌";
 		return `<div class="worktree-cleanup-log-row">
       <span>${icon}</span>
-      <span class="worktree-cleanup-log-branch">${escapeHtml(e.branch)}</span>
-      <span class="worktree-cleanup-log-repo">${escapeHtml(e.repoLabel)}</span>
-      <span class="worktree-cleanup-log-reason">${escapeHtml(e.reason || "")}</span>
+      <div class="worktree-cleanup-log-details">
+        <div class="worktree-cleanup-log-headline">
+          <span class="worktree-cleanup-log-branch">${escapeHtml(e.branch)}</span>
+          <span class="worktree-cleanup-log-repo">${escapeHtml(e.repoLabel)}</span>
+        </div>
+        <div class="worktree-cleanup-log-path">${escapeHtml(e.path)}</div>
+        <div class="worktree-cleanup-log-reason">${escapeHtml(e.reason || "")}</div>
+      </div>
     </div>`;
 	}).join("");
 	return `<div class="worktree-cleanup-log">${rows}</div>`;

--- a/vscode-extension/src/webview/usage/styles.css
+++ b/vscode-extension/src/webview/usage/styles.css
@@ -1135,6 +1135,21 @@ background: var(--bg-tertiary);
 	background: var(--bg-tertiary);
 }
 
+.worktree-cleanup-log-details {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	min-width: 0;
+	flex: 1;
+}
+
+.worktree-cleanup-log-headline {
+	display: flex;
+	gap: 8px;
+	flex-wrap: wrap;
+	align-items: baseline;
+}
+
 .worktree-cleanup-log-branch {
 	font-weight: 600;
 	font-family: var(--vscode-editor-font-family, monospace);
@@ -1144,9 +1159,16 @@ background: var(--bg-tertiary);
 	color: var(--text-muted);
 }
 
+.worktree-cleanup-log-path {
+	color: var(--text-muted);
+	font-size: 11px;
+	word-break: break-all;
+}
+
 .worktree-cleanup-log-reason {
 	color: var(--text-muted);
-	flex: 1;
+	font-size: 11px;
+	word-break: break-word;
 }
 
 .worktree-repo-actions {

--- a/vscode-extension/src/worktreeBackgroundScan.ts
+++ b/vscode-extension/src/worktreeBackgroundScan.ts
@@ -8,6 +8,9 @@
  * the parts that are pure functions of their inputs, so they can be unit-tested directly,
  * following the same pattern as `insightsEngine.ts`.
  */
+import * as path from 'path';
+
+import { normalizeToRepoRoot } from '../../src/workspaceHelpers';
 
 /** One worktree's findings, as persisted after the background scan completes. */
 export interface WorktreeBackgroundScanEntry {
@@ -140,4 +143,37 @@ export function parseCleanupPushedWorktreesMessage(message: any): ParsedCleanupP
 export function buildCleanupConfirmTitle(count: number, scopeRepoLabel?: string): string {
 	const scopeText = scopeRepoLabel ? ` in "${scopeRepoLabel}"` : "";
 	return `Clean up ${count} pushed worktree${count === 1 ? "" : "s"}${scopeText}?`;
+}
+
+/** Evidence that a session workspace lives under the same repo root as a worktree candidate. */
+export interface WorktreeSessionRepoEvidence {
+	sessionWorkspacePath: string;
+	repoRoot: string;
+}
+
+/**
+ * Validate a worktree root against one or more session workspace paths.
+ *
+ * This accepts any session workspace path that normalizes to the same repo root as the worktree
+ * candidate, so a repo-scoped session can prove the repo even when the worktree itself is a
+ * transient subfolder.
+ */
+export function validateWorktreeRepoRootFromSessionPaths(
+	worktreePath: string,
+	sessionWorkspacePaths: (string | undefined)[],
+): WorktreeSessionRepoEvidence | undefined {
+	const worktreeRepoRoot = path.resolve(normalizeToRepoRoot(worktreePath));
+	for (const sessionWorkspacePath of sessionWorkspacePaths) {
+		const value = typeof sessionWorkspacePath === "string" ? sessionWorkspacePath.trim() : "";
+		if (!value) { continue; }
+		const sessionRepoRoot = path.resolve(normalizeToRepoRoot(value));
+		if (_normalizePathForComparison(sessionRepoRoot) === _normalizePathForComparison(worktreeRepoRoot)) {
+			return { sessionWorkspacePath: value, repoRoot: sessionRepoRoot };
+		}
+	}
+	return undefined;
+}
+
+function _normalizePathForComparison(value: string): string {
+	return path.resolve(value).replace(/\\/g, "/").toLowerCase();
 }

--- a/vscode-extension/src/worktreeBackgroundScan.ts
+++ b/vscode-extension/src/worktreeBackgroundScan.ts
@@ -8,9 +8,7 @@
  * the parts that are pure functions of their inputs, so they can be unit-tested directly,
  * following the same pattern as `insightsEngine.ts`.
  */
-import * as path from 'path';
-
-import { normalizeToRepoRoot } from '../../src/workspaceHelpers';
+import { normalizePathForDedup, normalizeToRepoRoot } from '../../src/workspaceHelpers';
 
 /** One worktree's findings, as persisted after the background scan completes. */
 export interface WorktreeBackgroundScanEntry {
@@ -162,18 +160,14 @@ export function validateWorktreeRepoRootFromSessionPaths(
 	worktreePath: string,
 	sessionWorkspacePaths: (string | undefined)[],
 ): WorktreeSessionRepoEvidence | undefined {
-	const worktreeRepoRoot = path.resolve(normalizeToRepoRoot(worktreePath));
+	const worktreeRepoRoot = normalizePathForDedup(normalizeToRepoRoot(worktreePath));
 	for (const sessionWorkspacePath of sessionWorkspacePaths) {
 		const value = typeof sessionWorkspacePath === "string" ? sessionWorkspacePath.trim() : "";
 		if (!value) { continue; }
-		const sessionRepoRoot = path.resolve(normalizeToRepoRoot(value));
-		if (_normalizePathForComparison(sessionRepoRoot) === _normalizePathForComparison(worktreeRepoRoot)) {
-			return { sessionWorkspacePath: value, repoRoot: sessionRepoRoot };
+		const sessionRepoRoot = normalizePathForDedup(normalizeToRepoRoot(value));
+		if (sessionRepoRoot === worktreeRepoRoot) {
+			return { sessionWorkspacePath: value, repoRoot: normalizeToRepoRoot(value) };
 		}
 	}
 	return undefined;
-}
-
-function _normalizePathForComparison(value: string): string {
-	return path.resolve(value).replace(/\\/g, "/").toLowerCase();
 }

--- a/vscode-extension/test/unit/usageWebviewMessageFlow.test.ts
+++ b/vscode-extension/test/unit/usageWebviewMessageFlow.test.ts
@@ -330,6 +330,42 @@ test('renders repository PR fetch progress into the panel', async () => {
 	assert.ok(rendered?.includes('1/2'), `expected fetch progress, got: ${rendered}`);
 });
 
+test('renders the cleanup log with the worktree path for failing entries', async () => {
+	const harness = await bootWebview(buildStats());
+	const worktreePath = 'C:\\Users\\me\\.copilot\\copilot-worktrees\\repo\\feature-x';
+
+	harness.post({
+		command: 'worktreeFound',
+		worktree: {
+			path: worktreePath,
+			repoLabel: 'repo',
+			branch: 'feature-x',
+			lastCommit: 'abc1234',
+			lastCommitDate: '2026-09-07T10:00:00.000Z',
+			pushed: 'yes',
+			files: 1,
+			folders: 1,
+			bytes: 1024,
+		},
+	});
+	harness.post({ command: 'cleanupStarted', total: 1 });
+	harness.post({
+		command: 'cleanupWorktreeResult',
+		path: worktreePath,
+		branch: 'feature-x',
+		repoLabel: 'repo',
+		status: 'error',
+		reason: `Could not safely locate the main repository for "${worktreePath}".`,
+		processed: 1,
+		total: 1,
+	});
+	harness.post({ command: 'cleanupComplete' });
+
+	const rendered = harness.text('.worktree-cleanup-log');
+	assert.ok(rendered?.includes(worktreePath), `expected the worktree path in the cleanup log, got: ${rendered}`);
+	assert.ok(rendered?.includes('Could not safely locate the main repository'), 'expected the cleanup reason to stay visible');
+});
+
 test('accepts payloads relayed the way VS Code actually delivers them', async () => {
 	// The panel hung with `delivered=true` logged host-side because the webview's source-trust
 	// check compared window identities. VS Code relays from an internal window, so every

--- a/vscode-extension/test/unit/utils-pathUtils.test.ts
+++ b/vscode-extension/test/unit/utils-pathUtils.test.ts
@@ -194,6 +194,13 @@ test('normalizeToRepoRoot: strips trailing sub-path below a "<repo>.worktrees" w
 	);
 });
 
+test('normalizeToRepoRoot: strips Copilot App ".copilot/copilot-worktrees" repo root', () => {
+	assert.equal(
+		normalizeToRepoRoot('C:\\Users\\me\\.copilot\\copilot-worktrees\\ai-engineering-fluency\\rajbos-supreme-carnival'),
+		'C:\\Users\\me\\.copilot\\copilot-worktrees\\ai-engineering-fluency'
+	);
+});
+
 // getRepoNameFromWorkspacePath tests
 test('getRepoNameFromWorkspacePath: app-store worktree resolves to the repo folder, not the worktree name', () => {
 	assert.equal(
@@ -243,4 +250,3 @@ test('getRepoNameFromWorkspacePath: Copilot App "<repo>.worktrees" layout resolv
 		'proj'
 	);
 });
-

--- a/vscode-extension/test/unit/worktreeBackgroundScan.test.ts
+++ b/vscode-extension/test/unit/worktreeBackgroundScan.test.ts
@@ -7,6 +7,7 @@ import {
 	sumWorktreeBytes,
 	parseCleanupPushedWorktreesMessage,
 	buildCleanupConfirmTitle,
+	validateWorktreeRepoRootFromSessionPaths,
 	WORKTREE_BACKGROUND_SCAN_INTERVAL_MS,
 	WORKTREE_SCAN_NOTIFY_MIN_BYTES,
 } from '../../src/worktreeBackgroundScan';
@@ -238,4 +239,31 @@ test('buildCleanupConfirmTitle: unscoped, singular vs. plural count', () => {
 
 test('buildCleanupConfirmTitle: names the repository when scoped', () => {
 	assert.equal(buildCleanupConfirmTitle(2, 'repo-a'), 'Clean up 2 pushed worktrees in "repo-a"?');
+});
+
+// ---------------------------------------------------------------------------
+// validateWorktreeRepoRootFromSessionPaths
+// ---------------------------------------------------------------------------
+
+test('validateWorktreeRepoRootFromSessionPaths: accepts a session workspace in the same repo root', () => {
+	const result = validateWorktreeRepoRootFromSessionPaths(
+		'C:\\Users\\me\\.copilot\\copilot-worktrees\\repo\\feature-x',
+		[
+			'C:\\Users\\me\\.copilot\\copilot-worktrees\\repo\\main',
+			'C:\\Users\\me\\.copilot\\copilot-worktrees\\repo\\feature-x\\nested',
+		],
+	);
+
+	assert.equal(result?.repoRoot, 'C:\\Users\\me\\.copilot\\copilot-worktrees\\repo');
+	assert.equal(result?.sessionWorkspacePath, 'C:\\Users\\me\\.copilot\\copilot-worktrees\\repo\\main');
+});
+
+test('validateWorktreeRepoRootFromSessionPaths: rejects unrelated session workspaces', () => {
+	assert.equal(
+		validateWorktreeRepoRootFromSessionPaths(
+			'C:\\Users\\me\\.copilot\\copilot-worktrees\\repo-a\\feature-x',
+			['C:\\Users\\me\\.copilot\\copilot-worktrees\\repo-b\\main'],
+		),
+		undefined,
+	);
 });


### PR DESCRIPTION
This tightens the worktree cleanup flow so repo lookup failures are easier to diagnose and the cleanup path can validate a candidate worktree against session-derived repo evidence before giving up.

### What changed
- Surface the exact worktree path in cleanup errors and cleanup log rows.
- Validate worktree repo roots against session workspace paths when git lookup is inconclusive.
- Add focused tests for the repo-root validation and the cleanup webview output.

### Notes
- If git and session evidence disagree, cleanup now fails explicitly instead of guessing a repo.
- The webview now keeps the worktree path visible next to each failed cleanup entry.