### PR TITLE
Fix stale Context Window data by merging pending SQLite WAL frames

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -94,3 +94,4 @@ Implementation notes and decisions captured during development sessions.
 | [adr/IMPLEMENTATION-SUMMARY-SOCIAL-SHARE.md](adr/IMPLEMENTATION-SUMMARY-SOCIAL-SHARE.md) | Social media share feature implementation summary |
 | [adr/FLUENCY-DATA-IMPLEMENTATION.md](adr/FLUENCY-DATA-IMPLEMENTATION.md) | Fluency data cloud upload — gap analysis and plan |
 | [adr/PR_SUMMARY.md](adr/PR_SUMMARY.md) | PR summary: comprehensive light theme support |
+| [adr/SQLITE-WAL-READS.md](adr/SQLITE-WAL-READS.md) | Why sql.js reads of data.db/opencode.db must merge pending WAL frames first |

--- a/docs/adr/SQLITE-WAL-READS.md
+++ b/docs/adr/SQLITE-WAL-READS.md
@@ -1,0 +1,65 @@
+# Reading SQLite databases another process may hold open (WAL mode)
+
+## Context
+
+The extension reads several local SQLite databases it does not own:
+
+- `~/.copilot/data.db` — the Copilot app's own database (session hierarchy,
+  context-window state). Read via `CopilotAppDataAccess`
+  (`vscode-extension/src/copilotAppData.ts`).
+- OpenCode's `opencode.db`. Read via `OpenCodeDataAccess` (`src/opencode.ts`).
+
+Both are read with [`sql.js`](https://github.com/sql-js/sql.js), a WASM build
+of SQLite that only understands a single in-memory buffer — it has no code
+path for SQLite's write-ahead log. When the owning process (the Copilot app,
+or the OpenCode CLI) keeps its database open in **WAL mode**, its most recent
+writes are appended to a `<dbfile>-wal` sidecar file and are only merged back
+into the main `.db` file when SQLite performs a **checkpoint** — typically
+when every connection to the database closes, or the WAL grows past a size
+threshold.
+
+If we read just the `.db` file's bytes while a WAL exists, `sql.js` returns a
+**silently stale snapshot**: no error, just missing the writer's most recent
+rows/columns. This exact gap caused the "Context Window & Long-Context
+Pricing" usage section to show "No data" for an actively-running Copilot CLI
+session — its `context_current_tokens` update was sitting in `data.db-wal`
+and only became visible after the session was restarted (closing the writer's
+connection triggered a checkpoint).
+
+You can confirm a database is in this state by checking for a non-empty
+`<dbfile>-wal` next to it:
+
+```powershell
+Get-ChildItem "$env:USERPROFILE\.copilot\data.db*"
+```
+
+## Decision
+
+Before loading any of these databases with `sql.js`, merge pending WAL frames
+first using `src/utils/sqliteWal.ts`:
+
+- `readDbBufferWithWal(dbPath)` — the one-call helper most callers should use.
+  Copies `<dbfile>`, `<dbfile>-wal`, and `<dbfile>-shm` (if present) to a temp
+  file, opens the copy with Node's built-in `node:sqlite` (Node.js 22+), runs
+  `PRAGMA wal_checkpoint(TRUNCATE)` to fold the WAL into the temp file, and
+  returns that buffer. Falls back to a bare `fs.readFileSync(dbPath)` when
+  there is no WAL, the WAL is empty, or `node:sqlite` is unavailable.
+- `getWalMtimeMs(dbPath)` — for cache-invalidation checks that need to notice
+  "the WAL changed" even when the main `.db` file's mtime/size did not (used
+  by `OpenCodeDataAccess`'s db cache).
+
+This avoids adding a native SQLite dependency to the extension's runtime
+while still getting a fully up-to-date, checkpoint-merged snapshot.
+
+## Consequences
+
+- Any new code that opens a local SQLite database another process may still
+  be writing to (Copilot app, OpenCode, or a future integration) should read
+  it through `readDbBufferWithWal()` rather than `fs.readFileSync()` directly.
+- The merge does a real file copy + `node:sqlite` open per read, so it is not
+  free — callers that poll frequently should keep doing so through a
+  stat-based cache (mtime/size **and** WAL mtime, see `getWalMtimeMs`) rather
+  than re-merging on every call.
+- If `node:sqlite` is ever removed/unavailable in the extension's Node
+  runtime, the helper degrades gracefully to a direct file read (the original,
+  potentially-stale behavior) rather than throwing.

