### PR TITLE
Fix share card period refresh

### DIFF
--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -846,13 +846,6 @@ function renderShareCardTab(detailedFiles: SessionFileDetails[], isLoadingSessio
   </div>`;
 }
 
-function renderShareCardContent(): void {
-  const container = document.getElementById("tab-share");
-  if (!container) { return; }
-  setHtml(container, renderShareCardTab(storedDetailedFiles, isLoading));
-  setupShareSummaryButtonHandler();
-}
-
 function renderDebugTab(counters: GlobalStateCounters | undefined): string {
   const c = counters ?? { openCount: 0, unknownMcpOpenCount: 0, fluencyBannerDismissed: false, unknownMcpDismissedVersion: '', efficiencyTabBannerDismissed: false };
   return `

--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -846,6 +846,13 @@ function renderShareCardTab(detailedFiles: SessionFileDetails[], isLoadingSessio
   </div>`;
 }
 
+function renderShareCardContent(): void {
+  const container = document.getElementById("tab-share");
+  if (!container) { return; }
+  setHtml(container, renderShareCardTab(storedDetailedFiles, isLoading));
+  setupShareSummaryButtonHandler();
+}
+
 function renderDebugTab(counters: GlobalStateCounters | undefined): string {
   const c = counters ?? { openCount: 0, unknownMcpOpenCount: 0, fluencyBannerDismissed: false, unknownMcpDismissedVersion: '', efficiencyTabBannerDismissed: false };
   return `
@@ -2089,7 +2096,7 @@ function renderShareCardPeriodSelector(): void {
     onChange: (value) => {
       currentShareCardPeriod = value as Period;
       diagState.patch({ shareCardPeriod: currentShareCardPeriod });
-      reRenderShareCard();
+      renderShareCardContent();
     },
   });
   wrapper.append(select);
@@ -2110,6 +2117,7 @@ function buildCurrentShareSummaryText(): string {
 /** Wires the "Copy Summary Text" button, social share buttons, and period selector on the Share
  * Card tab. Re-run after `reRenderShareCard()` replaces the tab's markup, since these elements are recreated. */
 function setupShareSummaryButtonHandler(): void {
+  if (!document.getElementById("share-card-period-selector")) { return; }
   renderShareCardPeriodSelector();
   document.getElementById("btn-copy-share-summary")?.addEventListener("click", () => {
     vscode.postMessage({ command: "copyText", text: buildCurrentShareSummaryText() });

--- a/vscode-extension/src/webview/diagnostics/main.ts
+++ b/vscode-extension/src/webview/diagnostics/main.ts
@@ -2089,7 +2089,7 @@ function renderShareCardPeriodSelector(): void {
     onChange: (value) => {
       currentShareCardPeriod = value as Period;
       diagState.patch({ shareCardPeriod: currentShareCardPeriod });
-      renderShareCardContent();
+      reRenderShareCard();
     },
   });
   wrapper.append(select);

--- a/vscode-extension/test/unit/diagnosticsWebviewMessageFlow.test.ts
+++ b/vscode-extension/test/unit/diagnosticsWebviewMessageFlow.test.ts
@@ -208,6 +208,70 @@ test('a githubAuth value from an early backendStorageInfoLoaded message also sur
 	assert.ok(rendered?.includes('octocat'), `expected the authenticated GitHub user to render, got: ${rendered}`);
 });
 
+test('changing the Share Card period refreshes the card and keeps its controls interactive', async () => {
+	await preloadBundle();
+	const recent = new Date().toISOString();
+	const old = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000).toISOString();
+	const session = (file: string, lastInteraction: string) => ({
+		file,
+		size: 100,
+		modified: lastInteraction,
+		interactions: 2,
+		tokens: 1_000,
+		contextReferences: {},
+		firstInteraction: lastInteraction,
+		lastInteraction,
+		editorSource: 'VS Code',
+	});
+	const harness = bootWebviewUnsettled(buildInitialData({
+		detailedSessionFiles: [session('recent.json', recent), session('old.json', old)],
+	}));
+	await harness.settle();
+
+	const initialCard = harness.text('#tab-share');
+	assert.ok(initialCard?.includes('Last 14 Days · 1 editor detected'));
+	assert.ok(initialCard?.includes('1 Sessions'));
+
+	const selector = harness.window.document.getElementById('share-card-period-select') as HTMLSelectElement;
+	selector.value = 'allTime';
+	selector.dispatchEvent(new harness.window.Event('change', { bubbles: true }));
+
+	const refreshedCard = harness.text('#tab-share');
+	assert.ok(refreshedCard?.includes('All Time · 1 editor detected'));
+	assert.ok(refreshedCard?.includes('2 Sessions'));
+	assert.equal(harness.window.document.querySelectorAll('#tab-share').length, 1);
+	const refreshedSelector = harness.window.document.getElementById('share-card-period-select') as HTMLSelectElement;
+	assert.equal(refreshedSelector.value, 'allTime');
+
+	(harness.window.document.getElementById('btn-copy-share-summary') as HTMLButtonElement).click();
+	assert.equal(harness.posted.at(-1)?.command, 'copyText');
+	assert.match(harness.posted.at(-1)?.text, /2 sessions.*of all time/);
+});
+
+test('a backendStorageInfoLoaded message delivered before the layout renders is not discarded by the first paint', async () => {
+	// The host sends this message as early as possible (sendBackendStorageInfoEarly), racing the
+	// webview's own bootstrap() which awaits a dynamic import before building any DOM. Dispatching
+	// synchronously right after eval — before the pending import microtask resolves — reproduces
+	// that race deterministically: renderLayout() has not run yet, so no #tab-backend exists.
+	await preloadBundle();
+	const harness = bootWebviewUnsettled(buildInitialData({ backendStorageInfo: null }));
+
+	assert.equal(harness.window.document.getElementById('tab-backend'), null, 'layout must not exist yet');
+	harness.postSync({ command: 'backendStorageInfoLoaded', backendStorageInfo: configuredBackendStorageInfo(), githubAuth: { authenticated: true, username: 'octocat' } });
+
+	await harness.settle();
+
+	const rendered = harness.text('#tab-backend');
+	assert.ok(
+		rendered?.includes('Configured & Enabled'),
+		`the early message's data must survive into the first paint, got: ${rendered}`,
+	);
+	assert.ok(
+		!rendered?.includes('Loading backend storage status'),
+		'the first paint must not silently fall back to the placeholder once real data already arrived',
+	);
+});
+
 test('OTel Delta tab shows a detecting message while comparison data is still loading', async () => {
 	await preloadBundle();
 	const harness = bootWebviewUnsettled(buildInitialData({ otelComparison: undefined }));

--- a/vscode-extension/test/unit/diagnosticsWebviewMessageFlow.test.ts
+++ b/vscode-extension/test/unit/diagnosticsWebviewMessageFlow.test.ts
@@ -142,6 +142,17 @@ function bootWebviewUnsettled(initialData: Record<string, unknown> | null): Harn
 	};
 }
 
+/**
+ * Reads one Share Card stat tile ("Sessions", "Interactions", …) by its label. The value and the
+ * label live in sibling divs with no whitespace between them, so `harness.text()` would run them
+ * together ("1Sessions"); going through the DOM keeps the assertion readable.
+ */
+function shareStat(harness: Harness, label: string): string | undefined {
+	const tiles = Array.from(harness.window.document.querySelectorAll('#tab-share .share-stat')) as any[];
+	const tile = tiles.find((t) => t.querySelector('.share-stat-label')?.textContent === label);
+	return tile?.querySelector('.share-stat-value')?.textContent;
+}
+
 let syncBundle: string | undefined;
 function getSyncBundle(): string {
 	if (syncBundle === undefined) { throw new Error('Bundle not preloaded — call preloadBundle() first'); }
@@ -229,16 +240,22 @@ test('changing the Share Card period refreshes the card and keeps its controls i
 	await harness.settle();
 
 	const initialCard = harness.text('#tab-share');
-	assert.ok(initialCard?.includes('Last 14 Days · 1 editor detected'));
-	assert.ok(initialCard?.includes('1 Sessions'));
+	assert.ok(
+		initialCard?.includes('Last 14 days · 1 editor detected'),
+		`expected the default 14-day subtitle, got: ${initialCard}`,
+	);
+	assert.equal(shareStat(harness, 'Sessions'), '1', 'only the recent session falls inside the default period');
 
 	const selector = harness.window.document.getElementById('share-card-period-select') as HTMLSelectElement;
 	selector.value = 'allTime';
 	selector.dispatchEvent(new harness.window.Event('change', { bubbles: true }));
 
 	const refreshedCard = harness.text('#tab-share');
-	assert.ok(refreshedCard?.includes('All Time · 1 editor detected'));
-	assert.ok(refreshedCard?.includes('2 Sessions'));
+	assert.ok(
+		refreshedCard?.includes('All time · 1 editor detected'),
+		`expected the card to re-render for the new period, got: ${refreshedCard}`,
+	);
+	assert.equal(shareStat(harness, 'Sessions'), '2', 'the 60-day-old session joins the count once the period is All time');
 	assert.equal(harness.window.document.querySelectorAll('#tab-share').length, 1);
 	const refreshedSelector = harness.window.document.getElementById('share-card-period-select') as HTMLSelectElement;
 	assert.equal(refreshedSelector.value, 'allTime');


### PR DESCRIPTION
The share card was not reliably updating when the period selector changed, so the preview could get out of sync with the selected time window.

## What changed
- Re-render the share card content directly when the period changes.
- Keep the selector/button wiring in sync after the content refresh so the new markup stays interactive.
- Guard the share-card setup helper so it only runs when the selector exists.

## Notes
- This is a focused UI fix in the diagnostics webview; no data model changes.