### PR TITLE
Show every model a session used in Recent Sessions (fixes missing HydraFusion sessions)

### DIFF
--- a/src/recentSessions.ts
+++ b/src/recentSessions.ts
@@ -29,3 +29,29 @@ export function buildRecentSessionBuckets<T>(
 
 	return buckets;
 }
+
+/** Placeholder key the per-turn efficiency counters use when a turn carries no model id. */
+const UNKNOWN_MODEL_KEY = 'unknown';
+
+/**
+ * Returns every model a session actually used, token-attributed models first.
+ *
+ * `modelUsage` only lists models that produced an attributable usage record, so a model
+ * that served turns without one is missing there while still being counted per turn in
+ * `modelEfficiency`. The Recent Sessions Models column, its pill filters and the
+ * HydraFusion badge all read this list, so both sources are unioned — otherwise a model
+ * can rank in "Most used models locally" while no session row ever mentions it. The
+ * `unknown` placeholder is dropped from the efficiency side: it is not a model anyone can
+ * look up or filter on.
+ */
+export function collectSessionModelIds(
+	modelUsage: { [model: string]: unknown } | undefined,
+	modelEfficiency: { [model: string]: unknown } | undefined,
+): string[] {
+	const models = Object.keys(modelUsage ?? {});
+	for (const model of Object.keys(modelEfficiency ?? {})) {
+		if (model === UNKNOWN_MODEL_KEY || models.includes(model)) { continue; }
+		models.push(model);
+	}
+	return models;
+}

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -339,7 +339,7 @@ import { getNonce, buildCspMeta, getCodiconStylesheetTag } from './utils/webview
 import { getAzureTableStorageEndpoint } from './utils/azureEndpoints';
 import { isGuidMcpTool, isMcpFamilyResolvedTool, lookupKnownToolName } from '../../src/utils/toolUtils';
 import { toLocalDayKey } from '../../src/utils/dayKeys';
-import { buildRecentSessionBuckets as bucketRecentSessions } from '../../src/recentSessions';
+import { buildRecentSessionBuckets as bucketRecentSessions, collectSessionModelIds } from '../../src/recentSessions';
 import { determineOnboardingAction } from './onboarding';
 import { mergeNotifiedEditors, mergeSeenEditors } from './editorDiscovery';
 import { TtftScanResultCache } from './ttftAnalysisCache';
@@ -4875,7 +4875,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 			thinkingTokens: sessionData.thinkingTokens || 0, cachedTokens: cachedTok,
 			totalTokens: computeSessionTotalTokens(inputTok, outputTok, sessionData.thinkingTokens || 0),
 			estimatedCost: sessionData.copilotExactCostDollars ?? this.calculateEstimatedCost(modelUsage),
-			editor: this.detectEditorSource(sessionFile), models: Object.keys(modelUsage),
+			editor: this.detectEditorSource(sessionFile), models: collectSessionModelIds(modelUsage, analysis?.modelEfficiency),
 			lastActivity: sessionData.lastInteraction || new Date(mtime).toISOString(),
 			...(sessionData.truncationCount ? { truncationCount: sessionData.truncationCount } : {}),
 			...(sessionData.maxRequestInputTokens ? { maxRequestInputTokens: sessionData.maxRequestInputTokens } : {}),

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -1142,8 +1142,16 @@ function formatCompactSessionNumber(value: number): { html: string; title: strin
 	return { html: formatCompact(value), title: formatNumber(value) };
 }
 
