### PR TITLE
Make worktree cleanup failures actionable

### DIFF
--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the VS Code extension will be documented in this file.
 ## [Unreleased]
 
 ### Features
+- Worktree cleanup now explains *why* each worktree could not be removed and lets you act on it: every skipped/failed row shows when the folder was last touched, the last commit's age, whether the branch still has a remote (and whether that remote branch was deleted), the ahead/behind push status, and the number of modified/untracked files — plus "💻 Open in VS Code", "📂 Reveal folder" and "🗑️ Delete anyway…" buttons on the row itself
 - New "What's New" view (command palette: *AI Engineering Fluency: What's New*) listing the last 5 releases in plain English, plus a one-at-a-time notification that points out a new view/tab/section after an update — at most one a day, at most 3 per release, and never one you already opened yourself. Turn the notifications off with `aiEngineeringFluency.whatsNew.notificationsEnabled`; see [docs/features/WHATS-NEW.md](../docs/features/WHATS-NEW.md)
 - New "Research > TTFT" tab in the Diagnostic Report: time-to-first-token averages by day/week/month with a trendline per model, read from VS Code Copilot Chat's own debug log (`attrs.ttft`) — no setup required, see [docs/features/TTFT-TRENDS.md](../docs/features/TTFT-TRENDS.md)
 - New "Skill Suggestions" section in the Usage Analysis Tools & Integrations tab: clusters the first prompt of each session to find tasks you keep prompting for manually (candidates for a reusable skill or prompt file), plus a new insight when a task repeats across 3+ sessions
@@ -15,6 +16,7 @@ All notable changes to the VS Code extension will be documented in this file.
 - Show only the model part of a three-part custom-endpoint model ID (`customendpoint/Mistral/mistral-medium-latest` → `mistral-medium-latest`), and estimate its cost from that model's pricing entry
 
 ### Bug Fixes
+- The worktree cleanup report no longer disappears when the run empties the worktree list — the skipped/failed rows you still have to act on stayed hidden behind the "No worktrees found yet" empty state
 - Fix the "Efficiency" nav button in the Efficiency view doing nothing when clicked — the view passed no active view to the shared nav bar, so its own button rendered enabled with no click handler instead of being marked as the current page
 - Surface a warning when copying a path from the Usage Analysis view fails: the webview reported the failure but nothing on the extension side listened, so a failed copy was completely silent
 - Sharing-server sync now reports "Copilot App" and "Claude (VS Code)" as their own editor labels (matching the local Interaction Modes view) instead of lumping them into "Copilot CLI"/"Claude Code" — the team dashboard's "Editors Used" panel previously had no way to show these categories at all, since the synced `editor` field never carried the distinction

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -502,6 +502,36 @@ interface WorktreeScanResult {
 	bytes: number;
 }
 
+/**
+ * Extra git/filesystem context gathered for a worktree the bulk cleanup could not delete.
+ * A bare "Has uncommitted or untracked changes." tells the user nothing about *what* to do,
+ * so every field here exists to answer a remediation question: is this stale or still active
+ * (lastModified/lastCommitDate), does the branch exist on the remote and is it in sync
+ * (remoteBranch/ahead/behind), and how much local work is actually at risk (modifiedFiles/
+ * untrackedFiles). Fields are optional because each probe is best-effort — a git failure
+ * degrades that one field, it never fails the whole report.
+ */
+interface WorktreeCleanupDiagnostics {
+	/** Newest mtime seen at the worktree root (ISO), i.e. when the folder was last touched. */
+	lastModified?: string;
+	/** ISO timestamp of the last commit on the checked-out branch. */
+	lastCommitDate?: string;
+	/** Human-readable relative age of the last commit ("3 weeks ago"). */
+	lastCommitRelative?: string;
+	/** Upstream tracking ref (e.g. "origin/feature-x"), or undefined when the branch has no upstream. */
+	remoteBranch?: string;
+	/** True when a remote branch with this name actually exists on the remote right now. */
+	remoteBranchExists?: boolean;
+	/** Commits on HEAD not on the upstream branch. */
+	ahead?: number;
+	/** Commits on the upstream branch not on HEAD. */
+	behind?: number;
+	/** Tracked files with uncommitted modifications. */
+	modifiedFiles?: number;
+	/** Untracked files (excluding ignored ones). */
+	untrackedFiles?: number;
+}
+
 type UsageAnalysisTab = 'activity' | 'tools' | 'health' | 'worktrees' | 'insights' | 'corrections';
 
 /** Narrows an arbitrary tab name (e.g. from the what's-new catalog) to one `showUsageAnalysisOnTab` accepts. */
@@ -7918,6 +7948,7 @@ private computeFallbackDailyRollup(
 			scanWorktrees: (message) => this.dispatch('scanWorktrees:analysis', () => this.diagHandleScanWorktrees(message)),
 			cancelWorktreeScan: () => this.dispatch('cancelWorktreeScan:analysis', () => this.diagHandleCancelWorktreeScan()),
 			deleteWorktree: (message) => this.dispatch('deleteWorktree:analysis', () => this.diagHandleDeleteWorktree(message)),
+			openWorktreeInEditor: (message) => this.dispatch('openWorktreeInEditor:analysis', () => this.diagHandleOpenWorktreeInEditor(message)),
 			cleanupPushedWorktrees: (message) => this.dispatch('cleanupPushedWorktrees:analysis', () => this.diagHandleCleanupPushedWorktrees(message)),
 			cancelCleanupPushedWorktrees: () => this.dispatch('cancelCleanupPushedWorktrees:analysis', () => this.diagHandleCancelCleanupPushedWorktrees()),
 			// The webview posts this when navigator.clipboard rejects (no permission,
@@ -11145,6 +11176,77 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString(), startedAtMs)}
     return match ? match[1] : remoteUrl;
   }
 
