### PR TITLE
Add privacy-separated Team Insights for sharing-server users

### DIFF
--- a/.github/instructions/sharing-server.instructions.md
+++ b/.github/instructions/sharing-server.instructions.md
@@ -1,0 +1,17 @@
+---
+applyTo: "sharing-server/**,docs/sharing-server/**"
+---
+
+# Sharing server — coding and testing
+
+Read and follow [sharing-server/AGENTS.md](../../sharing-server/AGENTS.md), the
+authoritative data separation contract, before changing server code, tests,
+documentation or downstream route overrides. It defines owner-only personal
+data, identity-free team projections, server-authorized admin detail, exact
+comparison semantics and HTTP/HTML privacy regression coverage.
+
+Use the server `check-types`, `build`, `test` and headless `check:interaction`
+scripts as described there, including the existing Playwright/Chromium
+prerequisite. Use isolated SQLite fixtures and stubbed GitHub access, never production
+data or live GitHub. Keep implementation and testing descriptions linked to the
+contract rather than creating alternative privacy rules.

--- a/.github/workflows/sharing-server-deploy.yml
+++ b/.github/workflows/sharing-server-deploy.yml
@@ -177,9 +177,21 @@ jobs:
         working-directory: sharing-server
         run: npm run check-types
 
-      - name: Run unit tests
+      - name: Run server and data separation regression tests
         working-directory: sharing-server
         run: npm test
+
+      - name: Install existing headless browser tooling
+        working-directory: .github/workflows/dependencies/playwright
+        run: |
+          npm ci --ignore-scripts --no-audit --no-fund
+          npx --no-install playwright install --with-deps chromium
+
+      - name: Check member interactions and identity-free downloads
+        working-directory: sharing-server
+        env:
+          NODE_PATH: ${{ github.workspace }}/.github/workflows/dependencies/playwright/node_modules
+        run: npm run check:interaction
 
       - name: Build library (lib/)
         working-directory: sharing-server

--- a/.github/workflows/sharing-server-publish.yml
+++ b/.github/workflows/sharing-server-publish.yml
@@ -63,6 +63,9 @@ jobs:
       - name: Run type checking
         run: npm run check-types
 
+      - name: Run server and data separation regression tests
+        run: npm test
+
       - name: Build library (lib/)
         run: npm run build:lib
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,11 @@ This document provides top-level guidance for AI agents contributing to this rep
 | `cli/` | `.github/instructions/cli.instructions.md` |
 | `visualstudio-extension/` | `.github/instructions/visualstudio-extension.instructions.md` |
 | `jetbrains-plugin/` | `.github/instructions/jetbrains-plugin.instructions.md` |
+| `sharing-server/` | [sharing-server/AGENTS.md](sharing-server/AGENTS.md), `.github/instructions/sharing-server.instructions.md` |
 | `.github/workflows/` | `.github/instructions/workflows.instructions.md` |
+
+All sharing-server coding, testing, documentation and downstream customization
+must follow the [server data separation contract](sharing-server/AGENTS.md).
 
 ## Building Everything
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,4 @@
 @AGENTS.md
+
+For sharing-server code, tests, docs and downstream extensions, also read
+@sharing-server/AGENTS.md — the authoritative server data separation contract.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -322,6 +322,12 @@ Some dependencies (like `@vscode/webview-ui-toolkit`) declare peer dependencies 
 
 ### Development Principles
 