+/**
+ * Whether a raw model id refers to HydraFusion.
+ *
+ * Ids arrive in several shapes (`hydrafusion`, `copilot/hydrafusion`, `hydra-fusion`,
+ * a dated/preview suffix), so separators are stripped and the name must start the id —
+ * that keeps unrelated models that merely end in the word (`unrelated-hydrafusion`) out.
+ */
 function isHydraFusionModel(model: string): boolean {
-	return getModelLookupCandidates(model).some(candidate => candidate.toLowerCase() === 'hydrafusion');
+	return getModelLookupCandidates(model)
+		.some(candidate => candidate.toLowerCase().replace(/[-_. ]/g, '').startsWith('hydrafusion'));
 }
 
 /**

--- a/vscode-extension/test/unit/recentSessions.test.ts
+++ b/vscode-extension/test/unit/recentSessions.test.ts
@@ -1,6 +1,6 @@
 import { describe, test } from 'node:test';
 import * as assert from 'node:assert/strict';
-import { buildRecentSessionBuckets } from '../../../src/recentSessions';
+import { buildRecentSessionBuckets, collectSessionModelIds } from '../../../src/recentSessions';
 import { sanitizeRecentSessionBuckets } from '../../src/webview/usage/recentSessionsSanitizer';
 
 const validSessionSummary = {
@@ -58,5 +58,26 @@ describe('sanitizeRecentSessionBuckets', () => {
 
 	test('rejects partial payloads so callers can use their lazy-loading fallback', () => {
 		assert.equal(sanitizeRecentSessionBuckets({ last7: [] }), undefined);
+	});
+});
+
+describe('collectSessionModelIds', () => {
+	test('adds models that only served turns without an attributable usage record', () => {
+		assert.deepEqual(
+			collectSessionModelIds({ 'gpt-5': {} }, { 'gpt-5': {}, hydrafusion: {} }),
+			['gpt-5', 'hydrafusion'],
+		);
+	});
+
+	test('keeps token-attributed models first and drops the unknown placeholder', () => {
+		assert.deepEqual(
+			collectSessionModelIds({ 'claude-opus-5': {} }, { unknown: {}, 'gpt-5.6-terra': {} }),
+			['claude-opus-5', 'gpt-5.6-terra'],
+		);
+	});
+
+	test('falls back to the efficiency models when token attribution is empty', () => {
+		assert.deepEqual(collectSessionModelIds({}, { hydrafusion: {} }), ['hydrafusion']);
+		assert.deepEqual(collectSessionModelIds(undefined, undefined), []);
 	});
 });

--- a/vscode-extension/test/unit/usageWebviewMessageFlow.test.ts
+++ b/vscode-extension/test/unit/usageWebviewMessageFlow.test.ts
@@ -397,12 +397,17 @@ test('marks HydraFusion sessions in the recent sessions list', async () => {
 	};
 	stats.todaySessions = [
 		hydraFusionSession,
-		{ ...hydraFusionSession, title: 'Unrelated task', models: ['unrelated-hydrafusion'] },
+		// Id variants seen in real session logs must all be recognized...
+		{ ...hydraFusionSession, title: 'Prefixed task', filePath: 'b.jsonl', models: ['copilot/hydrafusion'] },
+		{ ...hydraFusionSession, title: 'Separated task', filePath: 'c.jsonl', models: ['hydra-fusion'] },
+		{ ...hydraFusionSession, title: 'Suffixed task', filePath: 'd.jsonl', models: ['hydrafusion-preview'] },
+		// ...while a different model that merely ends in the name must not be.
+		{ ...hydraFusionSession, title: 'Unrelated task', filePath: 'e.jsonl', models: ['unrelated-hydrafusion'] },
 	];
 	const harness = await bootWebview(stats);
 
 	const badges = harness.window.document.querySelectorAll('.hydrafusion-session-badge');
-	assert.equal(badges.length, 1, 'only the HydraFusion model identifier should be marked');
+	assert.equal(badges.length, 4, 'every HydraFusion id variant should be marked, and only those');
 	const badge = badges[0];
 	assert.ok(badge, 'expects a marker for HydraFusion sessions');
 	assert.equal(badge.textContent, 'HydraFusion');


### PR DESCRIPTION
HydraFusion sessions were nowhere to be found in the Recent Sessions table — no badge, no pill filter — even though HydraFusion shows up in "Most used models locally".

## Root cause

The two views read different model sources:

| View | Source | Populated from |
|---|---|---|
| Most used models locally | `usageAnalysis.modelEfficiency` | every turn's model (`event.model ?? defaultModel`) |
| Recent Sessions `models` | `sessionData.modelUsage` | only turns that produced an attributable token-usage record |

`collectTodaySessionInfo` built the row's model list as `Object.keys(modelUsage)`, so any model that served turns without a usage record was silently absent from the session row. Since the HydraFusion badge and the HydraFusion pill filter both read that same list, they could never fire for those sessions — and the model never appeared in the Editor/Vendor/Model pill row either.

## Changes

- New shared helper `collectSessionModelIds` in `src/recentSessions.ts` unions both sources — token-attributed models first, then per-turn models not already listed, dropping the `unknown` placeholder (not a model anyone can look up or filter on).
- `collectTodaySessionInfo` uses it, so the Models column, the pill filters and the badge all reflect every model the session actually used. This applies to every lookback period, since longer windows are built from the same summaries.
- `isHydraFusionModel` now matches separator-insensitively and accepts prefixed/suffixed ids (`copilot/hydrafusion`, `hydra-fusion`, `hydrafusion-preview`) while still excluding models that merely end in the name (`unrelated-hydrafusion`), so a versioned id variant can't silently drop the badge again.

## Validation

- `npm run validate` (type-check + lint + build) — clean, only pre-existing complexity warnings
- `npm run test:node` — full unit suite passes
- `npm run check:contract` — every webview message has a handler
- `npm run check:interaction` — every control in every panel still does something when clicked
- New tests: `collectSessionModelIds` union/ordering/`unknown`-drop cases in `recentSessions.test.ts`; the HydraFusion badge test in `usageWebviewMessageFlow.test.ts` now covers all four id variants plus the negative case

## Note

If HydraFusion turns out to be recorded under an id that doesn't start with the name at all (e.g. a vendor-prefixed catalog id), the badge still won't match — the exact raw id from the Models column would settle it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RKmhri9s6Hs7g7u4KGCitx

---
_Generated by [Claude Code](https://claude.ai/code/session_01RKmhri9s6Hs7g7u4KGCitx)_