### PR TITLE
fix(corrections): reduce false positives, add sentiment proxies

### DIFF
--- a/docs/features/CORRECTIONS.md
+++ b/docs/features/CORRECTIONS.md
@@ -12,11 +12,35 @@ agent**. It is the first step towards correction-driven insights about where age
 | `edit-retry` | Tool-call sequence | Repeat edit to a file whose immediately preceding tool call was an edit to the same file (same definition as model efficiency "retry") |
 | `edit-self-correction` | Tool-call sequence | Repeat edit to a file already edited in the same turn, with other tool calls in between (same definition as model efficiency "self-correction") |
 | `tool-error` | Tool result | A failed tool call (`success: false`); marked **retried** when the same tool is called again later in the session |
-| `agent-self-correction` | Assistant response text | Heuristic patterns: "my mistake", "let me fix", "you're right", "that failed", apologies, ... |
+| `agent-self-correction` | Assistant response text | Heuristic patterns: "my mistake", "let me fix", "you're right", "that failed", apologies, ... — **only counted when corroborated** by a `tool-error`, `edit-retry`/`edit-self-correction` in the same turn, or a `user-correction` in this turn or the one before it (see `corroboratedBy`) |
 
 The pattern-based detectors are **heuristics** — they produce candidates, not verdicts. The edit-based
 detectors intentionally share their definitions with `src/modelEfficiency.ts` so counts stay comparable
 with the model-efficiency counters.
+
+`agent-self-correction` phrasing ("let me fix", "you're right", ...) is extremely common narration even
+when nothing went wrong, so the bare phrase alone is not enough — it must be corroborated by an
+independent failure signal nearby (see the table above). This cut a large share of false positives found
+when the detector was run against real local sessions (see the "Precision notes" section below).
+
+`user-correction` matching skips auto-injected editor/tool notifications (e.g. VS Code's
+background-terminal "done" ping, which lands in the same `userMessage` field as a typed message but
+isn't authored by the human) — see `isHumanAuthored` in `src/correctionDetection.ts`.
+
+### Sentiment proxies
+
+No supported editor's session logs carry an actual sentiment/feedback score (there is no "the user
+rated this response" field anywhere), so two cheap proxies are layered on top of `user-correction`
+instead:
+
+- **`intensity: 'strong'`** — the message itself carries shouting (an ALL-CAPS word), repeated `!`/`?`,
+  or an intensifier ("again", "seriously", "for the last time").
+- **`escalated: true`** — this correction lands within `ESCALATION_WINDOW_TURNS` (4) turns of an earlier
+  one in the same session, i.e. corrections are clustering rather than one-off. `CorrectionCounts.
+  escalatedUserCorrections` and `CorrectionPeriodCounts.sessionsWithEscalations` aggregate this.
+
+Both are heuristics, not a verdict on how the user feels — they exist because no real signal is
+available, not as a replacement for one.
 
 ## Data flow
 
@@ -32,17 +56,20 @@ with the model-efficiency counters.
    - Copilot CLI JSONL: `user.message` / `assistant.message` text is accumulated onto the efficiency
      turns, and `tool.execution_complete` with `success: false` marks the turn's tool call as failed.
 3. Moments are cached per session in `SessionUsageAnalysis.correctionMoments` (inside the normal
-   `SessionFileCache`; `CACHE_VERSION` 65). `mergeUsageAnalysis` folds per-session moments into
+   `SessionFileCache`; `CACHE_VERSION` 71). `mergeUsageAnalysis` folds per-session moments into
    period-level `UsageAnalysisPeriod.corrections` counters.
 4. `CopilotTokenTracker.buildCorrectionReport()` regroups the already-parsed sessions **per
    repository** (`SessionFileCache.repository`), keeping each repo's **25 most recent sessions** with
    moments, and attaches the report to `UsageAnalysisStats.correctionReport`.
-5. The Usage Analysis webview renders the report in the Corrections tab; the insights engine reads
-   `last30Days.corrections` for two insights:
+5. The Usage Analysis webview renders the report in the Corrections tab (moments show a 📈 badge when
+   `escalated` and a 🔥 badge when `intensity: 'strong'`); the insights engine reads
+   `last30Days.corrections` for three insights:
    - `corrections-user-pushback` (≥ 3 user corrections in 30 days) — suggests capturing conventions in
      `copilot-instructions.md` / `AGENTS.md`;
    - `corrections-tool-errors` (≥ 5 tool errors or ≥ 10 edit retries/self-corrections in 30 days) —
-     points at recurring self-correction loops.
+     points at recurring self-correction loops;
+   - `corrections-user-escalation` (≥ 2 escalated corrections in 30 days) — corrections clustering
+     within a session, the closest local proxy to "this conversation is going badly".
 
 ## Coverage and limitations
 
@@ -52,6 +79,19 @@ with the model-efficiency counters.
 - Pattern-based matches can be false positives (e.g. "actually," starting a new request). Patterns
   live in `USER_CORRECTION_PATTERNS` / `AGENT_SELF_CORRECTION_PATTERNS` in `src/correctionDetection.ts` and
   are expected to be tuned as real reports are triaged.