+  /** Counts `git status --porcelain` lines, split into untracked ("??") and modified/staged. */
+  private async getWorktreeDirtyCounts(worktreeRoot: string): Promise<{ modifiedFiles?: number; untrackedFiles?: number }> {
+    const status = await this.runGit(["status", "--porcelain"], worktreeRoot);
+    if (!status.ok) { return {}; }
+    const lines = status.stdout.split(/\r?\n/).filter((line) => line.trim().length > 0);
+    const untrackedFiles = lines.filter((line) => line.startsWith("??")).length;
+    return { modifiedFiles: lines.length - untrackedFiles, untrackedFiles };
+  }
+
+  /**
+   * Upstream tracking info: the upstream ref name, whether it still exists on the remote
+   * (a branch deleted after a merged PR is the single most common reason a leftover worktree
+   * is safe to remove), and the ahead/behind commit counts against it.
+   */
+  private async getWorktreeRemoteBranchInfo(worktreeRoot: string): Promise<{ remoteBranch?: string; remoteBranchExists?: boolean; ahead?: number; behind?: number }> {
+    const upstream = await this.runGit(["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"], worktreeRoot);
+    if (!upstream.ok || !upstream.stdout) { return { remoteBranchExists: false }; }
+    const remoteBranch = upstream.stdout;
+    // Resolving the remote-tracking ref locally (no network) tells us whether git still knows
+    // about that branch; a pruned/deleted remote branch leaves the upstream name but no ref.
+    const refExists = await this.runGit(["rev-parse", "--verify", "--quiet", `refs/remotes/${remoteBranch}`], worktreeRoot);
+    const counts = await this.runGit(["rev-list", "--left-right", "--count", `HEAD...${remoteBranch}`], worktreeRoot);
+    const [aheadRaw, behindRaw] = counts.ok ? counts.stdout.split(/\s+/) : [];
+    return {
+      remoteBranch,
+      remoteBranchExists: refExists.ok && refExists.stdout.length > 0,
+      ahead: Number.isFinite(Number(aheadRaw)) && aheadRaw !== undefined ? Number(aheadRaw) : undefined,
+      behind: Number.isFinite(Number(behindRaw)) && behindRaw !== undefined ? Number(behindRaw) : undefined,
+    };
+  }
+
+  /** Newest mtime among the worktree root's direct entries, as an ISO string ("when was this last touched"). */
+  private async getWorktreeLastModified(worktreeRoot: string): Promise<string | undefined> {
+    try {
+      const entries = await fs.promises.readdir(worktreeRoot, { withFileTypes: true });
+      let newest = (await fs.promises.stat(worktreeRoot)).mtimeMs;
+      for (const entry of entries) {
+        if (entry.name === ".git") { continue; }
+        try {
+          const stat = await fs.promises.stat(path.join(worktreeRoot, entry.name));
+          if (stat.mtimeMs > newest) { newest = stat.mtimeMs; }
+        } catch { /* unreadable entry, ignore */ }
+      }
+      return new Date(newest).toISOString();
+    } catch {
+      return undefined;
+    }
+  }
+
+  /**
+   * Best-effort remediation context for a worktree the cleanup skipped or failed on. Every
+   * probe degrades independently, so a partially broken repository still yields whatever
+   * fields could be read instead of an all-or-nothing failure.
+   */
+  private async collectWorktreeCleanupDiagnostics(worktreeRoot: string): Promise<WorktreeCleanupDiagnostics> {
+    const [lastModified, lastCommitDate, lastCommitRelative, remoteInfo, dirty] = await Promise.all([
+      this.getWorktreeLastModified(worktreeRoot),
+      this.runGit(["log", "-1", "--format=%cI"], worktreeRoot),
+      this.runGit(["log", "-1", "--format=%cr"], worktreeRoot),
+      this.getWorktreeRemoteBranchInfo(worktreeRoot),
+      this.getWorktreeDirtyCounts(worktreeRoot),
+    ]);
+    return {
+      lastModified,
+      lastCommitDate: lastCommitDate.ok && lastCommitDate.stdout ? lastCommitDate.stdout : undefined,
+      lastCommitRelative: lastCommitRelative.ok && lastCommitRelative.stdout ? lastCommitRelative.stdout : undefined,
+      ...remoteInfo,
+      ...dirty,
+    };
+  }
+
   /**
    * Resolve the main (non-linked) repository root that owns a given worktree, so `git worktree
    * remove` can be run from a location git recognizes as the repository. Returns null when the
@@ -11277,6 +11379,24 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString(), startedAtMs)}
     }
   }
 
+  /**
+   * Opens a worktree folder in a VS Code window so the user can immediately deal with whatever
+   * blocked its cleanup (commit, push, or delete files). Uses a new window rather than replacing
+   * the current one so the Usage Analysis panel — and the cleanup report it is showing — survives.
+   */
+  private async diagHandleOpenWorktreeInEditor(message: any): Promise<void> {
+    const worktreePath = typeof message?.path === "string" ? message.path.trim() : "";
+    if (!worktreePath) { return; }
+    try {
+      const stat = await fs.promises.stat(worktreePath);
+      if (!stat.isDirectory()) { throw new Error("not a directory"); }
+    } catch {
+      vscode.window.showErrorMessage(`Could not open "${worktreePath}" — the folder no longer exists.`);
+      return;
+    }
+    await vscode.commands.executeCommand("vscode.openFolder", vscode.Uri.file(worktreePath), { forceNewWindow: true });
+  }
+
   private diagHandleCancelCleanupPushedWorktrees(): void {
     this.worktreeCleanupId++;
     if (this.analysisPanel && this.isPanelOpen(this.analysisPanel)) {
@@ -11333,10 +11453,12 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString(), startedAtMs)}
       if (outcome.status === "deleted") { deleted++; send({ command: "worktreeDeleted", path: target.path }); }
       else if (outcome.status === "skipped") { skipped++; }
       else { errors++; }
