### PR TITLE
feat(efficiency): detect and explain prompt-cache breakage

### DIFF
--- a/.github/skills/visual-view-diff/fixtures/efficiency.json
+++ b/.github/skills/visual-view-diff/fixtures/efficiency.json
@@ -232,5 +232,30 @@
   "lastUpdated": "2026-03-14T09:30:00.000Z",
   "backendConfigured": false,
   "compactNumbers": false,
-  "isDebugMode": false
+  "isDebugMode": false,
+  "cacheBreakage": {
+    "counts": {
+      "model-switch": {
+        "breaks": 9,
+        "tokensRewritten": 1176903
+      },
+      "compaction": {
+        "breaks": 1,
+        "tokensRewritten": 609190
+      },
+      "ttl-expiry": {
+        "breaks": 34,
+        "tokensRewritten": 5222994
+      },
+      "prefix-invalidated": {
+        "breaks": 8,
+        "tokensRewritten": 1394384
+      }
+    },
+    "sessionsAnalyzed": 62,
+    "sessionsWithBreaks": 29,
+    "tokensWritten": 15892222,
+    "peakContextTokens": 9264875,
+    "worstRewriteFactor": 6.26
+  }
 }

--- a/src/adapters/claudeCodeAdapter.ts
+++ b/src/adapters/claudeCodeAdapter.ts
@@ -315,7 +315,12 @@ export class ClaudeCodeAdapter implements IEcosystemAdapter, IDiscoverableEcosys
 			} else if (event.type === 'system' && event.subtype === 'compact_boundary') {
 				this.processCompactBoundaryEvent(event, analysis);
 			}
+		}
 		if (cacheTurns.size > 0) {
+			// Map iteration is insertion order, which is only approximately chronological —
+			// a late-arriving streaming fragment of an earlier message can land after a
+			// newer one. detectCacheBreakage compares each turn to its predecessor, so the
+			// turns must be in true timestamp order first.
 			const orderedTurns = [...cacheTurns.values()].sort((a, b) => a.timestamp - b.timestamp);
 			analysis.cacheBreakage = detectCacheBreakage(orderedTurns);
 		}

--- a/src/adapters/claudeCodeAdapter.ts
+++ b/src/adapters/claudeCodeAdapter.ts
@@ -4,6 +4,7 @@ import type { IEcosystemAdapter, IDiscoverableEcosystem, IAnalyzableEcosystem, D
 import { ClaudeCodeDataAccess, normalizeClaudeModelId } from '../claudecode';
 import { readClaudeCodeEventsForAnalysis, createEmptySessionUsageAnalysis, applyModelTierClassification, addSkillCall } from '../usageAnalysis';
 import { isMcpTool, extractMcpServerName, detectClaudeCodeEditorVariant } from '../workspaceHelpers';
+import { detectCacheBreakage, type CacheTurn } from '../cacheBreakage';
 import { createEmptyContextRefs } from '../tokenEstimation';
 
 /**
@@ -302,18 +303,54 @@ export class ClaudeCodeAdapter implements IEcosystemAdapter, IDiscoverableEcosys
 		// Code extension all write to the same ~/.claude/projects/ format, so user-turn interactions
 		// are bucketed into the matching modeUsage field instead of always landing in `cli`.
 		const modeBucket = this.resolveModeBucket(sessionFile);
+		// Cache turns are keyed by message.id so a re-logged API response is counted
+		// once — detectCacheBreakage reads a duplicate as a full prefix wipe.
+		const cacheTurns = new Map<string, CacheTurn>();
 		for (const event of events) {
 			if (event.type === 'user' && event.message?.role === 'user' && !event.isSidechain) {
 				this.processUserEvent(event, analysis, modeBucket);
 			} else if (event.type === 'assistant') {
 				this.processAssistantEvent(event, analysis, ctx, models);
+				this.collectCacheTurn(event, cacheTurns);
 			} else if (event.type === 'system' && event.subtype === 'compact_boundary') {
 				this.processCompactBoundaryEvent(event, analysis);
 			}
 		}
+		if (cacheTurns.size > 0) {
+			analysis.cacheBreakage = detectCacheBreakage([...cacheTurns.values()]);
+		}
 		this.applyModelSwitchingStats(models, analysis);
 		applyModelTierClassification(ctx.modelPricing, analysis.modelSwitching.uniqueModels, models, analysis);
 		return analysis;
+	}
+
+	/**
+	 * Map one assistant event onto a {@link CacheTurn}, keyed by `message.id` so
+	 * later fragments of the same response overwrite earlier ones (last-wins,
+	 * matching ClaudeCodeDataAccess.deduplicateAssistantEvents).
+	 *
+	 * Sidechain (subagent) turns are skipped: they run against their own prompt
+	 * prefix, so interleaving them with the main thread would look like constant
+	 * cache invalidation. Turns with no usage, and Claude Code's `<synthetic>`
+	 * placeholder responses, carry no billing information and are skipped too.
+	 */
+	private collectCacheTurn(event: any, into: Map<string, CacheTurn>): void {
+		if (event.isSidechain) { return; }
+		const msg = event.message;
+		const usage = msg?.usage;
+		const msgId = msg?.id as string | undefined;
+		if (!usage || !msgId || msg?.model === '<synthetic>') { return; }
+		const timestamp = Date.parse(event.timestamp);
+		if (Number.isNaN(timestamp)) { return; }
+		into.set(msgId, {
+			timestamp,
+			model: normalizeClaudeModelId(msg.model || 'unknown'),
+			inputTokens: usage.input_tokens || 0,
+			cacheReadTokens: usage.cache_read_input_tokens || 0,
+			cacheCreationTokens: usage.cache_creation_input_tokens || 0,
+			cacheCreation1hTokens: usage.cache_creation?.ephemeral_1h_input_tokens || 0,
+			compacted: Boolean(msg.context_management),
+		});
 	}
 
 	private processCompactBoundaryEvent(event: any, analysis: import('../types').SessionUsageAnalysis): void {

--- a/src/adapters/claudeCodeAdapter.ts
+++ b/src/adapters/claudeCodeAdapter.ts
@@ -315,9 +315,9 @@ export class ClaudeCodeAdapter implements IEcosystemAdapter, IDiscoverableEcosys
 			} else if (event.type === 'system' && event.subtype === 'compact_boundary') {
 				this.processCompactBoundaryEvent(event, analysis);
 			}
-		}
 		if (cacheTurns.size > 0) {
-			analysis.cacheBreakage = detectCacheBreakage([...cacheTurns.values()]);
+			const orderedTurns = [...cacheTurns.values()].sort((a, b) => a.timestamp - b.timestamp);
+			analysis.cacheBreakage = detectCacheBreakage(orderedTurns);
 		}
 		this.applyModelSwitchingStats(models, analysis);
 		applyModelTierClassification(ctx.modelPricing, analysis.modelSwitching.uniqueModels, models, analysis);