+- English-only: phrasing patterns and intensity intensifiers ("again", "seriously", ...) don't match
+  corrections written in another language.
+
+### Precision notes (from running detection against real local sessions)
+
+Running the detector against real local VS Code Copilot Chat history surfaced two concrete false-positive
+sources, both addressed above:
+
+- `agent-self-correction` fired on completely routine task narration ("Let me fix this", "You're right")
+  far more often than on an actual recovered mistake — this is why it now requires corroboration.
+- Auto-injected editor notifications (e.g. a background-terminal "command finished" ping) landed in the
+  same field as a typed user message and matched boilerplate phrasing (e.g. "...or kill_terminal to
+  **stop** it.") as a `user-correction` — this is why those are now excluded before matching.
 
 ## Privacy
 

--- a/src/correctionDetection.ts
+++ b/src/correctionDetection.ts
@@ -20,11 +20,25 @@
  *                             (Copilot CLI JSONL). `retried` is set when the
  *                             same tool is called again later in the session.
  * - `agent-self-correction` — heuristic patterns on the assistant response text
- *                             ("my mistake", "let me fix", "you're right", ...).
+ *                             ("my mistake", "let me fix", "you're right", ...),
+ *                             only counted when corroborated by a tool-error,
+ *                             edit-retry, or user-correction nearby (see
+ *                             `corroboratedBy`) — the bare phrase alone is far
+ *                             too common in ordinary task narration.
  *
  * The pattern-based detectors are heuristics and intentionally cheap — they
  * produce candidates, not verdicts. The edit-based detectors share their
  * definitions with modelEfficiency.ts so counts stay comparable.
+ *
+ * No editor's session logs carry an actual sentiment/feedback score, so two
+ * cheap proxies are layered on top of `user-correction` instead: `intensity`
+ * (shouting/punctuation/intensifier cues on the message itself) and
+ * `escalated` (this correction lands within a few turns of the previous one,
+ * i.e. corrections are clustering rather than one-off).
+ *
+ * Auto-injected editor/tool notifications (e.g. VS Code's background-terminal
+ * "done" ping, which lands in the same field as a typed user message) are
+ * excluded from `user-correction` matching — see `isHumanAuthored`.
  *
  * This module is intentionally pure (no VS Code API, no filesystem access) so
  * it can be unit-tested with mocked data and reused by the CLI and the webview.
@@ -86,6 +100,36 @@ export const AGENT_SELF_CORRECTION_PATTERNS: CorrectionPattern[] = [
 	{ re: /\bcorrecting (my|that|the above)/i, label: "'correcting ...'" },
 ];
 
+/**
+ * Text cues that make a `user-correction` message read as more heated than a plain
+ * correction: shouting (an all-caps word), repeated `!`/`?`, or an explicit intensifier
+ * ("again", "seriously", "for the last time"). Purely a proxy — no sentiment data is
+ * available from any supported editor's session logs (see docs/features/CORRECTIONS.md).
+ */
+const INTENSITY_PATTERNS: RegExp[] = [
+	/\b[A-Z]{3,}\b/, // a shouted word, e.g. "STOP" or "WHY"
+	/[!?]{2,}/, // "??" / "!!" / "?!"
+	/\b(again|seriously|for the (last|third|second) time)\b/i,
+];
+
+function hasIntensityCue(text: string): boolean {
+	return INTENSITY_PATTERNS.some(re => re.test(text));
+}
+
+/**
+ * Matches editor/tool-injected notifications that land in the `userMessage` field
+ * without the user having typed anything — e.g. VS Code's background-terminal
+ * "notification" message auto-sent into chat when a long-running command finishes.
+ * Scanning these for correction phrases produces false positives (the boilerplate
+ * "...or kill_terminal to stop it." reads as a `stop ...` correction) because the text
+ * isn't authored by the human at all.
+ */
+const AUTO_NOTIFICATION_RE = /^\s*\[Terminal\b[^\]]*\bnotification\b/i;
+
+function isHumanAuthored(text: string | undefined): text is string {
+	return !!text && !AUTO_NOTIFICATION_RE.test(text);
+}
+
 // ---------------------------------------------------------------------------
 // Detection
 // ---------------------------------------------------------------------------
@@ -122,6 +166,8 @@ export interface CorrectionDetectionResult {
 
 interface CorrectionDetectionState extends CorrectionDetectionResult {
 	openToolErrors: Map<string, CorrectionMoment>;
+	/** Turn number of the most recent `user-correction` moment, for escalation clustering. */
+	lastUserCorrectionTurn: number | null;
 }
 
 function retainMoment(state: CorrectionDetectionState, moment: CorrectionMoment): void {
@@ -139,15 +185,17 @@ function retainMoment(state: CorrectionDetectionState, moment: CorrectionMoment)
 	}
 }
 
+/** Returns true when at least one edit-retry / edit-self-correction moment was recorded. */
 function detectEditMoments(
 	toolCalls: NonNullable<CorrectionTurn['toolCalls']>,
 	turnNumber: number,
 	timestamp: string | null,
 	state: CorrectionDetectionState
-): void {
+): boolean {
 	const editedFiles = new Set<string>();
 	let lastEditFile: string | null = null;
 	let unknownPathCounter = 0;
+	let found = false;
 
 	for (const call of toolCalls) {
 		if (!isEditToolName(call.toolName)) {
@@ -166,11 +214,20 @@ function detectEditMoments(
 				snippet: file ? `Re-edited ${file}` : 'Re-edited a file (path unknown)',
 				...(file ? { file } : {}),
 			});
+			found = true;
 		}
 		editedFiles.add(key);
 		lastEditFile = key;
 	}
+	return found;
 }