--- a/src/opencode.ts
+++ b/src/opencode.ts
@@ -11,6 +11,7 @@ import type { ModelUsage, ModelId } from './types';
 import { normalizePathForComparison } from './workspaceHelpers';
 import { isUnsafeObjectKey } from './utils/protoGuard';
 import { readTextFileWithSizeGuardSync } from './utils/safeFileRead';
+import { readDbBufferWithWal, getWalMtimeMs } from './utils/sqliteWal';
 
 // Access SqlJsStatic and Database via the globally declared initSqlJs namespace.
 type SqlJsStatic = initSqlJs.SqlJsStatic;
@@ -137,81 +138,26 @@ export class OpenCodeDataAccess {
 		}
 	}
 
-	/** Returns the WAL file's mtime in milliseconds, or 0 if no WAL file exists. */
-	private getWalMtimeMs(dbPath: string): number {
-		try {
-			return fs.statSync(dbPath + '-wal').mtimeMs;
-		} catch {
-			return 0;
-		}
-	}
-
 	private isCachedDbCurrent(dbPath: string, stats: fs.Stats): boolean {
 		return this._dbCache?.path === dbPath
 			&& this._dbCache.mtimeMs === stats.mtimeMs
 			&& this._dbCache.size === stats.size
-			&& this._dbCache.walMtimeMs === this.getWalMtimeMs(dbPath);
+			&& this._dbCache.walMtimeMs === getWalMtimeMs(dbPath);
 	}
 
 	private getDbCacheKey(dbPath: string, stats: fs.Stats): string {
-		return `${dbPath}:${stats.mtimeMs}:${stats.size}:wal${this.getWalMtimeMs(dbPath)}`;
+		return `${dbPath}:${stats.mtimeMs}:${stats.size}:wal${getWalMtimeMs(dbPath)}`;
 	}
 
 	private sameDbStats(left: fs.Stats, right: fs.Stats): boolean {
 		return left.mtimeMs === right.mtimeMs && left.size === right.size;
 	}
 