+Sharing-server contributions (including tests, docs and downstream overrides)
+must follow the [server data separation contract](sharing-server/AGENTS.md).
+For server build and test commands, use the
+[server validation guidance](docs/VALIDATION.md#sharing-server), not the
+extension-specific workflow below.
+
 1. **Minimal Changes:** Only modify files directly needed for your changes
 2. **Focused Modifications:** Make surgical, precise changes
 3. **Preserve Structure:** Maintain existing code organization
@@ -364,6 +370,10 @@ npm run lint:json
 **Note:** JSON validation is automatically run in CI/CD pipelines to catch syntax errors early.
 
 ## Testing
+
+For the sharing server, follow the [required privacy tests](sharing-server/AGENTS.md#required-validation)
+and [server validation guidance](docs/VALIDATION.md#sharing-server). Tests use
+isolated SQLite fixtures and stubbed GitHub access, never production data.
 
 - Test the extension manually in the Extension Development Host (F5)
 - Verify token tracking works correctly

--- a/build.ps1
+++ b/build.ps1
@@ -293,7 +293,11 @@ function Build-Sharing {
         switch ($Target) {
             'build'   { Ensure-NpmDeps .; npm run build }
             'package' { Ensure-NpmDeps .; npm run build:production }
-            'test'    { Write-Host "    (no sharing-server tests yet)" }
+            'test'    {
+                Ensure-NpmDeps .
+                npm test
+                if ($LASTEXITCODE -ne 0) { throw "Sharing-server tests failed" }
+            }
             'clean'   { Remove-Item -Recurse -Force dist -ErrorAction SilentlyContinue }
         }
         Write-Ok "sharing-server done."

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,7 +36,8 @@ Per-component guides and READMEs.
 | [vscode-extension/DESIGN.md](vscode-extension/DESIGN.md) | VS Code extension UI design system (DESIGN.md spec) |
 | [vscode-extension/WEBVIEW-MESSAGING.md](vscode-extension/WEBVIEW-MESSAGING.md) | How data reaches a webview panel: trust model, readiness/replay, diagnostics, companion-extension impact |
 | [visual-studio/](visual-studio/README.md) | Visual Studio extension guide |
-| [sharing-server/](sharing-server/README.md) | Sharing server guide |
+| [sharing-server/](sharing-server/README.md) | Sharing server setup, personal dashboard and Team Insights |
+| [Sharing server data separation contract](../sharing-server/AGENTS.md) | Authoritative server privacy, comparison semantics and coding/testing requirements |
 | [specs/backend.md](specs/backend.md) | Backend API specification |
 | [specs/nonCopilotFilesDetection.md](specs/nonCopilotFilesDetection.md) | Non-Copilot file detection spec |
 

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -206,3 +206,52 @@ interaction smoke does gate, because a dead control never is.
 - **A dead control that is already the selected option** is reported as
   `noop-selected`, not as a finding. That is the trade for not carrying three
   standing false positives on the chart view's segmented controls.
+
+## Sharing server
+
+The extension preflight above does not validate the sharing server. Server coding
+and testing follow the [authoritative data separation contract](../sharing-server/AGENTS.md),
+including its HTTP/HTML privacy regression checklist. Unlike the extension's
+`local` stage, server tests must never read production data or call live GitHub:
+use isolated temporary SQLite fixtures, never user databases, and stub authentication.
+
+From `sharing-server`, run:
+
+```sh
+npm run check-types
+npm run build
+npm test
+npm run check:interaction
+```
+
+The server's `check:interaction` is a reproducible headless browser check,
+separate from the extension command of the same name. It requires an existing
+Playwright installation and its Chromium browser, resolved through
+`.github/skills/visual-view-diff/lib/browser.js`; no new dependencies are added.
+Against an isolated temporary-fixture server, it clicks period links, team-total
+and daily-average trend modes, raw daily-total expansion, CSV/JSON downloads and
+personal-dashboard navigation. It never launches an editor or IDE and does not
+use production data or live GitHub.
+
+The root test entry point is:
+
+```powershell
+.\build.ps1 -Project sharing -Target test
+```
+
+It runs the server's `npm test`, not the separate type/build/interaction checks.
+The deployment workflow gates on `npm test` and `npm run check:interaction`,
+using the repository's locked Playwright tooling. The package publishing workflow
+also runs `npm test` before the library build.
+
+Exercise `/team` with a session cookie and `/api/team-insights` with a bearer token
+through actual HTTP routes, plus both CSV and JSON `/team/export` downloads with
+a session cookie. Verify the full-page period links also work without JavaScript,
+daily-average denominators use daily active uploaders, and expanded totals match
+the safe payload. Inspect complete responses, including hidden markup
+and embedded scripts, with exact key allowlists and seeded sentinel-absence
+assertions. Cover owner/admin authorization, identity-free admin member views,
+private/no-store caching, and the contract's UTC-window, activity, ties, quartiles
+and no-peer edge cases. New exports and downstream route overrides need the same
+checks. A chart screenshot or a helper-only unit test cannot establish separation.
+All automated verification is non-interactive; never launch a GUI editor/IDE.

--- a/docs/sharing-server/README.md
+++ b/docs/sharing-server/README.md
@@ -9,6 +9,9 @@ you own. It is a lightweight Node.js API backed by SQLite — run it with Docker
 machine, point your team's VS Code extensions at it, and get a shared dashboard without
 needing an Azure account.
 
+For server coding, testing or customization, follow the
+[authoritative data separation contract](../../sharing-server/AGENTS.md).
+
 ## What it does
 
 ```
@@ -26,6 +29,8 @@ needing an Azure account.
 3. **View** — Team members sign in to the web dashboard with GitHub OAuth and see their
    own usage — input/output tokens, interactions, days active, editor breakdown, and
    usage trends over time.
+4. **Compare** — Open **Team Insights** at `/team` to compare your usage with anonymous
+   active uploaders without exposing their identities or uploaded detail.
 
 ## Dashboard preview
 
@@ -34,6 +39,37 @@ needing an Azure account.
 The web dashboard shows per-user usage summaries with time-range filters (Today /
 Last 7 Days / Last 30 Days), an editor breakdown chart, and a token usage trend graph
 grouped by editor or model.
+
+## Team Insights
+
+The cookie-authenticated `/team` page offers 7-, 30- and 90-day windows, each
+covering exactly N UTC dates including today and excluding future dates.
+It shows exact anonymous active-member token/interaction totals, activity-day
+counts and a self marker, together with your rank, share of team tokens,
+percentile and **Light / Medium / Heavy / Very heavy** relative usage cohort.
+Only positive tokens or interactions make a member active; inactive viewers
+have no comparison. Trends show the team aggregate and your own usage, never
+individual peers' daily series.
+
+Period links (`/team?days=N`) work without JavaScript. The page includes cohort
+counts/thresholds and an exact numeric member table, plus expandable daily
+team/own totals. The aggregate chart can show team totals or the average per
+daily active uploader alongside your own line. CSV and JSON downloads at
+`/team/export?days=N&format=csv|json` (choose one format) require the same session
+cookie and reuse the safe projection; they cannot reveal additional peer detail.
+
+Cohorts use interpolated p25/p50/p75 of active members' total input + output tokens
+with `<=` boundaries. Ties share rank/cohort; percentile is the percentage of
+other active uploaders strictly below you, and is undefined without peers.
+See the [comparison definitions](../../sharing-server/AGENTS.md#period-and-comparison-semantics)
+and [API reference](../../sharing-server/README.md#team-insights) for
+`GET /api/team-insights?days=7|30|90` (choose one value; bearer authentication).
+
+**Anonymous labels are not guaranteed anonymity.** Direct identifiers are removed,
+but exact totals and small-team comparisons can still re-identify members.
+There is no minimum count or suppression. Named admin detail remains on separate
+server-authorized admin routes, and personal uploaded rows remain owner-only.
+Even admins viewing Team Insights receive the same identity-free projection.
 
 ---
 
@@ -147,15 +183,19 @@ members of that GitHub organization.
   provide a server URL.
 - **Self-hosted** — The server runs on your infrastructure. Data never leaves your
   network (unless you expose the server publicly).
-- **Identified mode** — Every upload is linked to a GitHub user ID. There is no
-  anonymous or pseudonymous mode (unlike the Azure Storage backend).
+- **Identified storage** — Every upload is linked to a GitHub user ID; uploads are
+  not anonymous or pseudonymous (unlike the Azure Storage backend). Team Insights
+  removes direct peer identifiers at the server response boundary; see the
+  [data separation contract](../../sharing-server/AGENTS.md#team-projection)
+  for the allowlist and residual re-identification risk.
 - **Workspace/machine names** — Included or excluded based on the extension's
   `shareWorkspaceMachineNames` setting (off by default).
 - **Rollups only** — The extension sends daily aggregates (tokens, interactions, model
   names), not raw prompts or completions.
 - **Editor attribution** — Each rollup includes the session's editor label. This preserves
   session-specific sources such as `Copilot CLI (App)` separately from terminal
-  `Copilot CLI` usage in the team dashboard.
+  `Copilot CLI` usage in the personal dashboard. Peer model/editor labels are
+  not included in Team Insights.
 
 ---
 
@@ -174,3 +214,7 @@ sqlite3 /data/sharing.db .dump > backup.sql
 
 See the [sharing server README](../../sharing-server/README.md) for instructions on
 building from source and running locally with Node.js.
+
+For changes, use the [server validation guidance](../VALIDATION.md#sharing-server)
+and the [required privacy regression tests](../../sharing-server/AGENTS.md#required-validation).
+Downstream route overrides and exports must preserve the same contract.

--- a/sharing-server/AGENTS.md
+++ b/sharing-server/AGENTS.md
@@ -1,0 +1,104 @@
+# Sharing server — data separation contract
+
+This is the authoritative privacy contract for all sharing-server coding, testing,
+documentation, route overrides and downstream extensions. Read it alongside the
+[repository instructions](../AGENTS.md). Keep other server guidance linked here
+rather than maintaining separate, potentially conflicting privacy rules.
+
+## Access boundaries
+
+- **Personal data:** own raw uploaded rollups and detailed breakdowns are owner-only.
+  Derive the owner from the authenticated server identity, never a query parameter.
+- **Team Insights:** cookie-authenticated `/team` and `/team/export`, and
+  bearer-authenticated `/api/team-insights`, expose only the identity-free
+  projection below. An admin visiting these member surfaces receives the same
+  projection, not extra details.
+- **Named administrator detail:** stays on separate admin-only routes with
+  server-side authorization. Hiding links or columns is not access control.
+- Reject unauthenticated data requests (HTML may redirect to login); deny non-admins
+  access to admin data. Set `Cache-Control: private, no-store` on personalized and
+  team responses. Any new export must reuse the same authorized projection.
+
+## Team projection
+
+Construct explicit allowlisted response objects before serialization; never spread
+database rows or rely on client-side removal. Per-member data may contain only
+numeric period totals (input/output/total tokens and interactions), activity-day
+counts, a self flag, and calculated cohort labels/comparisons. Rank, token share and
+percentile are derived from the active uploaders in the selected period.
+
+Downstream routes can import `getTeamInsights`, `parseTeamDays` and the public
+projection types from the server package. Authenticate first and derive
+`viewerId` only from that identity, never query/request input. Reusing the helper
+does not replace route authorization. This contract ships in the npm package.
+
+Never expose peers' names, logins, avatars, profile links, GitHub/internal IDs,
+hashed or stable aliases, workspace/machine/dataset identifiers or names,
+model/editor labels, fluency blobs, upload timestamps, or per-peer daily series.
+This applies to API JSON, full HTML, hidden DOM, embedded scripts, chart payloads
+and exports, not just visible text. Trends may show only the team aggregate and
+the authenticated user's own series. Anonymous display labels must not encode
+identity or provide a stable cross-request alias.
+
+**Anonymous labels remove direct identifiers; they do not guarantee anonymity.**
+Exact numeric totals and comparisons can re-identify people, especially in small
+teams or by differencing aggregates. This risk is explicitly accepted: do not add
+minimum-team-size checks, suppression, rounding or noise to conceal these totals.
+
+## Period and comparison semantics
+
+- Accept 7, 30 or 90 days: exactly N UTC calendar dates including today, starting
+  N−1 dates ago. Exclude future dates from totals, membership and trends.
+- A member is active only with positive tokens **or** interactions in that window.
+  Do not count merely registered users or zero-activity uploads. An inactive
+  viewer has a zero-valued `self` row with `rank`, `percentile` and `cohort` set
+  to `null`, and is excluded from `members`, not ranked as a zero-usage member.
+- Compare selected-period **input + output tokens**. Rank is one plus the number
+  of active uploaders with strictly greater totals; ties share rank and cohort.
+  `sharePercent` is 100 × the member's fraction of team tokens. If team tokens
+  are zero, return `0` (displayed as `0.0%`): a presentation convention, not a
+  mathematically defined share.
+- Sort active members' token totals and interpolate p25/p50/p75 at `(n−1) × p`,
+  linearly between neighboring values. Cohorts are **Light** (`<= p25`),
+  **Medium** (`<= p50`), **Heavy** (`<= p75`), otherwise **Very heavy**.
+  These are relative usage groups, not productivity or proficiency judgments.
+- Percentile is 100 × the fraction of **other active uploaders** with strictly
+  fewer tokens. Tied peers are not below; no peers means no percentile, not 100%.
+
+## Required validation
+
+Use isolated temporary SQLite fixtures, clean them up, and stub GitHub
+authentication/network calls. Never read user or production databases or call
+live GitHub in tests. Do not launch a GUI editor/IDE.
+
+Test real HTTP route responses and complete rendered HTML, including embedded
+scripts: assert allowlisted keys and the absence of seeded peer-identity/metadata
+sentinels, not merely that visible names are hidden. Verify user A cannot fetch
+user B's personal data with query parameters; unauthenticated requests are
+rejected; non-admins cannot fetch admin data; admins on member surfaces receive
+the same identity-free shape; and cache headers and exports preserve this contract.
+Cover empty/single/small teams, inactive viewers, interaction-only activity,
+ties, zero-token denominators, interpolated thresholds, each supported period,
+UTC boundaries and future-date exclusion.
+
+From `sharing-server`, run the existing checks for server code changes:
+
+```sh
+npm run check-types
+npm run build
+npm test
+npm run check:interaction
+```
+
+The headless interaction check requires the existing Playwright/Chromium setup
+used by `.github/skills/visual-view-diff/lib/browser.js`; it adds no dependency.
+It clicks period links, trend modes, daily-total expansion, downloads and
+personal-dashboard navigation against an isolated fixture server, never an IDE.
+
+The root `.\build.ps1 -Project sharing -Target test` also runs `npm test`; it does
+not replace the other checks. Deployment CI runs the server tests and headless
+interaction gate using the repository's locked Playwright tooling. Package
+publication CI runs server tests before building the library.
+
+See [README.md](README.md) for the API and
+[validation guide](../docs/VALIDATION.md#sharing-server) for test scope.

--- a/sharing-server/README.md
+++ b/sharing-server/README.md
@@ -4,6 +4,11 @@ A self-hosted API server + web dashboard that makes sharing AI Engineering Fluen
 across a team dramatically easier. No Azure account required — anyone with Docker can
 host it in minutes.
 
+Development, testing and downstream customization must follow the
+[data separation contract](https://github.com/rajbos/ai-engineering-fluency/blob/main/sharing-server/AGENTS.md)
+(`sharing-server/AGENTS.md` in this repository, also shipped as `AGENTS.md` in
+the published npm package).
+
 ## How it works
 
 ```
@@ -90,6 +95,11 @@ prompt — it reuses your existing GitHub session.
 
 ## Building from source
 
+For code changes, also run the [server validation checks](../docs/VALIDATION.md#sharing-server)
+and satisfy the data separation contract's HTTP/HTML privacy tests.
+The root `.\build.ps1 -Project sharing -Target test` runs the server's `npm test`;
+run the type/build/headless interaction checks separately as described there.
+
 ```bash
 # From the repo root:
 ./build.ps1 -Project sharing
@@ -154,7 +164,10 @@ curl http://localhost:3000/health
 # → {"status":"ok","timestamp":"..."}
 ```
 
-Open `http://localhost:3000/dashboard` in your browser to test the OAuth login flow.
+For manual verification, open `http://localhost:3000/dashboard` in your browser
+to test the OAuth login flow. Automated tests use isolated SQLite fixtures and
+stubbed GitHub access, never production data or live GitHub; see the
+[required validation contract](AGENTS.md#required-validation).
 
 ## Environment variables
 
@@ -210,6 +223,75 @@ uploads are safe and idempotent.
 | `GET` | `/auth/github/callback` | Public | OAuth callback |
 | `GET` | `/auth/logout` | Session | Clear session |
 | `GET` | `/dashboard` | Session cookie | Web dashboard |
+| `GET` | `/team?days=30` | Session cookie | Identity-free Team Insights page |
+| `GET` | `/team/export?days=30&format=csv` | Session cookie | Team Insights download (`csv` or `json`), using the same safe projection |
+| `GET` | `/api/team-insights?days=30` | Bearer token | Identity-free team totals and own comparison |
+
+### Team Insights
+
+`/team` and `/api/team-insights` accept `days=7`, `days=30` or `days=90`.
+Omitted, malformed or unsupported values default to 30.
+Each window covers exactly N UTC calendar dates including today, beginning N−1
+dates ago; future-dated uploads are excluded.
+
+Team Insights shows exact numeric period totals for anonymous active members,
+marks your own row, and compares your input + output tokens with active uploaders:
+rank, share of team tokens, percentile and a **Light / Medium / Heavy / Very heavy**
+usage cohort. Registered users without positive tokens or interactions in the
+window are not active members. If you are inactive, your `self` row has zero
+numeric totals/activity/share and `rank`, `percentile` and `cohort` are `null`;
+you are excluded from `members`.
+Only aggregate team and your own daily trends are exposed, never peer daily series.
+
+Period filters are full-page `/team?days=N` links and work without JavaScript.
+The page includes cohort counts/thresholds, an exact numeric member table and
+expandable exact daily team/own totals. Trend modes compare your own line with
+either team totals or the team average per **daily active uploader**, not all
+registered users or the entire period's active-member count.
+
+Download the selected period with cookie-authenticated
+`/team/export?days=N&format=csv` or `format=json` (N is 7, 30 or 90).
+Both formats use the same safe Team Insights projection; exports do not add
+peer identities, metadata or per-peer daily data.
+
+Tied token totals have the same rank and cohort. Cohorts use interpolated
+p25/p50/p75 thresholds with `<=` boundaries; percentile counts only other active
+uploaders with strictly lower totals, and is undefined when there are no peers.
+These are relative usage groups, not productivity ratings. See the
+[authoritative comparison definitions](AGENTS.md#period-and-comparison-semantics).
+If team tokens total zero, `sharePercent` is `0` and the UI displays `0.0%` by
+convention, rather than claiming a mathematically defined share.
+
+**Anonymous labels remove direct identifiers, not all re-identification risk.**
+Exact totals and small-team comparisons can reveal identity; there is no
+minimum team size or suppression. Peer responses are an explicit numeric
+allowlist plus self flags and calculated comparisons/cohorts, not uploaded rows.
+The [data separation contract](AGENTS.md#team-projection) applies to API JSON,
+HTML, embedded scripts, chart data and any new exports. Personal uploaded data
+remains owner-only; named member detail remains server-authorized admin-only.
+Admins using member surfaces receive the same identity-free team shape.
+Personalized and team responses use `Cache-Control: private, no-store`.
+
+#### Team Insights JSON response
+
+The API returns the following explicit projection (the server keeps grouping IDs
+internal):
+
+| Field | Contents |
+|---|---|
+| `days`, `startDay`, `endDay` | Selected duration and inclusive UTC date bounds |
+| `summary` | `activeUsers`, `inputTokens`, `outputTokens`, `totalTokens`, `interactions`, `averageTokens`, `medianTokens` |
+| `members` | Active member rows, without identifiers |
+| `self` | Your member row, including the zero-valued inactive case |
+| `cohorts` | Rows with `label` and `members` (count) |
+| `daily` | Rows with `day`, `inputTokens`, `outputTokens`, `totalTokens`, `interactions`, `ownTokens`, `activeUsers` |
+| `quartiles` | Interpolated token thresholds `q1`, `q2`, `q3` |
+
+Each `members`/`self` row contains only `isSelf`, `inputTokens`, `outputTokens`,
+`totalTokens`, `interactions`, `daysActive`, `tokensPerActiveDay`, `sharePercent`,
+`rank`, `percentile` and `cohort`. `daily.activeUsers` is that date's active
+uploader count; `daily.ownTokens` belongs only to the authenticated viewer.
+There are no stable member aliases or peer-specific daily rows.
 
 ## Rate limits
 
@@ -272,10 +354,18 @@ await startServer(app);
 | `createApp({ mountApi, mountDashboard })` | Opt out of the built-in route groups. |
 | `registerSchemaExtension(name, fn)` | Add tables/indexes/migrations. Call before the first `getDb()`. |
 | `requireBearerAuth` | Authenticate with the same GitHub token as `/api/upload`, so your rows share the same `user_id`. |
+| `getTeamInsights(viewerId, days)`, `parseTeamDays(raw)` | Reuse the safe Team Insights projection and supported-period parsing. Derive `viewerId` only from server-authenticated identity, never request/query input. |
+| `TeamInsights`, `TeamMember`, `UsageCohort` | Public TypeScript types for the identity-free projection. |
 | `startServer(app, opts)` | Backup/restore, DB init with retry, periodic backup, graceful shutdown. |
 
 ### Guidance
 
+- **Preserve the [data separation contract](https://github.com/rajbos/ai-engineering-fluency/blob/main/sharing-server/AGENTS.md).**
+  Overrides registered before built-in routes can bypass their protection:
+  retain owner/admin authorization and the same allowlisted member projection,
+  including caching, charts and exports. Add the contract's HTTP/HTML privacy
+  regression tests for custom routes; importing the library alone does not
+  enforce these boundaries on your extensions.
 - **Add tables, don't widen `usage_uploads`.** Keeping downstream tables separate means
   core migrations and your migrations never conflict.
 - **Join on `(user_id, dataset_id, day, workspace_id, machine_id)`** — the natural rollup
@@ -302,6 +392,10 @@ Unlike the Azure Storage backend which supports anonymized and pseudonymous mode
 the sharing server is **identified mode only** — every upload is linked to a GitHub
 user ID. Workspace and machine names are included or excluded based on the extension's
 `shareWorkspaceMachineNames` setting (off by default).
+
+Identified storage does not grant peers access to those fields. The personal
+dashboard, identity-free Team Insights and named admin views have separate
+server-enforced access boundaries; see the [data separation contract](AGENTS.md).
 
 ## Data schema
 

--- a/sharing-server/package.json
+++ b/sharing-server/package.json
@@ -27,6 +27,7 @@
   },
   "files": [
     "lib",
+    "AGENTS.md",
     "README.md"
   ],
   "repository": {
@@ -45,6 +46,7 @@
     "clean:db": "node clean-db.js",
     "update": "npm ci && node esbuild.js",
     "check-types": "tsc --noEmit",
+    "check:interaction": "node scripts/check-team-interaction.cjs",
     "test": "node esbuild.tests.js && node --test \"out/test/*.test.js\""
   },
   "dependencies": {

--- a/sharing-server/scripts/check-team-interaction.cjs
+++ b/sharing-server/scripts/check-team-interaction.cjs
@@ -1,0 +1,149 @@
+'use strict';
+
+// Uses the existing headless harness with a temporary loopback server and isolated data.
+const assert = require('node:assert/strict');
+const { mkdtempSync, rmSync, readFileSync } = require('node:fs');
+const { tmpdir } = require('node:os');
+const path = require('node:path');
+const { buildSync } = require('esbuild');
+const { loadChromium } = require('../../.github/skills/visual-view-diff/lib/browser.js');
+
+async function main() {
+	const chromium = loadChromium();
+	const root = path.resolve(__dirname, '..');
+	const scratch = mkdtempSync(path.join(tmpdir(), 'team-interactions-'));
+	let browser;
+	let server;
+	let closeDb;
+	try {
+		process.env.LOCAL_DATA_DIR = scratch;
+		process.env.SESSION_SECRET = 'headless-fixture-session-key-not-a-real-secret';
+		process.env.CHART_JS_PATH = path.join(path.dirname(require.resolve('chart.js')), 'chart.umd.min.js');
+		delete process.env.ADMIN_GITHUB_LOGINS;
+		const bundle = path.join(scratch, 'fixture.cjs');
+		buildSync({
+			stdin: {
+				contents: `
+					export { createApp } from './src/app.ts';
+					export { upsertUser, upsertUpload, closeDb } from './src/db.ts';
+					export { encodeSession, makeClaims, COOKIE_NAME } from './src/session.ts';
+					export { serve } from '@hono/node-server';
+				`,
+				resolveDir: root, loader: 'ts',
+			},
+			bundle: true, platform: 'node', format: 'cjs', target: 'node22',
+			external: ['node:sqlite'], outfile: bundle, logLevel: 'silent',
+		});
+		const fixture = require(bundle);
+		closeDb = fixture.closeDb;
+		const app = fixture.createApp({ imagesDir: path.join(root, 'images') });
+		const address = await new Promise(resolve => {
+			server = fixture.serve({ fetch: app.fetch, hostname: '127.0.0.1', port: 0 }, resolve);
+		});
+		const baseUrl = `http://127.0.0.1:${address.port}`;
+		assert.equal((await fetch(`${baseUrl}/health`)).status, 200);
+		const today = new Date().toISOString().slice(0, 10);
+		const old = new Date();
+		old.setUTCDate(old.getUTCDate() - 40);
+		const viewer = fixture.upsertUser(78001, 'self-login', 'Your profile', null);
+		const forbidden = ['PRIVATE_PEER_LOGIN', 'PRIVATE_PEER_NAME', 'PRIVATE_WORKSPACE', 'PRIVATE_MACHINE', 'PRIVATE_MODEL'];
+		for (let i = 0; i < 4; i++) {
+			const user = i === 0 ? viewer : fixture.upsertUser(78001 + i, forbidden[0] + i, forbidden[1] + i, null);
+			fixture.upsertUpload(user.id, {
+				day: today, workspaceId: forbidden[2], machineId: forbidden[3], model: forbidden[4],
+				inputTokens: (i + 1) * 100, outputTokens: 0, interactions: i + 1,
+			});
+			if (i === 0) fixture.upsertUpload(user.id, {
+				day: old.toISOString().slice(0, 10), workspaceId: 'own-old', machineId: 'own-old', model: 'own-old',
+				inputTokens: 1000, outputTokens: 0, interactions: 10,
+			});
+		}
+		const assertPrivate = text => {
+			for (const value of forbidden) assert.ok(!text.includes(value), `leaked ${value}`);
+		};
+		browser = await chromium.launch({ headless: true });
+		const context = await browser.newContext({ viewport: { width: 1440, height: 1000 }, acceptDownloads: true });
+		await context.addCookies([{
+			name: fixture.COOKIE_NAME, value: fixture.encodeSession(fixture.makeClaims(viewer.id)),
+			url: baseUrl, httpOnly: true, sameSite: 'Lax',
+		}]);
+		await context.route('**/*', async route => {
+			assert.equal(new URL(route.request().url()).origin, baseUrl, 'no external network requests allowed');
+			await route.continue();
+		});
+		const page = await context.newPage();
+		const errors = [];
+		page.on('pageerror', error => errors.push(error.message));
+		await page.goto(`${baseUrl}/team`);
+		assert.equal(await page.locator('#team-member-table tbody tr').count(), 4);
+		assertPrivate(await page.content());
+		assert.equal(await page.locator('.team-self td').first().textContent(), '4');
+
+		for (const days of [7, 90, 30]) {
+			await page.getByRole('link', { name: `Last ${days} days`, exact: true }).click();
+			await page.waitForURL(`**/team?days=${days}`);
+			assert.equal(await page.locator('#team-daily-numbers tbody tr').count(), days);
+			assert.equal(await page.locator('.team-self td').first().textContent(), days === 90 ? '1' : '4');
+			assertPrivate(await page.content());
+		}
+		await page.getByRole('button', { name: 'Per-user average', exact: true }).click();
+		assert.equal(await page.getByRole('button', { name: 'Per-user average', exact: true }).getAttribute('aria-pressed'), 'true');
+		let chart = await page.evaluate(() => {
+			const chart = Chart.getChart(document.getElementById('team-trend-chart'));
+			return { label: chart.data.datasets[0].label, last: chart.data.datasets[0].data.at(-1), own: chart.data.datasets[1].data.at(-1) };
+		});
+		assert.deepEqual(chart, { label: 'Mean per daily active uploader', last: 250, own: 100 });
+		await page.getByRole('button', { name: 'Team total', exact: true }).click();
+		assert.equal(await page.evaluate(() => Chart.getChart(document.getElementById('team-trend-chart')).data.datasets[0].data.at(-1)), 1000);
+		await page.locator('#team-daily-numbers summary').click();
+		assert.equal(await page.locator('#team-daily-numbers').getAttribute('open'), '');
+		for (const format of ['CSV', 'JSON']) {
+			const downloadPromise = page.waitForEvent('download');
+			await page.getByRole('link', { name: `Download ${format}`, exact: true }).click();
+			const download = await downloadPromise;
+			assert.equal(download.suggestedFilename(), `team-insights-30days.${format.toLowerCase()}`);
+			const contents = readFileSync(await download.path(), 'utf8');
+			assertPrivate(contents);
+			if (format === 'JSON') {
+				const data = JSON.parse(contents);
+				assert.equal(data.self.totalTokens, 100);
+				assert.equal(data.summary.totalTokens, 1000);
+			} else {
+				assert.ok(contents.includes('"You","4","100","0","100"'));
+			}
+		}
+		await page.setViewportSize({ width: 390, height: 844 });
+		await page.waitForFunction(() => document.documentElement.scrollWidth <= window.innerWidth);
+		await page.getByRole('link', { name: 'Your detailed dashboard', exact: true }).click();
+		await page.waitForURL('**/dashboard');
+		await page.getByRole('link', { name: 'Team Insights', exact: true }).click();
+		await page.waitForURL('**/team');
+		await page.getByRole('link', { name: 'Sign out', exact: true }).click();
+		await page.waitForURL('**/dashboard');
+		await page.goto(`${baseUrl}/team`);
+		assert.equal(new URL(page.url()).pathname, '/dashboard');
+		assertPrivate(await page.content());
+		assert.deepEqual(errors, [], 'browser runtime errors');
+		const noScript = await browser.newContext({ javaScriptEnabled: false });
+		await noScript.addCookies([{
+			name: fixture.COOKIE_NAME, value: fixture.encodeSession(fixture.makeClaims(viewer.id)),
+			url: baseUrl, httpOnly: true, sameSite: 'Lax',
+		}]);
+		const plainPage = await noScript.newPage();
+		await plainPage.goto(`${baseUrl}/team`);
+		for (const days of [7, 90, 30]) {
+			await plainPage.getByRole('link', { name: `Last ${days} days`, exact: true }).click();
+			await plainPage.waitForURL(`**/team?days=${days}`);
+			assert.equal(await plainPage.locator('#team-daily-numbers tbody tr').count(), days);
+			assertPrivate(await plainPage.content());
+		}
+		console.log('Team interactions passed: period navigation (with/without JS), chart modes, daily table, exports, mobile layout, own dashboard, sign-out, privacy.');
+	} finally {
+		if (browser) await browser.close();
+		if (server) await new Promise((resolve, reject) => server.close(error => error ? reject(error) : resolve()));
+		if (closeDb) closeDb();
+		rmSync(scratch, { recursive: true, force: true });
+	}
+}
+
+main().catch(error => { console.error(error); process.exitCode = 1; });

--- a/sharing-server/src/db.ts
+++ b/sharing-server/src/db.ts
@@ -404,6 +404,28 @@ export function getAllUsers(): UserRow[] {
 	return getDb().prepare('SELECT * FROM users ORDER BY created_at DESC').all() as unknown as UserRow[];
 }
 
+/** Internal aggregates for Team Insights; user IDs must never leave the server. */
+export interface TeamUsageDayRow {
+	user_id: number;
+	day: string;
+	input_tokens: number;
+	output_tokens: number;
+	interactions: number;
+}
+
+export function getTeamUsageDays(startDay: string, endDay: string): TeamUsageDayRow[] {
+	return getDb().prepare(`
+		SELECT user_id, day,
+			SUM(input_tokens) AS input_tokens,
+			SUM(output_tokens) AS output_tokens,
+			SUM(interactions) AS interactions
+		FROM usage_uploads
+		WHERE day >= ? AND day <= ?
+		GROUP BY user_id, day
+		HAVING SUM(input_tokens) + SUM(output_tokens) > 0 OR SUM(interactions) > 0
+	`).all(startDay, endDay) as unknown as TeamUsageDayRow[];
+}
+
 export interface AdminUploadRow extends UploadRow {
 	github_login: string;
 }

--- a/sharing-server/src/index.ts
+++ b/sharing-server/src/index.ts
@@ -25,6 +25,15 @@ export {
 export { api } from './routes/api.js';
 export { dashboard } from './routes/dashboard.js';
 
+// Reuse the member-safe projection rather than exposing admin queries to team members.
+export {
+	getTeamInsights,
+	parseTeamDays,
+	type TeamInsights,
+	type TeamMember,
+	type UsageCohort,
+} from './teamInsights.js';
+
 // Auth — reuse so downstream endpoints authenticate the *same* user as core uploads.
 // This is what makes the two datasets joinable on `user_id`.
 export {

--- a/sharing-server/src/routes/api.ts
+++ b/sharing-server/src/routes/api.ts
@@ -3,6 +3,7 @@ import { requireBearerAuth, checkUploadRateLimit, type AuthVariables } from '../
 import { upsertUpload, deleteUploadsForDays, getUploadsForUser, getDb, upsertUserFluencyScore, type UploadEntry } from '../db.js';
 import { MAX_ENTRIES_PER_UPLOAD } from '../config.js';
 import { validateEntry } from '../validation/uploadSchema.js';
+import { getTeamInsights, parseTeamDays } from '../teamInsights.js';
 
 // Fluency score payload limits
 const MAX_FLUENCY_LABEL_LENGTH = 128;
@@ -92,6 +93,7 @@ api.post('/upload', requireBearerAuth, async (c) => {
 /** GET /api/me — Return the authenticated user's GitHub profile info. */
 api.get('/me', requireBearerAuth, (c) => {
 	const user = c.get('user');
+	c.header('Cache-Control', 'private, no-store');
 	return c.json({
 		githubId: user.github_id,
 		login: user.github_login,
@@ -104,10 +106,17 @@ api.get('/me', requireBearerAuth, (c) => {
 /** GET /api/data?days=30 — Return the authenticated user's own upload data. */
 api.get('/data', requireBearerAuth, (c) => {
 	const user = c.get('user');
+	c.header('Cache-Control', 'private, no-store');
 	const daysRaw = c.req.query('days');
 	const days = clampDays(daysRaw);
 	const data = getUploadsForUser(user.id, days);
 	return c.json(data);
+});
+
+/** GET /api/team-insights?days=30 — Anonymous team totals with authenticated self context. */
+api.get('/team-insights', requireBearerAuth, (c) => {
+	c.header('Cache-Control', 'private, no-store');
+	return c.json(getTeamInsights(c.get('user').id, parseTeamDays(c.req.query('days'))));
 });
 
 /**

--- a/sharing-server/src/routes/dashboard.ts
+++ b/sharing-server/src/routes/dashboard.ts
@@ -1,4 +1,4 @@
-import { Hono } from 'hono';
+import { Hono, type Context } from 'hono';
 import { getCookie, setCookie, deleteCookie } from 'hono/cookie';
 import { readFileSync } from 'fs';
 import { join, dirname } from 'path';
@@ -13,7 +13,14 @@ import {
 	type UploadRow, type UserRow, type UserUsageSummary, type AdminDailyRow,
 } from '../db.js';
 import { OAUTH_STATE_MAX_AGE_SECONDS } from '../config.js';
+import { getTeamInsights, parseTeamDays } from '../teamInsights.js';
+import { renderTeamInsights, teamInsightsCsv } from './teamPage.js';
 export const dashboard = new Hono();
+
+dashboard.use('*', async (c, next) => {
+	c.header('Cache-Control', 'private, no-store');
+	await next();
+});
 
 const GITHUB_CLIENT_ID = process.env.GITHUB_CLIENT_ID ?? '';
 const GITHUB_CLIENT_SECRET = process.env.GITHUB_CLIENT_SECRET ?? '';
@@ -258,6 +265,44 @@ dashboard.get('/admin', (c) => {
 	const dailyTotals = getAdminDailyTotals(90);
 
 	return c.html(adminDashboardPage(user, userSummaries, dailyTotals));
+});
+
+function getSessionUser(c: Context): UserRow | undefined {
+	const cookie = getCookie(c, COOKIE_NAME);
+	const claims = cookie ? decodeSession(cookie) : null;
+	return claims ? getUserById(claims.sub) : undefined;
+}
+
+dashboard.get('/team', (c) => {
+	const user = getSessionUser(c);
+	if (!user) return c.redirect('/dashboard');
+
+	const data = getTeamInsights(user.id, parseTeamDays(c.req.query('days')));
+	return c.html(layout('Team Insights', `
+<div class="header">
+  <h1><img src="/icon.png" class="header-icon" alt="AI Engineering Fluency"></h1>
+  <span class="spacer"></span>
+  ${user.is_admin === 1 ? '<a href="/admin">Admin Dashboard</a>' : ''}
+  <a href="/dashboard">My Dashboard</a>
+  <strong aria-current="page">Team Insights</strong>
+  <span>${h(user.github_name ?? user.github_login)}</span>
+  <a href="/auth/logout">Sign out</a>
+</div>
+<script>${_chartJsCode}</script>
+${renderTeamInsights(data)}`));
+});
+
+dashboard.get('/team/export', (c) => {
+	const user = getSessionUser(c);
+	if (!user) return c.redirect('/dashboard');
+	const format = c.req.query('format') ?? 'csv';
+	if (format !== 'csv' && format !== 'json') {
+		return c.json({ error: 'Supported export formats: csv, json.' }, 400);
+	}
+	const data = getTeamInsights(user.id, parseTeamDays(c.req.query('days')));
+	c.header('Content-Disposition', `attachment; filename="team-insights-${data.days}days.${format}"`);
+	if (format === 'json') return c.json(data);
+	return c.body(teamInsightsCsv(data), 200, { 'Content-Type': 'text/csv; charset=utf-8' });
 });
 
 // ── HTML Rendering ────────────────────────────────────────────────────────────
@@ -1045,6 +1090,7 @@ function dashboardPage(user: UserRow, uploads: UploadRow[], isAdmin: boolean): s
   <span class="spacer"></span>
   ${fluencyBadgeHtml}
   ${isAdmin ? `<a href="/admin" style="margin-left:8px;color:#e3b341">Admin Dashboard</a><span style="margin-left:8px;color:#e6edf3;font-size:0.875rem;font-weight:600">My Dashboard</span>` : ''}
+  <a href="/team">Team Insights</a>
   ${avatarUrl ? `<img src="${avatarUrl}" class="avatar-sm" alt="${login}" style="margin-left:8px">` : ''}
   <span style="color:#c9d1d9;font-size:0.875rem">${displayName}</span>
   <a href="/auth/logout" style="margin-left:8px">Sign out</a>
@@ -1413,6 +1459,7 @@ function adminDashboardPage(
   <span class="spacer"></span>
   <span style="color:#e6edf3;font-size:0.875rem;font-weight:600">Admin Dashboard</span>
   <a href="/dashboard" style="margin-left:8px">My Dashboard</a>
+  <a href="/team">Team Insights</a>
   ${adminAvatar ? `<img src="${adminAvatar}" class="avatar-sm" alt="${adminLogin}" style="margin-left:8px">` : ''}
   <span style="color:#c9d1d9;font-size:0.875rem">${adminName}</span>
   <a href="/auth/logout" style="margin-left:8px">Sign out</a>

--- a/sharing-server/src/routes/teamPage.ts
+++ b/sharing-server/src/routes/teamPage.ts
@@ -1,0 +1,220 @@
+import type { TeamInsights, TeamMember } from '../teamInsights.js';
+
+const exact = (n: number): string => n.toLocaleString('en-US', { maximumFractionDigits: 2 });
+const percent = (n: number): string => `${n.toFixed(1)}%`;
+
+function stat(label: string, value: string): string {
+	return `<div class="stat-card"><div class="label">${label}</div><div class="value team-value">${value}</div></div>`;
+}
+
+function memberCells(member: TeamMember): string {
+	return `<td>${exact(member.inputTokens)}</td><td>${exact(member.outputTokens)}</td>
+<td>${exact(member.totalTokens)}</td><td>${exact(member.interactions)}</td>
+<td>${member.daysActive}</td><td>${exact(member.tokensPerActiveDay)}</td>
+<td>${percent(member.sharePercent)}</td><td>${member.cohort ?? 'No activity'}</td>`;
+}
+
+/** CSV is explicitly projected too: never export database rows or profile metadata. */
+export function teamInsightsCsv(data: TeamInsights): string {
+	const rows: (string | number)[][] = [[
+		'Period start (UTC)', 'Period end (UTC)', 'Member', 'Rank', 'Input tokens', 'Output tokens',
+		'Total tokens', 'Interactions', 'Days active', 'Tokens per active day', 'Team share (%)', 'Cohort',
+	]];
+	let peer = 0;
+	for (const member of data.members) {
+		rows.push([
+			data.startDay, data.endDay, member.isSelf ? 'You' : `Peer ${++peer}`, member.rank ?? '',
+			member.inputTokens, member.outputTokens, member.totalTokens, member.interactions,
+			member.daysActive, member.tokensPerActiveDay, member.sharePercent, member.cohort ?? '',
+		]);
+	}
+	return rows.map(row => row.map(value => `"${String(value).replace(/"/g, '""')}"`).join(',')).join('\r\n') + '\r\n';
+}
+
+function cohortCards(data: TeamInsights): string {
+	const { q1, q2, q3 } = data.quartiles;
+	const ranges = [
+		`Up to ${exact(q1)} tokens`,
+		`Above ${exact(q1)}, up to ${exact(q2)}`,
+		`Above ${exact(q2)}, up to ${exact(q3)}`,
+		`Above ${exact(q3)} tokens`,
+	];
+	return data.cohorts.map((cohort, i) => `<div class="stat-card">
+  <div class="label">${cohort.label}${data.self.cohort === cohort.label ? ' <span class="pill">You</span>' : ''}</div>
+  <div class="value">${cohort.members}</div>
+  <p class="team-muted">${data.summary.activeUsers ? percent(cohort.members / data.summary.activeUsers * 100) : '0.0%'} of active uploaders</p>
+  <meter min="0" max="${Math.max(1, data.summary.activeUsers)}" value="${cohort.members}" aria-label="${cohort.label} uploaders">${cohort.members}</meter>
+  <p class="team-muted">${ranges[i]}</p>
+</div>`).join('');
+}
+
+export function renderTeamInsights(data: TeamInsights): string {
+	const { summary, self } = data;
+	let peer = 0;
+	const rows = data.members.map(member => `<tr${member.isSelf ? ' class="team-self" data-self="true"' : ''}>
+  <th scope="row">${member.isSelf ? '<strong>You</strong>' : `Peer ${++peer}`}</th>
+  <td>${member.rank ?? '-'}</td>${memberCells(member)}
+</tr>`).join('');
+	const selfPosition = self.rank === null
+		? '<p class="alert alert-warn">You have no active uploads in this period. Upload your usage to see your position; inactive users are not ranked.</p>'
+		: `<div class="stat-grid">
+${stat('Your total tokens', exact(self.totalTokens))}
+${stat('Your token rank', `${self.rank} of ${summary.activeUsers}`)}
+${stat('Your share of team tokens', percent(self.sharePercent))}
+${stat('Your usage cohort', self.cohort ?? 'No activity')}
+</div>
+<p class="team-muted">${self.percentile === null
+	? 'No other active uploaders in this period yet; a peer percentile is not available.'
+	: `Your token total is higher than ${percent(self.percentile)} of the other active uploaders. Equal totals share a rank and cohort.`}</p>`;
+	// Only numeric aggregate series and server-generated ISO dates reach chart code.
+	const chartData = JSON.stringify(data.daily).replace(/</g, '\\u003c');
+	return `
+<style>
+  .team-page { --team-muted: #8b949e; --team-accent: #58a6ff; --team-grid: #30363d; --team-own: #e3b341; }
+  .team-page h2 { margin: 0 0 8px; }
+  .team-muted { color: var(--team-muted); font-size: 0.85rem; line-height: 1.5; }
+  .team-value { font-size: 1.3rem !important; overflow-wrap: anywhere; line-height: 1.25 !important; }
+  .team-page .tab { text-decoration: none; }
+  .team-page > .card { min-width: 0; }
+  .team-page .chart-wrap { min-width: 0; }
+  .team-page meter { width: 100%; accent-color: var(--team-accent); }
+  .team-page .team-self { outline: 1px solid var(--team-accent); outline-offset: -1px; }
+  .team-page td, .team-page th { font-variant-numeric: tabular-nums; }
+  .team-page caption { text-align: left; padding: 8px 0; color: var(--team-muted); }
+  .team-page a:not(.tab):not(.btn) { color: var(--team-accent); }
+  .header { flex-wrap: wrap; }
+  .team-actions { display: flex; gap: 8px; flex-wrap: wrap; }
+  @media (max-width: 480px) {
+    .team-page .tabs { flex-wrap: wrap; }
+    .team-page .tab { padding: 5px 10px; }
+  }
+</style>
+<main class="content team-page">
+  <section class="card">
+    <div class="card-header">
+      <div><h2>Team Insights</h2><span class="team-muted">${data.startDay} to ${data.endDay} &middot; UTC &middot; ${data.days} days including today</span></div>
+      <nav class="tabs" aria-label="Team usage period">${[7, 30, 90].map(days =>
+		`<a class="tab${data.days === days ? ' active' : ''}" href="/team?days=${days}"${data.days === days ? ' aria-current="page"' : ''}>Last ${days} days</a>`).join('')}</nav>
+    </div>
+    <p class="team-muted">Your uploaded usage in context, compared with active uploaders on this server. Usage volume is not productivity, skill, or fluency.</p>
+    <div class="alert alert-warn"><strong>Names are hidden, not guaranteed anonymous.</strong>
+      Exact usage patterns may identify a teammate, especially in small teams. Peer numbers below are row labels, not persistent identities.
+      Profiles, workspaces, machines, and individual peer timelines are never included in this view or its exports.</div>
+  </section>
+
+  <section class="card" aria-labelledby="team-overview">
+    <div class="card-header"><h3 id="team-overview">Team overview</h3></div>
+    <div class="stat-grid">
+      ${stat('Active uploaders', exact(summary.activeUsers))}
+      ${stat('Total tokens', exact(summary.totalTokens))}
+      ${stat('Input tokens', exact(summary.inputTokens))}
+      ${stat('Output tokens', exact(summary.outputTokens))}
+      ${stat('Interactions', exact(summary.interactions))}
+      ${stat('Mean tokens / uploader', exact(summary.averageTokens))}
+      ${stat('Median tokens / uploader', exact(summary.medianTokens))}
+    </div>
+    <p class="team-muted">Active means positive tokens or interactions in this period. Totals reflect uploaded data, not necessarily all usage. Means and medians include you when active.</p>
+  </section>
+
+  <section class="card" aria-labelledby="your-position">
+    <div class="card-header"><h3 id="your-position">Where you stand</h3><a href="/dashboard">Your detailed dashboard</a></div>
+    ${selfPosition}
+  </section>
+
+  <section class="card" aria-labelledby="team-cohorts">
+    <div class="card-header"><h3 id="team-cohorts">Usage cohorts</h3></div>
+    ${summary.activeUsers ? `<div class="stat-grid">${cohortCards(data)}</div>` : '<p>No active uploads in this period yet.</p>'}
+    <p class="team-muted">Relative to this team, not fixed usage limits: Light / Medium / Heavy / Very heavy are split at the interpolated 25th, 50th, and 75th percentiles of total tokens.
+      A boundary value belongs to the lower cohort. Ties are kept together, so cohorts may be uneven or empty.
+      Small samples are not representative; cohorts may change with the period or new uploads.</p>
+  </section>
+
+  <section class="card" aria-labelledby="team-trend">
+    <div class="card-header"><h3 id="team-trend">Usage trend</h3>
+      <div class="tabs" aria-label="Trend comparison">
+        <button type="button" class="tab active" data-team-mode="total" aria-pressed="true">Team total</button>
+        <button type="button" class="tab" data-team-mode="average" aria-pressed="false">Per-user average</button>
+      </div>
+    </div>
+    <p class="team-muted">Compare your tokens with the team total or the mean per active uploader on each UTC day. No individual peer series.</p>
+    <div class="chart-wrap"><canvas id="team-trend-chart" role="img" aria-label="Your daily tokens compared with team usage. Exact values are in Daily raw numbers below."></canvas></div>
+    <p id="team-chart-unavailable" class="team-muted" hidden>The chart is unavailable. All values remain available in Daily raw numbers below.</p>
+    <details id="team-daily-numbers">
+      <summary>Daily raw numbers</summary>
+      <div class="table-scroll"><table>
+        <caption>Exact team totals and your own tokens by UTC day</caption>
+        <thead><tr><th scope="col">Day (UTC)</th><th scope="col">Input tokens</th><th scope="col">Output tokens</th><th scope="col">Total tokens</th><th scope="col">Interactions</th><th scope="col">Active uploaders</th><th scope="col">Your tokens</th></tr></thead>
+        <tbody>${data.daily.map(day => `<tr><th scope="row">${day.day}</th><td>${exact(day.inputTokens)}</td><td>${exact(day.outputTokens)}</td><td>${exact(day.totalTokens)}</td><td>${exact(day.interactions)}</td><td>${day.activeUsers}</td><td>${exact(day.ownTokens)}</td></tr>`).join('')}</tbody>
+      </table></div>
+    </details>
+  </section>
+
+  <section class="card" aria-labelledby="team-members">
+    <div class="card-header"><h3 id="team-members">Raw numbers by active uploader</h3>
+      <div class="team-actions">
+        <a class="btn btn-secondary" href="/team/export?days=${data.days}&amp;format=csv">Download CSV</a>
+        <a class="btn btn-secondary" href="/team/export?days=${data.days}&amp;format=json">Download JSON</a>
+      </div>
+    </div>
+    <p class="team-muted">Sorted by total tokens, highest first. Peer labels only identify rows in this result; they cannot be used to open another person's data.
+      CSV contains this table; JSON also includes the team overview, comparisons, cohorts, and daily team/own totals.</p>
+    ${data.members.length ? `<div class="table-scroll"><table id="team-member-table">
+      <caption>Full token counts, not rounded K / M / B abbreviations. Derived averages are shown to two decimals and shares to one.</caption>
+      <thead><tr><th scope="col">Member</th><th scope="col">Rank</th><th scope="col">Input tokens</th><th scope="col">Output tokens</th><th scope="col">Total tokens</th><th scope="col">Interactions</th><th scope="col">Days active</th><th scope="col">Tokens / active day</th><th scope="col">Team share</th><th scope="col">Cohort</th></tr></thead>
+      <tbody>${rows}</tbody>
+    </table></div>` : '<p>No active uploaders in this period. Your uploads will appear here once available.</p>'}
+  </section>
+</main>
+<script>
+(function () {
+  var daily = ${chartData};
+  var buttons = document.querySelectorAll('[data-team-mode]');
+  if (typeof Chart === 'undefined') {
+    document.getElementById('team-chart-unavailable').hidden = false;
+    document.getElementById('team-trend-chart').hidden = true;
+    buttons.forEach(function(button) { button.disabled = true; });
+    return;
+  }
+  var style = getComputedStyle(document.querySelector('.team-page'));
+  var accent = style.getPropertyValue('--team-accent').trim();
+  var own = style.getPropertyValue('--team-own').trim();
+  var muted = style.getPropertyValue('--team-muted').trim();
+  var grid = style.getPropertyValue('--team-grid').trim();
+  var chart = new Chart(document.getElementById('team-trend-chart'), {
+    type: 'line',
+    data: {
+      labels: daily.map(function(day) { return day.day; }),
+      datasets: [
+        { label: 'Team total', data: daily.map(function(day) { return day.totalTokens; }), borderColor: accent, backgroundColor: accent, borderWidth: 2, pointRadius: 2 },
+        { label: 'You', data: daily.map(function(day) { return day.ownTokens; }), borderColor: own, backgroundColor: own, borderWidth: 2, pointRadius: 2 }
+      ]
+    },
+    options: {
+      responsive: true, maintainAspectRatio: false, interaction: { mode: 'index', intersect: false },
+      scales: {
+        x: { ticks: { color: muted, maxTicksLimit: 12 }, grid: { color: grid } },
+        y: { beginAtZero: true, ticks: { color: muted }, grid: { color: grid }, title: { display: true, text: 'Tokens', color: muted } }
+      },
+      plugins: {
+        legend: { position: 'bottom', labels: { color: muted } },
+        tooltip: { callbacks: { label: function(context) { return context.dataset.label + ': ' + context.parsed.y.toLocaleString('en-US', { maximumFractionDigits: 2 }) + ' tokens'; } } }
+      }
+    }
+  });
+  buttons.forEach(function(button) {
+    button.addEventListener('click', function() {
+      var average = button.getAttribute('data-team-mode') === 'average';
+      buttons.forEach(function(item) {
+        item.classList.toggle('active', item === button);
+        item.setAttribute('aria-pressed', String(item === button));
+      });
+      chart.data.datasets[0].label = average ? 'Mean per daily active uploader' : 'Team total';
+      chart.data.datasets[0].data = daily.map(function(day) {
+        return average ? (day.activeUsers ? day.totalTokens / day.activeUsers : 0) : day.totalTokens;
+      });
+      chart.update();
+    });
+  });
+})();
+</script>`;
+}

--- a/sharing-server/src/teamInsights.ts
+++ b/sharing-server/src/teamInsights.ts
@@ -1,0 +1,150 @@
+import { getTeamUsageDays } from './db.js';
+
+export type UsageCohort = 'Light' | 'Medium' | 'Heavy' | 'Very heavy';
+
+export interface TeamMember {
+	isSelf: boolean;
+	inputTokens: number;
+	outputTokens: number;
+	totalTokens: number;
+	interactions: number;
+	daysActive: number;
+	tokensPerActiveDay: number;
+	sharePercent: number;
+	rank: number | null;
+	percentile: number | null;
+	cohort: UsageCohort | null;
+}
+
+export interface TeamInsights {
+	days: number;
+	startDay: string;
+	endDay: string;
+	summary: {
+		activeUsers: number;
+		inputTokens: number;
+		outputTokens: number;
+		totalTokens: number;
+		interactions: number;
+		averageTokens: number;
+		medianTokens: number;
+	};
+	members: TeamMember[];
+	self: TeamMember;
+	cohorts: Array<{ label: UsageCohort; members: number }>;
+	daily: Array<{
+		day: string;
+		inputTokens: number;
+		outputTokens: number;
+		totalTokens: number;
+		interactions: number;
+		ownTokens: number;
+		activeUsers: number;
+	}>;
+	quartiles: { q1: number; q2: number; q3: number };
+}
+
+export function parseTeamDays(raw: string | undefined): number {
+	return raw === '7' ? 7 : raw === '90' ? 90 : 30;
+}
+
+function emptyMember(isSelf: boolean): TeamMember {
+	return {
+		isSelf, inputTokens: 0, outputTokens: 0, totalTokens: 0,
+		interactions: 0, daysActive: 0, tokensPerActiveDay: 0, sharePercent: 0,
+		rank: null, percentile: null, cohort: null,
+	};
+}
+
+function quantile(sorted: number[], fraction: number): number {
+	if (sorted.length === 0) return 0;
+	const position = (sorted.length - 1) * fraction;
+	const lower = Math.floor(position);
+	return sorted[lower] + (sorted[Math.ceil(position)] - sorted[lower]) * (position - lower);
+}
+
+/** Explicit identity-free projection shared by bearer API and cookie-authenticated HTML. */
+export function getTeamInsights(viewerId: number, days: number): TeamInsights {
+	days = parseTeamDays(String(days));
+	const end = new Date();
+	end.setUTCHours(0, 0, 0, 0);
+	const start = new Date(end);
+	start.setUTCDate(start.getUTCDate() - days + 1);
+	const startDay = start.toISOString().slice(0, 10);
+	const endDay = end.toISOString().slice(0, 10);
+	const daily: TeamInsights['daily'] = Array.from({ length: days }, (_, index) => {
+		const date = new Date(start);
+		date.setUTCDate(date.getUTCDate() + index);
+		return {
+			day: date.toISOString().slice(0, 10), inputTokens: 0, outputTokens: 0,
+			totalTokens: 0, interactions: 0, ownTokens: 0, activeUsers: 0,
+		};
+	});
+	const byDay = new Map(daily.map(day => [day.day, day]));
+	const byUser = new Map<number, TeamMember>();
+	for (const row of getTeamUsageDays(startDay, endDay)) {
+		const day = byDay.get(row.day);
+		if (!day) continue;
+		let member = byUser.get(row.user_id);
+		if (!member) {
+			member = emptyMember(row.user_id === viewerId);
+			byUser.set(row.user_id, member);
+		}
+		const total = row.input_tokens + row.output_tokens;
+		member.inputTokens += row.input_tokens;
+		member.outputTokens += row.output_tokens;
+		member.totalTokens += total;
+		member.interactions += row.interactions;
+		member.daysActive++;
+		day.inputTokens += row.input_tokens;
+		day.outputTokens += row.output_tokens;
+		day.totalTokens += total;
+		day.interactions += row.interactions;
+		day.activeUsers++;
+		if (member.isSelf) day.ownTokens += total;
+	}
+
+	const members = [...byUser.values()].sort((a, b) => b.totalTokens - a.totalTokens);
+	const ascendingTotals = members.map(member => member.totalTokens).reverse();
+	const quartiles = {
+		q1: quantile(ascendingTotals, 0.25),
+		q2: quantile(ascendingTotals, 0.5),
+		q3: quantile(ascendingTotals, 0.75),
+	};
+	const summary: TeamInsights['summary'] = {
+		activeUsers: members.length,
+		inputTokens: 0, outputTokens: 0, totalTokens: 0, interactions: 0,
+		averageTokens: 0, medianTokens: quartiles.q2,
+	};
+	for (const member of members) {
+		summary.inputTokens += member.inputTokens;
+		summary.outputTokens += member.outputTokens;
+		summary.totalTokens += member.totalTokens;
+		summary.interactions += member.interactions;
+	}
+	summary.averageTokens = members.length ? summary.totalTokens / members.length : 0;
+	const labels: UsageCohort[] = ['Light', 'Medium', 'Heavy', 'Very heavy'];
+	const cohorts = labels.map(label => ({ label, members: 0 }));
+	for (let first = 0; first < members.length;) {
+		let after = first + 1;
+		while (after < members.length && members[after].totalTokens === members[first].totalTokens) after++;
+		for (let index = first; index < after; index++) {
+			const member = members[index];
+			const cohortIndex = member.totalTokens <= quartiles.q1 ? 0
+				: member.totalTokens <= quartiles.q2 ? 1 : member.totalTokens <= quartiles.q3 ? 2 : 3;
+			member.rank = first + 1;
+			member.percentile = members.length > 1 ? (members.length - after) / (members.length - 1) * 100 : null;
+			member.cohort = labels[cohortIndex];
+			member.tokensPerActiveDay = member.totalTokens / member.daysActive;
+			member.sharePercent = summary.totalTokens ? member.totalTokens / summary.totalTokens * 100 : 0;
+			cohorts[cohortIndex].members++;
+		}
+		first = after;
+	}
+
+	return {
+		days, startDay, endDay, summary, members,
+		self: members.find(member => member.isSelf) ?? emptyMember(true),
+		cohorts, daily, quartiles,
+	};
+}

--- a/sharing-server/src/test/teamDashboard.test.ts
+++ b/sharing-server/src/test/teamDashboard.test.ts
@@ -1,0 +1,182 @@
+import { after, before, describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createApp } from '../app.js';
+import { closeDb, getDb, upsertUpload, upsertUser, type UserRow } from '../db.js';
+import { COOKIE_NAME, encodeSession, makeClaims } from '../session.js';
+import { getTeamInsights } from '../teamInsights.js';
+
+const app = createApp();
+const sentinels = [
+	'PEER_LOGIN_SENTINEL', 'PEER_NAME_SENTINEL', 'PEER_AVATAR_SENTINEL',
+	'PEER_WORKSPACE_ID_SENTINEL', 'PEER_WORKSPACE_NAME_SENTINEL',
+	'PEER_MACHINE_ID_SENTINEL', 'PEER_MACHINE_NAME_SENTINEL', 'PEER_DATASET_SENTINEL',
+	'PEER_MODEL_SENTINEL', 'PEER_EDITOR_SENTINEL', 'PEER_FLUENCY_SENTINEL',
+];
+let dataDir: string;
+let viewer: UserRow;
+let peer: UserRow;
+let admin: UserRow;
+let inactive: UserRow;
+const previousDataDir = process.env.LOCAL_DATA_DIR;
+const previousAdmins = process.env.ADMIN_GITHUB_LOGINS;
+
+function cookie(user: UserRow): string {
+	return `${COOKIE_NAME}=${encodeSession(makeClaims(user.id))}`;
+}
+
+async function request(path: string, user: UserRow = viewer): Promise<Response> {
+	return app.request(path, { headers: { Cookie: cookie(user) } });
+}
+
+function assertNoPeerMetadata(text: string): void {
+	for (const sentinel of sentinels) assert.ok(!text.includes(sentinel), `leaked ${sentinel}`);
+}
+
+before(() => {
+	dataDir = mkdtempSync(join(tmpdir(), 'sharing-team-dashboard-'));
+	process.env.LOCAL_DATA_DIR = dataDir;
+	delete process.env.ADMIN_GITHUB_LOGINS;
+	viewer = upsertUser(910001, 'viewer', 'Viewer Name', null);
+	peer = upsertUser(910002, sentinels[0], sentinels[1], `https://example.invalid/${sentinels[2]}`);
+	admin = upsertUser(910003, 'admin', 'Admin Name', null);
+	inactive = upsertUser(910004, 'inactive', 'Inactive Name', null);
+	getDb().prepare('UPDATE users SET is_admin = 1 WHERE id = ?').run(admin.id);
+	const day = new Date().toISOString().slice(0, 10);
+	upsertUpload(viewer.id, {
+		day, model: 'own-model', workspaceId: 'own-workspace', machineId: 'own-machine',
+		inputTokens: 12345, outputTokens: 6789, interactions: 12,
+	});
+	upsertUpload(peer.id, {
+		day, model: sentinels[8], workspaceId: sentinels[3], workspaceName: sentinels[4],
+		machineId: sentinels[5], machineName: sentinels[6], datasetId: sentinels[7],
+		editor: sentinels[9], fluencyMetrics: { sentinel: sentinels[10] },
+		inputTokens: 43210, outputTokens: 9876, interactions: 34,
+	});
+});
+
+after(() => {
+	closeDb();
+	if (previousDataDir === undefined) delete process.env.LOCAL_DATA_DIR;
+	else process.env.LOCAL_DATA_DIR = previousDataDir;
+	if (previousAdmins === undefined) delete process.env.ADMIN_GITHUB_LOGINS;
+	else process.env.ADMIN_GITHUB_LOGINS = previousAdmins;
+	rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe('member dashboard privacy boundary', () => {
+	test('rejects missing, forged, expired and deleted-user sessions on pages and exports', async () => {
+		const expired = encodeSession({ ...makeClaims(viewer.id), exp: 1 });
+		const unknown = encodeSession(makeClaims(999999));
+		for (const path of ['/team', '/team/export?format=json', '/team/export?format=csv']) {
+			for (const value of ['', 'forged', expired, unknown]) {
+				const response = await app.request(path, { headers: { Cookie: `${COOKIE_NAME}=${value}` } });
+				assert.equal(response.status, 302);
+				assert.equal(response.headers.get('location'), '/dashboard');
+				assert.equal(response.headers.get('cache-control'), 'private, no-store');
+				assertNoPeerMetadata(await response.text());
+			}
+		}
+	});
+
+	test('renders exact anonymous numbers and marks only the authenticated viewer, for every period', async () => {
+		for (const days of [7, 30, 90]) {
+			const response = await request(`/team?days=${days}&userId=${peer.id}&github_login=${peer.github_login}`);
+			assert.equal(response.status, 200);
+			assert.equal(response.headers.get('cache-control'), 'private, no-store');
+			const html = await response.text();
+			assertNoPeerMetadata(html);
+			assert.ok(html.includes('Viewer Name'));
+			assert.ok(html.includes(`href="/team?days=${days}" aria-current="page"`));
+			assert.ok(html.includes('Names are hidden, not guaranteed anonymous.'));
+			assert.ok(html.includes('43,210'));
+			assert.ok(html.includes('9,876'));
+			const ownRow = html.match(/<tr class="team-self" data-self="true">[\s\S]*?<\/tr>/g);
+			assert.equal(ownRow?.length, 1);
+			assert.ok(ownRow![0].includes('12,345'));
+			assert.ok(!ownRow![0].includes('43,210'));
+			assert.ok(html.includes(`<a class="btn btn-secondary" href="/team/export?days=${days}&amp;format=csv">`));
+			assert.ok(html.includes(`<a class="btn btn-secondary" href="/team/export?days=${days}&amp;format=json">`));
+			assert.ok(!html.includes('ADMIN_CHART_DATA'));
+			assert.ok(!html.includes('href="/admin"'));
+		}
+	});
+
+	test('full JSON exports equal the shared allowlisted projection and ignore identity selectors', async () => {
+		for (const user of [viewer, peer, admin]) {
+			const response = await request(`/team/export?format=json&days=7&user_id=${peer.id}`, user);
+			assert.equal(response.status, 200);
+			assert.equal(response.headers.get('content-disposition'), 'attachment; filename="team-insights-7days.json"');
+			assert.equal(response.headers.get('cache-control'), 'private, no-store');
+			const body = await response.text();
+			// Even when the peer signs in, exports contain no profiles at all.
+			assertNoPeerMetadata(body);
+			assert.deepEqual(JSON.parse(body), getTeamInsights(user.id, 7));
+		}
+	});
+
+	test('CSV is exact, numeric and anonymous, with self labeling and no private fields', async () => {
+		const response = await request('/team/export?format=csv&days=30');
+		assert.equal(response.status, 200);
+		assert.equal(response.headers.get('content-type'), 'text/csv; charset=utf-8');
+		assert.equal(response.headers.get('cache-control'), 'private, no-store');
+		assert.equal(response.headers.get('content-disposition'), 'attachment; filename="team-insights-30days.csv"');
+		const csv = await response.text();
+		assertNoPeerMetadata(csv);
+		const lines = csv.trim().split('\r\n');
+		assert.equal(lines.length, 3);
+		assert.ok(lines[1].includes('"Peer 1","1","43210","9876","53086","34","1"'));
+		assert.ok(lines[2].includes('"You","2","12345","6789","19134","12","1"'));
+		assert.ok(!csv.includes('viewer'));
+	});
+
+	test('exports reject unsupported formats and normalize unsupported periods', async () => {
+		assert.equal((await request('/team/export?format=html')).status, 400);
+		const response = await request('/team/export?format=json&days=9999');
+		assert.equal((await response.json()).days, 30);
+	});
+
+	test('admin membership never expands the member projection or its HTML', async () => {
+		const response = await request('/team', admin);
+		assert.equal(response.status, 200);
+		const html = await response.text();
+		assertNoPeerMetadata(html);
+		assert.ok(html.includes('href="/admin"'));
+		assert.ok(html.includes('You have no active uploads in this period.'));
+		assert.ok(!html.includes('ADMIN_CHART_DATA'));
+	});
+
+	test('admin details remain server-authorized and owner pages stay owner-only', async () => {
+		const denied = await request(`/admin?is_admin=1&user_id=${admin.id}`);
+		assert.equal(denied.status, 302);
+		assert.equal(denied.headers.get('location'), '/dashboard');
+		const allowed = await request('/admin', admin);
+		assert.equal(allowed.status, 200);
+		assert.equal(allowed.headers.get('cache-control'), 'private, no-store');
+		assert.ok((await allowed.text()).includes(peer.github_login));
+		const own = await request(`/dashboard?user_id=${peer.id}`);
+		assert.equal(own.status, 200);
+		assert.equal(own.headers.get('cache-control'), 'private, no-store');
+		assertNoPeerMetadata(await own.text());
+		getDb().prepare('UPDATE users SET is_admin = 0 WHERE id = ?').run(admin.id);
+		assert.equal((await request('/admin', admin)).status, 302, 'role changes take effect on the next request');
+	});
+
+	test('inactive members are not ranked, and zero-activity windows explain the empty state', async () => {
+		const html = await (await request('/team', inactive)).text();
+		assert.ok(html.includes('You have no active uploads in this period.'));
+		assert.ok(!html.includes('data-self="true"'));
+		// Temporarily move fixture data outside all supported periods; restore it even on failure.
+		getDb().prepare("UPDATE usage_uploads SET day = date(day, '-100 days')").run();
+		try {
+			const empty = await (await request('/team')).text();
+			assert.ok(empty.includes('No active uploaders in this period.'));
+			assert.ok(empty.includes('No active uploads in this period yet.'));
+			assertNoPeerMetadata(empty);
+		} finally {
+			getDb().prepare("UPDATE usage_uploads SET day = date(day, '+100 days')").run();
+		}
+	});
+});

--- a/sharing-server/src/test/teamInsights.test.ts
+++ b/sharing-server/src/test/teamInsights.test.ts
@@ -1,0 +1,336 @@
+import { after, afterEach, before, beforeEach, describe, mock, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { Hono } from 'hono';
+import { closeDb, getDb, upsertUpload, upsertUser, upsertUserFluencyScore, type UploadEntry } from '../db.js';
+import { getTeamInsights, parseTeamDays, type TeamInsights } from '../teamInsights.js';
+import { api } from '../routes/api.js';
+
+const NOW = Date.parse('2026-03-01T00:30:00Z');
+const TODAY = '2026-03-01';
+const SENTINEL = 'FORBIDDEN-PEER-IDENTITY';
+const originalEnv = {
+	LOCAL_DATA_DIR: process.env.LOCAL_DATA_DIR,
+	ALLOWED_GITHUB_ORG: process.env.ALLOWED_GITHUB_ORG,
+	ADMIN_GITHUB_LOGINS: process.env.ADMIN_GITHUB_LOGINS,
+};
+const realFetch = globalThis.fetch;
+let dataDir: string;
+let nextGithubId = 800000;
+
+before(() => {
+	// Keep the real SQLite fixture inside the workspace, never in a user/server database.
+	dataDir = mkdtempSync(join(process.cwd(), '.team-insights-test-'));
+	process.env.LOCAL_DATA_DIR = dataDir;
+	delete process.env.ALLOWED_GITHUB_ORG;
+	delete process.env.ADMIN_GITHUB_LOGINS;
+});
+
+beforeEach(() => {
+	mock.timers.enable({ apis: ['Date'], now: NOW });
+	globalThis.fetch = async () => { throw new Error('Unexpected network request'); };
+	getDb().exec('DELETE FROM usage_uploads; DELETE FROM users;');
+});
+
+afterEach(() => mock.timers.reset());
+
+after(() => {
+	globalThis.fetch = realFetch;
+	closeDb();
+	for (const [key, value] of Object.entries(originalEnv)) {
+		if (value === undefined) delete process.env[key];
+		else process.env[key] = value;
+	}
+	rmSync(dataDir, { recursive: true, force: true });
+});
+
+function user() {
+	const id = ++nextGithubId;
+	return upsertUser(id, `${SENTINEL}-login-${id}`, `${SENTINEL}-name`, `https://example.test/${SENTINEL}`);
+}
+
+function upload(userId: number, inputTokens: number, outputTokens = 0, overrides: Partial<UploadEntry> = {}): void {
+	upsertUpload(userId, {
+		day: TODAY, model: `${SENTINEL}-model`, datasetId: `${SENTINEL}-dataset`,
+		workspaceId: `${SENTINEL}-workspace-id`, workspaceName: `${SENTINEL}-workspace-name`,
+		machineId: `${SENTINEL}-machine-id`, machineName: `${SENTINEL}-machine-name`,
+		editor: `${SENTINEL}-editor`, fluencyMetrics: { privateValue: SENTINEL },
+		inputTokens, outputTokens, interactions: 1, ...overrides,
+	});
+}
+
+function keys(value: object, allowed: string[]): void {
+	assert.deepEqual(Object.keys(value).sort(), [...allowed].sort());
+}
+
+function assertPrivateProjection(result: TeamInsights): void {
+	keys(result, ['days', 'startDay', 'endDay', 'summary', 'members', 'self', 'cohorts', 'daily', 'quartiles']);
+	keys(result.summary, ['activeUsers', 'inputTokens', 'outputTokens', 'totalTokens', 'interactions', 'averageTokens', 'medianTokens']);
+	keys(result.quartiles, ['q1', 'q2', 'q3']);
+	for (const member of [...result.members, result.self]) {
+		keys(member, ['isSelf', 'inputTokens', 'outputTokens', 'totalTokens', 'interactions',
+			'daysActive', 'tokensPerActiveDay', 'sharePercent', 'rank', 'percentile', 'cohort']);
+	}
+	for (const cohort of result.cohorts) keys(cohort, ['label', 'members']);
+	for (const day of result.daily) {
+		keys(day, ['day', 'inputTokens', 'outputTokens', 'totalTokens', 'interactions', 'ownTokens', 'activeUsers']);
+		assert.match(day.day, /^\d{4}-\d{2}-\d{2}$/);
+	}
+	assert.ok(!JSON.stringify(result).includes(SENTINEL));
+}
+
+describe('Team Insights projection', () => {
+	test('strictly parses supported periods and normalizes direct calls', () => {
+		for (const [raw, expected] of [['7', 7], ['30', 30], ['90', 90]] as const) {
+			assert.equal(parseTeamDays(raw), expected);
+		}
+		for (const raw of [undefined, '', '0', '1', '31', '91', '-7', '7junk', '7.0', '07', ' 7', 'Infinity']) {
+			assert.equal(parseTeamDays(raw), 30);
+		}
+		for (const days of [0, 1, 31, -7, 7.5, NaN, Infinity]) {
+			assert.equal(getTeamInsights(-1, days).days, 30);
+		}
+	});
+
+	test('no data returns an inactive self and zero-filled period, without counting registered users', () => {
+		const viewer = user();
+		const peer = user();
+		upload(peer.id, 0, 0, { interactions: 0 });
+		const result = getTeamInsights(viewer.id, 7);
+		assert.deepEqual(result.summary, {
+			activeUsers: 0, inputTokens: 0, outputTokens: 0, totalTokens: 0,
+			interactions: 0, averageTokens: 0, medianTokens: 0,
+		});
+		assert.deepEqual(result.self, {
+			isSelf: true, inputTokens: 0, outputTokens: 0, totalTokens: 0, interactions: 0,
+			daysActive: 0, tokensPerActiveDay: 0, sharePercent: 0,
+			rank: null, percentile: null, cohort: null,
+		});
+		assert.deepEqual(result.members, []);
+		assert.deepEqual(result.quartiles, { q1: 0, q2: 0, q3: 0 });
+		assert.deepEqual(result.cohorts, ['Light', 'Medium', 'Heavy', 'Very heavy'].map(label => ({ label, members: 0 })));
+		assert.equal(result.daily.length, 7);
+		for (const day of result.daily) {
+			assert.deepEqual(day, { day: day.day, inputTokens: 0, outputTokens: 0, totalTokens: 0, interactions: 0, ownTokens: 0, activeUsers: 0 });
+		}
+		assertPrivateProjection(result);
+	});
+
+	test('one active uploader has rank one, null percentile, and Light cohort', () => {
+		const viewer = user();
+		upload(viewer.id, 75, 25);
+		const result = getTeamInsights(viewer.id, 30);
+		assert.deepEqual(result.quartiles, { q1: 100, q2: 100, q3: 100 });
+		assert.equal(result.summary.averageTokens, 100);
+		assert.equal(result.summary.medianTokens, 100);
+		assert.equal(result.self.rank, 1);
+		assert.equal(result.self.percentile, null);
+		assert.equal(result.self.cohort, 'Light');
+		assert.equal(result.self.sharePercent, 100);
+		assert.deepEqual(result.members, [result.self]);
+		assertPrivateProjection(result);
+	});
+
+	test('interpolates quartiles and assigns all four cohorts in descending order', () => {
+		const viewers = [user(), user(), user(), user()];
+		viewers.forEach((viewer, index) => upload(viewer.id, (index + 1) * 10));
+		const result = getTeamInsights(viewers[1].id, 7);
+		assert.deepEqual(result.quartiles, { q1: 17.5, q2: 25, q3: 32.5 });
+		assert.equal(result.summary.averageTokens, 25);
+		assert.equal(result.summary.medianTokens, 25);
+		assert.deepEqual(result.members.map(member => member.totalTokens), [40, 30, 20, 10]);
+		assert.deepEqual(result.members.map(member => member.cohort), ['Very heavy', 'Heavy', 'Medium', 'Light']);
+		assert.deepEqual(result.members.map(member => member.rank), [1, 2, 3, 4]);
+		assert.deepEqual(result.members.map(member => member.percentile), [100, 2 / 3 * 100, 1 / 3 * 100, 0]);
+		assert.deepEqual(result.members.map(member => member.isSelf), [false, false, true, false]);
+		assert.ok(result.cohorts.every(cohort => cohort.members === 1));
+		assertPrivateProjection(result);
+	});
+
+	test('ties share inclusive cohort thresholds, competition rank and strictly-lower peer percentile', () => {
+		const viewers = [user(), user(), user(), user(), user()];
+		[10, 10, 20, 30, 30].forEach((tokens, index) => upload(viewers[index].id, tokens));
+		const result = getTeamInsights(viewers[0].id, 7);
+		assert.deepEqual(result.quartiles, { q1: 10, q2: 20, q3: 30 });
+		assert.deepEqual(result.members.map(member => member.rank), [1, 1, 3, 4, 4]);
+		assert.deepEqual(result.members.map(member => member.percentile), [75, 75, 50, 0, 0]);
+		assert.deepEqual(result.members.map(member => member.cohort), ['Heavy', 'Heavy', 'Medium', 'Light', 'Light']);
+		assert.deepEqual(result.cohorts.map(cohort => cohort.members), [2, 1, 2, 0]);
+	});
+
+	test('all equal totals stay Light with rank one and zero percentile', () => {
+		const viewers = [user(), user(), user()];
+		for (const viewer of viewers) upload(viewer.id, 12);
+		const result = getTeamInsights(viewers[0].id, 7);
+		assert.deepEqual(result.quartiles, { q1: 12, q2: 12, q3: 12 });
+		assert.ok(result.members.every(member => member.cohort === 'Light' && member.rank === 1 && member.percentile === 0));
+	});
+
+	test('zero-token interactions are active, zero-only uploads are not', () => {
+		const viewer = user();
+		const zeroOnly = user();
+		upload(viewer.id, 0, 0, { interactions: 3 });
+		upload(viewer.id, 0, 0, { day: '2026-02-28', interactions: 0 });
+		upload(zeroOnly.id, 0, 0, { interactions: 0 });
+		const result = getTeamInsights(viewer.id, 7);
+		assert.equal(result.summary.activeUsers, 1);
+		assert.equal(result.summary.totalTokens, 0);
+		assert.equal(result.summary.interactions, 3);
+		assert.equal(result.self.daysActive, 1);
+		assert.equal(result.self.tokensPerActiveDay, 0);
+		assert.equal(result.self.sharePercent, 0);
+		assert.equal(result.self.rank, 1);
+		assert.equal(result.self.cohort, 'Light');
+		assert.equal(result.daily.at(-1)!.activeUsers, 1);
+		assert.equal(result.daily.at(-1)!.interactions, 3);
+		assert.equal(result.daily.at(-2)!.activeUsers, 0);
+		assertPrivateProjection(result);
+	});
+
+	test('counts exactly N UTC dates including today and excludes old and future uploads', () => {
+		const viewer = user();
+		for (const [days, startDay] of [[7, '2026-02-23'], [30, '2026-01-31'], [90, '2025-12-02']] as const) {
+			getDb().exec('DELETE FROM usage_uploads');
+			const beforeStart = new Date(`${startDay}T00:00:00Z`);
+			beforeStart.setUTCDate(beforeStart.getUTCDate() - 1);
+			upload(viewer.id, 10, 0, { day: startDay });
+			upload(viewer.id, 20);
+			upload(viewer.id, 10000, 0, { day: beforeStart.toISOString().slice(0, 10) });
+			upload(viewer.id, 20000, 0, { day: '2026-03-02' });
+			const result = getTeamInsights(viewer.id, days);
+			assert.equal(result.days, days);
+			assert.equal(result.startDay, startDay);
+			assert.equal(result.endDay, TODAY);
+			assert.equal(result.daily.length, days);
+			assert.equal(new Set(result.daily.map(day => day.day)).size, days);
+			assert.equal(result.daily[0].day, startDay);
+			assert.equal(result.daily.at(-1)!.day, TODAY);
+			assert.equal(result.self.daysActive, 2);
+			assert.equal(result.summary.totalTokens, 30);
+			for (let index = 1; index < result.daily.length; index++) {
+				assert.equal(Date.parse(result.daily[index].day) - Date.parse(result.daily[index - 1].day), 86400000);
+			}
+		}
+	});
+
+	test('aggregates datasets and editors without duplicating active days or re-uploaded rows', () => {
+		const viewer = user();
+		const peer = user();
+		upload(viewer.id, 100, 20);
+		upload(viewer.id, 100, 20);
+		upload(viewer.id, 10, 20, { datasetId: 'second-dataset', interactions: 2 });
+		upload(viewer.id, 15, 5, { editor: 'second-editor', interactions: 3 });
+		upload(viewer.id, 10, 20, { day: '2026-02-28', interactions: 4 });
+		upload(peer.id, 300, 100, { interactions: 5 });
+		upsertUserFluencyScore(peer.id, JSON.stringify({ privateData: SENTINEL }));
+		const result = getTeamInsights(viewer.id, 7);
+		assert.deepEqual(result.summary, {
+			activeUsers: 2, inputTokens: 435, outputTokens: 165, totalTokens: 600,
+			interactions: 15, averageTokens: 300, medianTokens: 300,
+		});
+		assert.deepEqual(result.self, {
+			isSelf: true, inputTokens: 135, outputTokens: 65, totalTokens: 200, interactions: 10,
+			daysActive: 2, tokensPerActiveDay: 100, sharePercent: 200 / 600 * 100,
+			rank: 2, percentile: 0, cohort: 'Light',
+		});
+		assert.deepEqual(result.daily.at(-1), {
+			day: TODAY, inputTokens: 425, outputTokens: 145, totalTokens: 570,
+			interactions: 11, ownTokens: 170, activeUsers: 2,
+		});
+		assert.deepEqual(result.daily.at(-2), {
+			day: '2026-02-28', inputTokens: 10, outputTokens: 20, totalTokens: 30,
+			interactions: 4, ownTokens: 30, activeUsers: 1,
+		});
+		assert.equal(result.daily.reduce((sum, day) => sum + day.totalTokens, 0), result.summary.totalTokens);
+		assert.equal(result.daily.reduce((sum, day) => sum + day.ownTokens, 0), result.self.totalTokens);
+		assertPrivateProjection(result);
+	});
+
+	test('an inactive viewer is not a member and does not change peer quartiles', () => {
+		const viewer = user();
+		const peer = user();
+		upload(peer.id, 100);
+		upload(viewer.id, 500, 0, { day: '2026-03-02' });
+		const result = getTeamInsights(viewer.id, 7);
+		assert.equal(result.members.length, 1);
+		assert.equal(result.members[0].isSelf, false);
+		assert.equal(result.self.totalTokens, 0);
+		assert.equal(result.self.rank, null);
+		assert.equal(result.self.percentile, null);
+		assert.equal(result.self.cohort, null);
+		assert.deepEqual(result.quartiles, { q1: 100, q2: 100, q3: 100 });
+		assert.ok(result.daily.every(day => day.ownTokens === 0));
+		assertPrivateProjection(result);
+	});
+});
+
+describe('GET /api/team-insights', () => {
+	const app = new Hono().route('/api', api);
+
+	test('rejects missing, malformed and invalid bearer authentication', async () => {
+		for (const authorization of [undefined, 'Basic invalid', 'Bearer ', 'Bearer invalid-team-token']) {
+			globalThis.fetch = async () => new Response('{}', { status: 401 });
+			const response = await app.request('/api/team-insights', {
+				headers: authorization ? { Authorization: authorization } : {},
+			});
+			assert.equal(response.status, 401);
+			assert.deepEqual(await response.json(), { error: 'Unauthorized' });
+		}
+	});
+
+	test('derives self only from auth, ignores identity selectors, and returns private no-store JSON', async () => {
+		const viewer = user();
+		const peer = user();
+		upload(viewer.id, 100);
+		upload(peer.id, 900);
+		upsertUserFluencyScore(peer.id, JSON.stringify({ privateData: SENTINEL }));
+		globalThis.fetch = async () => Response.json({
+			id: viewer.github_id, login: viewer.github_login,
+			name: viewer.github_name, avatar_url: viewer.avatar_url,
+		});
+		const selectors = `userId=${peer.id}&viewerId=${peer.id}&user_id=${peer.id}&login=${peer.github_login}`;
+		const response = await app.request(`/api/team-insights?days=7&${selectors}`, {
+			headers: { Authorization: `Bearer team-viewer-${viewer.github_id}`, 'X-User-Id': String(peer.id) },
+		});
+		assert.equal(response.status, 200);
+		assert.equal(response.headers.get('Cache-Control'), 'private, no-store');
+		assert.match(response.headers.get('Content-Type')!, /application\/json/);
+		const result = await response.json() as TeamInsights;
+		assert.deepEqual(result, getTeamInsights(viewer.id, 7));
+		assert.equal(result.self.totalTokens, 100);
+		assert.deepEqual(result.members.map(member => member.isSelf), [false, true]);
+		assertPrivateProjection(result);
+
+		const fallback = await app.request('/api/team-insights?days=7junk', {
+			headers: { Authorization: `Bearer team-viewer-${viewer.github_id}` },
+		});
+		assert.equal((await fallback.json() as TeamInsights).days, 30);
+	});
+
+	test('personal API responses are private no-store and cannot select another owner', async () => {
+		const viewer = user();
+		const peer = user();
+		// /data uses SQLite's current UTC date rather than the mocked JavaScript clock.
+		const { day } = getDb().prepare("SELECT date('now') AS day").get() as { day: string };
+		upload(viewer.id, 100, 0, { day });
+		upload(peer.id, 900, 0, { day });
+		globalThis.fetch = async () => Response.json({
+			id: viewer.github_id, login: viewer.github_login,
+			name: viewer.github_name, avatar_url: viewer.avatar_url,
+		});
+		const headers = { Authorization: `Bearer personal-viewer-${viewer.github_id}` };
+		const response = await app.request(`/api/data?userId=${peer.id}&user_id=${peer.id}`, { headers });
+		assert.equal(response.status, 200);
+		assert.equal(response.headers.get('Cache-Control'), 'private, no-store');
+		const rows = await response.json() as Array<{ user_id: number; input_tokens: number }>;
+		assert.equal(rows.length, 1);
+		assert.equal(rows[0].user_id, viewer.id);
+		assert.equal(rows[0].input_tokens, 100);
+
+		const profile = await app.request(`/api/me?userId=${peer.id}`, { headers });
+		assert.equal(profile.status, 200);
+		assert.equal(profile.headers.get('Cache-Control'), 'private, no-store');
+		assert.equal((await profile.json() as { githubId: number }).githubId, viewer.github_id);
+	});
+});


### PR DESCRIPTION
## Why

People uploading usage need to see their raw numbers and understand where they sit relative to the team, without receiving other members' names or private upload metadata.

## Approach

- Add an authenticated Team Insights page with exact anonymous member totals, a highlighted own row, token rank, percentile, team share, and relative Light / Medium / Heavy / Very heavy cohorts.
- Support 7/30/90-day UTC windows, team-total or daily-active-uploader-average trends, expandable daily numbers, and CSV/JSON downloads. A bearer-authenticated API and exported library helpers reuse the same server-side allowlisted projection.
- Keep personal uploads owner-only and named administrator detail admin-only. Exclude peer identities, stable identifiers, workspace/machine metadata, and individual peer timelines from member responses, embedded scripts, charts, and exports. Personalized responses use private/no-store caching.
- Make data separation a documented contract across contributor, agent, server, and downstream-extension guidance. Wire privacy regressions into root testing and publish/deploy gates, with headless interaction coverage before deployment.

## Deliberate trade-offs

Exact anonymous per-person totals are available even for small teams, as requested. Removing direct identifiers does not prevent re-identification from distinctive usage; the page and documentation explicitly warn about this. Cohorts are team-relative token quartiles, not productivity ratings. Ties stay together, so some cohorts may be empty.

## Validation

- 61 server tests passed, including HTTP/HTML/export privacy boundaries and comparison edge cases.
- Type-check, server build, library build, public exports, and package contents verified.
- Headless Chromium exercised filters with and without JavaScript, trend modes, daily tables, downloads, mobile layout, navigation, and sign-out.
- Updated workflows passed actionlint.

No production data migration or live deployment was performed.