### PR TITLE
Hide zero-cost providers in Cost by Provider panel

### DIFF
--- a/vscode-extension/src/webview/details/main.ts
+++ b/vscode-extension/src/webview/details/main.ts
@@ -558,17 +558,18 @@ function buildProviderTotalCard(stats: DetailedStats, allProviders: string[]): H
  */
 function buildProviderPanel(stats: DetailedStats): HTMLElement | null {
 	const allProviders = getAllProviders(stats);
+	const providersWithMonthlyCost = allProviders.filter(provider => (stats.month.billingGroupCosts?.[provider] ?? 0) > 0);
 	// With zero or one provider the panel adds no value (nothing to compare or
 	// filter), so hide it entirely.
-	if (allProviders.length <= 1) { return null; }
+	if (providersWithMonthlyCost.length <= 1) { return null; }
 
 	const section = el('div', 'section');
 	section.append(iconHeading('h3', 'credit-card', 'Cost by Provider'));
 	section.append(el('div', 'provider-panel-hint', 'Click a provider to hide/show it — this also filters the Editor & Model usage lists below.'));
 
 	const grid = el('div', 'provider-cards');
-	grid.append(buildProviderTotalCard(stats, allProviders));
-	allProviders.forEach(provider => grid.append(buildProviderCard(stats, provider)));
+	grid.append(buildProviderTotalCard(stats, providersWithMonthlyCost));
+	providersWithMonthlyCost.forEach(provider => grid.append(buildProviderCard(stats, provider)));
 	section.append(grid);
 	return section;
 }


### PR DESCRIPTION
## Problem

When users view the "Cost by Provider" panel, all providers detected across session data are shown—even those with $0.00 cost this month. This creates visual clutter and makes the most relevant cost comparison less prominent.

## Solution

Filter the displayed provider cards to show only providers with positive cost in the current month. The panel still hides when fewer than two non-zero-cost providers remain (no value in comparing a single provider).

The filtering applies only to the UI panel display; the underlying provider-filter system (used to hide/show providers in usage lists below) remains unchanged and continues to track all providers.

## Changes

- Modified `buildProviderPanel()` to filter providers by current-month cost before rendering
- Cards now display only providers where `stats.month.billingGroupCosts[provider] > 0`
- Panel hides when zero or one non-zero-cost provider is detected (same logic as before, just applied to the filtered list)

All tests pass: validate, test:node, check:contract, check:interaction.