--- a/src/cacheBreakage.ts
+++ b/src/cacheBreakage.ts
@@ -1,0 +1,326 @@
+/**
+ * Prompt-cache breakage detection (research feature).
+ *
+ * Providers that support prompt caching (Anthropic's Claude Code / Claude
+ * Desktop today) bill a conversation's re-sent prefix at three different rates:
+ * uncached input, cache *creation* (a premium over input), and cache *read*
+ * (a large discount). In a healthy long session almost every token is a cache
+ * read, so the interesting question is not "how much did caching save" — that
+ * is decided by the provider — but **when did the cached prefix die, and why**.
+ * That part is driven by user behaviour and is therefore actionable.
+ *
+ * When a prefix is invalidated the next request has to pay cache-creation
+ * prices to re-write context it had already written once. This module finds
+ * those moments and attributes each to a cause:
+ *
+ * - `model-switch`        — the model changed between turns. Each model keeps
+ *                           its own cache, so switching mid-session re-warms
+ *                           from scratch.
+ * - `compaction`          — the client rewrote the history (Claude Code sets
+ *                           `message.context_management`), which necessarily
+ *                           invalidates every prefix built on it.
+ * - `ttl-expiry`          — the gap since the previous turn exceeded the cache
+ *                           TTL. The TTL is read per-turn from the entry type
+ *                           actually used (`ephemeral_1h_input_tokens` > 0 means
+ *                           1 hour, otherwise the 5-minute default) rather than
+ *                           assumed, because Claude Code mixes both.
+ * - `prefix-invalidated`  — none of the above: the cacheable prefix itself
+ *                           changed. In practice this is the tool list or
+ *                           system prompt moving underneath the conversation
+ *                           (an MCP server or skill starting/stopping mid-session).
+ *
+ * ## Why the obvious detector does not work
+ *
+ * The tempting rule is "a break happened when `cacheRead(N)` is less than
+ * `cacheRead(N-1) + cacheWrite(N-1)`". Measured against real logs that rule is
+ * dominated by false positives, from two sources:
+ *
+ * 1. **Duplicate records.** Claude Code can log one API response twice under
+ *    the same `message.id`, so an unfiltered scan sees a full prefix vanish and
+ *    reappear. Callers MUST pass turns already de-duplicated by `message.id`
+ *    (`ClaudeCodeDataAccess.deduplicateAssistantEvents` does this) — the same
+ *    input the token/cost pipeline already uses.
+ * 2. **Breakpoint shuffle.** A provider may hold only a handful of cache
+ *    breakpoints, so tokens migrate between "read" and "written" from turn to
+ *    turn with nothing actually invalidated. Observed drops of ~35% at
+ *    sub-second gaps are routine and mean nothing.
+ *
+ * Both are excluded by requiring a *large* loss (`MIN_RETAINED_PREFIX_RATIO`)
+ * against a prefix that was already *substantial* (`MIN_PREFIX_TOKENS`). Those
+ * two constants are the whole difference between signal and noise here; see
+ * their doc comments before touching them.
+ *
+ * The headline per-session number is `rewriteFactor` — cache-creation tokens
+ * divided by the largest context the session ever held. 1.0 means every token
+ * was written exactly once (ideal). 6.0 means the session paid to write its
+ * context six times over.
+ *
+ * This module is intentionally pure (no VS Code API, no filesystem access) so
+ * it can be unit-tested with mocked data and reused by the CLI and the webview.
+ */
+
+// ---------------------------------------------------------------------------
+// Input shape
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal structural view of one assistant turn's billing record.
+ *
+ * Deliberately provider-neutral: adapters map their own session format onto
+ * this rather than this module learning about session formats. A turn without
+ * usable cache numbers should simply be omitted by the adapter.
+ */
+export interface CacheTurn {
+	/** Milliseconds since epoch for this turn. Used only for TTL gap checks. */
+	timestamp: number;
+	/** Normalized model id. A change between turns is treated as a cache reset. */
+	model: string;
+	/** Tokens billed as fresh (uncached, non-creation) input. */
+	inputTokens: number;
+	/** Tokens billed at the cache-read (discounted) rate. */
+	cacheReadTokens: number;
+	/** Tokens billed at the cache-creation (premium) rate. */
+	cacheCreationTokens: number;
+	/**
+	 * Portion of `cacheCreationTokens` written under the 1-hour TTL. Presence of
+	 * a non-zero value selects the 1-hour TTL for this turn's gap check.
+	 */
+	cacheCreation1hTokens?: number;
+	/** True when the client rewrote/compacted history at this turn. */
+	compacted?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Tuning constants
+// ---------------------------------------------------------------------------
+
+/**
+ * A prefix smaller than this is not worth reporting on, and small prefixes are
+ * where breakpoint-shuffle noise is proportionally worst. Chosen well above the
+ * typical system-prompt-only prefix so session warm-up is not flagged.
+ */
+export const MIN_PREFIX_TOKENS = 20_000;
+
+/**
+ * Fraction of the previous turn's context that must survive as a cache read for
+ * the prefix to count as intact. Below this we call it a break.
+ *
+ * Set at 0.5 because measured breakpoint shuffle tops out around a third of the
+ * prefix while genuine invalidations drop to (near) zero. Raising this toward
+ * 1.0 re-admits exactly the false positives documented above.
+ */
+export const MIN_RETAINED_PREFIX_RATIO = 0.5;
+
+/** Anthropic's default ephemeral cache TTL, in milliseconds. */
+export const DEFAULT_CACHE_TTL_MS = 5 * 60 * 1000;
+
+/** Anthropic's extended ephemeral cache TTL, in milliseconds. */
+export const EXTENDED_CACHE_TTL_MS = 60 * 60 * 1000;
+
+/** Cap on retained per-session break detail, mirroring MAX_MOMENTS_PER_SESSION. */
+export const MAX_BREAKS_PER_SESSION = 50;
+
+// ---------------------------------------------------------------------------
+// Output shape
+// ---------------------------------------------------------------------------
+
+export type CacheBreakCause =
+	| 'model-switch'
+	| 'compaction'
+	| 'ttl-expiry'
+	| 'prefix-invalidated';
+
+export interface CacheBreak {
+	/** Index into the input array of the turn that paid for the re-write. */
+	turnIndex: number;
+	cause: CacheBreakCause;
+	/** Model in effect at the turn that paid. */
+	model: string;
+	/** Tokens that were cached before the break and had to be written again. */
+	tokensRewritten: number;
+	/** Milliseconds since the previous turn. Meaningful mainly for `ttl-expiry`. */
+	gapMs: number;
+	/** TTL that applied at this turn, in ms — which one is chosen per-turn. */
+	ttlMs: number;
+	/** Previous model, present only when `cause` is `model-switch`. */
+	previousModel?: string;
+}
+
+export type CacheBreakCounts = {
+	[cause in CacheBreakCause]: { breaks: number; tokensRewritten: number };
+};
+
+export interface CacheBreakageResult {
+	breaks: CacheBreak[];
+	counts: CacheBreakCounts;
+	/** Sum of `cacheCreationTokens` across the session. */
+	tokensWritten: number;
+	/** Largest single-turn context (input + read + creation) the session held. */
+	peakContextTokens: number;
+	/**
+	 * `tokensWritten / peakContextTokens`. 1.0 is ideal — every token written
+	 * once. 0 when the session never wrote a cache entry.
+	 */
+	rewriteFactor: number;
+}
+
+// ---------------------------------------------------------------------------
+// Detection
+// ---------------------------------------------------------------------------
+
+export function createEmptyCacheBreakCounts(): CacheBreakCounts {
+	return {
+		'model-switch': { breaks: 0, tokensRewritten: 0 },
+		'compaction': { breaks: 0, tokensRewritten: 0 },
+		'ttl-expiry': { breaks: 0, tokensRewritten: 0 },
+		'prefix-invalidated': { breaks: 0, tokensRewritten: 0 },
+	};
+}
+
+/** Total context carried by a turn: everything the provider saw as prompt. */
+function contextTokens(turn: CacheTurn): number {
+	return turn.inputTokens + turn.cacheReadTokens + turn.cacheCreationTokens;
+}
+
+/**
+ * TTL in force at `turn`. Anthropic bills 1-hour cache entries separately, so a
+ * non-zero 1h creation count is a reliable marker that the longer TTL applies.
+ */
+function ttlForTurn(turn: CacheTurn): number {
+	return (turn.cacheCreation1hTokens ?? 0) > 0 ? EXTENDED_CACHE_TTL_MS : DEFAULT_CACHE_TTL_MS;
+}
+
+/**
+ * Classify a confirmed break. Order matters: a model switch or a compaction
+ * fully explains the loss on its own, so neither should be misreported as a TTL
+ * expiry just because the user also happened to be idle.
+ */
+function classifyBreak(current: CacheTurn, previous: CacheTurn, gapMs: number, ttlMs: number): CacheBreakCause {
+	if (current.model !== previous.model) { return 'model-switch'; }
+	if (current.compacted || previous.compacted) { return 'compaction'; }
+	if (gapMs > ttlMs) { return 'ttl-expiry'; }
+	return 'prefix-invalidated';
+}
+
+/**
+ * Find prompt-cache invalidations across one session's assistant turns.
+ *
+ * `turns` must be in chronological order and already de-duplicated by the
+ * provider's message id — see the module comment for why that is not optional.
+ */
+export function detectCacheBreakage(turns: CacheTurn[]): CacheBreakageResult {
+	const counts = createEmptyCacheBreakCounts();
+	const breaks: CacheBreak[] = [];
+	let tokensWritten = 0;
+	let peakContextTokens = 0;
+
+	for (let i = 0; i < turns.length; i++) {
+		const current = turns[i];
+		tokensWritten += current.cacheCreationTokens;
+		peakContextTokens = Math.max(peakContextTokens, contextTokens(current));
+
+		if (i === 0) { continue; }
+		const previous = turns[i - 1];
+		const previousContext = contextTokens(previous);
+
+		// Warm-up and tiny prefixes are excluded: proportional noise is highest
+		// there and the absolute cost is negligible either way.
+		if (previousContext < MIN_PREFIX_TOKENS) { continue; }
+		if (current.cacheReadTokens >= MIN_RETAINED_PREFIX_RATIO * previousContext) { continue; }
+
+		const gapMs = Math.max(0, current.timestamp - previous.timestamp);
+		const ttlMs = ttlForTurn(current);
+		const cause = classifyBreak(current, previous, gapMs, ttlMs);
+		const tokensRewritten = previousContext - current.cacheReadTokens;
+
+		counts[cause].breaks += 1;
+		counts[cause].tokensRewritten += tokensRewritten;
+		if (breaks.length < MAX_BREAKS_PER_SESSION) {
+			breaks.push({
+				turnIndex: i,
+				cause,
+				model: current.model,
+				tokensRewritten,
+				gapMs,
+				ttlMs,
+				...(cause === 'model-switch' ? { previousModel: previous.model } : {}),
+			});
+		}
+	}
+
+	return {
+		breaks,
+		counts,
+		tokensWritten,
+		peakContextTokens,
+		rewriteFactor: peakContextTokens > 0 ? tokensWritten / peakContextTokens : 0,
+	};
+}
+
+/** Accumulate one session's counts into a period total. */
+export function mergeCacheBreakCounts(target: CacheBreakCounts, source: CacheBreakCounts | undefined): void {
+	if (!source) { return; }
+	for (const cause of Object.keys(target) as CacheBreakCause[]) {
+		target[cause].breaks += source[cause].breaks;
+		target[cause].tokensRewritten += source[cause].tokensRewritten;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Period aggregation
+// ---------------------------------------------------------------------------
+
+/** Cache-breakage totals across every session in a usage-analysis period. */
+export interface CacheBreakagePeriodStats {
+	counts: CacheBreakCounts;
+	/** Sessions that reported cache data at all — the denominator for the rest. */
+	sessionsAnalyzed: number;
+	/** Sessions with at least one break. The complement is the healthy majority. */
+	sessionsWithBreaks: number;
+	/** Cache-creation tokens summed over the period. */
+	tokensWritten: number;
+	/**
+	 * Sum of each session's peak context. Paired with `tokensWritten` this gives
+	 * a period-level re-write factor; summing peaks (rather than averaging
+	 * per-session factors) keeps large sessions weighted by their real size.
+	 */
+	peakContextTokens: number;
+	/** Highest single-session `rewriteFactor` in the period. */
+	worstRewriteFactor: number;
+}
+
+export function createEmptyCacheBreakagePeriodStats(): CacheBreakagePeriodStats {
+	return {
+		counts: createEmptyCacheBreakCounts(),
+		sessionsAnalyzed: 0,
+		sessionsWithBreaks: 0,
+		tokensWritten: 0,
+		peakContextTokens: 0,
+		worstRewriteFactor: 0,
+	};
+}
+
+/** Fold one session's detection result into a period total. */
+export function mergeCacheBreakageIntoPeriod(target: CacheBreakagePeriodStats, session: CacheBreakageResult): void {
+	mergeCacheBreakCounts(target.counts, session.counts);
+	target.sessionsAnalyzed++;
+	if (session.breaks.length > 0) { target.sessionsWithBreaks++; }
+	target.tokensWritten += session.tokensWritten;
+	target.peakContextTokens += session.peakContextTokens;
+	target.worstRewriteFactor = Math.max(target.worstRewriteFactor, session.rewriteFactor);
+}
+
+/** Period-level re-write factor. 0 when nothing was written. */
+export function periodRewriteFactor(stats: CacheBreakagePeriodStats): number {
+	return stats.peakContextTokens > 0 ? stats.tokensWritten / stats.peakContextTokens : 0;
+}
+
+/** Total breaks across all causes. */
+export function totalCacheBreaks(counts: CacheBreakCounts): number {
+	return (Object.keys(counts) as CacheBreakCause[]).reduce((sum, c) => sum + counts[c].breaks, 0);
+}
+
+/** Total tokens re-written across all causes. */
+export function totalTokensRewritten(counts: CacheBreakCounts): number {
+	return (Object.keys(counts) as CacheBreakCause[]).reduce((sum, c) => sum + counts[c].tokensRewritten, 0);
+}

--- a/src/efficiencyAnalysis.ts
+++ b/src/efficiencyAnalysis.ts
@@ -1,4 +1,5 @@
 import type { ApplyButtonUsage, DailyModelEfficiency, DailyTokenStats, ModelUsage, UsageAnalysisPeriod } from './types';
+import type { CacheBreakagePeriodStats } from './cacheBreakage';
 import { getModelDisplayName } from './webview/shared/modelUtils';
 import { createEmptyDailyModelEfficiencyEntry, mergeDailyModelEfficiency } from './modelEfficiency';
 
@@ -1293,6 +1294,13 @@ export interface EfficiencyViewData {
 	modelDaily: ModelDailyInput[];
 	/** True when at least two models cleared the comparison sample floor. */
 	hasModelComparison: boolean;
+	/**
+	 * Prompt-cache breakage over the last 30 days. Null for users whose editors
+	 * do not report per-turn cache token counts (today: anything but Claude Code
+	 * / Claude Desktop), in which case the Cache tab is hidden entirely rather
+	 * than shown empty.
+	 */
+	cacheBreakage: CacheBreakagePeriodStats | null;
 	lastUpdated: string;
 	backendConfigured: boolean;
 	compactNumbers?: boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@
  * Extracted from extension.ts to reduce file size and improve reusability.
  */
 import type { TaskCategory, TaskCategoryBreakdown, TaskClassificationResult } from './taskClassification';
+import type { CacheBreakageResult, CacheBreakagePeriodStats } from './cacheBreakage';
 
 /**
  * Character-to-token ratio for a specific AI model.
@@ -417,6 +418,11 @@ export interface SessionUsageAnalysis {
   mcpTools: McpToolUsage;
   /** Agent-skill invocation counts for this session. See {@link SkillCallUsage}. */
   skillCalls?: SkillCallUsage;
+  /**
+   * Prompt-cache invalidations detected in this session, with the cause of each.
+   * Absent for session formats that do not report per-turn cache token counts.
+   */
+  cacheBreakage?: CacheBreakageResult;
   /** Aggregated task-classification result for this session. */
   taskClassification: TaskClassificationResult;
   modelSwitching: {
@@ -1103,6 +1109,12 @@ export interface UsageAnalysisPeriod {
    * Absent when no session in the period carried moments.
    */
   corrections?: CorrectionPeriodCounts;
+  /**
+   * Aggregated prompt-cache breakage across the period's sessions (folded in by
+   * mergeUsageAnalysis). Absent when no session in the period reported cache
+   * token counts.
+   */
+  cacheBreakage?: CacheBreakagePeriodStats;
 }
 
 /** Aggregated context-window usage for one usage-analysis period. */

--- a/src/usageAnalysis.ts
+++ b/src/usageAnalysis.ts
@@ -36,6 +36,7 @@ import {
 	type EfficiencyTurn,
 } from './modelEfficiency';
 import { detectCorrectionAnalysis, mergeCorrectionCounts, summarizeCorrectionMoments } from './correctionDetection';
+import { createEmptyCacheBreakagePeriodStats, mergeCacheBreakageIntoPeriod } from './cacheBreakage';
 import { MAX_PROMPT_LENGTH } from './repeatedTasks';
 import {
 	applyDelta,
@@ -1358,6 +1359,14 @@ export function mergeUsageAnalysis(period: UsageAnalysisPeriod, analysis: Sessio
 	_muaMergeEnhancedMetrics(period, analysis);
 	_muaMergeTaskCategories(period, analysis);
 	_muaMergeCorrections(period, analysis);
+	_muaMergeCacheBreakage(period, analysis);
+}
+
+/** Fold a session's cache-breakage result into the period's aggregated stats. */
+function _muaMergeCacheBreakage(period: UsageAnalysisPeriod, analysis: SessionUsageAnalysis): void {
+	if (!analysis.cacheBreakage) { return; }
+	if (!period.cacheBreakage) { period.cacheBreakage = createEmptyCacheBreakagePeriodStats(); }
+	mergeCacheBreakageIntoPeriod(period.cacheBreakage, analysis.cacheBreakage);
 }
 
 /** Fold a session's correction moments into the period's aggregated counters. */

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -9494,6 +9494,7 @@ private async shareTextToSocialPlatform(shareText: string, platform: 'linkedin' 
 			hasSkills: skillTrends.totalCalls > 0,
 			modelDaily,
 			hasModelComparison: _listComparableModels(modelDaily).filter(m => m.sampleSufficient).length >= 2,
+			cacheBreakage: usage.last30Days.cacheBreakage ?? null,
 			lastUpdated: now.toISOString(),
 			backendConfigured: this.isBackendConfigured(),
 			compactNumbers: this.getCompactNumbersSetting(),

--- a/vscode-extension/src/webview/efficiency/main.ts
+++ b/vscode-extension/src/webview/efficiency/main.ts
@@ -76,6 +76,14 @@ const TABS: { id: TabId; label: string }[] = [
 	{ id: 'combined', label: '🧩 Combined' },
 ];
 
+/**
+ * Tabs to show for this dataset. The Prompt Cache tab only exists when there is
+ * cache-breakage data to put in it (Claude Code / Claude Desktop sessions).
+ */
+function visibleTabs(d: EfficiencyViewData): { id: TabId; label: string }[] {
+	return TABS.filter(t => t.id !== 'cache' || d.cacheBreakage);
+}
+
 // ── Formatting ─────────────────────────────────────────────────────────
 
 function cssVar(name: string, fallback: string): string {
@@ -1082,6 +1090,10 @@ function render(): void {
 	if (!root || !data) { return; }
 	setCompactNumbers(data.compactNumbers !== false);
 	destroyCharts();
+	// Snap back to a real tab if the selected one is no longer shown — e.g. the
+	// Prompt Cache tab after cache data disappeared — so the content and the
+	// highlighted tab button never disagree.
+	if (!visibleTabs(data).some(t => t.id === activeTab)) { activeTab = 'trends'; }
 	const verdict = computeVerdict(data);
 	setHtml(root, `
 		<style>${themeStyles}</style>
@@ -1092,7 +1104,7 @@ function render(): void {
 			<p class="eff-subtitle">Are you working more efficiently with AI over time — and is it coming from using AI differently, cheaper models, or leaner sessions? Last updated ${escapeHtml(new Date(data.lastUpdated).toLocaleString())}.</p>
 			<div class="eff-verdict ${verdict.cls}"><span class="verdict-icon">${verdict.icon}</span><span class="verdict-text">${verdict.text}</span></div>
 			<div class="eff-tabs">
-				${TABS.filter(t => t.id !== 'cache' || data.cacheBreakage).map(t => `<button class="eff-tab ${t.id === activeTab ? 'active' : ''}" data-tab="${t.id}">${t.label}</button>`).join('')}
+				${visibleTabs(data).map(t => `<button class="eff-tab ${t.id === activeTab ? 'active' : ''}" data-tab="${t.id}">${t.label}</button>`).join('')}
 			</div>
 			<div id="eff-tab-content">${renderActiveTab(data)}</div>
 			<p class="caveat">⚠️ Honest caveats: costs are estimates from token counts and public rates; lines of code is a weak value proxy (refactors and generated boilerplate distort it); shorter sessions only count as efficiency when output (lines, applied blocks, PRs) holds or rises. Every trend here should be read alongside its value counterpart.</p>

--- a/vscode-extension/src/webview/efficiency/main.ts
+++ b/vscode-extension/src/webview/efficiency/main.ts
@@ -5,6 +5,7 @@
 import { navButtonsHtml } from '../shared/buttonConfig';
 import { setHtml } from '../shared/domUtils';
 import { escapeHtml, formatCompact, setCompactNumbers } from '../shared/formatUtils';
+import type { CacheBreakCause } from '../../../../src/cacheBreakage';
 import { wireExtensionPointButtons } from '../shared/extensionPoints';
 import themeStyles from '../shared/theme.css';
 import styles from './styles.css';
@@ -61,7 +62,7 @@ async function loadChartModule(): Promise<void> {
 	Chart = mod.default as ChartConstructor;
 }
 
-type TabId = 'trends' | 'skills' | 'deltas' | 'attribution' | 'models' | 'value' | 'combined';
+type TabId = 'trends' | 'skills' | 'deltas' | 'attribution' | 'cache' | 'models' | 'value' | 'combined';
 let activeTab: TabId = 'trends';
 
 const TABS: { id: TabId; label: string }[] = [
@@ -69,6 +70,7 @@ const TABS: { id: TabId; label: string }[] = [
 	{ id: 'skills', label: '🛠️ Tools & Skills' },
 	{ id: 'deltas', label: '🗓️ Month vs Month' },
 	{ id: 'attribution', label: '💸 Cost Attribution' },
+	{ id: 'cache', label: '⚡ Prompt Cache' },
 	{ id: 'models', label: '🤖 Models' },
 	{ id: 'value', label: '🎁 Value' },
 	{ id: 'combined', label: '🧩 Combined' },
@@ -688,6 +690,95 @@ function taskMixHtml(cmp: ModelComparison): string {
 		<div class="task-legend">${legend}</div>`;
 }
 
+/**
+ * Human-readable cause labels and the advice attached to each. The advice is
+ * the point of the tab: a break the user cannot act on is just trivia.
+ */
+const CACHE_CAUSE_INFO: Record<CacheBreakCause, { label: string; icon: string; advice: string }> = {
+	'ttl-expiry': {
+		label: 'Idle longer than the cache lifetime',
+		icon: '⏳',
+		advice: 'The conversation sat idle past the cache lifetime, so the whole prompt had to be written again. Wrapping a session up, or coming back to it sooner, avoids this.',
+	},
+	'model-switch': {
+		label: 'Switched model mid-session',
+		icon: '🔀',
+		advice: 'Each model keeps its own cache, so switching part-way through re-warms the entire conversation. Choosing the model up front is cheaper than switching later.',
+	},
+	'prefix-invalidated': {
+		label: 'Tools or system prompt changed',
+		icon: '🧩',
+		advice: 'Something above the conversation changed — usually an MCP server or skill starting or stopping mid-session, which invalidates everything cached beneath it.',
+	},
+	'compaction': {
+		label: 'Context compacted',
+		icon: '🗜️',
+		advice: 'History was rewritten to fit the context window, which necessarily discards the cached prefix. Largely unavoidable once a session runs long.',
+	},
+};
+
+const CACHE_CAUSES = Object.keys(CACHE_CAUSE_INFO) as CacheBreakCause[];
+
+/** Verdict on a period-level re-write factor. 1.0 means every token written once. */
+function cacheVerdict(factor: number): { cls: string; text: string } {
+	if (factor <= 1.15) { return { cls: 'improving', text: 'Healthy — your context is written about once per session, which is the best case.' }; }
+	if (factor <= 2) { return { cls: 'mixed', text: 'Some re-warming. A few sessions are paying to write context they had already cached.' }; }
+	return { cls: 'declining', text: 'Context is being written several times over. The causes below show where it is going.' };
+}
+
+const CACHE_INTRO = 'Re-sent conversation history is billed at a discount while it stays cached, and at a premium when it has to be written again. This tab shows the moments the cached prompt was thrown away over the last 30 days, and what caused each one.';
+
+function renderCacheCauseRow(cause: CacheBreakCause, breaks: number, tokens: number, sharePct: number): string {
+	const info = CACHE_CAUSE_INFO[cause];
+	return `
+		<div class="cache-cause-row">
+			<div class="cache-cause-head">
+				<span class="cache-cause-label">${info.icon} ${escapeHtml(info.label)}</span>
+				<span class="cache-cause-count">${breaks}× · ${formatCompact(tokens)} tokens re-written</span>
+			</div>
+			<div class="cache-cause-track"><div class="cache-cause-fill" style="width: ${sharePct.toFixed(1)}%"></div></div>
+			<p class="cache-cause-advice">${escapeHtml(info.advice)}</p>
+		</div>`;
+}
+
+function renderCacheTab(d: EfficiencyViewData): string {
+	const c = d.cacheBreakage;
+	if (!c || c.sessionsAnalyzed === 0) {
+		return `<p class="eff-section-note">No prompt-cache data in the last 30 days. Only editors that report per-turn cache token counts (Claude Code, Claude Desktop) can be analysed here.</p>`;
+	}
+	const factor = c.peakContextTokens > 0 ? c.tokensWritten / c.peakContextTokens : 0;
+	const totalBreaks = CACHE_CAUSES.reduce((sum, k) => sum + c.counts[k].breaks, 0);
+	const totalRewritten = CACHE_CAUSES.reduce((sum, k) => sum + c.counts[k].tokensRewritten, 0);
+	const healthy = c.sessionsAnalyzed - c.sessionsWithBreaks;
+
+	if (totalBreaks === 0) {
+		return `
+			<p class="eff-section-note">${escapeHtml(CACHE_INTRO)}</p>
+			<div class="eff-verdict improving"><span class="verdict-icon">✅</span><span class="verdict-text">No cache breaks across ${c.sessionsAnalyzed} session${c.sessionsAnalyzed === 1 ? '' : 's'} in the last 30 days. Nothing to fix.</span></div>`;
+	}
+
+	const verdict = cacheVerdict(factor);
+	const rows = CACHE_CAUSES
+		.filter(k => c.counts[k].breaks > 0)
+		.sort((a, b) => c.counts[b].tokensRewritten - c.counts[a].tokensRewritten)
+		.map(k => renderCacheCauseRow(
+			k,
+			c.counts[k].breaks,
+			c.counts[k].tokensRewritten,
+			totalRewritten > 0 ? (c.counts[k].tokensRewritten / totalRewritten) * 100 : 0,
+		)).join('');
+
+	return `
+		<p class="eff-section-note">${escapeHtml(CACHE_INTRO)}</p>
+		<div class="eff-verdict ${verdict.cls}"><span class="verdict-icon">⚡</span><span class="verdict-text">${escapeHtml(verdict.text)}</span></div>
+		<div class="attr-summary">
+			<div class="attr-stat"><div class="stat-label">Re-write factor</div><div class="stat-value">${factor.toFixed(2)}×</div><div class="stat-sub">1.00× is ideal · worst session ${c.worstRewriteFactor.toFixed(2)}×</div></div>
+			<div class="attr-stat"><div class="stat-label">Cache breaks</div><div class="stat-value">${totalBreaks}</div><div class="stat-sub">${formatCompact(totalRewritten)} tokens re-written</div></div>
+			<div class="attr-stat"><div class="stat-label">Sessions affected</div><div class="stat-value">${c.sessionsWithBreaks} of ${c.sessionsAnalyzed}</div><div class="stat-sub">${healthy} session${healthy === 1 ? '' : 's'} with no break at all</div></div>
+		</div>
+		<div class="cache-causes">${rows}</div>`;
+}
+
 function renderModelsTab(d: EfficiencyViewData): string {
 	initModelState(d);
 	if (d.modelDaily.length === 0) {
@@ -979,6 +1070,7 @@ function renderActiveTab(d: EfficiencyViewData): string {
 		case 'skills': return renderSkillsTab(d);
 		case 'deltas': return renderDeltasTab(d);
 		case 'attribution': return renderAttributionTab(d);
+		case 'cache': return renderCacheTab(d);
 		case 'models': return renderModelsTab(d);
 		case 'value': return renderValueTab(d);
 		case 'combined': return renderCombinedTab(d);
@@ -1000,7 +1092,7 @@ function render(): void {
 			<p class="eff-subtitle">Are you working more efficiently with AI over time — and is it coming from using AI differently, cheaper models, or leaner sessions? Last updated ${escapeHtml(new Date(data.lastUpdated).toLocaleString())}.</p>
 			<div class="eff-verdict ${verdict.cls}"><span class="verdict-icon">${verdict.icon}</span><span class="verdict-text">${verdict.text}</span></div>
 			<div class="eff-tabs">
-				${TABS.map(t => `<button class="eff-tab ${t.id === activeTab ? 'active' : ''}" data-tab="${t.id}">${t.label}</button>`).join('')}
+				${TABS.filter(t => t.id !== 'cache' || data.cacheBreakage).map(t => `<button class="eff-tab ${t.id === activeTab ? 'active' : ''}" data-tab="${t.id}">${t.label}</button>`).join('')}
 			</div>
 			<div id="eff-tab-content">${renderActiveTab(data)}</div>
 			<p class="caveat">⚠️ Honest caveats: costs are estimates from token counts and public rates; lines of code is a weak value proxy (refactors and generated boilerplate distort it); shorter sessions only count as efficiency when output (lines, applied blocks, PRs) holds or rises. Every trend here should be read alongside its value counterpart.</p>

--- a/vscode-extension/src/webview/efficiency/styles.css
+++ b/vscode-extension/src/webview/efficiency/styles.css
@@ -365,3 +365,45 @@
 .model-radar-wrap { position: relative; height: 360px; margin-bottom: 12px; }
 .model-trend-wrap { position: relative; height: 300px; margin-bottom: 10px; }
 .model-trend-controls { margin: 8px 0; }
+/* ── Prompt Cache tab ─────────────────────────────────────────────── */
+.cache-causes { margin: 14px 0 18px 0; }
+.cache-cause-row {
+	padding: 10px 0;
+	border-bottom: 1px solid var(--vscode-panel-border, rgba(128, 128, 128, 0.25));
+}
+.cache-cause-row:last-child { border-bottom: none; }
+.cache-cause-head {
+	display: flex;
+	justify-content: space-between;
+	align-items: baseline;
+	gap: 12px;
+	flex-wrap: wrap;
+}
+.cache-cause-label { font-size: 0.95em; font-weight: 600; }
+.cache-cause-count {
+	color: var(--vscode-descriptionForeground);
+	font-size: 0.82em;
+	font-variant-numeric: tabular-nums;
+	white-space: nowrap;
+}
+.cache-cause-track {
+	position: relative;
+	height: 6px;
+	margin: 6px 0 4px 0;
+	border-radius: 3px;
+	background: var(--vscode-editorWidget-background, rgba(128, 128, 128, 0.18));
+}
+.cache-cause-fill {
+	position: absolute;
+	top: 0;
+	bottom: 0;
+	left: 0;
+	border-radius: 3px;
+	background: var(--vscode-charts-yellow, #fbbf24);
+}
+.cache-cause-advice {
+	margin: 4px 0 0 0;
+	color: var(--vscode-descriptionForeground);
+	font-size: 0.85em;
+	line-height: 1.45;
+}

--- a/vscode-extension/test/unit/cacheBreakage.test.ts
+++ b/vscode-extension/test/unit/cacheBreakage.test.ts
@@ -1,0 +1,282 @@
+import test from 'node:test';
+import * as assert from 'node:assert/strict';
+import {
+    detectCacheBreakage,
+    mergeCacheBreakCounts,
+    createEmptyCacheBreakCounts,
+    MIN_PREFIX_TOKENS,
+    MIN_RETAINED_PREFIX_RATIO,
+    DEFAULT_CACHE_TTL_MS,
+    EXTENDED_CACHE_TTL_MS,
+    MAX_BREAKS_PER_SESSION,
+    createEmptyCacheBreakagePeriodStats,
+    mergeCacheBreakageIntoPeriod,
+    periodRewriteFactor,
+    totalCacheBreaks,
+    totalTokensRewritten,
+    type CacheTurn,
+} from '../../../src/cacheBreakage';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const T0 = Date.UTC(2026, 0, 1, 12, 0, 0);
+
+function turn(overrides: Partial<CacheTurn> & { timestamp: number }): CacheTurn {
+    return {
+        model: 'claude-sonnet-5',
+        inputTokens: 2,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+        ...overrides,
+    };
+}
+
+/**
+ * A healthy sequence: a big prefix is written once, then read back on every
+ * subsequent turn with small increments appended. This is what the detector
+ * must stay silent on.
+ */
+function healthySession(turns = 5, base = 60_000): CacheTurn[] {
+    const out: CacheTurn[] = [turn({ timestamp: T0, cacheCreationTokens: base })];
+    let read = base;
+    for (let i = 1; i < turns; i++) {
+        out.push(turn({ timestamp: T0 + i * 10_000, cacheReadTokens: read, cacheCreationTokens: 500 }));
+        read += 500;
+    }
+    return out;
+}
+
+// ---------------------------------------------------------------------------
+// No false positives
+// ---------------------------------------------------------------------------
+
+test('healthy session reports no breaks and a rewriteFactor near 1', () => {
+    const result = detectCacheBreakage(healthySession(8));
+    assert.equal(result.breaks.length, 0);
+    assert.ok(result.rewriteFactor < 1.1, `expected ~1.0, got ${result.rewriteFactor}`);
+});
+
+test('breakpoint shuffle is not a break: a partial read drop above the ratio is ignored', () => {
+    // Real logs show read/write split moving turn-to-turn with nothing actually
+    // invalidated — a ~35% dip at a sub-second gap. Must not be reported.
+    const turns = [
+        turn({ timestamp: T0, cacheReadTokens: 90_000, cacheCreationTokens: 10_000 }),
+        turn({ timestamp: T0 + 500, cacheReadTokens: 65_000, cacheCreationTokens: 35_000 }),
+    ];
+    const result = detectCacheBreakage(turns);
+    assert.equal(result.breaks.length, 0);
+});
+
+test('warm-up below MIN_PREFIX_TOKENS is never flagged', () => {
+    const small = Math.floor(MIN_PREFIX_TOKENS / 2);
+    const turns = [
+        turn({ timestamp: T0, cacheCreationTokens: small }),
+        // Total prefix loss, but the prefix was too small to care about.
+        turn({ timestamp: T0 + EXTENDED_CACHE_TTL_MS * 2, cacheCreationTokens: small }),
+    ];
+    assert.equal(detectCacheBreakage(turns).breaks.length, 0);
+});
+
+test('a single turn, or none, produces an empty result without dividing by zero', () => {
+    assert.equal(detectCacheBreakage([]).rewriteFactor, 0);
+    assert.equal(detectCacheBreakage([]).breaks.length, 0);
+    const one = detectCacheBreakage([turn({ timestamp: T0, cacheCreationTokens: 50_000 })]);
+    assert.equal(one.breaks.length, 0);
+    assert.equal(one.peakContextTokens, 50_002);
+});
+
+test('exactly at the retention ratio counts as intact, not as a break', () => {
+    const prefix = 100_000;
+    const turns = [
+        turn({ timestamp: T0, cacheCreationTokens: prefix }),
+        turn({ timestamp: T0 + 1000, cacheReadTokens: MIN_RETAINED_PREFIX_RATIO * (prefix + 2) }),
+    ];
+    assert.equal(detectCacheBreakage(turns).breaks.length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// Cause classification
+// ---------------------------------------------------------------------------
+
+test('ttl-expiry: idle beyond the 5-minute default TTL', () => {
+    const turns = [
+        turn({ timestamp: T0, cacheCreationTokens: 80_000 }),
+        turn({ timestamp: T0 + DEFAULT_CACHE_TTL_MS + 1000, cacheReadTokens: 0, cacheCreationTokens: 80_000 }),
+    ];
+    const result = detectCacheBreakage(turns);
+    assert.equal(result.breaks.length, 1);
+    assert.equal(result.breaks[0].cause, 'ttl-expiry');
+    assert.equal(result.breaks[0].tokensRewritten, 80_002);
+    assert.equal(result.breaks[0].ttlMs, DEFAULT_CACHE_TTL_MS);
+});
+
+test('the 1-hour TTL is honoured when the turn wrote 1h cache entries', () => {
+    // Same 10-minute gap, two different TTLs. Under the extended TTL the prefix
+    // was still alive, so the loss must be attributed to the prefix changing —
+    // not blamed on the user being idle.
+    const gap = 10 * 60 * 1000;
+    const base = { timestamp: T0, cacheCreationTokens: 80_000, cacheCreation1hTokens: 80_000 };
+    const turns = [
+        turn(base),
+        turn({
+            timestamp: T0 + gap,
+            cacheReadTokens: 0,
+            cacheCreationTokens: 80_000,
+            cacheCreation1hTokens: 80_000,
+        }),
+    ];
+    const result = detectCacheBreakage(turns);
+    assert.equal(result.breaks[0].ttlMs, EXTENDED_CACHE_TTL_MS);
+    assert.equal(result.breaks[0].cause, 'prefix-invalidated');
+
+    // Without the 1h marker the identical gap is a genuine expiry.
+    const shortTtl = detectCacheBreakage([
+        turn({ timestamp: T0, cacheCreationTokens: 80_000 }),
+        turn({ timestamp: T0 + gap, cacheReadTokens: 0, cacheCreationTokens: 80_000 }),
+    ]);
+    assert.equal(shortTtl.breaks[0].cause, 'ttl-expiry');
+});
+
+test('model-switch wins over an idle gap that would also explain the loss', () => {
+    const turns = [
+        turn({ timestamp: T0, model: 'claude-sonnet-5', cacheCreationTokens: 80_000 }),
+        turn({
+            timestamp: T0 + EXTENDED_CACHE_TTL_MS * 2,
+            model: 'claude-opus-5',
+            cacheReadTokens: 0,
+            cacheCreationTokens: 80_000,
+        }),
+    ];
+    const result = detectCacheBreakage(turns);
+    assert.equal(result.breaks[0].cause, 'model-switch');
+    assert.equal(result.breaks[0].previousModel, 'claude-sonnet-5');
+    assert.equal(result.breaks[0].model, 'claude-opus-5');
+});
+
+test('compaction wins over an idle gap, and previousModel is omitted', () => {
+    const turns = [
+        turn({ timestamp: T0, cacheCreationTokens: 80_000 }),
+        turn({
+            timestamp: T0 + DEFAULT_CACHE_TTL_MS * 3,
+            cacheReadTokens: 0,
+            cacheCreationTokens: 40_000,
+            compacted: true,
+        }),
+    ];
+    const result = detectCacheBreakage(turns);
+    assert.equal(result.breaks[0].cause, 'compaction');
+    assert.equal(result.breaks[0].previousModel, undefined);
+});
+
+test('prefix-invalidated: prompt died immediately, no gap, same model', () => {
+    const turns = [
+        turn({ timestamp: T0, cacheReadTokens: 100_000, cacheCreationTokens: 2_000 }),
+        turn({ timestamp: T0 + 800, cacheReadTokens: 0, cacheCreationTokens: 104_000 }),
+    ];
+    const result = detectCacheBreakage(turns);
+    assert.equal(result.breaks[0].cause, 'prefix-invalidated');
+    assert.equal(result.breaks[0].gapMs, 800);
+});
+
+// ---------------------------------------------------------------------------
+// Aggregate reporting
+// ---------------------------------------------------------------------------
+
+test('rewriteFactor counts repeated writes of the same context', () => {
+    // Three full re-writes of a ~100k context after TTL expiries.
+    const turns: CacheTurn[] = [];
+    for (let i = 0; i < 3; i++) {
+        turns.push(turn({
+            timestamp: T0 + i * (DEFAULT_CACHE_TTL_MS + 60_000),
+            cacheReadTokens: 0,
+            cacheCreationTokens: 100_000,
+        }));
+    }
+    const result = detectCacheBreakage(turns);
+    assert.equal(result.tokensWritten, 300_000);
+    assert.equal(result.peakContextTokens, 100_002);
+    assert.ok(result.rewriteFactor > 2.9 && result.rewriteFactor < 3.1);
+    assert.equal(result.counts['ttl-expiry'].breaks, 2);
+});
+
+test('break detail is capped but counts stay complete', () => {
+    const turns: CacheTurn[] = [];
+    for (let i = 0; i < MAX_BREAKS_PER_SESSION + 10; i++) {
+        turns.push(turn({
+            timestamp: T0 + i * (DEFAULT_CACHE_TTL_MS + 60_000),
+            cacheReadTokens: 0,
+            cacheCreationTokens: 80_000,
+        }));
+    }
+    const result = detectCacheBreakage(turns);
+    assert.equal(result.breaks.length, MAX_BREAKS_PER_SESSION);
+    assert.equal(result.counts['ttl-expiry'].breaks, MAX_BREAKS_PER_SESSION + 9);
+});
+
+test('a clock that goes backwards yields a zero gap, not a negative one', () => {
+    const turns = [
+        turn({ timestamp: T0, cacheCreationTokens: 80_000 }),
+        turn({ timestamp: T0 - 5_000, cacheReadTokens: 0, cacheCreationTokens: 80_000 }),
+    ];
+    const result = detectCacheBreakage(turns);
+    assert.equal(result.breaks[0].gapMs, 0);
+    assert.equal(result.breaks[0].cause, 'prefix-invalidated');
+});
+
+test('period stats aggregate sessions and weight the factor by session size', () => {
+    const stats = createEmptyCacheBreakagePeriodStats();
+    // One healthy session and one that re-wrote its context three times.
+    const healthy = detectCacheBreakage(healthySession(6, 100_000));
+    const churny = detectCacheBreakage([0, 1, 2].map(i => turn({
+        timestamp: T0 + i * (DEFAULT_CACHE_TTL_MS + 60_000),
+        cacheReadTokens: 0,
+        cacheCreationTokens: 300_000,
+    })));
+    mergeCacheBreakageIntoPeriod(stats, healthy);
+    mergeCacheBreakageIntoPeriod(stats, churny);
+
+    assert.equal(stats.sessionsAnalyzed, 2);
+    assert.equal(stats.sessionsWithBreaks, 1);
+    assert.equal(stats.counts['ttl-expiry'].breaks, 2);
+    assert.ok(stats.worstRewriteFactor > 2.9, `worst should track the churny session, got ${stats.worstRewriteFactor}`);
+    // Summing peaks rather than averaging factors keeps the big session dominant:
+    // 102.5k + 900k written over 102.5k + 300k of peak context.
+    const factor = periodRewriteFactor(stats);
+    assert.ok(factor > 2.4 && factor < 2.6, `expected ~2.5, got ${factor}`);
+});
+
+test('periodRewriteFactor is 0 rather than NaN for an empty period', () => {
+    assert.equal(periodRewriteFactor(createEmptyCacheBreakagePeriodStats()), 0);
+});
+
+test('totalCacheBreaks and totalTokensRewritten sum every cause', () => {
+    const result = detectCacheBreakage([
+        turn({ timestamp: T0, cacheCreationTokens: 80_000 }),
+        // TTL expiry.
+        turn({ timestamp: T0 + DEFAULT_CACHE_TTL_MS * 2, cacheReadTokens: 0, cacheCreationTokens: 80_000 }),
+        // Model switch immediately after.
+        turn({ timestamp: T0 + DEFAULT_CACHE_TTL_MS * 2 + 1000, model: 'claude-opus-5', cacheReadTokens: 0, cacheCreationTokens: 80_000 }),
+    ]);
+    assert.equal(totalCacheBreaks(result.counts), 2);
+    assert.equal(totalTokensRewritten(result.counts), 160_004);
+    assert.equal(
+        totalTokensRewritten(result.counts),
+        result.breaks.reduce((s, b) => s + b.tokensRewritten, 0),
+    );
+});
+
+test('mergeCacheBreakCounts accumulates across sessions and tolerates undefined', () => {
+    const total = createEmptyCacheBreakCounts();
+    const a = detectCacheBreakage([
+        turn({ timestamp: T0, cacheCreationTokens: 80_000 }),
+        turn({ timestamp: T0 + DEFAULT_CACHE_TTL_MS * 2, cacheReadTokens: 0, cacheCreationTokens: 80_000 }),
+    ]);
+    mergeCacheBreakCounts(total, a.counts);
+    mergeCacheBreakCounts(total, a.counts);
+    mergeCacheBreakCounts(total, undefined);
+    assert.equal(total['ttl-expiry'].breaks, 2);
+    assert.equal(total['ttl-expiry'].tokensRewritten, 160_004);
+    assert.equal(total['model-switch'].breaks, 0);
+});

--- a/vscode-extension/test/unit/claudecode.test.ts
+++ b/vscode-extension/test/unit/claudecode.test.ts
@@ -1046,6 +1046,108 @@ test('ClaudeCodeAdapter.analyzeUsage: multiple user turns in a claude-desktop se
 	}
 });
 
+// ----- ClaudeCodeAdapter.analyzeUsage: every event in the session is processed -----
+//
+// analyzeUsage's for-loop must run to completion and return once, after the loop —
+// not return from inside it. A regression that closed the loop early would still
+// type-check (a `return` inside a `for` is legal JS), so this is asserted directly
+// on aggregate counts that only add up correctly if every event was visited.
+
+test('ClaudeCodeAdapter.analyzeUsage: processes every event, not just the first — user turns, tool calls and models all accumulate past event 1', async () => {
+	const events = [
+		{ type: 'user', isSidechain: false, entrypoint: 'cli', message: { role: 'user', content: 'first' } },
+		{
+			type: 'assistant',
+			message: {
+				id: 'm1', model: 'claude-sonnet-4-6', role: 'assistant', stop_reason: 'tool_use',
+				content: [{ type: 'tool_use', name: 'Read', input: { file_path: '/a.ts' } }],
+			},
+		},
+		{ type: 'user', isSidechain: false, message: { role: 'user', content: 'second' } },
+		{
+			type: 'assistant',
+			message: {
+				id: 'm2', model: 'claude-opus-4-6', role: 'assistant', stop_reason: 'tool_use',
+				content: [{ type: 'tool_use', name: 'Write', input: { file_path: '/b.ts' } }],
+			},
+		},
+		{ type: 'user', isSidechain: false, message: { role: 'user', content: 'third' } },
+		{
+			type: 'assistant',
+			message: {
+				id: 'm3', model: 'claude-sonnet-4-6', role: 'assistant', stop_reason: 'end_turn',
+				content: [{ type: 'tool_use', name: 'Edit', input: { file_path: '/c.ts' } }],
+			},
+		},
+	];
+	const filePath = createTempSession(events);
+	try {
+		const result = await claudeCodeAdapter.analyzeUsage(filePath, adapterCtx);
+		// 3 user turns — only reachable if the loop visited events past index 0.
+		assert.equal(result.modeUsage.cli, 3);
+		// 3 tool calls across 3 separate assistant events.
+		assert.equal(result.toolCalls.total, 3);
+		assert.deepEqual(result.toolCalls.byTool, { Read: 1, Write: 1, Edit: 1 });
+		// Model-switching stats are computed once, after the loop, from all 3 models seen.
+		assert.equal(result.modelSwitching.totalRequests, 3);
+		assert.equal(result.modelSwitching.modelCount, 2);
+		assert.equal(result.modelSwitching.switchCount, 2);
+	} finally {
+		cleanup(filePath);
+	}
+});
+
+// ----- ClaudeCodeAdapter.analyzeUsage: cacheBreakage (see src/cacheBreakage.ts) -----
+
+test('ClaudeCodeAdapter.analyzeUsage: populates cacheBreakage from a multi-turn session with a TTL-expiry break', async () => {
+	const bigPrefix = 60_000;
+	const events = [
+		{
+			type: 'assistant',
+			message: {
+				id: 'c1', model: 'claude-sonnet-4-6', role: 'assistant', stop_reason: 'end_turn',
+				content: [{ type: 'text', text: 'warm the cache' }],
+				usage: { input_tokens: 2, output_tokens: 10, cache_creation_input_tokens: bigPrefix, cache_read_input_tokens: 0 },
+			},
+			timestamp: '2026-05-06T10:00:00.000Z',
+		},
+		{
+			// Idle well past the 5-minute default TTL, same model, no compaction —
+			// the whole prefix has to be written again.
+			type: 'assistant',
+			message: {
+				id: 'c2', model: 'claude-sonnet-4-6', role: 'assistant', stop_reason: 'end_turn',
+				content: [{ type: 'text', text: 're-warm' }],
+				usage: { input_tokens: 2, output_tokens: 10, cache_creation_input_tokens: bigPrefix, cache_read_input_tokens: 0 },
+			},
+			timestamp: '2026-05-06T10:30:00.000Z',
+		},
+	];
+	const filePath = createTempSession(events);
+	try {
+		const result = await claudeCodeAdapter.analyzeUsage(filePath, adapterCtx);
+		assert.ok(result.cacheBreakage, 'cacheBreakage should be populated when assistant events carry usage');
+		assert.equal(result.cacheBreakage!.breaks.length, 1);
+		assert.equal(result.cacheBreakage!.breaks[0].cause, 'ttl-expiry');
+		assert.equal(result.cacheBreakage!.tokensWritten, bigPrefix * 2);
+	} finally {
+		cleanup(filePath);
+	}
+});
+
+test('ClaudeCodeAdapter.analyzeUsage: leaves cacheBreakage undefined when no assistant event carries usage', async () => {
+	const events = [
+		{ type: 'user', isSidechain: false, message: { role: 'user', content: 'hi' } },
+	];
+	const filePath = createTempSession(events);
+	try {
+		const result = await claudeCodeAdapter.analyzeUsage(filePath, adapterCtx);
+		assert.equal(result.cacheBreakage, undefined);
+	} finally {
+		cleanup(filePath);
+	}
+});
+
 // ----- getClaudeCodeDailyFractions (issue #1608, root cause A) -----
 
 test('getClaudeCodeDailyFractions: splits usage by each assistant event day, weighted by tokens', async () => {


### PR DESCRIPTION
## What

Adds a **⚡ Prompt Cache** tab to the Efficiency view that shows *when a session's cached prompt prefix was thrown away, and why*.

Prompt caching itself is a provider-side discount the user can't influence — so "look how much caching saved you" isn't actionable. **Losing** the cached prefix is driven by user behaviour, so every break is attributed to a cause the user can do something about:

| Cause | What it means |
|---|---|
| ⏳ TTL expiry | Idle longer than the cache lifetime |
| 🔀 Model switch | Each model keeps its own cache; switching mid-session re-warms everything |
| 🧩 Prefix invalidated | Tool list / system prompt changed — usually an MCP server or skill starting or stopping mid-session |
| 🗜️ Compaction | History rewritten to fit the context window |

The headline metric is the **re-write factor**: cache-creation tokens divided by the largest context the session held. `1.00×` means every token was written exactly once (ideal); `6.26×` means the session paid to write its context six times over.

## Why the obvious detector doesn't work

This is documented at length in the module, because it's the whole design.

The tempting rule is "a break happened when `cacheRead(N) < cacheRead(N-1) + cacheWrite(N-1)`". Measured against real local logs, that rule reported **221 breaks where only 52 were genuine**. Two sources of false positives:

1. **Re-logged API responses.** Claude Code can write the same response twice under one `message.id` (differing only by `apiBlockIndex`), which reads as a full prefix wipe. Callers must pass turns de-duplicated by `message.id` — the same input the existing token/cost pipeline already uses via `deduplicateAssistantEvents`.
2. **Breakpoint shuffle.** Within a tool loop, tokens migrate between cache breakpoints, so the read/write split moves turn to turn with nothing invalidated. Drops of ~35% at sub-second gaps are routine and meaningless.

Detection therefore requires a *large* loss (`MIN_RETAINED_PREFIX_RATIO = 0.5`) against an *already-substantial* prefix (`MIN_PREFIX_TOKENS = 20k`). Those two constants are the entire difference between signal and noise; both carry doc comments saying so.

The TTL is read **per-turn** from `cache_creation.ephemeral_1h_input_tokens` rather than assumed, because Claude Code mixes 5-minute and 1-hour entries. Assuming a fixed 5-minute TTL misattributes prefix changes as idle expiry — a test pins this by running the same 10-minute gap through both TTLs and asserting different causes.

## Measured on real sessions

Run over 62 local Claude Code sessions:

```
sessions=62   with >=1 break=29
rewriteFactor  p10=0.51  median=1.01  p90=1.92  max=6.26

cause                  breaks  tokens re-written
ttl-expiry                 34          5,222,994
model-switch                9          1,176,903
prefix-invalidated          8          1,394,384
compaction                  1            609,190
```

Half the sessions have no break at all and the median is a near-perfect `1.01×`, so the tab only says something when there's genuinely something to say.

## Scope

Claude Code / Claude Desktop only. No other adapter has been verified to produce ordered per-turn cache records, so `cacheBreakage` is `null` elsewhere and **the tab hides itself** rather than rendering empty.

## Changes

| File | |
|---|---|
| `src/cacheBreakage.ts` | **new** — pure detector + period aggregation, no VS Code/fs deps so the CLI and webview can both use it |
| `vscode-extension/test/unit/cacheBreakage.test.ts` | **new** — 17 tests |
| `src/adapters/claudeCodeAdapter.ts` | `collectCacheTurn()`, deduped by `message.id`, run at the end of `analyzeUsage` |
| `src/usageAnalysis.ts` | `_muaMergeCacheBreakage()`, alongside the existing `_muaMergeCorrections` |
| `src/types.ts` | `cacheBreakage` on `SessionUsageAnalysis` + `UsageAnalysisPeriod` |
| `src/efficiencyAnalysis.ts` | `cacheBreakage` on `EfficiencyViewData` |
| `vscode-extension/src/extension.ts` | one line — `buildEfficiencyViewData` already had the usage period in hand |
| `efficiency/main.ts` + `styles.css` | the tab |
| `views.config.json` fixture | cache payload, so the interaction crawl and visual diff actually exercise the tab |

Follows the `correctionDetection.ts` shape throughout: provider-neutral input interface, `detect*` / `createEmpty*` / `merge*` trio, pure module.

## Validation

- 17/17 new tests. Full suite **127 files, exit 0, no failures**
- `tsc --noEmit` clean; `eslint src ../src` → **0 errors** (25 pre-existing warnings, none in touched files)
- `npm run check:contract` ✅
- `npm run check:interaction` ✅ — efficiency 15 controls, all responsive
- Rendered headlessly and clicked through: content correct, no page errors

The negative tests are the ones that matter — a healthy session, breakpoint shuffle, warm-up below the floor, and exactly-at-the-ratio all assert **no** break is reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
