### PR TITLE
Add Kilo Code session tracking

### DIFF
--- a/src/adapters/kiloAdapter.ts
+++ b/src/adapters/kiloAdapter.ts
@@ -6,6 +6,7 @@ import { KiloDataAccess } from '../kilo';
 import { createEmptyContextRefs } from '../tokenEstimation';
 import { createEmptySessionUsageAnalysis, applyModelTierClassification } from '../usageAnalysis';
 import { pathExists } from '../utils/fsAsync';
+import { isUnsafeObjectKey } from '../utils/protoGuard';
 
 export class KiloAdapter implements IEcosystemAdapter, IDiscoverableEcosystem, IAnalyzableEcosystem {
 	readonly id = 'kilo';
@@ -215,6 +216,7 @@ export class KiloAdapter implements IEcosystemAdapter, IDiscoverableEcosystem, I
 		const parts = await this.kilo.getKiloPartsForMessage(msg.id);
 		for (const part of parts) {
 			if (part.type !== 'tool' || !part.tool) { continue; }
+			if (typeof part.tool !== 'string' || isUnsafeObjectKey(part.tool)) { continue; }
 			analysis.toolCalls.total++;
 			analysis.toolCalls.byTool[part.tool] = (analysis.toolCalls.byTool[part.tool] || 0) + 1;
 		}

--- a/src/kilo.ts
+++ b/src/kilo.ts
@@ -43,6 +43,11 @@ type KiloModelUsageWithInteractions = {
 	[modelName: ModelId]: ModelUsage[ModelId] & { interactions?: number };
 };
 
+function toFiniteNumber(value: unknown): number {
+	const numberValue = typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : 0;
+	return Number.isFinite(numberValue) ? numberValue : 0;
+}
+
 export class KiloDataAccess {
 	private _sqlJsModule: SqlJsStatic | null = null;
 	private _sqlJsInitPromise: Promise<SqlJsStatic> | null = null;
@@ -370,10 +375,9 @@ export class KiloDataAccess {
 		let sessionTotal = 0;
 		for (const msg of messages) {
 			if (msg.role === 'assistant' && msg.tokens) {
-				if (typeof msg.tokens.total === 'number') {
-					sessionTotal = msg.tokens.total; // cumulative — last one wins
-				}
-				thinkingTokens += msg.tokens.reasoning || 0;
+				const total = toFiniteNumber(msg.tokens.total);
+				if (total > 0) { sessionTotal = total; } // cumulative — last one wins
+				thinkingTokens += toFiniteNumber(msg.tokens.reasoning);
 			}
 		}
 
@@ -415,7 +419,7 @@ export class KiloDataAccess {
 	private computeTurnCumTotal(turnAssistantMsgs: any[], prevTotal: number): number {
 		let cumTotal = prevTotal;
 		for (const am of turnAssistantMsgs) {
-			if (typeof am.tokens?.total === 'number') { cumTotal = Math.max(cumTotal, am.tokens.total); }
+			cumTotal = Math.max(cumTotal, toFiniteNumber(am.tokens?.total));
 		}
 		return cumTotal;
 	}
@@ -436,11 +440,12 @@ export class KiloDataAccess {
 			// Untrusted `model` string from parsed session JSON — see protoGuard.ts.
 			if (isUnsafeObjectKey(model)) { prevTotal = turnCumTotal; continue; }
 			if (!modelUsage[model]) { modelUsage[model] = { inputTokens: 0, outputTokens: 0, sessions: 0 }; }
-			const turnOutput = turnAssistantMsgs.reduce((sum, m) => sum + (m.tokens?.output || 0) + (m.tokens?.reasoning || 0), 0);
+			const turnOutput = turnAssistantMsgs.reduce((sum, m) =>
+				sum + toFiniteNumber(m.tokens?.output) + toFiniteNumber(m.tokens?.reasoning), 0);
 			modelUsage[model].inputTokens += Math.max(0, turnTokens - turnOutput);
 			modelUsage[model].outputTokens += turnOutput;
-			const turnCachedRead = turnAssistantMsgs.reduce((sum, m) => sum + (m.tokens?.cache?.read || 0), 0);
-			const turnCacheCreation = turnAssistantMsgs.reduce((sum, m) => sum + (m.tokens?.cache?.write || 0), 0);
+			const turnCachedRead = turnAssistantMsgs.reduce((sum, m) => sum + toFiniteNumber(m.tokens?.cache?.read), 0);
+			const turnCacheCreation = turnAssistantMsgs.reduce((sum, m) => sum + toFiniteNumber(m.tokens?.cache?.write), 0);
 			if (turnCachedRead > 0) { modelUsage[model].cachedReadTokens = (modelUsage[model].cachedReadTokens ?? 0) + turnCachedRead; }
 			if (turnCacheCreation > 0) { modelUsage[model].cacheCreationTokens = (modelUsage[model].cacheCreationTokens ?? 0) + turnCacheCreation; }
 			prevTotal = turnCumTotal;
@@ -460,7 +465,7 @@ export class KiloDataAccess {
 		// Messages store their timestamp in the nested `time.created` field.
 		let timestamp = Date.now();
 		const created = messages[0]?.time?.created;
-		if (typeof created === 'number') {
+		if (typeof created === 'number' && Number.isFinite(created)) {
 			timestamp = created;
 		} else if (typeof created === 'string') {
 			const parsed = Date.parse(created);

--- a/vscode-extension/test/unit/ecosystemAdapters.test.ts
+++ b/vscode-extension/test/unit/ecosystemAdapters.test.ts
@@ -202,6 +202,42 @@ test('KiloAdapter.handles: rejects OpenCode paths and unrelated paths', () => {
     assert.ok(!kiloAdapter.handles(path.join(os.homedir(), '.claude', 'projects', 'hash', 'abc.jsonl')));
 });
 
+test('KiloDataAccess: coerces numeric token strings and ISO timestamps', async () => {
+    const dataAccess = new KiloDataAccess(null as any);
+    dataAccess.getKiloMessagesForSession = async () => [
+        { id: 'user-1', role: 'user', time: { created: '2026-09-07T12:00:00.000Z' } },
+        {
+            id: 'assistant-1', role: 'assistant', parentID: 'user-1', modelID: 'test-model',
+            tokens: { total: '150', output: '20', reasoning: '5', cache: { read: '10', write: '3' } }
+        }
+    ];
+
+    const result = await dataAccess.getKiloSessionData('kilo.db#ses_test');
+
+    assert.equal(result.timestamp, Date.parse('2026-09-07T12:00:00.000Z'));
+    assert.equal(result.tokens, 150);
+    assert.equal(result.modelUsage['test-model'].inputTokens, 125);
+    assert.equal(result.modelUsage['test-model'].outputTokens, 25);
+    assert.equal(result.modelUsage['test-model'].cachedReadTokens, 10);
+    assert.equal(result.modelUsage['test-model'].cacheCreationTokens, 3);
+});
+
+test('KiloAdapter.analyzeUsage: ignores unsafe tool names', async () => {
+    const dataAccess = new KiloDataAccess(null as any);
+    dataAccess.getKiloMessagesForSession = async () => [{ id: 'assistant-1', role: 'assistant', modelID: 'test-model' }];
+    dataAccess.getKiloPartsForMessage = async () => [
+        { type: 'tool', tool: '__proto__' },
+        { type: 'tool', tool: 'read_file' }
+    ];
+    const adapter = new KiloAdapter(dataAccess);
+
+    const analysis = await adapter.analyzeUsage('kilo.db#ses_test', { modelPricing: {}, toolNameMap: {} });
+
+    assert.equal(analysis.toolCalls.total, 1);
+    assert.deepEqual(analysis.toolCalls.byTool, { read_file: 1 });
+    assert.equal(Object.prototype.hasOwnProperty.call(analysis.toolCalls.byTool, '__proto__'), false);
+});
+
 test('ContinueAdapter.handles: recognises ~/.continue/sessions paths', () => {
     const p = path.join(os.homedir(), '.continue', 'sessions', 'abc123.json');
     assert.ok(continueAdapter.handles(p));


### PR DESCRIPTION
Adds Kilo Code's SQLite-backed sessions to the shared adapter registry so both the VS Code extension and CLI can discover sessions, attribute token and model usage, and display Kilo Code alongside other supported tools.

- Uses WAL-aware reads of `kilo.db` and virtual `kilo.db#ses_*` session paths.
- Adds Kilo editor attribution and UI icon support.
- Hardens parsed token fields against non-numeric values and rejects unsafe tool names before aggregation.
- Includes adapter coverage for discovery, token/timestamp handling, and tool-name safety.

Closes #1999

Supersedes #2000.