### PR TITLE
docs(visual-studio): correct the Known Limitations list

### DIFF
--- a/docs/visual-studio/README.md
+++ b/docs/visual-studio/README.md
@@ -71,10 +71,14 @@ The extension automatically discovers all sessions under the `.vs` folder for ea
     Mastodon buttons are handled by the Visual Studio host.
   - Sections and tabs that have no data in Visual Studio are hidden on the views
     that do ship: the Usage Analysis Dashboard hides the Workspace Health,
-    Repository PRs, Cloud Agent, Insights and Today's Sessions tabs plus the
+    Repository PRs, Cloud Agent, Insights and Recent Sessions tabs plus the
     Copilot Customization Files, Missed Potential and Repository Hygiene sections;
     the chart hides the By Repository toggle; the Fluency Score view hides the
     VS Code Marketplace MCP discovery button.
+  - **The Worktrees tab on the Usage Analysis Dashboard renders but does nothing.**
+    Unlike the other unsupported tabs it is not hidden, and the host has no
+    handlers for its `scanWorktrees`, `pickWorktreeRoot`, `deleteWorktree` or
+    cleanup commands, so scanning, picking a root and deleting are no-ops.
 
   The Usage Analysis Dashboard, the AI Engineering Fluency Score and its Scoring
   Guide **are** available in Visual Studio, along with the details, chart and

--- a/docs/visual-studio/README.md
+++ b/docs/visual-studio/README.md
@@ -75,10 +75,19 @@ The extension automatically discovers all sessions under the `.vs` folder for ea
     Copilot Customization Files, Missed Potential and Repository Hygiene sections;
     the chart hides the By Repository toggle; the Fluency Score view hides the
     VS Code Marketplace MCP discovery button.
-  - **The Worktrees tab on the Usage Analysis Dashboard renders but does nothing.**
-    Unlike the other unsupported tabs it is not hidden, and the host has no
-    handlers for its `scanWorktrees`, `pickWorktreeRoot`, `deleteWorktree` or
-    cleanup commands, so scanning, picking a root and deleting are no-ops.
+  - **Some controls render but do nothing.** Unlike the surfaces above these are
+    not hidden, and the host has no handler for the commands they post:
+    - The **Efficiency Trends** button in the toolbar of *every* view. It posts
+      `showEfficiency`, which the host does not handle. (The Team Dashboard
+      button beside it does not have this problem — the toolbar drops it when no
+      backend is configured, which is always the case here.)
+    - The **Worktrees** tab on the Usage Analysis Dashboard. `scanWorktrees`,
+      `pickWorktreeRoot`, `deleteWorktree` and the cleanup commands are all
+      unhandled, so scanning, picking a root and deleting are no-ops.
+    - On the **Tool Output** tab, the Tool Curation section's "open" links and
+      the suppress-tool control (`openFile`, `openFileFromList`,
+      `manageExtension`, `openAgentPlugins`, `suppressUnknownTool`). Suppressing
+      a tool updates the view but is not persisted.
 
   The Usage Analysis Dashboard, the AI Engineering Fluency Score and its Scoring
   Guide **are** available in Visual Studio, along with the details, chart and

--- a/docs/visual-studio/README.md
+++ b/docs/visual-studio/README.md
@@ -58,11 +58,27 @@ The extension automatically discovers all sessions under the `.vs` folder for ea
 
 - Token counts are **estimated**, not actual LLM API counts. See the note above.
 - Features available in the VS Code extension that are not yet available here:
-  - Cloud backend (Azure Storage sync)
-  - Usage Analysis Dashboard
-  - Copilot Fluency Score
-  - Export / social sharing
-  - Diagnostic reporting panel
+  - **Cloud backend (Azure Storage sync).** The extension has no backend or sign-in
+    path of its own — `backendConfigured` is only relayed from the CLI payload, so
+    anything that needs GitHub auth or synced team data is unavailable.
+  - **Views not shipped by this host**: Team Dashboard, Efficiency Trends,
+    Log Viewer and What's New. (Show Team Dashboard falls back to the details
+    view.)
+  - **Diagnostic reporting panel.** The toolbar button is hidden and the
+    diagnostics command redirects to the details view.
+  - **Export dropdown (image / PDF / PPTX) and Share to Issue** on the Fluency
+    Score view. Social sharing itself *is* supported — the LinkedIn, Bluesky and
+    Mastodon buttons are handled by the Visual Studio host.
+  - Sections and tabs that have no data in Visual Studio are hidden on the views
+    that do ship: the Usage Analysis Dashboard hides the Workspace Health,
+    Repository PRs, Cloud Agent, Insights and Today's Sessions tabs plus the
+    Copilot Customization Files, Missed Potential and Repository Hygiene sections;
+    the chart hides the By Repository toggle; the Fluency Score view hides the
+    VS Code Marketplace MCP discovery button.
+
+  The Usage Analysis Dashboard, the AI Engineering Fluency Score and its Scoring
+  Guide **are** available in Visual Studio, along with the details, chart and
+  environmental impact views.
 
 ---
 


### PR DESCRIPTION
## What changed

The "Known Limitations" section of `docs/visual-studio/README.md` listed two features as unavailable in Visual Studio that have in fact been shipping for a while:

- **Usage Analysis Dashboard**
- **Copilot Fluency Score**

Each is wired through all three places a view needs in this host — a `_WebviewBundle` entry in `AIEngineeringFluency.csproj`, a case in `TokenTrackerControl.xaml.cs` (`showUsageAnalysis` / `showMaturity`), and a `ViewToGlobalKey` mapping in `ThemedHtmlBuilder.cs`. The doc just was not updated.

Both entries are removed, and every remaining entry was re-verified against the host rather than assumed.

## Why each retained entry stayed

| Entry | Verdict | Evidence |
|---|---|---|
| Cloud backend (Azure Storage sync) | **Holds** | No `HttpClient`, upload, sync or OAuth code anywhere in the host; `BackendConfigured` is only relayed from the CLI payload, and there is no VS-side sign-in |
| Diagnostic reporting panel | **Holds** | `#btn-diagnostics` hidden by CSS; the `showDiagnostics` case redirects to details |
| Export / social sharing | **Narrowed** | `ThemedHtmlBuilder.cs` explicitly says social-share buttons *are* supported — `ShareFluencyScoreAsync` handles LinkedIn, Bluesky and Mastodon. Only the Export dropdown (image/PDF/PPTX) and Share-to-Issue are hidden, so the entry was narrowed rather than deleted |

## What was added

Two entries, both derived from the authoritative source (the `_WebviewBundle` items, via `node .github/skills/sync-host-views/sync-host-views.js`):

- **Views the host genuinely does not ship**: Team Dashboard, Efficiency Trends, Log Viewer and What's New.
- **Sections and tabs hidden within the views that do ship** — the Usage Analysis tabs gated on GitHub auth or backend data, the chart's By Repository toggle, the MCP discovery button. Without this the reader could reasonably conclude those views are unavailable entirely.

## Note for reviewers

The **Scoring Guide** (`fluency-level-viewer`) is deliberately *not* listed as a limitation. rajbos/ai-engineering-fluency#2019 merged during this work and added it to the host — `ViewToGlobalKey` now maps it to `__INITIAL_FLUENCY_LEVEL_DATA__`, `showFluencyLevelViewer` navigates to it, and the `#btn-level-viewer-inline` hide rule was deleted. `sync-host-views` confirms Visual Studio now tracks 7 views.

Docs only — no code changes, so no build or test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
