### PR TITLE
Cache Repository PRs snapshot with hourly trickle refresh

### DIFF
--- a/vscode-extension/src/cacheManager.ts
+++ b/vscode-extension/src/cacheManager.ts
@@ -130,7 +130,7 @@ export class CacheManager {
 			const now = Date.now();
 			let removedCount = 0;
 			for (const name of entries) {
-				if (!/^(cache|refresh|agenttasks)_dev-[0-9a-f]+\.(snapshot\.json|lock)$/.test(name)) { continue; }
+				if (!/^(cache|refresh|agenttasks|repoprs)_dev-[0-9a-f]+\.(snapshot\.json|lock)$/.test(name)) { continue; }
 				const filePath = path.join(dir, name);
 				try {
 					const stat = await fs.promises.stat(filePath);
@@ -178,6 +178,18 @@ export class CacheManager {
 	}
 
 	/**
+	 * Get the path for the repository-PRs refresh lock file.
+	 * Held by the single window that refreshes the hourly Repository PRs snapshot from the
+	 * GitHub API, so the other windows never duplicate those API calls. Kept separate from the
+	 * cache-refresh leader lock and the agent-tasks lock because all three run on independent
+	 * schedules and cost independent sets of GitHub API calls.
+	 */
+	getRepoPrLockPath(): string {
+		const cacheId = this.getCacheIdentifier();
+		return path.join(this.context.globalStorageUri.fsPath, `repoprs_${cacheId}.lock`);
+	}
+
+	/**
 	 * Acquire an exclusive file lock for cache writes.
 	 * Uses atomic file creation (O_EXCL / CREATE_NEW) to prevent concurrent writes
 	 * across multiple VS Code windows of the same edition.
@@ -198,6 +210,27 @@ export class CacheManager {
 	/** Release the agent-tasks refresh lock, but only if we own it. */
 	async releaseAgentTasksLock(): Promise<void> {
 		return this.releaseLock(this.getAgentTasksLockPath());
+	}
+
+	/**
+	 * Try to become the window that refreshes the repository-PRs snapshot. Returns false when
+	 * another window is already refreshing it, in which case this window serves the shared snapshot.
+	 */
+	async acquireRepoPrLock(): Promise<boolean> {
+		return this.acquireLock(this.getRepoPrLockPath());
+	}
+
+	/** Release the repository-PRs refresh lock, but only if we own it. */
+	async releaseRepoPrLock(): Promise<void> {
+		return this.releaseLock(this.getRepoPrLockPath());
+	}
+
+	/**
+	 * Renew (heartbeat) the repository-PRs lock so a slow GitHub API pass is not mistaken for a
+	 * stale lock by another window, which would let it duplicate the same API calls.
+	 */
+	async renewRepoPrLock(): Promise<boolean> {
+		return this.renewLock(this.getRepoPrLockPath());
 	}
 
 	/**

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -301,6 +301,15 @@ import {
 	readAgentTasksSnapshot,
 	writeAgentTasksSnapshot,
 } from './agentTasksCache';
+import {
+	REPO_PRS_CACHE_SCHEMA_VERSION,
+	REPO_PRS_REFRESH_INTERVAL_MS,
+	canServeRepoPrSnapshot,
+	getRepoPrCachePath,
+	isRepoPrEnvelopeUsable,
+	readRepoPrSnapshot,
+	writeRepoPrSnapshot,
+} from './repoPrCache';
 import { getConfiguredGitHubEnterpriseUri, getGitHubAuthProviderId } from './githubApiConfig';
 
 // --- View regression ---
@@ -717,8 +726,11 @@ class CopilotTokenTracker implements vscode.Disposable {
 		premium_interactions_remaining?: number;
 	} = {};
 
-	// Cached PR stats result for the repos tab
+	// Cached PR stats result for the repos tab (mirrors the shared snapshot on disk)
 	private _lastRepoPrStats?: RepoPrStatsResult;
+
+	// True while this window is refreshing the shared repository-PRs snapshot from the GitHub API
+	private _repoPrRefreshInFlight = false;
 
 	// Cached cloud agent sessions result for the cloud agent tab (mirrors the shared snapshot on disk)
 	private _lastAgentSessionsData?: AgentSessionsResult;
@@ -1901,9 +1913,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			if (this.analysisPanel) {
 				const since = new Date();
 				since.setDate(since.getDate() - 30);
-				const result: RepoPrStatsResult = { repos: [], authenticated: false, since: since.toISOString() };
-				this._lastRepoPrStats = result;
-				await this.analysisMessageReplay.publish('repoPrStats', { command: 'repoPrStatsLoaded', data: result });
+				await this.publishRepoPrStats(this.buildEmptyRepoPrStatsResult(since, false));
 				await this.publishAgentSessions(this.buildEmptyAgentSessionsResult(since, false));
 			}
 		} catch (error) {
@@ -1946,12 +1956,45 @@ class CopilotTokenTracker implements vscode.Disposable {
 		return this.githubSession;
 	}
 
-	/** Load PR stats for all discovered GitHub repos and send results to the analysis panel. */
+	private repoPrStatsSince(): Date {
+		const since = new Date();
+		since.setDate(since.getDate() - 30);
+		return since;
+	}
+
+	/** Path of the cross-window Repository PRs snapshot shared by every window of this VS Code edition. */
+	private repoPrCachePath(): string {
+		return getRepoPrCachePath(this.context.globalStorageUri.fsPath, this.cacheManager.getCacheIdentifier());
+	}
+
+	/** An empty snapshot — `fetchedAt: ''` marks "never fetched", which the panel renders as pending. */
+	private buildEmptyRepoPrStatsResult(since: Date, authenticated: boolean): RepoPrStatsResult {
+		return { repos: [], authenticated, since: since.toISOString(), fetchedAt: '' };
+	}
+
+	/**
+	 * Remember and push a snapshot to the analysis panel, if one is open. The refresh interval is
+	 * stamped on here so the panel can show when the next refresh is due without duplicating the
+	 * cache policy.
+	 */
+	private async publishRepoPrStats(result: RepoPrStatsResult): Promise<void> {
+		const stamped: RepoPrStatsResult = { ...result, refreshIntervalMs: REPO_PRS_REFRESH_INTERVAL_MS };
+		this._lastRepoPrStats = stamped;
+		const { delivered, wasReady } = await this.analysisMessageReplay.publish('repoPrStats', { command: 'repoPrStatsLoaded', data: stamped });
+		this.log(`🔎 Repository PR stats posted for ${stamped.repos.length} repo(s) (delivered=${delivered}, webviewReady=${wasReady}, ${this._describeAnalysisPanel()})`);
+	}
+
+	/**
+	 * Show Repository PR stats in the analysis panel.
+	 *
+	 * This never calls GitHub itself: it serves the shared hourly snapshot (see `repoPrCache.ts`)
+	 * so opening the tab is instant and costs no API calls, then asks for a refresh, which only
+	 * happens if the snapshot is stale *and* this window wins the repo-PRs lock.
+	 */
 	private async loadRepoPrStats(): Promise<void> {
 		if (!this.analysisPanel) { return; }
 
-		const since = new Date();
-		since.setDate(since.getDate() - 30);
+		const since = this.repoPrStatsSince();
 		this.log('🔎 Loading repository PR stats (last 30 days)…');
 		try {
 			await this.collectAndPublishRepoPrStats(since);
@@ -1962,28 +2005,20 @@ class CopilotTokenTracker implements vscode.Disposable {
 			// tolerates the panel being disposed mid-flight (postMessage on a disposed webview
 			// resolves false instead of throwing).
 			this.error('Failed to load repository PR stats', err);
-			const result: RepoPrStatsResult = {
-				repos: [], authenticated: !this._githubSignedOutByUser, since: since.toISOString(),
-				error: err instanceof Error ? err.message : String(err),
-			};
-			this._lastRepoPrStats = result;
-			await this.analysisMessageReplay.publish('repoPrStats', { command: 'repoPrStatsLoaded', data: result });
+			const fallback = this._lastRepoPrStats ?? this.buildEmptyRepoPrStatsResult(since, !this._githubSignedOutByUser);
+			await this.publishRepoPrStats({ ...fallback, error: err instanceof Error ? err.message : String(err) });
 		}
 	}
 
 	private async collectAndPublishRepoPrStats(since: Date): Promise<void> {
 		if (this._githubSignedOutByUser) {
-			const result: RepoPrStatsResult = { repos: [], authenticated: false, since: since.toISOString() };
-			this._lastRepoPrStats = result;
-			await this.analysisMessageReplay.publish('repoPrStats', { command: 'repoPrStatsLoaded', data: result });
+			await this.publishRepoPrStats(this.buildEmptyRepoPrStatsResult(since, false));
 			return;
 		}
 
 		const session = await vscode.authentication.getSession(getGitHubAuthProviderId(), ['read:user'], { silent: true });
 		if (!session) {
-			const result: RepoPrStatsResult = { repos: [], authenticated: false, since: since.toISOString() };
-			this._lastRepoPrStats = result;
-			await this.analysisMessageReplay.publish('repoPrStats', { command: 'repoPrStatsLoaded', data: result });
+			await this.publishRepoPrStats(this.buildEmptyRepoPrStatsResult(since, false));
 			return;
 		}
 
@@ -1994,27 +2029,99 @@ class CopilotTokenTracker implements vscode.Disposable {
 			this.log(`✅ GitHub session synced from existing VS Code auth: ${session.account.label}`);
 		}
 
+		await this.publishRepoPrStats(this._lastRepoPrStats ?? this.buildEmptyRepoPrStatsResult(since, true));
+		const snapshot = await _withTimeout(
+			readRepoPrSnapshot(this.repoPrCachePath()),
+			10_000,
+			'Reading the repository PRs snapshot',
+		);
+		if (isRepoPrEnvelopeUsable(snapshot, since)) {
+			await this.publishRepoPrStats(snapshot!.data);
+		}
+
+		void this.maybeRefreshRepoPrStats().catch((err) => {
+			this.warn(`Repository PRs refresh scheduling failed: ${err}`);
+		});
+	}
+
+	/**
+	 * Refresh the Repository PRs snapshot from the GitHub API, if it is due.
+	 *
+	 * Collecting it costs a PR-list call (plus a commit-messages call per PR to detect
+	 * co-authored-by AI) for every discovered repo, so it is deliberately rationed: at most once
+	 * every REPO_PRS_REFRESH_INTERVAL_MS, and only in the window that wins the repo-PRs lock — the
+	 * other windows read that window's snapshot from global storage instead of repeating the calls.
+	 * Runs on extension start and on every cache refresh cycle (both leader-gated), plus whenever
+	 * the Repository PRs tab is opened.
+	 */
+	private async maybeRefreshRepoPrStats(): Promise<void> {
+		if (this._repoPrRefreshInFlight || this._githubSignedOutByUser) { return; }
+		const since = this.repoPrStatsSince();
+		const cachePath = this.repoPrCachePath();
+		if (canServeRepoPrSnapshot(await readRepoPrSnapshot(cachePath), since, Date.now())) { return; }
+
+		const session = await vscode.authentication.getSession(getGitHubAuthProviderId(), ['read:user'], { silent: true });
+		if (!session) { return; }
+
+		let acquired = false;
+		try { acquired = await this.cacheManager.acquireRepoPrLock(); }
+		catch (err) { this.warn(`Failed to acquire repo-PRs lock: ${err}`); }
+		if (!acquired) {
+			this.log('⏭️ Repository PRs refresh skipped — another window is refreshing the shared snapshot');
+			return;
+		}
+
+		this._repoPrRefreshInFlight = true;
+		// Heartbeat the lock: a slow API pass must not look stale to another window, which would
+		// let it start the same collection in parallel.
+		const heartbeat = setInterval(() => { void this.cacheManager.renewRepoPrLock(); }, 60 * 1000);
+		try {
+			await this.refreshRepoPrStatsSnapshot(session.accessToken, session.account.label, since, cachePath);
+		} catch (err) {
+			this.warn(`Repository PRs refresh failed: ${err}`);
+		} finally {
+			clearInterval(heartbeat);
+			this._repoPrRefreshInFlight = false;
+			try { await this.cacheManager.releaseRepoPrLock(); }
+			catch (err) { this.warn(`Failed to release repo-PRs lock: ${err}`); }
+		}
+	}
+
+	/** Collect the snapshot from every discovered workspace repo, write it to disk and publish it. */
+	private async refreshRepoPrStatsSnapshot(token: string, userLogin: string | undefined, since: Date, cachePath: string): Promise<void> {
 		const workspacePaths = this._buildWorkspacePaths();
 		const discoveryStart = Date.now();
 		const repos = await discoverGitHubRepos(workspacePaths, getConfiguredGitHubEnterpriseUri());
-		this.log(`🔎 Discovered ${repos.length} GitHub repo(s) across ${workspacePaths.length} workspace path(s) in ${((Date.now() - discoveryStart) / 1000).toFixed(1)}s`);
+		this.log(`🔎 Refreshing repository PRs snapshot: discovered ${repos.length} GitHub repo(s) across ${workspacePaths.length} workspace path(s) in ${((Date.now() - discoveryStart) / 1000).toFixed(1)}s`);
 		await this.analysisMessageReplay.publish('repoPrStats', { command: 'repoPrStatsProgress', total: repos.length, done: 0 });
 
 		const results: RepoPrInfo[] = [];
 		for (let i = 0; i < repos.length; i++) {
 			const { owner, repo } = repos[i];
 			this.log(`🔎 Fetching PRs for ${owner}/${repo} (${i + 1}/${repos.length})…`);
-			const { prs, error } = await fetchRepoPrs(owner, repo, session.accessToken, since);
+			const { prs, error } = await fetchRepoPrs(owner, repo, token, since);
 			this.log(`🔎 Fetched ${prs.length} PR(s) for ${owner}/${repo}${error ? ` — ${error}` : ''}`);
-			const stats = this.collectAiPrStats(prs, error, session.account.label);
+			const stats = this.collectAiPrStats(prs, error, userLogin);
 			results.push({ owner, repo, repoUrl: `https://github.com/${owner}/${repo}`, ...stats, error });
 			await this.analysisMessageReplay.publish('repoPrStats', { command: 'repoPrStatsProgress', total: repos.length, done: i + 1 });
 		}
 
-		const result: RepoPrStatsResult = { repos: results, authenticated: true, since: since.toISOString() };
-		this._lastRepoPrStats = result;
-		const { delivered, wasReady } = await this.analysisMessageReplay.publish('repoPrStats', { command: 'repoPrStatsLoaded', data: result });
-		this.log(`🔎 Repository PR stats posted for ${results.length} repo(s) (delivered=${delivered}, webviewReady=${wasReady}, ${this._describeAnalysisPanel()})`);
+		const fetchedAt = new Date().toISOString();
+		const result: RepoPrStatsResult = { repos: results, authenticated: true, since: since.toISOString(), fetchedAt };
+
+		try {
+			await writeRepoPrSnapshot(cachePath, {
+				schemaVersion: REPO_PRS_CACHE_SCHEMA_VERSION,
+				fetchedAt,
+				since: result.since,
+				data: result,
+			});
+		} catch (err) {
+			this.warn(`Failed to write repository PRs snapshot: ${err}`);
+		}
+
+		this.log(`🔎 Repository PRs snapshot: ${results.length} repo(s)`);
+		await this.publishRepoPrStats(result);
 	}
 
 	/** Classify one PR, pushing any AI detail rows and returning its contribution to the counters. */
@@ -2788,11 +2895,13 @@ class CopilotTokenTracker implements vscode.Disposable {
 		// Piggyback the once-daily background worktree scan on the same leader election: only
 		// the window that won this refresh's leader lock may start it, and it runs detached
 		// (drip-throttled, can take far longer than this refresh cycle) so it never blocks it.
-		// The hourly cloud-agent snapshot refresh rides along for the same reason: it is leader-only
-		// GitHub API work that must not hold up the parse, and this also gives it a run at startup.
+		// The hourly cloud-agent and repository-PRs snapshot refreshes ride along for the same
+		// reason: they are leader-only GitHub API work that must not hold up the parse, and this
+		// also gives them a run at startup.
 		if (isLeader) {
 			void this.maybeStartBackgroundWorktreeScan();
 			void this.maybeRefreshAgentSessions();
+			void this.maybeRefreshRepoPrStats();
 		}
 
 		try {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -310,7 +310,7 @@ import {
 	readRepoPrSnapshot,
 	writeRepoPrSnapshot,
 } from './repoPrCache';
-import { getConfiguredGitHubEnterpriseUri, getGitHubAuthProviderId } from './githubApiConfig';
+import { getConfiguredGitHubEnterpriseUri, getConfiguredGitHubWebOrigin, getGitHubAuthProviderId } from './githubApiConfig';
 
 // --- View regression ---
 import {
@@ -2017,7 +2017,12 @@ class CopilotTokenTracker implements vscode.Disposable {
 			// resolves false instead of throwing).
 			this.error('Failed to load repository PR stats', err);
 			const fallback = this._lastRepoPrStats ?? this.buildEmptyRepoPrStatsResult(since, !this._githubSignedOutByUser);
-			await this.publishRepoPrStats({ ...fallback, error: err instanceof Error ? err.message : String(err) });
+			// The webview renders the error box in place of the repo table whenever `error` is
+			// set, even if `repos` is populated — so only surface it when there is no cached data
+			// to fall back to. A transient snapshot-read/timeout failure would otherwise blank out
+			// perfectly good previously-loaded PR data behind a "failed to load" message.
+			const message = err instanceof Error ? err.message : String(err);
+			await this.publishRepoPrStats(fallback.repos.length > 0 ? fallback : { ...fallback, error: message });
 		}
 	}
 
@@ -2106,6 +2111,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 		this.log(`🔎 Refreshing repository PRs snapshot: discovered ${repos.length} GitHub repo(s) across ${workspacePaths.length} workspace path(s) in ${((Date.now() - discoveryStart) / 1000).toFixed(1)}s`);
 		await this.analysisMessageReplay.publish('repoPrStats', { command: 'repoPrStatsProgress', total: repos.length, done: 0 });
 
+		const webOrigin = getConfiguredGitHubWebOrigin();
 		const results: RepoPrInfo[] = [];
 		for (let i = 0; i < repos.length; i++) {
 			const { owner, repo } = repos[i];
@@ -2113,7 +2119,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			const { prs, error } = await fetchRepoPrs(owner, repo, token, since);
 			this.log(`🔎 Fetched ${prs.length} PR(s) for ${owner}/${repo}${error ? ` — ${error}` : ''}`);
 			const stats = this.collectAiPrStats(prs, error, userLogin);
-			results.push({ owner, repo, repoUrl: `https://github.com/${owner}/${repo}`, ...stats, error });
+			results.push({ owner, repo, repoUrl: `${webOrigin}/${owner}/${repo}`, ...stats, error });
 			await this.analysisMessageReplay.publish('repoPrStats', { command: 'repoPrStatsProgress', total: repos.length, done: i + 1 });
 		}
 

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1982,6 +1982,17 @@ class CopilotTokenTracker implements vscode.Disposable {
 		this._lastRepoPrStats = stamped;
 		const { delivered, wasReady } = await this.analysisMessageReplay.publish('repoPrStats', { command: 'repoPrStatsLoaded', data: stamped });
 		this.log(`🔎 Repository PR stats posted for ${stamped.repos.length} repo(s) (delivered=${delivered}, webviewReady=${wasReady}, ${this._describeAnalysisPanel()})`);
+
+		// `fetchedAt` is only set on real (cache-read or freshly-fetched) snapshots — the instant
+		// placeholder served on cold open uses ''. If the Efficiency panel is already open and its
+		// Value tab was rendered before this real data landed (e.g. the user opened Repository PRs
+		// after Efficiency), its "no data" hint would otherwise persist until an explicit Refresh
+		// click, since showEfficiency() deliberately doesn't recompute on reveal. Push the update.
+		if (stamped.fetchedAt && this.efficiencyPanel) {
+			void this.dispatch('refresh:efficiency', () => this.refreshEfficiencyPanel()).catch((err) => {
+				this.warn(`Failed to refresh Efficiency view after repository PR stats update: ${err}`);
+			});
+		}
 	}
 
 	/**

--- a/vscode-extension/src/githubApiConfig.ts
+++ b/vscode-extension/src/githubApiConfig.ts
@@ -67,6 +67,37 @@ export function getConfiguredGitHubEnterpriseUri(): string | undefined {
 	return vscode.workspace.getConfiguration().get<string>('github-enterprise.uri') || undefined;
 }
 
+/**
+ * Derive the *web* origin (for building `https://host/owner/repo`-style links, as opposed to the
+ * REST API host from `deriveGitHubApiEndpoints`) for an optional GitHub Enterprise base URI.
+ * Unlike the API host, the web host never gets an `api.` prefix or an `/api/v3` path — both GHE.com
+ * and on-prem GitHub Enterprise Server serve their web UI from the same host the user configured.
+ *
+ * Pure function (no VS Code dependency) so it can be unit tested directly.
+ */
+export function deriveGitHubWebOrigin(enterpriseUri: string | undefined): string {
+	const GITHUB_DOT_COM_ORIGIN = 'https://github.com';
+	if (!enterpriseUri) { return GITHUB_DOT_COM_ORIGIN; }
+
+	let url: URL;
+	try {
+		url = new URL(enterpriseUri);
+	} catch {
+		return GITHUB_DOT_COM_ORIGIN;
+	}
+
+	const authority = url.host;
+	if (!authority || authority === 'github.com' || authority === 'www.github.com' || authority === 'api.github.com') {
+		return GITHUB_DOT_COM_ORIGIN;
+	}
+	return `${url.protocol}//${authority}`;
+}
+
+/** The GitHub web origin to use for building repo/PR links for the current configuration. */
+export function getConfiguredGitHubWebOrigin(): string {
+	return deriveGitHubWebOrigin(getConfiguredGitHubEnterpriseUri());
+}
+
 /** The GitHub API endpoints to use for the current configuration (github.com, GHE.com, or GHES). */
 export function getGitHubApiEndpoints(): GitHubApiEndpoints {
 	return deriveGitHubApiEndpoints(getConfiguredGitHubEnterpriseUri());

--- a/vscode-extension/src/githubPrService.ts
+++ b/vscode-extension/src/githubPrService.ts
@@ -37,6 +37,10 @@ export type RepoPrStatsResult = {
 	since: string; // ISO date string
 	/** Set when the collection itself failed (not a per-repo error) — the panel shows this instead of hanging on "Loading…". */
 	error?: string;
+	/** When the snapshot was fetched from GitHub; empty string when it has never been fetched. */
+	fetchedAt?: string;
+	/** How often the snapshot is refreshed, so the UI can say when the next refresh is due. */
+	refreshIntervalMs?: number;
 };
 
 // ---------------------------------------------------------------------------

--- a/vscode-extension/src/repoPrCache.ts
+++ b/vscode-extension/src/repoPrCache.ts
@@ -1,0 +1,125 @@
+/**
+ * Cross-window cache for the Repository PRs snapshot.
+ *
+ * Collecting AI PR activity costs a PR-list call (plus a commit-messages call per PR to detect
+ * co-authored-by AI) for every discovered repo, so it is deliberately expensive to refresh: the
+ * snapshot is written to a JSON file in the extension's global storage (shared by every VS Code
+ * window of this edition) and refreshed at most once an hour, by whichever window currently holds
+ * the repo-PRs lock. Every other window — and every panel open in between — reads this file
+ * instead of calling GitHub.
+ *
+ * The file I/O lives here; the freshness decisions are pure functions so they can be unit tested
+ * without touching disk. This mirrors the split used by `agentTasksCache.ts` for the Cloud Agent tab.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import type { RepoPrStatsResult } from './githubPrService';
+
+/** How often the repository-PRs snapshot may be refreshed from the GitHub API: once an hour. */
+export const REPO_PRS_REFRESH_INTERVAL_MS = 60 * 60 * 1000;
+
+/**
+ * Bumped whenever the shape of `RepoPrStatsResult` changes in a way that would make an older
+ * snapshot render incorrectly. Snapshots from a different version are ignored (and refetched).
+ */
+export const REPO_PRS_CACHE_SCHEMA_VERSION = 1;
+
+/** On-disk envelope: the snapshot plus what it takes to decide whether it is still usable. */
+export interface RepoPrCacheEnvelope {
+	schemaVersion: number;
+	/** When the snapshot was fetched from GitHub (ISO 8601). */
+	fetchedAt: string;
+	/** Start of the window the snapshot covers (ISO 8601), so a widened window invalidates it. */
+	since: string;
+	data: RepoPrStatsResult;
+}
+
+/** Path of the shared snapshot file for this cache identifier (dev and prod are kept separate). */
+export function getRepoPrCachePath(globalStoragePath: string, cacheIdentifier: string): string {
+	return path.join(globalStoragePath, `repoprs_${cacheIdentifier}.snapshot.json`);
+}
+
+/**
+ * Whether a snapshot is still fresh enough to serve without calling GitHub. A missing or
+ * unparseable timestamp counts as stale, and so does one in the future by more than the interval
+ * (a clock change) so a bad timestamp can never pin the cache open forever.
+ */
+export function isRepoPrSnapshotFresh(
+	fetchedAt: string | undefined,
+	now: number,
+	intervalMs: number = REPO_PRS_REFRESH_INTERVAL_MS,
+): boolean {
+	if (!fetchedAt) { return false; }
+	const fetchedMs = Date.parse(fetchedAt);
+	if (!Number.isFinite(fetchedMs)) { return false; }
+	const age = now - fetchedMs;
+	if (age < -intervalMs) { return false; }
+	return age < intervalMs;
+}
+
+/** Whether this envelope can be served as-is: right schema, same window, still fresh. */
+export function canServeRepoPrSnapshot(
+	envelope: RepoPrCacheEnvelope | undefined,
+	since: Date,
+	now: number,
+	intervalMs: number = REPO_PRS_REFRESH_INTERVAL_MS,
+): boolean {
+	if (!isRepoPrEnvelopeUsable(envelope, since)) { return false; }
+	return isRepoPrSnapshotFresh(envelope?.fetchedAt, now, intervalMs);
+}
+
+/**
+ * Whether an envelope may be shown at all (even when stale): a stale snapshot is still the best
+ * thing to render while the next hourly refresh is pending, but one from another schema version or
+ * covering a shorter window than asked for is not.
+ */
+export function isRepoPrEnvelopeUsable(
+	envelope: RepoPrCacheEnvelope | undefined,
+	since: Date,
+): boolean {
+	if (!envelope || envelope.schemaVersion !== REPO_PRS_CACHE_SCHEMA_VERSION) { return false; }
+	if (!envelope.data || !Array.isArray(envelope.data.repos)) { return false; }
+	const snapshotSince = Date.parse(envelope.since);
+	if (!Number.isFinite(snapshotSince)) { return false; }
+	// Tolerate a minute of drift: `since` is recomputed as "30 days ago" on every call.
+	return snapshotSince <= since.getTime() + 60_000;
+}
+
+/** When the next refresh becomes due, as an ISO timestamp (undefined when it is due now). */
+export function nextRepoPrRefreshAt(
+	fetchedAt: string | undefined,
+	intervalMs: number = REPO_PRS_REFRESH_INTERVAL_MS,
+): string | undefined {
+	if (!fetchedAt) { return undefined; }
+	const fetchedMs = Date.parse(fetchedAt);
+	if (!Number.isFinite(fetchedMs)) { return undefined; }
+	return new Date(fetchedMs + intervalMs).toISOString();
+}
+
+/** Read the shared snapshot, returning undefined when it is missing or unreadable. */
+export async function readRepoPrSnapshot(filePath: string): Promise<RepoPrCacheEnvelope | undefined> {
+	try {
+		const raw = await fs.promises.readFile(filePath, 'utf8');
+		const parsed = JSON.parse(raw);
+		if (!parsed || typeof parsed !== 'object') { return undefined; }
+		return parsed as RepoPrCacheEnvelope;
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * Write the shared snapshot. Writes to a temporary file first and renames it into place so a
+ * window reading concurrently never sees a half-written file.
+ */
+export async function writeRepoPrSnapshot(filePath: string, envelope: RepoPrCacheEnvelope): Promise<void> {
+	await fs.promises.mkdir(path.dirname(filePath), { recursive: true });
+	const tempPath = `${filePath}.${process.pid}.tmp`;
+	await fs.promises.writeFile(tempPath, JSON.stringify(envelope), 'utf8');
+	try {
+		await fs.promises.rename(tempPath, filePath);
+	} catch (err) {
+		await fs.promises.rm(tempPath, { force: true });
+		throw err;
+	}
+}

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -723,6 +723,10 @@ type RepoPrStatsResult = {
   authenticated: boolean;
   since: string;
   error?: string;
+  /** When the snapshot was fetched from GitHub; empty string when it has never been fetched. */
+  fetchedAt?: string;
+  /** How often the snapshot is refreshed, so the UI can say when the next refresh is due. */
+  refreshIntervalMs?: number;
 };
 
 const EFFORT_DISPLAY_NAMES: Record<string, string> = {
@@ -2360,6 +2364,8 @@ function sanitizeRepoPrStatsData(input: unknown): RepoPrStatsResult {
 		authenticated: Boolean(src.authenticated),
 		since: typeof src.since === 'string' || typeof src.since === 'number' ? src.since : Date.now(),
 		error: typeof src.error === 'string' ? escapeHtml(src.error) : undefined,
+		fetchedAt: typeof src.fetchedAt === 'string' ? src.fetchedAt : '',
+		refreshIntervalMs: toSafeNumber(src.refreshIntervalMs),
 		repos: repos.map((repo) => {
 			const r = (repo && typeof repo === 'object') ? (repo as Record<string, unknown>) : {};
 			const aiDetails = Array.isArray(r.aiDetails) ? r.aiDetails : [];
@@ -2437,6 +2443,25 @@ function renderRepoPrRow(r: RepoPrInfo, cell: string, cellCenter: string): strin
 	</tr>`;
 }
 
+/**
+ * Freshness line for the snapshot. The data is fetched at most once an hour, by whichever VS Code
+ * window holds the repo-PRs lock, so the panel always says how old what it shows is.
+ */
+function repoPrSnapshotFreshnessHtml(data: RepoPrStatsResult): string {
+  const box = 'margin-bottom:12px; padding:8px 10px; background:var(--bg-tertiary); border:1px solid var(--border-color); border-radius:6px; font-size:11px; color:var(--text-secondary);';
+  if (!data.fetchedAt) {
+    return `<div style="${box}">🕒 <strong>Not fetched yet.</strong> The snapshot is refreshed hourly by the main VS Code window — it will appear here once that first refresh completes.</div>`;
+  }
+  const fetchedMs = Date.parse(data.fetchedAt);
+  const nextRefresh = Number.isFinite(fetchedMs) && data.refreshIntervalMs
+    ? new Date(fetchedMs + data.refreshIntervalMs).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+    : 'unknown';
+  return `<div style="${box}">
+    🕒 Updated <strong>${escapeHtml(getTimeSince(data.fetchedAt))}</strong> · next refresh after ${escapeHtml(nextRefresh)}.
+    Cached and refreshed at most once an hour, by a single VS Code window, to keep GitHub API usage low.
+  </div>`;
+}
+
 function renderReposPrContent(data: RepoPrStatsResult): string {
 	const sinceDate = escapeHtml(new Date(data.since).toLocaleDateString());
 	if (data.error) {
@@ -2455,7 +2480,7 @@ function renderReposPrContent(data: RepoPrStatsResult): string {
 			</div>`;
 	}
 	if (data.repos.length === 0) {
-		return `
+		return `${repoPrSnapshotFreshnessHtml(data)}
 			<div style="margin-top:12px; font-size:12px; color:var(--text-secondary);">
 				No GitHub repositories detected in your workspace folders.
 			</div>`;
@@ -2468,6 +2493,7 @@ function renderReposPrContent(data: RepoPrStatsResult): string {
 	const rows = data.repos.map((r) => renderRepoPrRow(r, cell, cellCenter)).join('');
 
 	return `
+		${repoPrSnapshotFreshnessHtml(data)}
 		<div style="font-size:11px; color:var(--text-secondary); margin-bottom:12px;">
 			Showing PRs created since ${sinceDate}.
 			Reviewer requests are only visible for <strong>open</strong> PRs — the GitHub API clears this field after a PR is merged or closed.

--- a/vscode-extension/test/unit/cacheManager-lock.test.ts
+++ b/vscode-extension/test/unit/cacheManager-lock.test.ts
@@ -171,3 +171,48 @@ test('renewAgentTasksLock: refreshes our own timestamp and refuses to renew anot
 	fs.writeFileSync(lockPath, JSON.stringify({ sessionId: 'other-window', pid: process.pid, timestamp: Date.now() }));
 	assert.equal(await manager.renewAgentTasksLock(), false, 'never renew a lock this window does not own');
 });
+
+// ── Repo-PRs lock: only one window refreshes the hourly Repository PRs snapshot ────────
+
+test('acquireRepoPrLock: uses its own lock file, separate from the other leases', async () => {
+	const { manager } = makeDirAndManager();
+	assert.notEqual(manager.getRepoPrLockPath(), manager.getRefreshLockPath());
+	assert.notEqual(manager.getRepoPrLockPath(), manager.getAgentTasksLockPath());
+	assert.ok(manager.getRepoPrLockPath().includes('repoprs_'));
+
+	assert.equal(await manager.acquireRepoPrLock(), true);
+	assert.equal(await manager.acquireRefreshLock(), true, 'holding one lock must not block the other');
+	assert.equal(await manager.acquireAgentTasksLock(), true, 'holding one lock must not block the other');
+
+	await manager.releaseRepoPrLock();
+	await manager.releaseRefreshLock();
+	await manager.releaseAgentTasksLock();
+});
+
+test('acquireRepoPrLock: a second window is turned away while the lock is held, then let in', async () => {
+	const { manager } = makeDirAndManager();
+	await manager.acquireRepoPrLock();
+
+	const lockPath = manager.getRepoPrLockPath();
+	fs.writeFileSync(lockPath, JSON.stringify({ sessionId: 'other-window', pid: process.pid, timestamp: Date.now() }));
+	assert.equal(await manager.acquireRepoPrLock(), false, 'a live lock from another window blocks the refresh');
+
+	fs.unlinkSync(lockPath);
+	assert.equal(await manager.acquireRepoPrLock(), true);
+	await manager.releaseRepoPrLock();
+});
+
+test('renewRepoPrLock: refreshes our own timestamp and refuses to renew another window\'s lock', async () => {
+	const { manager } = makeDirAndManager();
+	await manager.acquireRepoPrLock();
+	const lockPath = manager.getRepoPrLockPath();
+	const before = JSON.parse(fs.readFileSync(lockPath, 'utf-8')).timestamp;
+
+	await new Promise(resolve => setTimeout(resolve, 5));
+	assert.equal(await manager.renewRepoPrLock(), true);
+	const after = JSON.parse(fs.readFileSync(lockPath, 'utf-8')).timestamp;
+	assert.ok(after >= before, 'renewing should move the timestamp forward');
+
+	fs.writeFileSync(lockPath, JSON.stringify({ sessionId: 'other-window', pid: process.pid, timestamp: Date.now() }));
+	assert.equal(await manager.renewRepoPrLock(), false, 'never renew a lock this window does not own');
+});

--- a/vscode-extension/test/unit/githubApiConfig.test.ts
+++ b/vscode-extension/test/unit/githubApiConfig.test.ts
@@ -3,7 +3,7 @@ import * as assert from 'node:assert/strict';
 import * as vscode from 'vscode';
 import { EventEmitter } from 'node:events';
 import type * as http from 'node:http';
-import { deriveGitHubApiEndpoints, getGitHubAuthProviderId, attachRequestFailureHandling } from '../../src/githubApiConfig';
+import { deriveGitHubApiEndpoints, deriveGitHubWebOrigin, getConfiguredGitHubWebOrigin, getGitHubAuthProviderId, attachRequestFailureHandling } from '../../src/githubApiConfig';
 
 /**
  * Minimal stand-in for `http.ClientRequest`, exercising exactly the surface
@@ -78,6 +78,40 @@ test('deriveGitHubApiEndpoints: derives api.<tenant> subdomain for GHE.com (data
 test('deriveGitHubApiEndpoints: derives /api/v3 and /api/graphql for on-prem GitHub Enterprise Server', () => {
 	const endpoints = deriveGitHubApiEndpoints('https://github.acme-corp.com');
 	assert.deepEqual(endpoints, { hostname: 'github.acme-corp.com', restPathPrefix: '/api/v3', graphQlPath: '/api/graphql' });
+});
+
+// ---------------------------------------------------------------------------
+// deriveGitHubWebOrigin / getConfiguredGitHubWebOrigin — the *web* host used to build
+// `https://host/owner/repo`-style repo links (as opposed to the REST API host above).
+// ---------------------------------------------------------------------------
+
+test('deriveGitHubWebOrigin: returns github.com for no enterprise URI, an empty string, or an unparseable URI', () => {
+	assert.equal(deriveGitHubWebOrigin(undefined), 'https://github.com');
+	assert.equal(deriveGitHubWebOrigin(''), 'https://github.com');
+	assert.equal(deriveGitHubWebOrigin('not a url'), 'https://github.com');
+});
+
+test('deriveGitHubWebOrigin: returns github.com for a github.com URI', () => {
+	assert.equal(deriveGitHubWebOrigin('https://github.com'), 'https://github.com');
+	assert.equal(deriveGitHubWebOrigin('https://www.github.com'), 'https://github.com');
+	assert.equal(deriveGitHubWebOrigin('https://api.github.com'), 'https://github.com');
+});
+
+test('deriveGitHubWebOrigin: returns the tenant origin (no api. prefix) for GHE.com (data residency)', () => {
+	assert.equal(deriveGitHubWebOrigin('https://customer.ghe.com'), 'https://customer.ghe.com');
+});
+
+test('deriveGitHubWebOrigin: returns the configured host origin (no /api/v3 suffix) for on-prem GitHub Enterprise Server', () => {
+	assert.equal(deriveGitHubWebOrigin('https://github.acme-corp.com'), 'https://github.acme-corp.com');
+});
+
+test('getConfiguredGitHubWebOrigin: reads the github-enterprise.uri setting and derives its web origin', () => {
+	withEnterpriseUri('https://github.acme-corp.com', () => {
+		assert.equal(getConfiguredGitHubWebOrigin(), 'https://github.acme-corp.com');
+	});
+	withEnterpriseUri(undefined, () => {
+		assert.equal(getConfiguredGitHubWebOrigin(), 'https://github.com');
+	});
 });
 
 // ---------------------------------------------------------------------------

--- a/vscode-extension/test/unit/repoPrCache.test.ts
+++ b/vscode-extension/test/unit/repoPrCache.test.ts
@@ -1,0 +1,142 @@
+import test from 'node:test';
+import * as assert from 'node:assert/strict';
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+	REPO_PRS_CACHE_SCHEMA_VERSION,
+	REPO_PRS_REFRESH_INTERVAL_MS,
+	canServeRepoPrSnapshot,
+	getRepoPrCachePath,
+	isRepoPrEnvelopeUsable,
+	isRepoPrSnapshotFresh,
+	nextRepoPrRefreshAt,
+	readRepoPrSnapshot,
+	writeRepoPrSnapshot,
+	type RepoPrCacheEnvelope,
+} from '../../src/repoPrCache';
+import type { RepoPrStatsResult } from '../../src/githubPrService';
+
+const NOW = Date.parse('2026-08-29T12:00:00Z');
+const SINCE = new Date('2026-07-30T12:00:00Z');
+
+function makeResult(overrides: Partial<RepoPrStatsResult> = {}): RepoPrStatsResult {
+	return {
+		repos: [],
+		authenticated: true,
+		since: SINCE.toISOString(),
+		fetchedAt: new Date(NOW).toISOString(),
+		...overrides,
+	};
+}
+
+function makeEnvelope(overrides: Partial<RepoPrCacheEnvelope> = {}): RepoPrCacheEnvelope {
+	return {
+		schemaVersion: REPO_PRS_CACHE_SCHEMA_VERSION,
+		fetchedAt: new Date(NOW).toISOString(),
+		since: SINCE.toISOString(),
+		data: makeResult(),
+		...overrides,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Freshness
+// ---------------------------------------------------------------------------
+
+test('isRepoPrSnapshotFresh: a snapshot younger than the interval is fresh', () => {
+	const fetchedAt = new Date(NOW - 59 * 60 * 1000).toISOString();
+	assert.equal(isRepoPrSnapshotFresh(fetchedAt, NOW), true);
+});
+
+test('isRepoPrSnapshotFresh: a snapshot at or past the interval is stale', () => {
+	const exactly = new Date(NOW - REPO_PRS_REFRESH_INTERVAL_MS).toISOString();
+	const older = new Date(NOW - 3 * REPO_PRS_REFRESH_INTERVAL_MS).toISOString();
+	assert.equal(isRepoPrSnapshotFresh(exactly, NOW), false);
+	assert.equal(isRepoPrSnapshotFresh(older, NOW), false);
+});
+
+test('isRepoPrSnapshotFresh: missing or unparseable timestamps are stale', () => {
+	assert.equal(isRepoPrSnapshotFresh(undefined, NOW), false);
+	assert.equal(isRepoPrSnapshotFresh('', NOW), false);
+	assert.equal(isRepoPrSnapshotFresh('not-a-date', NOW), false);
+});
+
+test('isRepoPrSnapshotFresh: a far-future timestamp (clock change) is stale, not pinned fresh', () => {
+	const future = new Date(NOW + 5 * REPO_PRS_REFRESH_INTERVAL_MS).toISOString();
+	assert.equal(isRepoPrSnapshotFresh(future, NOW), false);
+});
+
+test('nextRepoPrRefreshAt: one interval after the fetch, undefined without one', () => {
+	const fetchedAt = new Date(NOW).toISOString();
+	assert.equal(nextRepoPrRefreshAt(fetchedAt), new Date(NOW + REPO_PRS_REFRESH_INTERVAL_MS).toISOString());
+	assert.equal(nextRepoPrRefreshAt(undefined), undefined);
+	assert.equal(nextRepoPrRefreshAt('nonsense'), undefined);
+});
+
+// ---------------------------------------------------------------------------
+// Envelope usability
+// ---------------------------------------------------------------------------
+
+test('isRepoPrEnvelopeUsable: accepts a current-schema envelope covering the window', () => {
+	assert.equal(isRepoPrEnvelopeUsable(makeEnvelope(), SINCE), true);
+});
+
+test('isRepoPrEnvelopeUsable: rejects a snapshot written by another schema version', () => {
+	assert.equal(isRepoPrEnvelopeUsable(makeEnvelope({ schemaVersion: 0 }), SINCE), false);
+});
+
+test('isRepoPrEnvelopeUsable: rejects a snapshot covering a shorter window than asked for', () => {
+	const shorter = makeEnvelope({ since: new Date(SINCE.getTime() + 24 * 60 * 60 * 1000).toISOString() });
+	assert.equal(isRepoPrEnvelopeUsable(shorter, SINCE), false);
+});
+
+test('isRepoPrEnvelopeUsable: accepts a slightly older window (since is recomputed per call)', () => {
+	const drifted = makeEnvelope({ since: new Date(SINCE.getTime() - 30 * 1000).toISOString() });
+	assert.equal(isRepoPrEnvelopeUsable(drifted, SINCE), true);
+});
+
+test('isRepoPrEnvelopeUsable: rejects missing, malformed, and repo-less payloads', () => {
+	assert.equal(isRepoPrEnvelopeUsable(undefined, SINCE), false);
+	assert.equal(isRepoPrEnvelopeUsable(makeEnvelope({ since: 'garbage' }), SINCE), false);
+	assert.equal(isRepoPrEnvelopeUsable({ ...makeEnvelope(), data: undefined as any }, SINCE), false);
+});
+
+test('canServeRepoPrSnapshot: a usable but stale snapshot is not served without a refresh', () => {
+	const stale = makeEnvelope({ fetchedAt: new Date(NOW - 2 * REPO_PRS_REFRESH_INTERVAL_MS).toISOString() });
+	assert.equal(isRepoPrEnvelopeUsable(stale, SINCE), true);
+	assert.equal(canServeRepoPrSnapshot(stale, SINCE, NOW), false);
+	assert.equal(canServeRepoPrSnapshot(makeEnvelope(), SINCE, NOW), true);
+});
+
+// ---------------------------------------------------------------------------
+// Disk round-trip
+// ---------------------------------------------------------------------------
+
+test('getRepoPrCachePath: keeps dev and prod snapshots apart', () => {
+	assert.equal(getRepoPrCachePath('/store', 'prod'), path.join('/store', 'repoprs_prod.snapshot.json'));
+	assert.notEqual(getRepoPrCachePath('/store', 'dev-abc'), getRepoPrCachePath('/store', 'prod'));
+});
+
+test('writeRepoPrSnapshot/readRepoPrSnapshot: round-trips the snapshot', async () => {
+	const dir = await fs.promises.mkdtemp(path.join(process.cwd(), 'repoprs-'));
+	const filePath = getRepoPrCachePath(path.join(dir, 'nested'), 'prod');
+	const envelope = makeEnvelope({ data: makeResult({ repos: [{ owner: 'a', repo: 'b', repoUrl: 'https://github.com/a/b', totalPrs: 3, aiAuthoredPrs: 1, aiReviewRequestedPrs: 0, aiDetails: [] }] }) });
+
+	await writeRepoPrSnapshot(filePath, envelope);
+	const readBack = await readRepoPrSnapshot(filePath);
+
+	assert.deepEqual(readBack, envelope);
+	assert.deepEqual(await fs.promises.readdir(path.dirname(filePath)), [path.basename(filePath)]);
+	await fs.promises.rm(dir, { recursive: true, force: true });
+});
+
+test('readRepoPrSnapshot: missing or corrupt files read as undefined, never throw', async () => {
+	const dir = await fs.promises.mkdtemp(path.join(process.cwd(), 'repoprs-'));
+	const missing = path.join(dir, 'nope.json');
+	const corrupt = path.join(dir, 'corrupt.json');
+	await fs.promises.writeFile(corrupt, '{ this is not json', 'utf8');
+
+	assert.equal(await readRepoPrSnapshot(missing), undefined);
+	assert.equal(await readRepoPrSnapshot(corrupt), undefined);
+	await fs.promises.rm(dir, { recursive: true, force: true });
+});


### PR DESCRIPTION
## Summary

The Cloud Agent tab already had a cross-window shared snapshot, refreshed at most once an hour by a single VS Code window, with every other window/panel just reading it from disk. The Repository PRs tab didn't — it re-fetched every workspace repo's PR list (plus a commit-messages call per PR to detect AI co-authors) on every tab open, in every window.

This PR gives Repository PRs the same treatment:

- **`vscode-extension/src/repoPrCache.ts`** (new) — mirrors `agentTasksCache.ts`: schema-versioned on-disk envelope, freshness checks (`isRepoPrSnapshotFresh`), envelope usability checks (`isRepoPrEnvelopeUsable`), and atomic read/write of the shared snapshot file (`repoprs_<edition>.snapshot.json`).
- **`cacheManager.ts`** — adds `acquireRepoPrLock` / `releaseRepoPrLock` / `renewRepoPrLock`, a lock file (`repoprs_<edition>.lock`) independent from the cache-refresh leader lock and the agent-tasks lock, so exactly one window refreshes the Repository PRs snapshot at a time.
- **`extension.ts`** — `loadRepoPrStats` now serves the last-known/cached snapshot instantly when the tab opens (no API calls), then calls `maybeRefreshRepoPrStats()`, which only does the actual GitHub calls if the snapshot is stale *and* this window wins the lock — exactly the same pattern as `maybeRefreshAgentSessions`. Also wired into the leader-gated cache refresh cycle (extension start + periodic refresh) alongside the cloud-agent refresh.
- **`githubPrService.ts`** — `RepoPrStatsResult` gains `fetchedAt` / `refreshIntervalMs` so the UI can show freshness.
- **`webview/usage/main.ts`** — adds a freshness banner ("Updated X ago · next refresh after Y") to the Repository PRs tab, matching the Cloud Agent tab's banner.

## Testing

- `npm run check-types` ✅
- `npm run compile` ✅
- `npm run lint` — only pre-existing warnings, no new ones
- `npm run test:node` — full suite passes, including new `repoPrCache.test.ts` and new `cacheManager-lock.test.ts` cases for the repo-PRs lock
- `npm run check:contract` ✅