+      // Only the rows the user still has to act on get the (git-invoking) diagnostics pass.
+      const diagnostics = outcome.status === "deleted" ? undefined : await this.collectWorktreeCleanupDiagnostics(target.path);
       send({
         command: "cleanupWorktreeResult",
         path: target.path, branch: target.branch, repoLabel: target.repoLabel,
-        status: outcome.status, reason: outcome.reason,
+        status: outcome.status, reason: outcome.reason, diagnostics,
         processed: i + 1, total: candidates.length,
       });
     }

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -518,10 +518,15 @@ interface WorktreeCleanupDiagnostics {
 	lastCommitDate?: string;
 	/** Human-readable relative age of the last commit ("3 weeks ago"). */
 	lastCommitRelative?: string;
-	/** Upstream tracking ref (e.g. "origin/feature-x"), or undefined when the branch has no upstream. */
+	/** Upstream tracking ref (e.g. "origin/feature-x"), present only when `remoteStatus` is "tracked" or "gone". */
 	remoteBranch?: string;
-	/** True when a remote branch with this name actually exists on the remote right now. */
-	remoteBranchExists?: boolean;
+	/**
+	 * Tri-state so an unreadable worktree is never reported as a fact: "tracked" (upstream exists),
+	 * "gone" (upstream configured but its remote-tracking ref is gone), "none" (branch has no
+	 * upstream). Left undefined when the probe itself failed — the UI then shows no remote chip
+	 * rather than claiming the branch was never pushed.
+	 */
+	remoteStatus?: "tracked" | "gone" | "none";
 	/** Commits on HEAD not on the upstream branch. */
 	ahead?: number;
 	/** Commits on the upstream branch not on HEAD. */
@@ -11189,10 +11194,18 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString(), startedAtMs)}
    * Upstream tracking info: the upstream ref name, whether it still exists on the remote
    * (a branch deleted after a merged PR is the single most common reason a leftover worktree
    * is safe to remove), and the ahead/behind commit counts against it.
+   *
+   * A failing `@{upstream}` lookup is ambiguous — it means both "this branch has no upstream"
+   * and "this is not a readable git worktree" — so the worktree is probed for readability
+   * first. When that probe fails nothing is reported, because claiming "never pushed" for a
+   * worktree we could not read would put a false remediation fact in front of the user.
    */