-	/**
-	 * When an active WAL file is present, sql.js cannot see uncommitted WAL frames because
-	 * it reads only the raw `.db` bytes. This method copies the DB + WAL to a temp location,
-	 * opens the copy with Node's built-in SQLite (available in Node.js 22+), forces a WAL
-	 * checkpoint to merge all frames into the temp DB file, and returns the resulting buffer
-	 * so that sql.js can load a fully up-to-date snapshot.
-	 *
-	 * Returns null when no WAL is present, when the WAL is empty, or when node:sqlite is
-	 * unavailable — in all those cases the caller falls back to reading the DB file directly.
-	 */
-	private async tryReadDbWithWal(dbPath: string): Promise<Buffer | null> {
-		const walPath = dbPath + '-wal';
-		let walSize: number;
-		try {
-			walSize = fs.statSync(walPath).size;
-		} catch {
-			return null; // No WAL file — no merge needed
-		}
-		if (walSize === 0) { return null; }
-
-		try {
-			const { DatabaseSync } = require('node:sqlite') as typeof import('node:sqlite');
-			const tmpDir = path.join(os.homedir(), '.copilot', 'tmp');
-			fs.mkdirSync(tmpDir, { recursive: true, mode: 0o700 });
-			const tmpDb = path.join(tmpDir, `opencode-wal-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}.db`);
-			const tmpWal = tmpDb + '-wal';
-			const tmpShm = tmpDb + '-shm';
-			const shmPath = dbPath + '-shm';
-
-			fs.copyFileSync(dbPath, tmpDb);
-			fs.copyFileSync(walPath, tmpWal);
-			if (fs.existsSync(shmPath)) { fs.copyFileSync(shmPath, tmpShm); }
-
-			const nativeDb = new DatabaseSync(tmpDb);
-			nativeDb.exec('PRAGMA wal_checkpoint(TRUNCATE);');
-			nativeDb.close();
-
-			const buffer = fs.readFileSync(tmpDb);
-			for (const f of [tmpDb, tmpWal, tmpShm]) { try { fs.unlinkSync(f); } catch { /* ignore */ } }
-			return buffer;
-		} catch {
-			return null; // node:sqlite unavailable or copy failed — fall back to direct read
-		}
-	}
-
 	private async refreshOpenCodeDb(dbPath: string, stats: fs.Stats): Promise<SqlDatabase | null> {
 		let db: SqlDatabase;
 		try {
 			const SQL = await this.initSqlJs();
-			const walBuffer = await this.tryReadDbWithWal(dbPath);
-			const buffer = walBuffer ?? fs.readFileSync(dbPath);
+			const buffer = await readDbBufferWithWal(dbPath);
 			db = new SQL.Database(buffer);
 		} catch {
 			return this.getCachedDbForPath(dbPath);
@@ -227,7 +173,7 @@ export class OpenCodeDataAccess {
 		}
 
 		this.closeDbCache();
-		this._dbCache = { db, path: dbPath, mtimeMs: stats.mtimeMs, size: stats.size, walMtimeMs: this.getWalMtimeMs(dbPath) };
+		this._dbCache = { db, path: dbPath, mtimeMs: stats.mtimeMs, size: stats.size, walMtimeMs: getWalMtimeMs(dbPath) };
 		return db;
 	}
 

--- a/src/utils/sqliteWal.ts
+++ b/src/utils/sqliteWal.ts
@@ -1,0 +1,82 @@
+/**
+ * Shared helper for reading a SQLite database file that may have an active
+ * WAL (write-ahead log) sidecar.
+ *
+ * sql.js loads a database by reading raw bytes from the `.db` file only — it
+ * has no concept of the `-wal`/`-shm` sidecar files SQLite uses in WAL mode.
+ * When another process (e.g. the Copilot CLI) holds the database open in WAL
+ * mode, its most recent writes live only in the `-wal` file until a
+ * checkpoint merges them back into the main file. Reading just the `.db`
+ * bytes in that window silently returns a stale snapshot — no error, just
+ * missing recent rows/columns — until something else (e.g. the writer
+ * closing its connection) triggers a checkpoint.
+ *
+ * `tryReadDbWithWal` works around this without a native SQLite dependency in
+ * the extension's runtime: it copies the db + wal (+ shm) files to a temp
+ * location, opens the copy with Node's built-in `node:sqlite` (Node.js 22+),
+ * forces `PRAGMA wal_checkpoint(TRUNCATE)` to merge all WAL frames into the
+ * temp file, and returns the resulting buffer for sql.js to load.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+/**
+ * Returns a fully checked-out buffer for `dbPath` with any pending WAL frames
+ * merged in, or `null` when there is no WAL to merge (no `-wal` file, an
+ * empty one, or `node:sqlite` is unavailable / the merge attempt failed).
+ * Callers should fall back to `fs.readFileSync(dbPath)` when this returns null.
+ */
+export async function tryReadDbWithWal(dbPath: string): Promise<Buffer | null> {
+	const walPath = dbPath + '-wal';
+	let walSize: number;
+	try {
+		walSize = fs.statSync(walPath).size;
+	} catch {
+		return null; // No WAL file — no merge needed
+	}
+	if (walSize === 0) { return null; }
+
+	try {
+		const { DatabaseSync } = require('node:sqlite') as typeof import('node:sqlite');
+		const tmpDir = path.join(os.homedir(), '.copilot', 'tmp');
+		fs.mkdirSync(tmpDir, { recursive: true, mode: 0o700 });
+		const tmpDb = path.join(tmpDir, `sqlite-wal-${path.basename(dbPath)}-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}.db`);
+		const tmpWal = tmpDb + '-wal';
+		const tmpShm = tmpDb + '-shm';
+		const shmPath = dbPath + '-shm';
+
+		fs.copyFileSync(dbPath, tmpDb);
+		fs.copyFileSync(walPath, tmpWal);
+		if (fs.existsSync(shmPath)) { fs.copyFileSync(shmPath, tmpShm); }
+
+		const nativeDb = new DatabaseSync(tmpDb);
+		nativeDb.exec('PRAGMA wal_checkpoint(TRUNCATE);');
+		nativeDb.close();
+
+		const buffer = fs.readFileSync(tmpDb);
+		for (const f of [tmpDb, tmpWal, tmpShm]) { try { fs.unlinkSync(f); } catch { /* ignore */ } }
+		return buffer;
+	} catch {
+		return null; // node:sqlite unavailable or copy failed — fall back to direct read
+	}
+}
+
+/** The WAL sidecar's mtime in milliseconds, or 0 when no `-wal` file exists. */
+export function getWalMtimeMs(dbPath: string): number {
+	try {
+		return fs.statSync(dbPath + '-wal').mtimeMs;
+	} catch {
+		return 0;
+	}
+}
+
+/**
+ * Reads `dbPath` as a buffer, merging in any pending WAL frames first when
+ * possible. Always prefer this over a bare `fs.readFileSync(dbPath)` for
+ * SQLite databases that another process may hold open in WAL mode.
+ */
+export async function readDbBufferWithWal(dbPath: string): Promise<Buffer> {
+	const walBuffer = await tryReadDbWithWal(dbPath);
+	return walBuffer ?? fs.readFileSync(dbPath);
+}

--- a/src/utils/sqliteWal.ts
+++ b/src/utils/sqliteWal.ts
@@ -37,28 +37,39 @@ export async function tryReadDbWithWal(dbPath: string): Promise<Buffer | null> {
 	}
 	if (walSize === 0) { return null; }
 
+	let tmpDb: string | undefined;
+	let tmpWal: string | undefined;
+	let tmpShm: string | undefined;
+	let nativeDb: import('node:sqlite').DatabaseSync | undefined;
 	try {
 		const { DatabaseSync } = require('node:sqlite') as typeof import('node:sqlite');
 		const tmpDir = path.join(os.homedir(), '.copilot', 'tmp');
 		fs.mkdirSync(tmpDir, { recursive: true, mode: 0o700 });
-		const tmpDb = path.join(tmpDir, `sqlite-wal-${path.basename(dbPath)}-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}.db`);
-		const tmpWal = tmpDb + '-wal';
-		const tmpShm = tmpDb + '-shm';
+		tmpDb = path.join(tmpDir, `sqlite-wal-${path.basename(dbPath)}-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}.db`);
+		tmpWal = tmpDb + '-wal';
+		tmpShm = tmpDb + '-shm';
 		const shmPath = dbPath + '-shm';
 
 		fs.copyFileSync(dbPath, tmpDb);
 		fs.copyFileSync(walPath, tmpWal);
 		if (fs.existsSync(shmPath)) { fs.copyFileSync(shmPath, tmpShm); }
 
-		const nativeDb = new DatabaseSync(tmpDb);
+		nativeDb = new DatabaseSync(tmpDb);
 		nativeDb.exec('PRAGMA wal_checkpoint(TRUNCATE);');
 		nativeDb.close();
+		nativeDb = undefined;
 
-		const buffer = fs.readFileSync(tmpDb);
-		for (const f of [tmpDb, tmpWal, tmpShm]) { try { fs.unlinkSync(f); } catch { /* ignore */ } }
-		return buffer;
+		return fs.readFileSync(tmpDb);
 	} catch {
 		return null; // node:sqlite unavailable or copy failed — fall back to direct read
+	} finally {
+		// Always clean up, even when a step above threw — otherwise a failed merge attempt
+		// leaks a temp DB (and, on Windows, a still-open handle) on every such call.
+		if (nativeDb) { try { nativeDb.close(); } catch { /* ignore */ } }
+		for (const f of [tmpDb, tmpWal, tmpShm]) {
+			if (!f) { continue; }
+			try { fs.unlinkSync(f); } catch { /* ignore — may not have been created */ }
+		}
 	}
 }
 