+
+/**
+ * Turns within this many turn-positions of an earlier `user-correction` count as the
+ * same "cluster" for escalation purposes — corrections this close together read as
+ * the user repeatedly pushing back rather than two unrelated one-off notes.
+ */
+const ESCALATION_WINDOW_TURNS = 4;
 
 /**
  * Detect all correction moments in a session's turns.
@@ -181,6 +238,7 @@ export function detectCorrectionAnalysis(turns: CorrectionTurn[]): CorrectionDet
 		moments: [],
 		counts: createEmptyCorrectionCounts(),
 		openToolErrors: new Map(),
+		lastUserCorrectionTurn: null,
 	};
 
 	for (let i = 0; i < turns.length; i++) {
@@ -188,25 +246,27 @@ export function detectCorrectionAnalysis(turns: CorrectionTurn[]): CorrectionDet
 		const turnNumber = i + 1;
 		const timestamp = turn.timestamp ?? null;
 
-		const userMatch = matchPattern(turn.userMessage, USER_CORRECTION_PATTERNS);
+		// Auto-injected editor/tool notifications (e.g. a background-terminal "done" ping)
+		// aren't authored by the user — skip them so their boilerplate text can't match a
+		// correction phrase.
+		const userText = isHumanAuthored(turn.userMessage) ? turn.userMessage : undefined;
+		const prevTurnHadUserCorrection = state.lastUserCorrectionTurn === turnNumber - 1;
+
+		const userMatch = matchPattern(userText, USER_CORRECTION_PATTERNS);
 		if (userMatch) {
+			const escalated = state.lastUserCorrectionTurn !== null && turnNumber - state.lastUserCorrectionTurn <= ESCALATION_WINDOW_TURNS;
 			retainMoment(state, {
 				type: 'user-correction', turnNumber, timestamp,
-				snippet: makeSnippet(turn.userMessage!, userMatch.index),
+				snippet: makeSnippet(userText!, userMatch.index),
 				matchedPattern: userMatch.label,
+				...(hasIntensityCue(userText!) ? { intensity: 'strong' } : {}),
+				...(escalated ? { escalated: true } : {}),
 			});
-		}
-
-		const agentMatch = matchPattern(turn.assistantResponse, AGENT_SELF_CORRECTION_PATTERNS);
-		if (agentMatch) {
-			retainMoment(state, {
-				type: 'agent-self-correction', turnNumber, timestamp,
-				snippet: makeSnippet(turn.assistantResponse!, agentMatch.index),
-				matchedPattern: agentMatch.label,
-			});
+			state.lastUserCorrectionTurn = turnNumber;
 		}
 
 		const toolCalls = turn.toolCalls ?? [];
+		let turnHasToolError = false;
 		for (const call of toolCalls) {
 			// A later call of the same tool marks an earlier failure as recovered.
 			const openError = state.openToolErrors.get(call.toolName);
@@ -224,10 +284,34 @@ export function detectCorrectionAnalysis(turns: CorrectionTurn[]): CorrectionDet
 				};
 				retainMoment(state, moment);
 				state.openToolErrors.set(call.toolName, moment);
+				turnHasToolError = true;
 			}
 		}
 
-		detectEditMoments(toolCalls, turnNumber, timestamp, state);
+		const turnHasEditRetry = detectEditMoments(toolCalls, turnNumber, timestamp, state);
+
+		// agent-self-correction phrasing ("let me fix", "you're right", ...) is extremely
+		// common narration even when nothing actually went wrong, so it's only counted as a
+		// correction moment when corroborated by an independent signal: a tool failure or
+		// edit-retry in this turn, or a user-correction just before/in this turn.
+		const agentMatch = matchPattern(turn.assistantResponse, AGENT_SELF_CORRECTION_PATTERNS);
+		if (agentMatch) {
+			const corroboratedBy: CorrectionMoment['corroboratedBy'] = turnHasToolError
+				? 'tool-error'
+				: turnHasEditRetry
+					? 'edit-retry'
+					: (prevTurnHadUserCorrection || userMatch !== null)
+						? 'user-correction'
+						: undefined;
+			if (corroboratedBy) {
+				retainMoment(state, {
+					type: 'agent-self-correction', turnNumber, timestamp,
+					snippet: makeSnippet(turn.assistantResponse!, agentMatch.index),
+					matchedPattern: agentMatch.label,
+					corroboratedBy,
+				});
+			}
+		}
 	}
 
 	state.moments.sort((a, b) => a.turnNumber - b.turnNumber);
@@ -243,13 +327,16 @@ export function detectCorrectionMoments(turns: CorrectionTurn[]): CorrectionMome
 // ---------------------------------------------------------------------------
 
 export function createEmptyCorrectionCounts(): CorrectionCounts {
-	return { userCorrections: 0, editRetries: 0, editSelfCorrections: 0, toolErrors: 0, toolErrorsRetried: 0, agentSelfCorrections: 0 };
+	return { userCorrections: 0, editRetries: 0, editSelfCorrections: 0, toolErrors: 0, toolErrorsRetried: 0, agentSelfCorrections: 0, escalatedUserCorrections: 0 };
 }
 
 /** Fold one moment into the counter bucket. */
 export function addMomentToCounts(counts: CorrectionCounts, moment: CorrectionMoment): void {
 	switch (moment.type) {
-		case 'user-correction': counts.userCorrections++; break;
+		case 'user-correction':
+			counts.userCorrections++;
+			if (moment.escalated) { counts.escalatedUserCorrections++; }
+			break;
 		case 'edit-retry': counts.editRetries++; break;
 		case 'edit-self-correction': counts.editSelfCorrections++; break;
 		case 'tool-error':
@@ -276,4 +363,5 @@ export function mergeCorrectionCounts(target: CorrectionCounts, source: Correcti
 	target.toolErrors += source.toolErrors;
 	target.toolErrorsRetried += source.toolErrorsRetried;
 	target.agentSelfCorrections += source.agentSelfCorrections;
+	target.escalatedUserCorrections += source.escalatedUserCorrections;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -608,6 +608,26 @@ export interface CorrectionMoment {
   retried?: boolean;
   /** Label of the heuristic pattern that matched (pattern-based types only). */
   matchedPattern?: string;
+  /**
+   * `user-correction` only: set when the message itself carries extra intensity cues
+   * (ALL-CAPS emphasis, repeated `!`/`?`, "again"/"seriously"-style intensifiers) on top
+   * of the base correction phrasing. A rough proxy for "the user sounds more frustrated
+   * than a plain correction", not a verdict.
+   */
+  intensity?: 'strong';
+  /**
+   * `user-correction` only: set when this is the second (or later) user-correction
+   * within a short rolling window of turns, i.e. corrections are clustering rather than
+   * being one-off — the closest local proxy for rising frustration we can compute
+   * without any external sentiment data.
+   */
+  escalated?: boolean;
+  /**
+   * `agent-self-correction` only: which nearby signal corroborated the phrase match.
+   * `agent-self-correction` moments are only emitted when corroborated (see
+   * correctionDetection.ts) — this records why, mainly for UI/debugging transparency.
+   */
+  corroboratedBy?: 'tool-error' | 'edit-retry' | 'user-correction';
 }
 
 /** Aggregated correction-moment counters (per session, repo, or period). */
@@ -618,6 +638,8 @@ export interface CorrectionCounts {
   toolErrors: number;
   toolErrorsRetried: number;
   agentSelfCorrections: number;
+  /** Count of `user-correction` moments with `escalated: true` (see CorrectionMoment). */
+  escalatedUserCorrections: number;
 }
 
 /** Period-level correction counters plus the number of sessions that had any moment. */
@@ -625,6 +647,8 @@ export interface CorrectionPeriodCounts extends CorrectionCounts {
   sessionsWithMoments: number;
   /** Sessions containing at least one user-correction moment. */
   sessionsWithUserCorrections?: number;
+  /** Sessions containing at least one escalated user-correction moment. */
+  sessionsWithEscalations?: number;
 }
 
 /** One session's entry in the correction report. */

--- a/src/usageAnalysis.ts
+++ b/src/usageAnalysis.ts
@@ -1364,12 +1364,13 @@ export function mergeUsageAnalysis(period: UsageAnalysisPeriod, analysis: Sessio
 function _muaMergeCorrections(period: UsageAnalysisPeriod, analysis: SessionUsageAnalysis): void {
 	if (!analysis.correctionMoments || analysis.correctionMoments.length === 0) { return; }
 	if (!period.corrections) {
-		period.corrections = { userCorrections: 0, editRetries: 0, editSelfCorrections: 0, toolErrors: 0, toolErrorsRetried: 0, agentSelfCorrections: 0, sessionsWithMoments: 0, sessionsWithUserCorrections: 0 };
+		period.corrections = { userCorrections: 0, editRetries: 0, editSelfCorrections: 0, toolErrors: 0, toolErrorsRetried: 0, agentSelfCorrections: 0, escalatedUserCorrections: 0, sessionsWithMoments: 0, sessionsWithUserCorrections: 0, sessionsWithEscalations: 0 };
 	}
 	const counts = analysis.correctionCounts ?? summarizeCorrectionMoments(analysis.correctionMoments);
 	mergeCorrectionCounts(period.corrections, counts);
 	period.corrections.sessionsWithMoments++;
 	if (counts.userCorrections > 0) { period.corrections.sessionsWithUserCorrections!++; }
+	if (counts.escalatedUserCorrections > 0) { period.corrections.sessionsWithEscalations!++; }
 }
 
 /** @internal lookup table for analyzeContextReferences */

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -510,9 +510,10 @@ function isUsageAnalysisTab(tab: string): tab is UsageAnalysisTab {
 
 class CopilotTokenTracker implements vscode.Disposable {
 	// Cache version - increment this when making changes that require cache invalidation.
-	// The merged task-classification + chart-state work changes cached session metadata and
-	// daily rollup contracts, so invalidate older entries to force a clean rebuild.
-	private static readonly CACHE_VERSION = 70;
+	// Correction detection now requires corroboration for agent-self-correction moments and
+	// adds intensity/escalation fields to user-correction moments — old cached moments were
+	// computed under the previous (uncorroborated) logic and lack these fields.
+	private static readonly CACHE_VERSION = 71;
 	/** Initial stats should not wait indefinitely for one inaccessible or stalled session. */
 	private static readonly SESSION_PRELOAD_TIMEOUT_MS = 15_000;
 	// Maximum length for displaying workspace IDs in diagnostics/customization matrix

--- a/vscode-extension/src/insightsEngine.ts
+++ b/vscode-extension/src/insightsEngine.ts
@@ -1399,6 +1399,26 @@ export const INSIGHT_CATALOG: InsightDefinition[] = [
 		weight: 55,
 	},
 	{
+		id: 'corrections-user-escalation',
+		category: 'customization',
+		severity: 'opportunity',
+		title: '📈 Corrections are clustering, not one-off',
+		buildBody: (ctx) => {
+			const c = ctx.last30Days.corrections;
+			const escalated = c?.escalatedUserCorrections ?? 0;
+			const sessions = c?.sessionsWithEscalations ?? 0;
+			return `In the last 30 days, ${escalated} correction${escalated !== 1 ? 's' : ''} landed within a few turns of ` +
+				`an earlier one in the same session, across ${sessions} session${sessions !== 1 ? 's' : ''} — no single editor records a real ` +
+				`sentiment score, but repeated back-to-back pushback is the closest local signal we have to "this conversation is going badly". ` +
+				`When you see this, it's often faster to stop, restate the goal or constraint clearly, and start a fresh turn than to keep correcting course. ` +
+				`See the Corrections tab (moments marked 📈) for exactly where.`;
+		},
+		actionLabel: 'View Corrections',
+		actionCommand: 'aiEngineeringFluency.openCorrectionsTab',
+		appliesTo: (ctx) => (ctx.last30Days.corrections?.escalatedUserCorrections ?? 0) >= 2,
+		weight: 60,
+	},
+	{
 		id: 'repeated-task-skill-candidate',
 		category: 'customization',
 		severity: 'opportunity',

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -123,6 +123,12 @@ type CorrectionMoment = {
 	file?: string;
 	retried?: boolean;
 	matchedPattern?: string;
+	/** `user-correction` only: shouting/punctuation/intensifier cues on the message itself. */
+	intensity?: 'strong';
+	/** `user-correction` only: clustered with an earlier correction a few turns back. */
+	escalated?: boolean;
+	/** `agent-self-correction` only: which nearby signal corroborated the phrase match. */
+	corroboratedBy?: 'tool-error' | 'edit-retry' | 'user-correction';
 };
 
 type CorrectionCounts = {
@@ -132,6 +138,7 @@ type CorrectionCounts = {
 	toolErrors: number;
 	toolErrorsRetried: number;
 	agentSelfCorrections: number;
+	escalatedUserCorrections: number;
 };
 
 type CorrectionSessionEntry = {
@@ -1706,6 +1713,9 @@ function sanitizeCorrectionMoment(raw: any): CorrectionMoment | null {
 		file: typeof raw.file === 'string' ? raw.file : undefined,
 		retried: raw.retried === true ? true : undefined,
 		matchedPattern: typeof raw.matchedPattern === 'string' ? raw.matchedPattern : undefined,
+		intensity: raw.intensity === 'strong' ? 'strong' : undefined,
+		escalated: raw.escalated === true ? true : undefined,
+		corroboratedBy: ['tool-error', 'edit-retry', 'user-correction'].includes(raw.corroboratedBy) ? raw.corroboratedBy : undefined,
 	};
 }
 
@@ -1718,6 +1728,7 @@ function sanitizeCorrectionCounts(raw: any): CorrectionCounts {
 		toolErrors: num(raw?.toolErrors),
 		toolErrorsRetried: num(raw?.toolErrorsRetried),
 		agentSelfCorrections: num(raw?.agentSelfCorrections),
+		escalatedUserCorrections: num(raw?.escalatedUserCorrections),
 	};
 }
 
@@ -3540,9 +3551,16 @@ function buildCorrectionMomentHtml(moment: CorrectionMoment, sessionFile: string
 	const detail = moment.type === 'tool-error'
 		? `tool \`${moment.tool ?? '?'}\`${moment.retried ? ' — retried shortly after' : ''}`
 		: (moment.matchedPattern ? `matched ${moment.matchedPattern}` : '');
+	const escalationBadge = moment.escalated
+		? `<span title="Clustered with an earlier correction a few turns back" style="flex-shrink:0; font-size:10px; font-weight:700; padding:2px 8px; border-radius:10px; border:1px solid rgba(248,113,113,0.85); color:var(--text-primary); background:rgba(248,113,113,0.12); white-space:nowrap;">📈 escalating</span>`
+		: '';
+	const intensityBadge = moment.intensity === 'strong'
+		? `<span title="Shouting / repeated punctuation / an intensifier like &quot;again&quot;" style="flex-shrink:0; font-size:10px; font-weight:700; padding:2px 8px; border-radius:10px; border:1px solid rgba(248,113,113,0.85); color:var(--text-primary); background:rgba(248,113,113,0.12); white-space:nowrap;">🔥 intense</span>`
+		: '';
 	return `
 		<button type="button" class="correction-moment" data-correction-file="${escapeHtml(sessionFile)}" data-correction-turn="${moment.turnNumber}" title="Open this turn in the session log viewer" style="display:flex; width:100%; gap:10px; align-items:flex-start; padding:8px 0; border:0; border-bottom:1px solid var(--bg-tertiary); background:none; color:inherit; cursor:pointer; text-align:left;">
 			<span style="flex-shrink:0; font-size:10px; font-weight:700; letter-spacing:0.03em; padding:2px 8px; border-radius:10px; border:1px solid ${meta.color}; color:var(--text-primary); background:${meta.color.replace('0.85', '0.12')}; white-space:nowrap;">${escapeHtml(meta.label)}</span>
+			${escalationBadge}${intensityBadge}
 			<div style="flex:1; min-width:0;">
 				<div style="font-size:12px; color:var(--text-primary); opacity:0.9; overflow-wrap:anywhere;">${escapeHtml(moment.snippet)}</div>
 				<div style="font-size:11px; color:var(--text-secondary); margin-top:3px;">
@@ -3607,6 +3625,9 @@ function buildCorrectionsTabPanelHtml(report: CorrectionReport | null | undefine
 		chip(c.editSelfCorrections, 'edit self-corrections', 'edit-self-correction'),
 		chip(c.agentSelfCorrections, 'agent self-corrections', 'agent-self-correction'),
 	].filter(Boolean).join(' ');
+	const escalationNote = c.escalatedUserCorrections > 0
+		? `<span title="Corrections landing within a few turns of an earlier one — no sentiment data is available from any editor, this is the closest local proxy for rising frustration" style="font-size:11px; padding:2px 10px; border-radius:10px; background:rgba(248,113,113,0.12); border:1px solid rgba(248,113,113,0.85); color:var(--text-primary);">📈 ${c.escalatedUserCorrections} escalating</span>`
+		: '';
 
 	const repoSections = report.repos.map(repo => {
 		const sessions = repo.sessions
@@ -3641,7 +3662,7 @@ function buildCorrectionsTabPanelHtml(report: CorrectionReport | null | undefine
 					sessions without corrections are not listed. Summary counts include all detected moments; long sessions show a capped detail sample.
 					Pattern-based matches are candidates, not verdicts; open the session in the log viewer for full context.
 				</div>
-				<div style="display:flex; flex-wrap:wrap; gap:6px; margin-top:12px;">${summaryChips}</div>
+				<div style="display:flex; flex-wrap:wrap; gap:6px; margin-top:12px;">${summaryChips}${escalationNote}</div>
 				${repoSections}
 				${emptyFilteredState}
 			</div>

--- a/vscode-extension/test/unit/correctionDetection.test.ts
+++ b/vscode-extension/test/unit/correctionDetection.test.ts
@@ -76,7 +76,7 @@ test('user-correction: leaves ordinary requests alone', () => {
 // agent-self-correction
 // ---------------------------------------------------------------------------
 
-test('agent-self-correction: detects admission phrasings', () => {
+test('agent-self-correction: detects admission phrasings when corroborated by a tool error', () => {
     const cases = [
         'Let me fix that for you.',
         'My mistake — the path was wrong.',
@@ -87,15 +87,130 @@ test('agent-self-correction: detects admission phrasings', () => {
         'I incorrectly assumed the file existed.',
     ];
     for (const response of cases) {
-        const moments = detectCorrectionMoments([{ assistantResponse: response }]);
-        assert.equal(moments.length, 1, `"${response}" should produce one moment`);
-        assert.equal(moments[0].type, 'agent-self-correction');
+        const moments = detectCorrectionMoments([{
+            assistantResponse: response,
+            toolCalls: [{ toolName: 'run', isError: true }],
+        }]);
+        const selfCorrections = moments.filter(m => m.type === 'agent-self-correction');
+        assert.equal(selfCorrections.length, 1, `"${response}" should produce one moment`);
+        assert.equal(selfCorrections[0].corroboratedBy, 'tool-error');
     }
 });
 
 test('agent-self-correction: leaves ordinary responses alone', () => {
     const moments = detectCorrectionMoments([{ assistantResponse: 'Done — I added the login page and tests pass.' }]);
     assert.equal(moments.length, 0);
+});
+
+test('agent-self-correction: an uncorroborated phrase (routine narration) produces no moment', () => {
+    // "Let me fix" etc. are extremely common even when nothing went wrong — without a
+    // nearby tool-error, edit-retry, or user-correction, it's just task narration.
+    const moments = detectCorrectionMoments([{ assistantResponse: 'Let me fix the imports while I am in this file.' }]);
+    assert.equal(moments.length, 0);
+});
+
+test('agent-self-correction: corroborated by an edit-retry in the same turn', () => {
+    const moments = detectCorrectionMoments([{
+        assistantResponse: 'Let me fix that.',
+        toolCalls: [editCall('/a.ts'), editCall('/a.ts')],
+    }]);
+    const selfCorrection = moments.find(m => m.type === 'agent-self-correction');
+    assert.ok(selfCorrection, 'should be corroborated by the edit-retry');
+    assert.equal(selfCorrection!.corroboratedBy, 'edit-retry');
+});
+
+test('agent-self-correction: corroborated by a user-correction in the previous turn', () => {
+    const turns: CorrectionTurn[] = [
+        { userMessage: 'no, that is wrong' },
+        { assistantResponse: 'My mistake, let me fix it.' },
+    ];
+    const moments = detectCorrectionMoments(turns);
+    const selfCorrection = moments.find(m => m.type === 'agent-self-correction');
+    assert.ok(selfCorrection, 'should be corroborated by the previous turn\'s user-correction');
+    assert.equal(selfCorrection!.corroboratedBy, 'user-correction');
+});
+
+test('agent-self-correction: a user-correction two turns earlier does not corroborate', () => {
+    const turns: CorrectionTurn[] = [
+        { userMessage: 'no, that is wrong' },
+        { userMessage: 'add a login page' },
+        { assistantResponse: 'My mistake, let me fix it.' },
+    ];
+    const moments = detectCorrectionMoments(turns);
+    assert.equal(moments.some(m => m.type === 'agent-self-correction'), false);
+});
+
+// ---------------------------------------------------------------------------
+// auto-injected notifications (not authored by the human)
+// ---------------------------------------------------------------------------
+
+test('user-correction: ignores auto-injected terminal notifications', () => {
+    // VS Code auto-sends a "[Terminal ... notification: ...]" message into chat when a
+    // background command finishes — this is not something the user typed, and its
+    // boilerplate ("...or kill_terminal to stop it.") would otherwise read as a correction.
+    const notification = '[Terminal 0f67ade5 notification: command completed with exit code 1. ' +
+        'Use send_to_terminal to send another command or kill_terminal to stop it.]\nTerminal output:\n...';
+    const moments = detectCorrectionMoments([{ userMessage: notification }]);
+    assert.equal(moments.length, 0);
+});
+
+test('user-correction: a real message starting with "no" alongside pasted terminal output still fires', () => {
+    const moments = detectCorrectionMoments([{ userMessage: 'no, restart the dev server\n[some pasted log output]' }]);
+    assert.equal(moments.length, 1);
+    assert.equal(moments[0].type, 'user-correction');
+});
+
+// ---------------------------------------------------------------------------
+// intensity
+// ---------------------------------------------------------------------------
+
+test('user-correction: flags intensity cues (shouting, repeated punctuation, intensifiers)', () => {
+    const cases = [
+        'STOP, that is not what I asked for',
+        "that's wrong again??",
+        'stop doing that, seriously',
+    ];
+    for (const message of cases) {
+        const [moment] = detectCorrectionMoments([{ userMessage: message }]);
+        assert.equal(moment.intensity, 'strong', `"${message}" should be flagged as strong intensity`);
+    }
+});
+
+test('user-correction: a plain correction has no intensity flag', () => {
+    const [moment] = detectCorrectionMoments([{ userMessage: 'no, use the other endpoint please' }]);
+    assert.equal(moment.intensity, undefined);
+});
+
+// ---------------------------------------------------------------------------
+// escalation
+// ---------------------------------------------------------------------------
+
+test('user-correction: clustering corrections are marked escalated', () => {
+    const turns: CorrectionTurn[] = [
+        { userMessage: 'no, wrong file' },
+        { userMessage: 'add a test' },
+        { userMessage: 'no, that is still not right' },
+        { userMessage: 'stop changing that' },
+    ];
+    const result = detectCorrectionAnalysis(turns);
+    const userCorrections = result.moments.filter(m => m.type === 'user-correction').sort((a, b) => a.turnNumber - b.turnNumber);
+    assert.equal(userCorrections.length, 3);
+    assert.equal(userCorrections[0].escalated, undefined, 'the first correction has nothing to escalate from');
+    assert.equal(userCorrections[1].escalated, true);
+    assert.equal(userCorrections[2].escalated, true);
+    assert.equal(result.counts.escalatedUserCorrections, 2);
+});
+
+test('user-correction: corrections far apart are not escalated', () => {
+    const turns: CorrectionTurn[] = [
+        { userMessage: 'no, wrong file' },
+        ...Array.from({ length: 10 }, () => ({ userMessage: 'add another feature' })),
+        { userMessage: 'no, that is still not right' },
+    ];
+    const result = detectCorrectionAnalysis(turns);
+    const userCorrections = result.moments.filter(m => m.type === 'user-correction');
+    assert.equal(userCorrections.every(m => !m.escalated), true);
+    assert.equal(result.counts.escalatedUserCorrections, 0);
 });
 
 // ---------------------------------------------------------------------------
@@ -272,9 +387,9 @@ test('mergeCorrectionCounts: sums all fields and tolerates undefined', () => {
     const target = createEmptyCorrectionCounts();
     mergeCorrectionCounts(target, undefined);
     assert.deepEqual(target, createEmptyCorrectionCounts());
-    mergeCorrectionCounts(target, { userCorrections: 2, editRetries: 1, editSelfCorrections: 0, toolErrors: 3, toolErrorsRetried: 2, agentSelfCorrections: 1 });
-    mergeCorrectionCounts(target, { userCorrections: 1, editRetries: 0, editSelfCorrections: 4, toolErrors: 0, toolErrorsRetried: 0, agentSelfCorrections: 0 });
-    assert.deepEqual(target, { userCorrections: 3, editRetries: 1, editSelfCorrections: 4, toolErrors: 3, toolErrorsRetried: 2, agentSelfCorrections: 1 });
+    mergeCorrectionCounts(target, { userCorrections: 2, editRetries: 1, editSelfCorrections: 0, toolErrors: 3, toolErrorsRetried: 2, agentSelfCorrections: 1, escalatedUserCorrections: 1 });
+    mergeCorrectionCounts(target, { userCorrections: 1, editRetries: 0, editSelfCorrections: 4, toolErrors: 0, toolErrorsRetried: 0, agentSelfCorrections: 0, escalatedUserCorrections: 0 });
+    assert.deepEqual(target, { userCorrections: 3, editRetries: 1, editSelfCorrections: 4, toolErrors: 3, toolErrorsRetried: 2, agentSelfCorrections: 1, escalatedUserCorrections: 1 });
 });
 
 test('pattern catalogs stay non-empty and well-formed', () => {

--- a/vscode-extension/test/unit/insightsEngine.test.ts
+++ b/vscode-extension/test/unit/insightsEngine.test.ts
@@ -721,7 +721,7 @@ test('mode-diversity-low: does NOT fire with too little data', () => {
 // ---------------------------------------------------------------------------
 
 function emptyCorrections() {
-	return { userCorrections: 0, editRetries: 0, editSelfCorrections: 0, toolErrors: 0, toolErrorsRetried: 0, agentSelfCorrections: 0, sessionsWithMoments: 0 };
+	return { userCorrections: 0, editRetries: 0, editSelfCorrections: 0, toolErrors: 0, toolErrorsRetried: 0, agentSelfCorrections: 0, escalatedUserCorrections: 0, sessionsWithMoments: 0 };
 }
 
 test('corrections-user-pushback: fires at >= 3 user corrections', () => {
@@ -761,6 +761,24 @@ test('corrections-tool-errors: does NOT fire on low volume or missing data', () 
 	low.last30Days.corrections = { ...emptyCorrections(), toolErrors: 4, editRetries: 4, sessionsWithMoments: 2 };
 	assert.equal(evaluateInsights(low, {}, 7, null).find(i => i.id === 'corrections-tool-errors'), undefined);
 	assert.equal(evaluateInsights(makeCtx(), {}, 7, null).find(i => i.id === 'corrections-tool-errors'), undefined);
+});
+
+test('corrections-user-escalation: fires at >= 2 escalated corrections', () => {
+	const ctx = makeCtx();
+	ctx.last30Days.corrections = { ...emptyCorrections(), userCorrections: 3, escalatedUserCorrections: 2, sessionsWithMoments: 2, sessionsWithEscalations: 1 };
+	const results = evaluateInsights(ctx, {}, 7, null);
+	const insight = results.find(i => i.id === 'corrections-user-escalation');
+	assert.ok(insight, 'should fire at the threshold');
+	assert.match(insight.body, /2 corrections/);
+	assert.match(insight.body, /across 1 session/);
+	assert.equal(insight.actionCommand, 'aiEngineeringFluency.openCorrectionsTab');
+});
+
+test('corrections-user-escalation: does NOT fire below the threshold or without data', () => {
+	const below = makeCtx();
+	below.last30Days.corrections = { ...emptyCorrections(), userCorrections: 1, escalatedUserCorrections: 1, sessionsWithMoments: 1 };
+	assert.equal(evaluateInsights(below, {}, 7, null).find(i => i.id === 'corrections-user-escalation'), undefined);
+	assert.equal(evaluateInsights(makeCtx(), {}, 7, null).find(i => i.id === 'corrections-user-escalation'), undefined);
 });
 
 // ---------------------------------------------------------------------------

--- a/vscode-extension/test/unit/usageAnalysis.test.ts
+++ b/vscode-extension/test/unit/usageAnalysis.test.ts
@@ -184,13 +184,14 @@ test('mergeUsageAnalysis: uses uncapped correction counts and tracks user-correc
     }];
     analysis.correctionCounts = {
         userCorrections: 2, editRetries: 60, editSelfCorrections: 4,
-        toolErrors: 70, toolErrorsRetried: 50, agentSelfCorrections: 1,
+        toolErrors: 70, toolErrorsRetried: 50, agentSelfCorrections: 1, escalatedUserCorrections: 1,
     };
     mergeUsageAnalysis(period, analysis);
     assert.equal(period.corrections?.editRetries, 60);
     assert.equal(period.corrections?.toolErrors, 70);
     assert.equal(period.corrections?.sessionsWithMoments, 1);
     assert.equal(period.corrections?.sessionsWithUserCorrections, 1);
+    assert.equal(period.corrections?.sessionsWithEscalations, 1);
 });
 
 test('mergeModelEfficiencyTokens: folds per-session model usage tokens and cost into the period', () => {


### PR DESCRIPTION
## Summary
- `agent-self-correction` no longer fires on bare phrasing ("let me fix", "you're right") — it now requires corroboration by a nearby `tool-error`, `edit-retry`/`edit-self-correction`, or `user-correction`. Running detection against real local sessions showed the bare phrase alone was routine task narration far more often than an actual recovered mistake.
- `user-correction` skips auto-injected editor/tool notifications (e.g. VS Code's background-terminal "command finished" ping) that land in the same field as a typed message but aren't authored by the user — this was matching boilerplate like "...or kill_terminal to stop it." as a correction.
- Added `intensity: 'strong'` (shouting/repeated punctuation/intensifiers) and `escalated` (clustering with an earlier correction within a few turns) on `user-correction` moments, plus a new `corrections-user-escalation` insight — the closest local proxy available for "this conversation is going badly", since no supported editor's session logs carry an actual sentiment/feedback score.
- Corrections tab shows 📈/🔥 badges for escalated/intense moments; `CACHE_VERSION` bumped so stale cached moments (computed under the old logic) are recomputed.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `correctionDetection.test.ts` — 32/32 (new tests cover corroboration, noise filtering, intensity, escalation)
- [x] `insightsEngine.test.ts` — 75/75 (new tests for `corrections-user-escalation`)
- [x] `usageAnalysis.test.ts` — 187/187
- [x] `eslint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)