### PR TITLE
Add session steps overview table to log viewer

### DIFF
--- a/vscode-extension/src/webview/logviewer/main.ts
+++ b/vscode-extension/src/webview/logviewer/main.ts
@@ -1055,6 +1055,124 @@ ${hasBreakdown ? `<div class="session-usage-breakdown">
 `;
 }
 
+// ── Turns overview table ─────────────────────────────────────────────────────
+
+type TurnOverviewRow = {
+	turnNumber: number;
+	model: string | null;
+	mode: ChatTurn['mode'];
+	input: number;
+	cached: number | null;
+	output: number;
+	total: number;
+	isActual: boolean;
+};
+
+/**
+ * Deduces per-turn cache-read tokens from `actualUsage.promptTokenDetails`,
+ * when the adapter reported a breakdown entry whose category/label mentions
+ * "cache" (e.g. Gemini CLI's `{ category: 'cached', label: 'Cache reads' }`).
+ * Returns `null` when no such entry exists — most adapters don't split cache
+ * reads out per turn, so the Cached column is only shown when at least one
+ * turn actually has this data (see `renderTurnsOverviewTable`).
+ */
+function getTurnCachedTokens(turn: ChatTurn): number | null {
+	const au = turn.actualUsage;
+	if (!au?.promptTokenDetails?.length) { return null; }
+	const cachedPct = au.promptTokenDetails
+		.filter(d => /cache/i.test(d.category) || /cache/i.test(d.label))
+		.reduce((sum, d) => sum + d.percentageOfPrompt, 0);
+	if (cachedPct <= 0) { return null; }
+	return Math.round(au.promptTokens * cachedPct / 100);
+}
+
+function buildTurnOverviewRows(data: SessionLogData): TurnOverviewRow[] {
+	return data.turns.map(turn => {
+		const au = turn.actualUsage;
+		const isActual = !!au;
+		const input = isActual ? au!.promptTokens : turn.inputTokensEstimate;
+		const output = isActual ? au!.completionTokens : turn.outputTokensEstimate;
+		const total = isActual
+			? (au!.promptTokens + au!.completionTokens)
+			: (turn.inputTokensEstimate + turn.outputTokensEstimate + turn.thinkingTokensEstimate);
+		return { turnNumber: turn.turnNumber, model: turn.model, mode: turn.mode, input, cached: getTurnCachedTokens(turn), output, total, isActual };
+	});
+}
+
+/** Stable string hash → hue, so each distinct model gets a consistent badge color across the overview table. */
+function hashModelToHue(model: string): number {
+	let hash = 0;
+	for (let i = 0; i < model.length; i++) {
+		hash = (hash * 31 + model.charCodeAt(i)) >>> 0;
+	}
+	return hash % 360;
+}
+
+function renderModelOverviewBadge(model: string | null): string {
+	if (!model) { return '<span class="overview-model-badge overview-model-unknown">—</span>'; }
+	const hue = hashModelToHue(model);
+	const style = `background: hsl(${hue}, 55%, 16%); color: hsl(${hue}, 70%, 78%); border-color: hsl(${hue}, 55%, 32%);`;
+	return `<span class="overview-model-badge" style="${style}" title="${escapeHtml(model)}">${escapeHtml(getModelDisplayName(model))}</span>`;
+}
+
+/**
+ * Renders the turns-overview table shown above the chat-turns list: one compact,
+ * clickable row per turn with its mode, model, and input/cached/output token
+ * usage, so a multi-model session (e.g. model-routing research) can be scanned
+ * at a glance without opening every turn card. A row's model badge differing
+ * from the one above it is flagged with ⇄ to spot model switches quickly.
+ * Clicking a row scrolls to and briefly highlights the matching turn card.
+ */
+function renderTurnsOverviewTable(data: SessionLogData): string {
+	if (data.turns.length === 0) { return ''; }
+	const rows = buildTurnOverviewRows(data);
+	const hasCached = rows.some(r => r.cached !== null);
+	const hasModelSwitches = rows.some((r, i) => i > 0 && r.model && rows[i - 1].model && r.model !== rows[i - 1].model);
+
+	const bodyRows = rows.map((row, i) => {
+		const switched = i > 0 && !!row.model && !!rows[i - 1].model && row.model !== rows[i - 1].model;
+		const cachedCell = hasCached ? `<td class="count-cell">${row.cached !== null ? formatCompact(row.cached) : '—'}</td>` : '';
+		return `<tr class="turns-overview-row${switched ? ' turns-overview-row-switch' : ''}" data-turn="${row.turnNumber}" title="Jump to turn #${row.turnNumber}">
+<td class="turns-overview-num">#${row.turnNumber}${switched ? ' <span class="overview-switch-icon" title="Model changed from the previous step">⇄</span>' : ''}</td>
+<td><span class="turn-mode" style="background: ${getModeColor(row.mode)};">${getModeIcon(row.mode)} ${escapeHtml(row.mode)}</span></td>
+<td>${renderModelOverviewBadge(row.model)}</td>
+<td class="count-cell">${formatCompact(row.input)}</td>
+${cachedCell}
+<td class="count-cell">${formatCompact(row.output)}</td>
+<td class="count-cell"><strong>${formatCompact(row.total)}</strong></td>
+<td class="turns-overview-actual" title="${row.isActual ? 'Actual API usage' : 'Estimated from text'}">${row.isActual ? '✓' : '~'}</td>
+</tr>`;
+	}).join('');
+
+	return `
+<div class="turns-overview">
+<div class="turns-overview-header">
+<span>🧭 Session Steps Overview (${rows.length})</span>
+${hasModelSwitches ? '<span class="overview-switch-note">⇄ marks a model change from the previous step</span>' : ''}
+</div>
+<div class="turns-overview-table-wrap">
+<table class="turns-overview-table">
+<thead>
+<tr>
+<th scope="col">Step</th>
+<th scope="col">Mode</th>
+<th scope="col">Model</th>
+<th scope="col">Input</th>
+${hasCached ? '<th scope="col">Cached</th>' : ''}
+<th scope="col">Output</th>
+<th scope="col">Total</th>
+<th scope="col" title="✓ actual API usage, ~ estimated from text">Src</th>
+</tr>
+</thead>
+<tbody>
+${bodyRows}
+</tbody>
+</table>
+</div>
+</div>
+`;
+}
+
 /**
  * Wires up all DOM event handlers after the layout has been injected into
  * `#root`. Must be called once immediately after `root.innerHTML` is set.
@@ -1120,6 +1238,16 @@ e.preventDefault();
 });
 }
 
+/** Clicking a turns-overview row jumps to and briefly highlights the matching turn card. */
+function wireUpTurnsOverviewHandlers(): void {
+document.querySelectorAll<HTMLElement>('.turns-overview-row').forEach(row => {
+row.addEventListener('click', () => {
+const turnNumber = parseInt(row.getAttribute('data-turn') || '0', 10);
+if (turnNumber > 0) { scrollAndFocusTurn(turnNumber); }
+});
+});
+}
+
 function wireUpEventHandlers(): void {
 document.getElementById('btn-raw')?.addEventListener('click', () => {
 vscode.postMessage({ command: 'openRawFile' });
@@ -1145,6 +1273,7 @@ vscode.postMessage({ command: 'openRawFile' });
 });
 
 wireUpToolCallHandlers();
+wireUpTurnsOverviewHandlers();
 }
 
 // ── Entry-point renderers (signatures preserved) ─────────────────────────────