--- a/vscode-extension/src/copilotAppData.ts
+++ b/vscode-extension/src/copilotAppData.ts
@@ -19,6 +19,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import initSqlJs from 'sql.js';
+import { readDbBufferWithWal } from '../../src/utils/sqliteWal';
 
 type SqlJsStatic = initSqlJs.SqlJsStatic;
 
@@ -102,7 +103,9 @@ export class CopilotAppDataAccess {
 
 		try {
 			const SQL = await this.initSqlJs();
-			const buffer = fs.readFileSync(dbPath);
+			// Merge any pending WAL frames first — the Copilot app may still hold data.db
+			// open in WAL mode, so a bare file read can silently miss its most recent writes.
+			const buffer = await readDbBufferWithWal(dbPath);
 			const db = new SQL.Database(buffer);
 			try {
 				return this._buildHierarchyFromDb(db, sessionUuids);
@@ -130,7 +133,10 @@ export class CopilotAppDataAccess {
 
 		try {
 			const SQL = await this.initSqlJs();
-			const buffer = fs.readFileSync(dbPath);
+			// Same WAL-merge rationale as getSessionHierarchy above: context_current_tokens
+			// etc. are updated continuously while a Copilot CLI session runs, and those
+			// writes can sit in data.db-wal, unseen by a bare file read, for a long time.
+			const buffer = await readDbBufferWithWal(dbPath);
 			const db = new SQL.Database(buffer);
 			try {
 				const ph = sessionUuids.map(() => '?').join(', ');

--- a/vscode-extension/test/unit/copilotAppData.test.ts
+++ b/vscode-extension/test/unit/copilotAppData.test.ts
@@ -1,0 +1,145 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { CopilotAppDataAccess } from '../../../vscode-extension/src/copilotAppData';
+
+type FakeRow = (string | number | null)[];
+
+/**
+ * Minimal fake sql.js `Database` used to control exactly what
+ * `getSessionHierarchy`/`getSessionContextInfo` see, without depending on a
+ * real SQLite file layout. `readDbBufferWithWal` still runs for real against
+ * `dbPath` (this is what we are testing) — only the sql.js parsing layer is
+ * faked, mirroring the approach in opencode-cache.test.ts.
+ */
+class FakeDatabase {
+	closed = false;
+	constructor(public readonly buffer: Buffer) {}
+
+	exec(sql: string): Array<{ columns: string[]; values: FakeRow[] }> {
+		if (sql.includes('FROM sessions')) {
+			return [{
+				columns: ['id', 'context_tier', 'context_current_tokens', 'context_input_token_limit'],
+				values: [['session-1', 'default', 4200, 128000]],
+			}];
+		}
+		if (sql.includes('workspace_parent_links')) {
+			return [];
+		}
+		return [];
+	}
+
+	close(): void {
+		this.closed = true;
+	}
+}
+
+function createHarness() {
+	const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'copilot-app-data-'));
+	const dbPath = path.join(tmpDir, 'data.db');
+	const opened: FakeDatabase[] = [];
+
+	const access = new CopilotAppDataAccess();
+	access.getDbPath = () => dbPath;
+	(access as any).initSqlJs = async () => ({
+		Database: class extends FakeDatabase {
+			constructor(buffer: Buffer) {
+				super(buffer);
+				opened.push(this);
+			}
+		},
+	});
+
+	return {
+		access,
+		dbPath,
+		opened,
+		cleanup: () => fs.rmSync(tmpDir, { recursive: true, force: true }),
+	};
+}
+
+test('getSessionContextInfo returns parsed context window data when no WAL file exists', async () => {
+	const harness = createHarness();
+	try {
+		fs.writeFileSync(harness.dbPath, 'fake-db-bytes');
+
+		const result = await harness.access.getSessionContextInfo(['session-1']);
+
+		assert.equal(result.size, 1);
+		assert.deepEqual(result.get('session-1'), {
+			uuid: 'session-1',
+			contextTier: 'default',
+			contextReachedTokens: 4200,
+			contextWindowLimit: 128000,
+		});
+		assert.equal(harness.opened.length, 1);
+		assert.equal(harness.opened[0].closed, true);
+	} finally {
+		harness.cleanup();
+	}
+});
+
+test('getSessionContextInfo returns empty map when data.db does not exist', async () => {
+	const harness = createHarness();
+	try {
+		// Note: dbPath is never written to disk.
+		const result = await harness.access.getSessionContextInfo(['session-1']);
+
+		assert.equal(result.size, 0);
+		assert.equal(harness.opened.length, 0);
+	} finally {
+		harness.cleanup();
+	}
+});
+
+test('getSessionContextInfo falls back to a direct read when the WAL file is empty', async () => {
+	const harness = createHarness();
+	try {
+		fs.writeFileSync(harness.dbPath, 'fake-db-bytes');
+		fs.writeFileSync(harness.dbPath + '-wal', ''); // empty WAL — no merge needed
+
+		const result = await harness.access.getSessionContextInfo(['session-1']);
+
+		assert.equal(result.size, 1);
+		assert.equal(result.get('session-1')?.contextReachedTokens, 4200);
+	} finally {
+		harness.cleanup();
+	}
+});
+
+test('getSessionContextInfo tolerates an unmergeable WAL file without leaking temp files', async () => {
+	const harness = createHarness();
+	try {
+		fs.writeFileSync(harness.dbPath, 'fake-db-bytes');
+		// Non-empty but not a real SQLite WAL — node:sqlite will fail to open the
+		// copied temp db, so tryReadDbWithWal should fall back to a direct read
+		// of the (unmerged) main file rather than throwing.
+		fs.writeFileSync(harness.dbPath + '-wal', 'not-a-real-wal-file');
+
+		const tmpDir = path.join(os.homedir(), '.copilot', 'tmp');
+		const before = fs.existsSync(tmpDir) ? fs.readdirSync(tmpDir).length : 0;
+
+		const result = await harness.access.getSessionContextInfo(['session-1']);
+
+		assert.equal(result.size, 1, 'should still read the main db file even when the WAL merge fails');
+
+		const after = fs.existsSync(tmpDir) ? fs.readdirSync(tmpDir).length : 0;
+		assert.equal(after, before, 'no temp WAL-merge files should remain after a failed merge attempt');
+	} finally {
+		harness.cleanup();
+	}
+});
+
+test('getSessionHierarchy returns an empty map for an empty input list without touching data.db', async () => {
+	const harness = createHarness();
+	try {
+		const result = await harness.access.getSessionHierarchy([]);
+
+		assert.equal(result.size, 0);
+		assert.equal(harness.opened.length, 0);
+	} finally {
+		harness.cleanup();
+	}
+});


### PR DESCRIPTION
## Why

The "Context Window & Long-Context Pricing" usage section could show "No data" even when the underlying data existed, because `CopilotAppDataAccess` read `~/.copilot/data.db` with a bare `fs.readFileSync()`. The Copilot app keeps that database open in WAL mode, so an actively-running CLI session's own writes (e.g. `context_current_tokens`) can sit only in the `data.db-wal` sidecar, uncommitted to the main file, until a checkpoint happens (typically when the writer's connection closes). `sql.js` has no concept of the WAL, so it silently loaded a stale snapshot with no error - the data only appeared after restarting the session forced a checkpoint.

## Approach

`opencode.ts` already had a working fix for the same problem on `opencode.db`: copy the db + wal (+ shm) to a temp file, open it with Node's built-in `node:sqlite`, run `PRAGMA wal_checkpoint(TRUNCATE)` to merge the WAL, then hand the merged buffer to `sql.js`.

This PR extracts that logic into a shared `src/utils/sqliteWal.ts` helper (`readDbBufferWithWal`, `getWalMtimeMs`) and applies it in both places:
- `src/opencode.ts` - replaced its private duplicate with the shared helper (no behavior change, verified by the existing `opencode-cache.test.ts` suite).
- `vscode-extension/src/copilotAppData.ts` - both `getSessionHierarchy` and `getSessionContextInfo` now read `data.db` through the WAL-merge helper instead of a raw file read.

Also added `docs/adr/SQLITE-WAL-READS.md` (linked from `docs/README.md`) documenting the gotcha and the rule for future code: any locally-owned SQLite database another process may still be writing to should go through `readDbBufferWithWal()` rather than `fs.readFileSync()`.

## Notes for reviewers

- Falls back gracefully to a direct file read when there's no WAL, the WAL is empty, or `node:sqlite` is unavailable, so behavior is unchanged in those cases.
- Verified with `tsc --noEmit`, `eslint`, and the `opencode-cache.test.ts` suite (9/9 passing) after the refactor.
- No new native dependency: `node:sqlite` is Node.js's own built-in module (Node 22+).