### PR TITLE
Clarify OTel Delta loading state

### DIFF
--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -3020,6 +3020,15 @@ ${filterPanel}
 }
 
 function renderOtelDeltaSetupNotice(comparison: CopilotCliOtelComparison | null | undefined): string {
+  if (comparison === undefined) {
+    return `<div class="info-box">
+<div class="info-box-title">📡 Copilot CLI OpenTelemetry Detection Running</div>
+<div>
+Detecting Copilot CLI OpenTelemetry export data…<br/><br/>
+This check compares this extension's estimated token counts against exact counts from local OTel export files.
+</div>
+</div>`;
+  }
   if (comparison && comparison.otelSessionsIndexed > 0) { return ''; }
   const dirStatus = comparison?.otelDirExists
     ? `The export directory exists but no session data has been indexed from it yet (${Number(comparison.otelFileCount)} file(s) found).`

--- a/vscode-extension/test/unit/diagnosticsWebviewMessageFlow.test.ts
+++ b/vscode-extension/test/unit/diagnosticsWebviewMessageFlow.test.ts
@@ -207,3 +207,13 @@ test('a githubAuth value from an early backendStorageInfoLoaded message also sur
 	const rendered = harness.text('#tab-github');
 	assert.ok(rendered?.includes('octocat'), `expected the authenticated GitHub user to render, got: ${rendered}`);
 });
+
+test('OTel Delta tab shows a detecting message while comparison data is still loading', async () => {
+	await preloadBundle();
+	const harness = bootWebviewUnsettled(buildInitialData({ otelComparison: undefined }));
+	await harness.settle();
+
+	const rendered = harness.text('#tab-otel-delta');
+	assert.ok(rendered?.includes('OpenTelemetry Detection Running'), `expected detecting title, got: ${rendered}`);
+	assert.ok(rendered?.includes('Detecting Copilot CLI OpenTelemetry export data'), `expected detecting body, got: ${rendered}`);
+});


### PR DESCRIPTION
## Summary
Clarifies the OTel Delta tab UX so users do not see a misleading "not detected" state while detection is still running.

## Changes
- Added an explicit in-progress setup notice when OTel comparison data is still loading (`otelComparison === undefined`).
- Kept the existing "not detected" setup guidance for the completed/no-export case.
- Added a unit test that asserts the OTel Delta tab renders the new detecting message during loading.

## Why
Previously the tab could look like OTel was not detected while async detection was still in progress, which was confusing and looked like a false negative.