-  private async getWorktreeRemoteBranchInfo(worktreeRoot: string): Promise<{ remoteBranch?: string; remoteBranchExists?: boolean; ahead?: number; behind?: number }> {
+  private async getWorktreeRemoteBranchInfo(worktreeRoot: string): Promise<{ remoteBranch?: string; remoteStatus?: "tracked" | "gone" | "none"; ahead?: number; behind?: number }> {
+    const readable = await this.runGit(["rev-parse", "--is-inside-work-tree"], worktreeRoot);
+    if (!readable.ok || readable.stdout !== "true") { return {}; }
+
     const upstream = await this.runGit(["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"], worktreeRoot);
-    if (!upstream.ok || !upstream.stdout) { return { remoteBranchExists: false }; }
+    if (!upstream.ok || !upstream.stdout) { return { remoteStatus: "none" }; }
     const remoteBranch = upstream.stdout;
     // Resolving the remote-tracking ref locally (no network) tells us whether git still knows
     // about that branch; a pruned/deleted remote branch leaves the upstream name but no ref.
@@ -11201,7 +11214,7 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString(), startedAtMs)}
     const [aheadRaw, behindRaw] = counts.ok ? counts.stdout.split(/\s+/) : [];
     return {
       remoteBranch,
-      remoteBranchExists: refExists.ok && refExists.stdout.length > 0,
+      remoteStatus: refExists.ok && refExists.stdout.length > 0 ? "tracked" : "gone",
       ahead: Number.isFinite(Number(aheadRaw)) && aheadRaw !== undefined ? Number(aheadRaw) : undefined,
       behind: Number.isFinite(Number(behindRaw)) && behindRaw !== undefined ? Number(behindRaw) : undefined,
     };

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -491,7 +491,7 @@ type WorktreeCleanupDiagnostics = {
 	lastCommitDate?: string;
 	lastCommitRelative?: string;
 	remoteBranch?: string;
-	remoteBranchExists?: boolean;
+	remoteStatus?: "tracked" | "gone" | "none";
 	ahead?: number;
 	behind?: number;
 	modifiedFiles?: number;
@@ -2295,7 +2295,7 @@ function sanitizeWorktreeCleanupDiagnostics(raw: unknown): WorktreeCleanupDiagno
 		lastCommitDate: str(d.lastCommitDate),
 		lastCommitRelative: str(d.lastCommitRelative),
 		remoteBranch: str(d.remoteBranch),
-		remoteBranchExists: typeof d.remoteBranchExists === "boolean" ? d.remoteBranchExists : undefined,
+		remoteStatus: d.remoteStatus === "tracked" || d.remoteStatus === "gone" || d.remoteStatus === "none" ? d.remoteStatus : undefined,
 		ahead: num(d.ahead),
 		behind: num(d.behind),
 		modifiedFiles: num(d.modifiedFiles),
@@ -4320,11 +4320,13 @@ function buildWorktreeAgeChips(d: WorktreeCleanupDiagnostics): string[] {
 /** Remote-branch + ahead/behind chips — whether the work here exists anywhere but this folder. */
 function buildWorktreeRemoteChips(d: WorktreeCleanupDiagnostics): string[] {
 	const chips: string[] = [];
-	if (!d.remoteBranch) {
+	// An undefined status means the probe itself failed, so no remote chip is shown at all —
+	// silence is correct here, whereas "never pushed" would be an invented fact.
+	if (d.remoteStatus === "none") {
 		chips.push(worktreeChip("⚠️", "Remote: none (never pushed)", "This branch was never pushed — it has no upstream tracking branch", true));
-	} else if (d.remoteBranchExists === false) {
-		chips.push(worktreeChip("⚠️", `Remote: ${d.remoteBranch} (gone)`, "The upstream branch no longer exists on the remote (deleted or pruned)", true));
-	} else {
+	} else if (d.remoteStatus === "gone") {
+		chips.push(worktreeChip("⚠️", `Remote: ${d.remoteBranch ?? "unknown"} (gone)`, "The upstream branch no longer exists on the remote (deleted or pruned)", true));
+	} else if (d.remoteStatus === "tracked" && d.remoteBranch) {
 		chips.push(worktreeChip("🌐", `Remote: ${d.remoteBranch}`, "Upstream tracking branch"));
 	}
 	if (d.ahead === undefined && d.behind === undefined) { return chips; }

--- a/vscode-extension/src/webview/usage/main.ts
+++ b/vscode-extension/src/webview/usage/main.ts
@@ -479,7 +479,22 @@ let worktreeCleanupInProgress = false;
 let worktreeCleanupConfirmPending = false;
 let worktreeCleanupStatus: { processed: number; total: number } = { processed: 0, total: 0 };
 type WorktreeCleanupOutcome = "deleted" | "skipped" | "error";
-type WorktreeCleanupLogEntry = { path: string; branch: string; repoLabel: string; status: WorktreeCleanupOutcome; reason?: string };
+/**
+ * Remediation context for a cleanup row the user still has to act on (see
+ * WorktreeCleanupDiagnostics in extension.ts — same shape, all fields best-effort).
+ */
+type WorktreeCleanupDiagnostics = {
+	lastModified?: string;
+	lastCommitDate?: string;
+	lastCommitRelative?: string;
+	remoteBranch?: string;
+	remoteBranchExists?: boolean;
+	ahead?: number;
+	behind?: number;
+	modifiedFiles?: number;
+	untrackedFiles?: number;
+};
+type WorktreeCleanupLogEntry = { path: string; branch: string; repoLabel: string; status: WorktreeCleanupOutcome; reason?: string; diagnostics?: WorktreeCleanupDiagnostics };
 let worktreeCleanupLog: WorktreeCleanupLogEntry[] = [];
 
 function numField(v: unknown): number { return Number(v ?? 0) || 0; }
@@ -2046,14 +2061,21 @@ function _handleWorktreeRootsListClick(target: HTMLElement): boolean {
 }
 
 function _handleWorktreeRowLinkClick(event: MouseEvent, target: HTMLElement): boolean {
-	const revealLink = target.closest(".worktree-reveal-link") as HTMLElement | null;
+	const openEditorBtn = target.closest(".worktree-open-editor-btn") as HTMLElement | null;
+	if (openEditorBtn) {
+		event.preventDefault();
+		const p = decodeURIComponent(openEditorBtn.getAttribute("data-path") || "");
+		if (p) { vscode.postMessage({ command: "openWorktreeInEditor", path: p }); }
+		return true;
+	}
+	const revealLink = target.closest(".worktree-reveal-link, .worktree-reveal-btn") as HTMLElement | null;
 	if (revealLink) {
 		event.preventDefault();
 		const p = decodeURIComponent(revealLink.getAttribute("data-path") || "");
 		if (p) { vscode.postMessage({ command: "revealPath", path: p }); }
 		return true;
 	}
-	const deleteLink = target.closest(".worktree-delete-link") as HTMLElement | null;
+	const deleteLink = target.closest(".worktree-delete-link, .worktree-delete-btn") as HTMLElement | null;
 	if (deleteLink) {
 		event.preventDefault();
 		const p = decodeURIComponent(deleteLink.getAttribute("data-path") || "");
@@ -2253,8 +2275,28 @@ function handleCleanupWorktreeResult(message: any): void {
 		repoLabel: String(message.repoLabel ?? ""),
 		status,
 		reason: typeof message.reason === "string" ? message.reason : undefined,
+		diagnostics: sanitizeWorktreeCleanupDiagnostics(message.diagnostics),
 	});
 	updateWorktreeResults();
+}
+
+/** Normalizes the optional diagnostics payload; a missing/!object value yields undefined (no detail line). */
+function sanitizeWorktreeCleanupDiagnostics(raw: unknown): WorktreeCleanupDiagnostics | undefined {
+	if (!raw || typeof raw !== "object") { return undefined; }
+	const d = raw as Record<string, unknown>;
+	const str = (v: unknown) => (typeof v === "string" && v ? v : undefined);
+	const num = (v: unknown) => (typeof v === "number" && Number.isFinite(v) ? v : undefined);
+	return {
+		lastModified: str(d.lastModified),
+		lastCommitDate: str(d.lastCommitDate),
+		lastCommitRelative: str(d.lastCommitRelative),
+		remoteBranch: str(d.remoteBranch),
+		remoteBranchExists: typeof d.remoteBranchExists === "boolean" ? d.remoteBranchExists : undefined,
+		ahead: num(d.ahead),
+		behind: num(d.behind),
+		modifiedFiles: num(d.modifiedFiles),
+		untrackedFiles: num(d.untrackedFiles),
+	};
 }
 
 function handleCleanupComplete(): void {
@@ -4186,6 +4228,88 @@ function renderWorktreeCleanupCard(): string {
   </div>`;
 }
 
+/** Local date/time label for an ISO string; empty when it is missing or unparseable. */
+function formatWorktreeTimestamp(iso: string | undefined): string {
+	if (!iso) { return ""; }
+	const date = new Date(iso);
+	return isNaN(date.getTime()) ? "" : date.toLocaleString();
+}
+
+/** One "label: value" chip; `danger` marks a fact that blocks or endangers the cleanup. */
+function worktreeChip(icon: string, text: string, title: string, danger = false): string {
+	return `<span class="worktree-cleanup-chip${danger ? " danger" : ""}" title="${escapeHtml(title)}">${icon} ${escapeHtml(text)}</span>`;
+}
+
+/** "Last updated" / "Last commit" chips — how stale (or how live) this worktree is. */
+function buildWorktreeAgeChips(d: WorktreeCleanupDiagnostics): string[] {
+	const chips: string[] = [];
+	const lastModified = formatWorktreeTimestamp(d.lastModified);
+	if (lastModified) {
+		chips.push(worktreeChip("🕒", `Last updated: ${lastModified}`, "Newest file modification at the worktree root"));
+	}
+	const commitTitle = formatWorktreeTimestamp(d.lastCommitDate) || "Last commit on the checked-out branch";
+	if (d.lastCommitRelative || d.lastCommitDate) {
+		chips.push(worktreeChip("📝", `Last commit: ${d.lastCommitRelative || commitTitle}`, commitTitle));
+	}
+	return chips;
+}
+
+/** Remote-branch + ahead/behind chips — whether the work here exists anywhere but this folder. */
+function buildWorktreeRemoteChips(d: WorktreeCleanupDiagnostics): string[] {
+	const chips: string[] = [];
+	if (!d.remoteBranch) {
+		chips.push(worktreeChip("⚠️", "Remote: none (never pushed)", "This branch was never pushed — it has no upstream tracking branch", true));
+	} else if (d.remoteBranchExists === false) {
+		chips.push(worktreeChip("⚠️", `Remote: ${d.remoteBranch} (gone)`, "The upstream branch no longer exists on the remote (deleted or pruned)", true));
+	} else {
+		chips.push(worktreeChip("🌐", `Remote: ${d.remoteBranch}`, "Upstream tracking branch"));
+	}
+	if (d.ahead === undefined && d.behind === undefined) { return chips; }
+	const ahead = d.ahead ?? 0, behind = d.behind ?? 0;
+	const synced = ahead === 0 && behind === 0;
+	chips.push(worktreeChip(
+		synced ? "✅" : "🔀",
+		`Push status: ${synced ? "up to date" : `${ahead} ahead · ${behind} behind`}`,
+		"Commits on this branch compared with its upstream",
+		ahead > 0,
+	));
+	return chips;
+}
+
+/** Working-tree chip — how much uncommitted work would be lost by a force-delete. */
+function buildWorktreeDirtyChips(d: WorktreeCleanupDiagnostics): string[] {
+	if (d.modifiedFiles === undefined && d.untrackedFiles === undefined) { return []; }
+	const modified = d.modifiedFiles ?? 0, untracked = d.untrackedFiles ?? 0;
+	const clean = modified === 0 && untracked === 0;
+	return [worktreeChip(
+		clean ? "✅" : "✏️",
+		`Changes: ${clean ? "clean" : `${modified} modified · ${untracked} untracked`}`,
+		"Uncommitted work in this worktree",
+		!clean,
+	)];
+}
+
+/**
+ * The remediation facts for one blocked cleanup row, as compact "label: value" chips. Each chip
+ * answers a question the user would otherwise have to open a terminal to answer: is this stale,
+ * does the branch still exist on the remote, is it in sync, and how much work is uncommitted.
+ */
+function buildWorktreeCleanupDetailChips(d: WorktreeCleanupDiagnostics | undefined): string {
+	if (!d) { return ""; }
+	const chips = [...buildWorktreeAgeChips(d), ...buildWorktreeRemoteChips(d), ...buildWorktreeDirtyChips(d)];
+	return chips.length === 0 ? "" : `<div class="worktree-cleanup-chips">${chips.join("")}</div>`;
+}
+
+/** Per-row remediation actions for a worktree the cleanup could not delete. */
+function buildWorktreeCleanupActions(e: WorktreeCleanupLogEntry): string {
+	const p = encodeURIComponent(e.path);
+	return `<div class="worktree-cleanup-log-actions">
+      <button type="button" class="button secondary worktree-open-editor-btn" data-path="${p}" title="Open this worktree folder in a new VS Code window so you can commit, push, or clean it up">💻 Open in VS Code</button>
+      <button type="button" class="button secondary worktree-reveal-btn" data-path="${p}" title="Show this folder in the OS file explorer">📂 Reveal folder</button>
+      <button type="button" class="button secondary worktree-delete-btn" data-path="${p}" data-branch="${encodeURIComponent(e.branch)}" data-repo="${encodeURIComponent(e.repoLabel)}" data-pushed="?" title="Try removing it again — you will be asked to confirm, and to force-delete if it still has uncommitted changes">🗑️ Delete anyway…</button>
+    </div>`;
+}
+
 /** Non-deleted cleanup outcomes (skipped/error) — successful deletions just remove the row, no need to list them. */
 function renderWorktreeCleanupLog(): string {
 	const notable = worktreeCleanupLog.filter((e) => e.status !== "deleted");
@@ -4201,6 +4325,8 @@ function renderWorktreeCleanupLog(): string {
         </div>
         <div class="worktree-cleanup-log-path">${escapeHtml(e.path)}</div>
         <div class="worktree-cleanup-log-reason">${escapeHtml(e.reason || "")}</div>
+        ${buildWorktreeCleanupDetailChips(e.diagnostics)}
+        ${buildWorktreeCleanupActions(e)}
       </div>
     </div>`;
 	}).join("");
@@ -4229,8 +4355,12 @@ function renderWorktreeCleanupStatus(): string {
 
 function renderWorktreeResults(): string {
 	if (worktreeResults.length === 0) {
+		// The cleanup report is still shown here: a run that deleted or errored on every
+		// remaining worktree empties this list, and dropping the report with it would hide
+		// exactly the rows the user still has to act on.
 		if (worktreeScanInProgress) { return '<div style="padding: 16px; color: var(--text-muted);">Discovering worktrees…</div>'; }
-		return '<div style="padding: 16px; color: var(--text-muted);">No worktrees found yet. Add root folders above and click Scan.</div>';
+		return '<div style="padding: 16px; color: var(--text-muted);">No worktrees found yet. Add root folders above and click Scan.</div>'
+			+ renderWorktreeCleanupStatus();
 	}
 	const groups = groupWorktreesByRepo(worktreeResults);
 	const totalBytes = worktreeResults.reduce((s, w) => s + knownBytes(w), 0);

--- a/vscode-extension/src/webview/usage/styles.css
+++ b/vscode-extension/src/webview/usage/styles.css
@@ -1227,6 +1227,41 @@ background: var(--bg-tertiary);
 	word-break: break-word;
 }
 
+.worktree-cleanup-chips {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 6px;
+	margin-top: 6px;
+}
+
+.worktree-cleanup-chip {
+	padding: 2px 8px;
+	border: 1px solid var(--border-color);
+	border-radius: 10px;
+	background: var(--bg-tertiary);
+	color: var(--text-secondary);
+	font-size: 11px;
+	white-space: nowrap;
+}
+
+/* Facts that block or endanger a cleanup (unpushed commits, dirty tree, missing remote). */
+.worktree-cleanup-chip.danger {
+	border-color: var(--vscode-errorForeground, #f14c4c);
+	color: var(--vscode-errorForeground, #f14c4c);
+}
+
+.worktree-cleanup-log-actions {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 6px;
+	margin-top: 8px;
+}
+
+.worktree-cleanup-log-actions .button {
+	padding: 3px 10px;
+	font-size: 11px;
+}
+
 .worktree-repo-actions {
 	white-space: nowrap;
 }

--- a/vscode-extension/test/unit/usageWebviewMessageFlow.test.ts
+++ b/vscode-extension/test/unit/usageWebviewMessageFlow.test.ts
@@ -366,6 +366,119 @@ test('renders the cleanup log with the worktree path for failing entries', async
 	assert.ok(rendered?.includes('Could not safely locate the main repository'), 'expected the cleanup reason to stay visible');
 });
 
+test('a blocked cleanup entry shows remediation details and actionable buttons', async () => {
+	// A bare "Has uncommitted or untracked changes." gives the user nothing to act on. The row
+	// has to say how stale the worktree is, whether the branch still exists on the remote, and
+	// whether it is pushed — and offer a way to go fix it.
+	const harness = await bootWebview(buildStats());
+	const worktreePath = 'C:\\Users\\me\\.copilot\\copilot-worktrees\\repo\\stale-branch';
+
+	harness.post({ command: 'cleanupStarted', total: 1 });
+	harness.post({
+		command: 'cleanupWorktreeResult',
+		path: worktreePath,
+		branch: 'stale-branch',
+		repoLabel: 'repo',
+		status: 'skipped',
+		reason: 'Has uncommitted or untracked changes.',
+		diagnostics: {
+			lastModified: '2026-09-01T08:30:00.000Z',
+			lastCommitDate: '2026-08-20T09:00:00.000Z',
+			lastCommitRelative: '3 weeks ago',
+			remoteBranch: 'origin/stale-branch',
+			remoteBranchExists: false,
+			ahead: 2,
+			behind: 5,
+			modifiedFiles: 3,
+			untrackedFiles: 1,
+		},
+		processed: 1,
+		total: 1,
+	});
+	harness.post({ command: 'cleanupComplete' });
+
+	const rendered = harness.text('.worktree-cleanup-log');
+	assert.ok(rendered?.includes('Last updated:'), `expected a last-updated chip, got: ${rendered}`);
+	assert.ok(rendered?.includes('Last commit: 3 weeks ago'), 'expected the relative last-commit age');
+	assert.ok(rendered?.includes('origin/stale-branch'), 'expected the remote branch name');
+	assert.ok(rendered?.includes('(gone)'), 'a deleted upstream branch must be called out');
+	assert.ok(rendered?.includes('2 ahead') && rendered?.includes('5 behind'), 'expected the ahead/behind push status');
+	assert.ok(rendered?.includes('3 modified') && rendered?.includes('1 untracked'), 'expected the dirty-file counts');
+	assert.ok(rendered?.includes('Open in VS Code'), 'expected an open-in-VS-Code remediation button');
+});
+
+test('a synced, never-dirty entry reports "up to date" rather than counts', async () => {
+	const harness = await bootWebview(buildStats());
+
+	harness.post({ command: 'cleanupStarted', total: 1 });
+	harness.post({
+		command: 'cleanupWorktreeResult',
+		path: 'C:\\wt\\clean',
+		branch: 'clean',
+		repoLabel: 'repo',
+		status: 'error',
+		reason: 'Could not delete worktree.',
+		diagnostics: { remoteBranch: 'origin/clean', remoteBranchExists: true, ahead: 0, behind: 0, modifiedFiles: 0, untrackedFiles: 0 },
+		processed: 1,
+		total: 1,
+	});
+	harness.post({ command: 'cleanupComplete' });
+
+	const rendered = harness.text('.worktree-cleanup-log');
+	assert.ok(rendered?.includes('Push status: up to date'), `expected an up-to-date push status, got: ${rendered}`);
+	assert.ok(rendered?.includes('Changes: clean'), 'a clean tree must say so instead of showing zero counts');
+	assert.ok(!rendered?.includes('(gone)'), 'an existing upstream branch must not be marked gone');
+});
+
+test('a branch that was never pushed is flagged as having no remote', async () => {
+	const harness = await bootWebview(buildStats());
+
+	harness.post({ command: 'cleanupStarted', total: 1 });
+	harness.post({
+		command: 'cleanupWorktreeResult',
+		path: 'C:\\wt\\local-only',
+		branch: 'local-only',
+		repoLabel: 'repo',
+		status: 'skipped',
+		reason: 'Worktree has commits not pushed to any remote.',
+		diagnostics: { remoteBranchExists: false },
+		processed: 1,
+		total: 1,
+	});
+	harness.post({ command: 'cleanupComplete' });
+
+	const rendered = harness.text('.worktree-cleanup-log');
+	assert.ok(rendered?.includes('Remote: none (never pushed)'), `expected a missing-remote warning, got: ${rendered}`);
+});
+
+test('clicking "Open in VS Code" asks the host to open that worktree folder', async () => {
+	const harness = await bootWebview(buildStats());
+	const worktreePath = 'C:\\wt\\needs-attention';
+
+	harness.post({ command: 'cleanupStarted', total: 1 });
+	harness.post({
+		command: 'cleanupWorktreeResult',
+		path: worktreePath,
+		branch: 'needs-attention',
+		repoLabel: 'repo',
+		status: 'skipped',
+		reason: 'Has uncommitted or untracked changes.',
+		diagnostics: { modifiedFiles: 2, untrackedFiles: 0 },
+		processed: 1,
+		total: 1,
+	});
+	harness.post({ command: 'cleanupComplete' });
+	harness.posted.length = 0;
+
+	const button = harness.window.document.querySelector('.worktree-open-editor-btn') as HTMLElement | null;
+	assert.ok(button, 'expected an open-in-VS-Code button on the blocked cleanup row');
+	button.dispatchEvent(new harness.window.MouseEvent('click', { bubbles: true }));
+
+	const posted = harness.posted.find((m) => m.command === 'openWorktreeInEditor');
+	assert.ok(posted, `expected an openWorktreeInEditor message, got: ${JSON.stringify(harness.posted)}`);
+	assert.equal(posted.path, worktreePath);
+});
+
 test('accepts payloads relayed the way VS Code actually delivers them', async () => {
 	// The panel hung with `delivered=true` logged host-side because the webview's source-trust
 	// check compared window identities. VS Code relays from an internal window, so every

--- a/vscode-extension/test/unit/usageWebviewMessageFlow.test.ts
+++ b/vscode-extension/test/unit/usageWebviewMessageFlow.test.ts
@@ -395,7 +395,7 @@ test('a blocked cleanup entry shows remediation details and actionable buttons',
 			lastCommitDate: '2026-08-20T09:00:00.000Z',
 			lastCommitRelative: '3 weeks ago',
 			remoteBranch: 'origin/stale-branch',
-			remoteBranchExists: false,
+			remoteStatus: 'gone',
 			ahead: 2,
 			behind: 5,
 			modifiedFiles: 3,
@@ -427,7 +427,7 @@ test('a synced, never-dirty entry reports "up to date" rather than counts', asyn
 		repoLabel: 'repo',
 		status: 'error',
 		reason: 'Could not delete worktree.',
-		diagnostics: { remoteBranch: 'origin/clean', remoteBranchExists: true, ahead: 0, behind: 0, modifiedFiles: 0, untrackedFiles: 0 },
+		diagnostics: { remoteBranch: 'origin/clean', remoteStatus: 'tracked', ahead: 0, behind: 0, modifiedFiles: 0, untrackedFiles: 0 },
 		processed: 1,
 		total: 1,
 	});
@@ -450,7 +450,7 @@ test('a branch that was never pushed is flagged as having no remote', async () =
 		repoLabel: 'repo',
 		status: 'skipped',
 		reason: 'Worktree has commits not pushed to any remote.',
-		diagnostics: { remoteBranchExists: false },
+		diagnostics: { remoteStatus: 'none' },
 		processed: 1,
 		total: 1,
 	});
@@ -458,6 +458,32 @@ test('a branch that was never pushed is flagged as having no remote', async () =
 
 	const rendered = harness.text('.worktree-cleanup-log');
 	assert.ok(rendered?.includes('Remote: none (never pushed)'), `expected a missing-remote warning, got: ${rendered}`);
+});
+
+test('a worktree whose remote could not be probed shows no remote claim at all', async () => {
+	// "Could not read this worktree" and "this branch has no upstream" both fail the same git
+	// lookup. Reporting the unreadable case as "never pushed" would be an invented fact, so the
+	// host omits remoteStatus entirely and the row must simply carry no remote chip.
+	const harness = await bootWebview(buildStats());
+
+	harness.post({ command: 'cleanupStarted', total: 1 });
+	harness.post({
+		command: 'cleanupWorktreeResult',
+		path: 'C:\\wt\\unreadable',
+		branch: '?',
+		repoLabel: 'repo',
+		status: 'error',
+		reason: 'Could not safely locate the main repository.',
+		diagnostics: { lastModified: '2026-09-01T08:30:00.000Z' },
+		processed: 1,
+		total: 1,
+	});
+	harness.post({ command: 'cleanupComplete' });
+
+	const rendered = harness.text('.worktree-cleanup-log');
+	assert.ok(rendered?.includes('Last updated:'), `expected the readable facts to still render, got: ${rendered}`);
+	assert.ok(!rendered?.includes('Remote:'), 'an unprobed remote must not be reported as a fact');
+	assert.ok(!rendered?.includes('never pushed'), 'an unreadable worktree must never be called "never pushed"');
 });
 
 test('clicking "Open in VS Code" asks the host to open that worktree folder', async () => {


### PR DESCRIPTION
## What

Worktree cleanup currently reports failures like `Has uncommitted or untracked changes.` — true, but there's nothing to act on. This makes every skipped/failed row self-explanatory and directly actionable.

### Per-row remediation facts (chips)
Gathered on the extension side, only for rows that were *not* deleted (so the extra git calls don't slow down a clean run):

- 🕒 **Last updated** — newest mtime at the worktree root
- 📝 **Last commit** — relative age, with the exact timestamp in the tooltip
- 🌐 **Remote** — the upstream tracking branch, flagged red as `(gone)` when the remote branch was deleted/pruned, or `none (never pushed)` when there is no upstream at all
- 🔀 **Push status** — `up to date`, or `N ahead · M behind`
- ✏️ **Changes** — `clean`, or `N modified · M untracked`

Chips that block or endanger a cleanup render in the error colour.

### Per-row actions
- 💻 **Open in VS Code** — opens the worktree folder in a new window (new `openWorktreeInEditor` message → `vscode.openFolder` with `forceNewWindow`, so the Usage Analysis panel and its cleanup report survive)
- 📂 **Reveal folder**
- 🗑️ **Delete anyway…** — reuses the existing single-delete flow, including its force-delete confirmation

### Bug fix
The cleanup report disappeared entirely when a run emptied the worktree list — the rows the user still had to act on were hidden behind the "No worktrees found yet" empty state.

## Notes

- Every diagnostics probe is best-effort and degrades independently; a broken repo still yields whatever fields could be read rather than failing the whole report.
- `remoteBranchExists` is resolved from the local remote-tracking ref, so there is **no network call** during cleanup.

## Validation

- `npm run check-types`, `npm run lint`, `npm run compile` — clean
- Full unit suite green; 4 new tests in `usageWebviewMessageFlow.test.ts` cover the chips (stale/gone remote, up-to-date/clean, never-pushed) and assert the Open in VS Code button actually posts `openWorktreeInEditor`
- `npm run check:contract` — ✅ every webview message has a handler
- `npm run check:interaction` — ✅ every control does something when clicked