@@ -1381,6 +1510,8 @@ ${renderSessionActualUsage(
 	actualStats.aggregatedBreakdown,
 )}
 
+${renderTurnsOverviewTable(data)}
+
 <div class="turns-header">
 <span>📝</span>
 <span>Chat Turns (${data.turns.length})${data.title ? ` - ${escapeHtml(data.title)}` : ''}</span>
@@ -1402,9 +1533,8 @@ ${data.turns.length > 0
 	focusRequestedTurn(data as SessionLogData & { focusedTurnNumber?: number; });
 }
 
-function focusRequestedTurn(data: SessionLogData & { focusedTurnNumber?: number; }): void {
-	const turnNumber = data.focusedTurnNumber;
-	if (typeof turnNumber !== 'number' || !Number.isSafeInteger(turnNumber) || turnNumber < 1) { return; }
+/** Scrolls to and briefly highlights the turn card for the given turn number, if it exists. */
+function scrollAndFocusTurn(turnNumber: number): void {
 	const turnCard = document.querySelector<HTMLElement>(`.turn-card[data-turn="${turnNumber}"]`);
 	if (!turnCard) { return; }
 	turnCard.classList.add('turn-card-focused');
@@ -1412,6 +1542,12 @@ function focusRequestedTurn(data: SessionLogData & { focusedTurnNumber?: number;
 	turnCard.focus({ preventScroll: true });
 	turnCard.scrollIntoView({ behavior: 'smooth', block: 'center' });
 	setTimeout(() => turnCard.classList.remove('turn-card-focused'), 2_000);
+}
+
+function focusRequestedTurn(data: SessionLogData & { focusedTurnNumber?: number; }): void {
+	const turnNumber = data.focusedTurnNumber;
+	if (typeof turnNumber !== 'number' || !Number.isSafeInteger(turnNumber) || turnNumber < 1) { return; }
+	scrollAndFocusTurn(turnNumber);
 }
 
 async function bootstrap(): Promise<void> {

--- a/vscode-extension/src/webview/logviewer/main.ts
+++ b/vscode-extension/src/webview/logviewer/main.ts
@@ -4,6 +4,7 @@ import { setHtml } from '../shared/domUtils';
 import { escapeHtml, formatCompact, formatFileSize, setCompactNumbers, getEditorIcon } from '../shared/formatUtils';
 import { getModelDisplayName } from '../../../../src/webview/shared/modelUtils';
 import type { McpToolUsage, ModeUsage, ToolCallUsage } from '../shared/types';
+import { buildTurnOverviewRows, hashModelToHue } from './turnsOverview';
 // CSS imported as text via esbuild
 import themeStyles from '../shared/theme.css';
 import styles from './styles.css';
@@ -1056,57 +1057,9 @@ ${hasBreakdown ? `<div class="session-usage-breakdown">
 }
 
 // ── Turns overview table ─────────────────────────────────────────────────────
-
-type TurnOverviewRow = {
-	turnNumber: number;
-	model: string | null;
-	mode: ChatTurn['mode'];
-	input: number;
-	cached: number | null;
-	output: number;
-	total: number;
-	isActual: boolean;
-};
-
-/**
- * Deduces per-turn cache-read tokens from `actualUsage.promptTokenDetails`,
- * when the adapter reported a breakdown entry whose category/label mentions
- * "cache" (e.g. Gemini CLI's `{ category: 'cached', label: 'Cache reads' }`).
- * Returns `null` when no such entry exists — most adapters don't split cache
- * reads out per turn, so the Cached column is only shown when at least one
- * turn actually has this data (see `renderTurnsOverviewTable`).
- */
-function getTurnCachedTokens(turn: ChatTurn): number | null {
-	const au = turn.actualUsage;
-	if (!au?.promptTokenDetails?.length) { return null; }
-	const cachedPct = au.promptTokenDetails
-		.filter(d => /cache/i.test(d.category) || /cache/i.test(d.label))
-		.reduce((sum, d) => sum + d.percentageOfPrompt, 0);
-	if (cachedPct <= 0) { return null; }
-	return Math.round(au.promptTokens * cachedPct / 100);
-}
-
-function buildTurnOverviewRows(data: SessionLogData): TurnOverviewRow[] {
-	return data.turns.map(turn => {
-		const au = turn.actualUsage;
-		const isActual = !!au;
-		const input = isActual ? au!.promptTokens : turn.inputTokensEstimate;
-		const output = isActual ? au!.completionTokens : turn.outputTokensEstimate;
-		const total = isActual
-			? (au!.promptTokens + au!.completionTokens)
-			: (turn.inputTokensEstimate + turn.outputTokensEstimate + turn.thinkingTokensEstimate);
-		return { turnNumber: turn.turnNumber, model: turn.model, mode: turn.mode, input, cached: getTurnCachedTokens(turn), output, total, isActual };
-	});
-}
-
-/** Stable string hash → hue, so each distinct model gets a consistent badge color across the overview table. */
-function hashModelToHue(model: string): number {
-	let hash = 0;
-	for (let i = 0; i < model.length; i++) {
-		hash = (hash * 31 + model.charCodeAt(i)) >>> 0;
-	}
-	return hash % 360;
-}
+// Row-building logic (getTurnCachedTokens, buildTurnOverviewRows, hashModelToHue)
+// lives in ./turnsOverview.ts so it can be unit-tested without the CSS/DOM
+// dependencies this file carries — see that module for its doc comments.
 
 function renderModelOverviewBadge(model: string | null): string {
 	if (!model) { return '<span class="overview-model-badge overview-model-unknown">—</span>'; }
@@ -1125,7 +1078,7 @@ function renderModelOverviewBadge(model: string | null): string {
  */
 function renderTurnsOverviewTable(data: SessionLogData): string {
 	if (data.turns.length === 0) { return ''; }
-	const rows = buildTurnOverviewRows(data);
+	const rows = buildTurnOverviewRows(data.turns);
 	const hasCached = rows.some(r => r.cached !== null);
 	const hasModelSwitches = rows.some((r, i) => i > 0 && r.model && rows[i - 1].model && r.model !== rows[i - 1].model);
 

--- a/vscode-extension/src/webview/logviewer/styles.css
+++ b/vscode-extension/src/webview/logviewer/styles.css
@@ -1173,6 +1173,114 @@ details[open] > summary .collapse-arrow {
 	}
 }
 
+/* Turns overview table */
+.turns-overview {
+	background: var(--bg-secondary);
+	border: 1px solid var(--border-subtle);
+	border-radius: 12px;
+	padding: 16px 20px 4px;
+	margin-bottom: 24px;
+	box-shadow: 0 4px 12px rgb(0, 0, 0, 0.3), 0 1px 3px rgb(0, 0, 0, 0.2);
+}
+
+.turns-overview-header {
+	font-size: 15px;
+	font-weight: 700;
+	color: var(--text-primary);
+	margin-bottom: 12px;
+	display: flex;
+	align-items: baseline;
+	gap: 10px;
+	flex-wrap: wrap;
+}
+
+.overview-switch-note {
+	font-size: 12px;
+	font-weight: 400;
+	color: var(--text-secondary);
+}
+
+.turns-overview-table-wrap {
+	overflow-x: auto;
+}
+
+.turns-overview-table {
+	width: 100%;
+	border-collapse: collapse;
+	font-size: 13px;
+}
+
+.turns-overview-table th,
+.turns-overview-table td {
+	padding: 6px 12px;
+	text-align: left;
+	border-bottom: 1px solid var(--border-subtle);
+	white-space: nowrap;
+}
+
+.turns-overview-table th {
+	color: var(--text-secondary);
+	font-weight: 600;
+	font-size: 11px;
+	text-transform: uppercase;
+	letter-spacing: 0.5px;
+	background: var(--bg-tertiary);
+	position: sticky;
+	top: 0;
+}
+
+.turns-overview-table .count-cell {
+	text-align: right;
+	font-variant-numeric: tabular-nums;
+}
+
+.turns-overview-row {
+	cursor: pointer;
+	transition: background 0.15s;
+}
+
+.turns-overview-row:hover {
+	background: var(--bg-tertiary);
+}
+
+.turns-overview-row-switch {
+	border-left: 3px solid var(--vscode-focusBorder, #3b82f6);
+}
+
+.turns-overview-num {
+	font-weight: 600;
+	color: var(--text-primary);
+}
+
+.overview-switch-icon {
+	font-size: 11px;
+	opacity: 0.8;
+}
+
+.turns-overview-actual {
+	text-align: center;
+	color: var(--text-secondary);
+}
+
+.overview-model-badge {
+	display: inline-block;
+	font-size: 11px;
+	font-weight: 600;
+	padding: 3px 9px;
+	border-radius: 6px;
+	border: 1px solid var(--border-subtle);
+	max-width: 180px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	vertical-align: middle;
+}
+
+.overview-model-unknown {
+	background: var(--bg-tertiary);
+	color: var(--text-secondary);
+}
+
 /* Session hierarchy card */
 .hierarchy-card-content {
 text-align: left;

--- a/vscode-extension/src/webview/logviewer/turnsOverview.ts
+++ b/vscode-extension/src/webview/logviewer/turnsOverview.ts
@@ -1,0 +1,78 @@
+// Pure helpers for the log viewer's "Session Steps Overview" table (see main.ts).
+// Deliberately dependency-free (no CSS/DOM/vscode imports) so this logic is
+// unit-testable directly in Node, unlike main.ts itself which can only be
+// exercised through the headless webview interaction/visual-diff harnesses.
+
+export type TurnOverviewPromptDetail = {
+	category: string;
+	label: string;
+	percentageOfPrompt: number;
+};
+
+export type TurnOverviewActualUsage = {
+	promptTokens: number;
+	completionTokens: number;
+	promptTokenDetails?: TurnOverviewPromptDetail[];
+};
+
+export type TurnOverviewSourceTurn = {
+	turnNumber: number;
+	model: string | null;
+	mode: string;
+	inputTokensEstimate: number;
+	outputTokensEstimate: number;
+	thinkingTokensEstimate: number;
+	actualUsage?: TurnOverviewActualUsage;
+};
+
+export type TurnOverviewRow = {
+	turnNumber: number;
+	model: string | null;
+	mode: string;
+	input: number;
+	cached: number | null;
+	output: number;
+	total: number;
+	isActual: boolean;
+};
+
+/**
+ * Deduces per-turn cache-read tokens from `actualUsage.promptTokenDetails`,
+ * when the adapter reported a breakdown entry whose category/label mentions
+ * "cache" (e.g. Gemini CLI's `{ category: 'cached', label: 'Cache reads' }`).
+ * Returns `null` when no such entry exists — most adapters don't split cache
+ * reads out per turn, so the Cached column is only shown when at least one
+ * turn actually has this data (see `renderTurnsOverviewTable` in main.ts).
+ */
+export function getTurnCachedTokens(turn: TurnOverviewSourceTurn): number | null {
+	const au = turn.actualUsage;
+	if (!au?.promptTokenDetails?.length) { return null; }
+	const cachedPct = au.promptTokenDetails
+		.filter(d => /cache/i.test(d.category) || /cache/i.test(d.label))
+		.reduce((sum, d) => sum + d.percentageOfPrompt, 0);
+	if (cachedPct <= 0) { return null; }
+	return Math.round(au.promptTokens * cachedPct / 100);
+}
+
+/** Builds one overview row per turn, preferring actual API usage over the text-based estimate when available. */
+export function buildTurnOverviewRows(turns: TurnOverviewSourceTurn[]): TurnOverviewRow[] {
+	return turns.map(turn => {
+		const au = turn.actualUsage;
+		const isActual = !!au;
+		const input = isActual ? au!.promptTokens : turn.inputTokensEstimate;
+		const output = isActual ? au!.completionTokens : turn.outputTokensEstimate;
+		const total = isActual
+			? (au!.promptTokens + au!.completionTokens)
+			: (turn.inputTokensEstimate + turn.outputTokensEstimate + turn.thinkingTokensEstimate);
+		return { turnNumber: turn.turnNumber, model: turn.model, mode: turn.mode, input, cached: getTurnCachedTokens(turn), output, total, isActual };
+	});
+}
+
+/** Stable string hash → hue (0-359), so each distinct model gets a consistent badge color across the overview table. */
+export function hashModelToHue(model: string): number {
+	let hash = 0;
+	for (let i = 0; i < model.length; i++) {
+		hash = (hash * 31 + model.charCodeAt(i)) >>> 0;
+	}
+	return hash % 360;
+}

--- a/vscode-extension/test/unit/webview-turnsOverview.test.ts
+++ b/vscode-extension/test/unit/webview-turnsOverview.test.ts
@@ -1,0 +1,136 @@
+import { describe, test } from 'node:test';
+import * as assert from 'node:assert/strict';
+
+import {
+	buildTurnOverviewRows,
+	getTurnCachedTokens,
+	hashModelToHue,
+	type TurnOverviewSourceTurn,
+} from '../../src/webview/logviewer/turnsOverview';
+
+function turn(overrides: Partial<TurnOverviewSourceTurn> = {}): TurnOverviewSourceTurn {
+	return {
+		turnNumber: 1,
+		model: 'claude-sonnet-4-6',
+		mode: 'agent',
+		inputTokensEstimate: 100,
+		outputTokensEstimate: 50,
+		thinkingTokensEstimate: 0,
+		...overrides,
+	};
+}
+
+describe('getTurnCachedTokens', () => {
+	test('returns null when the turn has no actual usage', () => {
+		assert.equal(getTurnCachedTokens(turn()), null);
+	});
+
+	test('returns null when promptTokenDetails carries no cache-related entry', () => {
+		const t = turn({
+			actualUsage: {
+				promptTokens: 1000,
+				completionTokens: 200,
+				promptTokenDetails: [{ category: 'System', label: 'Instructions', percentageOfPrompt: 60 }],
+			},
+		});
+		assert.equal(getTurnCachedTokens(t), null);
+	});
+
+	test('deduces cached tokens from a category matching "cache" (case-insensitive)', () => {
+		const t = turn({
+			actualUsage: {
+				promptTokens: 1000,
+				completionTokens: 200,
+				promptTokenDetails: [{ category: 'cached', label: 'Cache reads', percentageOfPrompt: 40 }],
+			},
+		});
+		assert.equal(getTurnCachedTokens(t), 400);
+	});
+
+	test('deduces cached tokens from a label matching "cache" even when the category does not', () => {
+		const t = turn({
+			actualUsage: {
+				promptTokens: 2000,
+				completionTokens: 0,
+				promptTokenDetails: [{ category: 'prompt', label: 'Cache Read', percentageOfPrompt: 25 }],
+			},
+		});
+		assert.equal(getTurnCachedTokens(t), 500);
+	});
+
+	test('sums percentages across multiple cache-related entries', () => {
+		const t = turn({
+			actualUsage: {
+				promptTokens: 1000,
+				completionTokens: 0,
+				promptTokenDetails: [
+					{ category: 'cached', label: 'Cache reads (short TTL)', percentageOfPrompt: 10 },
+					{ category: 'cached', label: 'Cache reads (long TTL)', percentageOfPrompt: 15 },
+				],
+			},
+		});
+		assert.equal(getTurnCachedTokens(t), 250);
+	});
+});
+
+describe('buildTurnOverviewRows', () => {
+	test('falls back to text-based estimates, including thinking tokens, when there is no actual usage', () => {
+		const rows = buildTurnOverviewRows([turn({ inputTokensEstimate: 120, outputTokensEstimate: 40, thinkingTokensEstimate: 30 })]);
+		assert.equal(rows.length, 1);
+		assert.equal(rows[0].isActual, false);
+		assert.equal(rows[0].input, 120);
+		assert.equal(rows[0].output, 40);
+		assert.equal(rows[0].total, 190);
+		assert.equal(rows[0].cached, null);
+	});
+
+	test('prefers actual API usage over the estimate, and excludes it from the total via completionTokens alone', () => {
+		const rows = buildTurnOverviewRows([
+			turn({
+				inputTokensEstimate: 999,
+				outputTokensEstimate: 999,
+				actualUsage: { promptTokens: 300, completionTokens: 60 },
+			}),
+		]);
+		assert.equal(rows[0].isActual, true);
+		assert.equal(rows[0].input, 300);
+		assert.equal(rows[0].output, 60);
+		assert.equal(rows[0].total, 360);
+	});
+
+	test('carries through turn number, model and mode unchanged', () => {
+		const rows = buildTurnOverviewRows([turn({ turnNumber: 3, model: 'gpt-4o', mode: 'ask' })]);
+		assert.equal(rows[0].turnNumber, 3);
+		assert.equal(rows[0].model, 'gpt-4o');
+		assert.equal(rows[0].mode, 'ask');
+	});
+
+	test('reports the deduced cached tokens per row when present', () => {
+		const rows = buildTurnOverviewRows([
+			turn({ actualUsage: { promptTokens: 800, completionTokens: 100, promptTokenDetails: [{ category: 'cached', label: 'Cache reads', percentageOfPrompt: 50 }] } }),
+		]);
+		assert.equal(rows[0].cached, 400);
+	});
+
+	test('produces one row per turn, in order', () => {
+		const rows = buildTurnOverviewRows([turn({ turnNumber: 1 }), turn({ turnNumber: 2 }), turn({ turnNumber: 3 })]);
+		assert.deepEqual(rows.map(r => r.turnNumber), [1, 2, 3]);
+	});
+});
+
+describe('hashModelToHue', () => {
+	test('is deterministic for the same input', () => {
+		assert.equal(hashModelToHue('claude-sonnet-4-6'), hashModelToHue('claude-sonnet-4-6'));
+	});
+
+	test('stays within the valid hue range [0, 360)', () => {
+		for (const model of ['gpt-4o', 'hydrafusion', 'claude-sonnet-4-6', '', 'a very long model identifier string']) {
+			const hue = hashModelToHue(model);
+			assert.ok(hue >= 0 && hue < 360, `hue ${hue} for "${model}" out of range`);
+		}
+	});
+
+	test('different model names usually hash to different hues', () => {
+		assert.notEqual(hashModelToHue('gpt-4o'), hashModelToHue('claude-sonnet-4-6'));
+	});
+});


### PR DESCRIPTION
## Summary
- Adds a "Session Steps Overview" table to the log viewer, placed below the summary cards / session actual-usage panel and above the chat-turns list.
- One row per turn showing mode, model, and input/cached/output token counts — so a multi-model session (e.g. model-routing research across different underlying models per step) can be scanned at a glance instead of opening every turn card.
- Each distinct model gets a stable, hash-derived badge color for quick visual grouping across steps; a row is flagged with a ⇄ icon when its model differs from the previous step's.
- The Cached column only appears when at least one turn actually carries cache-read data in `actualUsage.promptTokenDetails` (currently populated by the Gemini CLI adapter) — it's omitted for sessions/adapters without that data rather than showing an always-empty column.
- Clicking a row scrolls to and briefly highlights the matching turn card below (reusing/refactoring the existing deep-link focus logic into a shared `scrollAndFocusTurn` helper).

## Test plan
- [x] `npm run check-types`, `npm run lint`, `npm run compile` (via `npm run validate`) — no new errors, no new warnings
- [x] `npm run check:contract` — every webview message still has a handler
- [x] `npm run check:interaction` — new table renders and its row clicks respond (`logviewer: 9 control(s): 1 posted, 8 dom-only`)
- [x] `npm run test:node` — full unit suite passes
- [x] Rendered the log viewer headlessly via the `visual-view-diff` skill (dark + light themes) and visually reviewed the new table: distinct model badge colors, correct switch indicator on the model-change row, no regressions elsewhere in the page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uaDA1V3AQ1p1DdiwwX86x

---
_Generated by [Claude Code](https://claude.ai/code/session_017uaDA1V3AQ1p1DdiwwX86x)_