### PR TITLE
fix(vscode-extension): pin @types/vscode back to 1.134.0 to keep engines.vscode at ^1.134.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,11 +19,16 @@ updates:
     labels:
       - "dependencies"
       - "npm"
-    # Group minor and patch updates to reduce PR noise
+    # Group minor and patch updates to reduce PR noise.
+    # @types/vscode is excluded so its minor/patch bumps always land as their
+    # own PR — grouping it with everything else let a bump silently outrun
+    # engines.vscode and break the nightly VS Code packaging check.
     groups:
       minor-and-patch-updates:
         patterns:
           - "*"
+        exclude-patterns:
+          - "@types/vscode"
         update-types:
           - "minor"
           - "patch"

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -31,7 +31,7 @@
         "@types/mocha": "^10.0.10",
         "@types/node": "^26.4.1",
         "@types/sql.js": "1.4.11",
-        "@types/vscode": "1.136.0",
+        "@types/vscode": "1.134.0",
         "@typescript-eslint/eslint-plugin": "^8.69.0",
         "@typescript-eslint/parser": "^8.42.0",
         "@vscode/vsce": "^3.7.1",
@@ -3771,9 +3771,9 @@
       "license": "MIT"
     },
     "node_modules/@types/vscode": {
-      "version": "1.136.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.136.0.tgz",
-      "integrity": "sha512-DO746VAfnHk8+Y8CsUKYMm2rjWD0mxEuYBZI+ssaqJY7yvLJPf9lcwxSSz9W60gbdvdcGyvHQxHTyByfF9mVqg==",
+      "version": "1.134.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.134.0.tgz",
+      "integrity": "sha512-NDEu0hg4sF7+vvFsADsktqUJ6f80LHSZvVK2Ovo1XiQ0/VHck1O3zst+ZZyVA/uvz6vo6LcuoqU2q48YMqOwWw==",
       "dev": true,
       "license": "MIT"
     },

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -6,7 +6,7 @@
   "publisher": "RobBos",
   "icon": "assets/logo.png",
   "engines": {
-    "vscode": "^1.134.0"
+    "vscode": "^1.136.0"
   },
   "repository": {
     "type": "git",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -6,7 +6,7 @@
   "publisher": "RobBos",
   "icon": "assets/logo.png",
   "engines": {
-    "vscode": "^1.136.0"
+    "vscode": "^1.134.0"
   },
   "repository": {
     "type": "git",
@@ -561,7 +561,7 @@
     "@types/mocha": "^10.0.10",
     "@types/node": "^26.4.1",
     "@types/sql.js": "1.4.11",
-    "@types/vscode": "1.136.0",
+    "@types/vscode": "1.134.0",
     "@typescript-eslint/eslint-plugin": "^8.69.0",
     "@typescript-eslint/parser": "^8.42.0",
     "@vscode/vsce": "^3.7.1",


### PR DESCRIPTION
## Summary

The [nightly VS Code Pre-Release workflow](https://github.com/rajbos/ai-engineering-fluency/actions/runs/34178680702) failed with:

```
##[error]@types/vscode 1.136.0 greater than engines.vscode ^1.134.0. Either upgrade engines.vscode or use an older @types/vscode version
```

A prior Dependabot grouped update (`d4e557f`) bumped `@types/vscode` from `1.134.0` to `1.136.0` but left `engines.vscode` unchanged, which `vsce`'s packaging check rejects.

**Approach**: pin `@types/vscode` back down to `1.134.0` (matching the existing `engines.vscode` floor), rather than raising `engines.vscode` to `^1.136.0`. Raising the floor would have newly excluded every user still on VS Code 1.134-1.135 for no functional reason — nothing in the codebase actually uses any 1.135/1.136-only API. `tsc --noEmit` and a local `vsce package` run are both clean against the pinned-back types, confirming that.

- `vscode-extension/package.json` / `package-lock.json`: `@types/vscode` `1.136.0` → `1.134.0`.
- `.github/dependabot.yml`: `@types/vscode` excluded from the `minor-and-patch-updates` group so future type bumps always land as their own PR. That's what gives a human the chance to decide, bump by bump, whether raising `engines.vscode` is actually warranted — instead of a types-only bump silently outrunning the declared minimum again.

## Test plan

- [x] Confirmed the original failure via the workflow run logs
- [x] `tsc --noEmit` passes against `@types/vscode@1.134.0`
- [x] Local `vsce package` run completes without the engines/types mismatch error
- [ ] Nightly VS Code Pre-Release workflow passes on next scheduled/manual run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Euid3n5qmaj2sPr1uA9K31