### PR TITLE
Log viewer: show child sub-agent sessions and cost in Session Steps Overview

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1197,7 +1197,7 @@ export interface ChatTurn {
   userMessage: string;
   assistantResponse: string;
   model: string | null;
-  toolCalls: { toolName: string; arguments?: string; result?: string; isSubAgent?: boolean; subAgentModel?: string; subAgentTokens?: { input: number; output: number } }[];
+  toolCalls: { toolName: string; arguments?: string; result?: string; isSubAgent?: boolean; subAgentModel?: string; subAgentTokens?: { input: number; output: number }; subAgentCost?: number }[];
   contextReferences: ContextReferenceUsage;
   mcpTools: { server: string; tool: string }[];
   inputTokensEstimate: number;
@@ -1206,6 +1206,13 @@ export interface ChatTurn {
   actualUsage?: ActualUsage;
   /** Thinking effort level active when this turn was submitted (e.g. "low", "medium", "high"). */
   thinkingEffort?: string;
+  /**
+   * Estimated USD cost of this turn's own model call (excludes sub-agent/child costs),
+   * computed host-side via `calculateEstimatedCost()` from the turn's model + token
+   * usage (actual when available, otherwise the text-based estimate). Absent when the
+   * model is unknown or has no pricing entry.
+   */
+  estimatedCost?: number;
 }
 
 // Full session log data for the log viewer

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -6951,6 +6951,7 @@ private computeFallbackDailyRollup(
 				'For accurate billing data, check the Cursor dashboard at cursor.com/settings.',
 			],
 		} : undefined;
+		this.attachTurnCosts(turns);
 		return {
 			file: details.file, title: details.title || null, editorSource: details.editorSource,
 			editorName, size: details.size, modified: details.modified, interactions: details.interactions,
@@ -7315,6 +7316,32 @@ private computeFallbackDailyRollup(
 
 	public calculateEstimatedCost(modelUsage: ModelUsage, pricingSource: 'provider' | 'copilot' = 'provider'): number {
 		return _calculateEstimatedCost(modelUsage, this.modelPricing, pricingSource);
+	}
+
+	/**
+	 * Post-processes already-built `turns` with estimated USD costs, for the log viewer's
+	 * Session Steps Overview table: one cost per turn (its own model call — actual usage
+	 * tokens when available, otherwise the text-based estimate) and one per sub-agent/child
+	 * tool call (using its own `subAgentModel` + `subAgentTokens`). Mutates `turns` in place.
+	 * Silently leaves `estimatedCost`/`subAgentCost` unset when the model is unknown or has
+	 * no pricing entry (`calculateEstimatedCost` returns 0 for those, which we treat as "no cost").
+	 */
+	private attachTurnCosts(turns: ChatTurn[]): void {
+		for (const turn of turns) {
+			const input = turn.actualUsage ? turn.actualUsage.promptTokens : turn.inputTokensEstimate;
+			const output = turn.actualUsage ? turn.actualUsage.completionTokens : turn.outputTokensEstimate;
+			if (turn.model && (input > 0 || output > 0)) {
+				const cost = this.calculateEstimatedCost({ [turn.model]: { inputTokens: input, outputTokens: output, sessions: 1 } });
+				if (cost > 0) { turn.estimatedCost = cost; }
+			}
+			for (const tc of turn.toolCalls) {
+				if (!tc.isSubAgent || !tc.subAgentModel || !tc.subAgentTokens) { continue; }
+				const cost = this.calculateEstimatedCost({
+					[tc.subAgentModel]: { inputTokens: tc.subAgentTokens.input, outputTokens: tc.subAgentTokens.output, sessions: 1 },
+				});
+				if (cost > 0) { tc.subAgentCost = cost; }
+			}
+		}
 	}
 
 

--- a/vscode-extension/src/webview/logviewer/main.ts
+++ b/vscode-extension/src/webview/logviewer/main.ts
@@ -1,7 +1,7 @@
 // Log Viewer webview - displays session file details and chat turns
 import { ContextReferenceUsage, getTotalContextRefs, getImplicitContextRefs, getExplicitContextRefs, getContextRefsSummary } from '../shared/contextRefUtils';
 import { setHtml } from '../shared/domUtils';
-import { escapeHtml, formatCompact, formatFileSize, setCompactNumbers, getEditorIcon } from '../shared/formatUtils';
+import { escapeHtml, formatCompact, formatCost, formatFileSize, setCompactNumbers, getEditorIcon } from '../shared/formatUtils';
 import { getModelDisplayName } from '../../../../src/webview/shared/modelUtils';
 import type { McpToolUsage, ModeUsage, ToolCallUsage } from '../shared/types';
 import { buildTurnOverviewRows, hashModelToHue } from './turnsOverview';
@@ -34,6 +34,7 @@ result?: string;
 isSubAgent?: boolean;
 subAgentModel?: string;
 subAgentTokens?: { input: number; output: number };
+subAgentCost?: number;
 };
 
 type ChatTurn = {
@@ -51,6 +52,8 @@ outputTokensEstimate: number;
 thinkingTokensEstimate: number;
 actualUsage?: ActualUsage;
 thinkingEffort?: string;
+/** Estimated USD cost of this turn's own model call, computed host-side. Absent when unknown. */
+estimatedCost?: number;
 };
 
 type ThinkingEffortUsage = { byEffort: { [effort: string]: number }; switchCount: number; defaultEffort: string | null };
@@ -629,7 +632,7 @@ return `
 <td class="tool-name-cell">
 <span class="tool-name tool-call-link" data-turn="${turn.turnNumber}" data-toolcall="${idx}" title="${escapeHtml(tc.toolName)}" style="cursor:pointer;">${escapeHtml(displayName)}</span>
 ${tc.isSubAgent && tc.subAgentModel ? `<span class="sub-agent-model-badge">${escapeHtml(getModelDisplayName(tc.subAgentModel))}</span>` : ''}
-${tc.isSubAgent && tc.subAgentTokens ? `<span class="sub-agent-tokens">↑${tc.subAgentTokens.input.toLocaleString()} ↓${tc.subAgentTokens.output.toLocaleString()} tokens</span>` : ''}
+${tc.isSubAgent && tc.subAgentTokens ? `<span class="sub-agent-tokens">↑${formatCompact(tc.subAgentTokens.input)} ↓${formatCompact(tc.subAgentTokens.output)} tokens${tc.subAgentCost ? ` · ${formatCost(tc.subAgentCost)}` : ''}</span>` : ''}
 ${tc.arguments && !tc.isSubAgent ? `<details class="tool-details"><summary>Arguments</summary><pre>${escapeHtml(tc.arguments)}</pre></details>` : ''}
 ${tc.result && !tc.isSubAgent ? `<details class="tool-details"><summary>Result</summary><pre>${escapeHtml(truncateText(tc.result, 500))}</pre></details>` : ''}
 </td>
@@ -1081,10 +1084,25 @@ function renderTurnsOverviewTable(data: SessionLogData): string {
 	const rows = buildTurnOverviewRows(data.turns);
 	const hasCached = rows.some(r => r.cached !== null);
 	const hasModelSwitches = rows.some((r, i) => i > 0 && r.model && rows[i - 1].model && r.model !== rows[i - 1].model);
+	const hasCost = rows.some(r => r.cost !== null || r.children.some(c => c.cost !== null));
+	const totalChildren = rows.reduce((sum, r) => sum + r.children.length, 0);
+
+	const costCell = (cost: number | null): string => hasCost ? `<td class="count-cell">${cost !== null ? formatCost(cost) : '—'}</td>` : '';
 
 	const bodyRows = rows.map((row, i) => {
 		const switched = i > 0 && !!row.model && !!rows[i - 1].model && row.model !== rows[i - 1].model;
 		const cachedCell = hasCached ? `<td class="count-cell">${row.cached !== null ? formatCompact(row.cached) : '—'}</td>` : '';
+		const childRows = row.children.map(child => `<tr class="turns-overview-row turns-overview-child-row" data-turn="${row.turnNumber}" title="Sub-agent call from step #${row.turnNumber} — jump to turn">
+<td class="turns-overview-num">↳ 🤖</td>
+<td><span class="turn-mode turns-overview-child-tool" title="${escapeHtml(child.toolName)}">${escapeHtml(child.toolName)}</span></td>
+<td>${renderModelOverviewBadge(child.model)}</td>
+<td class="count-cell">${formatCompact(child.input)}</td>
+${hasCached ? '<td class="count-cell">—</td>' : ''}
+<td class="count-cell">${formatCompact(child.output)}</td>
+<td class="count-cell"><strong>${formatCompact(child.total)}</strong></td>
+${costCell(child.cost)}
+<td class="turns-overview-actual" title="Estimated from text">~</td>
+</tr>`).join('');
 		return `<tr class="turns-overview-row${switched ? ' turns-overview-row-switch' : ''}" data-turn="${row.turnNumber}" title="Jump to turn #${row.turnNumber}">
 <td class="turns-overview-num">#${row.turnNumber}${switched ? ' <span class="overview-switch-icon" title="Model changed from the previous step">⇄</span>' : ''}</td>
 <td><span class="turn-mode" style="background: ${getModeColor(row.mode)};">${getModeIcon(row.mode)} ${escapeHtml(row.mode)}</span></td>
@@ -1093,8 +1111,9 @@ function renderTurnsOverviewTable(data: SessionLogData): string {
 ${cachedCell}
 <td class="count-cell">${formatCompact(row.output)}</td>
 <td class="count-cell"><strong>${formatCompact(row.total)}</strong></td>
+${costCell(row.cost)}
 <td class="turns-overview-actual" title="${row.isActual ? 'Actual API usage' : 'Estimated from text'}">${row.isActual ? '✓' : '~'}</td>
-</tr>`;
+</tr>${childRows}`;
 	}).join('');
 
 	return `
@@ -1102,6 +1121,7 @@ ${cachedCell}
 <div class="turns-overview-header">
 <span>🧭 Session Steps Overview (${rows.length})</span>
 ${hasModelSwitches ? '<span class="overview-switch-note">⇄ marks a model change from the previous step</span>' : ''}
+${totalChildren > 0 ? `<span class="overview-switch-note">🤖 ↳ marks a sub-agent/child session delegated from that step</span>` : ''}
 </div>
 <div class="turns-overview-table-wrap">
 <table class="turns-overview-table">
@@ -1114,6 +1134,7 @@ ${hasModelSwitches ? '<span class="overview-switch-note">⇄ marks a model chang
 ${hasCached ? '<th scope="col">Cached</th>' : ''}
 <th scope="col">Output</th>
 <th scope="col">Total</th>
+${hasCost ? '<th scope="col">Cost</th>' : ''}
 <th scope="col" title="✓ actual API usage, ~ estimated from text">Src</th>
 </tr>
 </thead>

--- a/vscode-extension/src/webview/logviewer/styles.css
+++ b/vscode-extension/src/webview/logviewer/styles.css
@@ -1247,6 +1247,23 @@ details[open] > summary .collapse-arrow {
 	border-left: 3px solid var(--vscode-focusBorder, #3b82f6);
 }
 
+.turns-overview-child-row {
+	background: var(--bg-tertiary);
+	font-size: 11px;
+	opacity: 0.9;
+}
+
+.turns-overview-child-row .turns-overview-num {
+	font-weight: 400;
+	color: var(--text-secondary);
+}
+
+.turns-overview-child-tool {
+	background: transparent !important;
+	border: 1px dashed var(--border-subtle);
+	color: var(--text-secondary);
+}
+
 .turns-overview-num {
 	font-weight: 600;
 	color: var(--text-primary);

--- a/vscode-extension/src/webview/logviewer/turnsOverview.ts
+++ b/vscode-extension/src/webview/logviewer/turnsOverview.ts
@@ -15,6 +15,14 @@ export type TurnOverviewActualUsage = {
 	promptTokenDetails?: TurnOverviewPromptDetail[];
 };
 
+export type TurnOverviewSourceToolCall = {
+	toolName: string;
+	isSubAgent?: boolean;
+	subAgentModel?: string;
+	subAgentTokens?: { input: number; output: number };
+	subAgentCost?: number;
+};
+
 export type TurnOverviewSourceTurn = {
 	turnNumber: number;
 	model: string | null;
@@ -23,6 +31,20 @@ export type TurnOverviewSourceTurn = {
 	outputTokensEstimate: number;
 	thinkingTokensEstimate: number;
 	actualUsage?: TurnOverviewActualUsage;
+	/** Estimated USD cost of this turn's own model call, computed host-side. Absent when unknown. */
+	estimatedCost?: number;
+	/** Tool calls made during this turn; sub-agent/child delegations among these become `children` rows. */
+	toolCalls?: TurnOverviewSourceToolCall[];
+};
+
+/** One sub-agent/child session delegation nested under its parent turn's row. */
+export type TurnOverviewChildRow = {
+	toolName: string;
+	model: string | null;
+	input: number;
+	output: number;
+	total: number;
+	cost: number | null;
 };
 
 export type TurnOverviewRow = {
@@ -34,6 +56,8 @@ export type TurnOverviewRow = {
 	output: number;
 	total: number;
 	isActual: boolean;
+	cost: number | null;
+	children: TurnOverviewChildRow[];
 };
 
 /**
@@ -54,6 +78,18 @@ export function getTurnCachedTokens(turn: TurnOverviewSourceTurn): number | null
 	return Math.round(au.promptTokens * cachedPct / 100);
 }
 
+/** Builds the sub-agent/child session rows nested under one turn, from its sub-agent tool calls. */
+export function buildTurnChildRows(turn: TurnOverviewSourceTurn): TurnOverviewChildRow[] {
+	if (!turn.toolCalls?.length) { return []; }
+	return turn.toolCalls
+		.filter(tc => tc.isSubAgent)
+		.map(tc => {
+			const input = tc.subAgentTokens?.input ?? 0;
+			const output = tc.subAgentTokens?.output ?? 0;
+			return { toolName: tc.toolName, model: tc.subAgentModel ?? null, input, output, total: input + output, cost: tc.subAgentCost ?? null };
+		});
+}
+
 /** Builds one overview row per turn, preferring actual API usage over the text-based estimate when available. */
 export function buildTurnOverviewRows(turns: TurnOverviewSourceTurn[]): TurnOverviewRow[] {
 	return turns.map(turn => {
@@ -64,7 +100,11 @@ export function buildTurnOverviewRows(turns: TurnOverviewSourceTurn[]): TurnOver
 		const total = isActual
 			? (au!.promptTokens + au!.completionTokens)
 			: (turn.inputTokensEstimate + turn.outputTokensEstimate + turn.thinkingTokensEstimate);
-		return { turnNumber: turn.turnNumber, model: turn.model, mode: turn.mode, input, cached: getTurnCachedTokens(turn), output, total, isActual };
+		return {
+			turnNumber: turn.turnNumber, model: turn.model, mode: turn.mode, input, cached: getTurnCachedTokens(turn), output, total, isActual,
+			cost: turn.estimatedCost ?? null,
+			children: buildTurnChildRows(turn),
+		};
 	});
 }
 

--- a/vscode-extension/test/unit/webview-turnsOverview.test.ts
+++ b/vscode-extension/test/unit/webview-turnsOverview.test.ts
@@ -2,6 +2,7 @@ import { describe, test } from 'node:test';
 import * as assert from 'node:assert/strict';
 
 import {
+	buildTurnChildRows,
 	buildTurnOverviewRows,
 	getTurnCachedTokens,
 	hashModelToHue,
@@ -115,6 +116,43 @@ describe('buildTurnOverviewRows', () => {
 	test('produces one row per turn, in order', () => {
 		const rows = buildTurnOverviewRows([turn({ turnNumber: 1 }), turn({ turnNumber: 2 }), turn({ turnNumber: 3 })]);
 		assert.deepEqual(rows.map(r => r.turnNumber), [1, 2, 3]);
+	});
+
+	test('carries through the host-computed estimatedCost as cost, or null when absent', () => {
+		const rows = buildTurnOverviewRows([turn({ estimatedCost: 0.0123 }), turn({ turnNumber: 2 })]);
+		assert.equal(rows[0].cost, 0.0123);
+		assert.equal(rows[1].cost, null);
+	});
+
+	test('has no children when the turn has no sub-agent tool calls', () => {
+		const rows = buildTurnOverviewRows([turn({ toolCalls: [{ toolName: 'view' }, { toolName: 'edit' }] })]);
+		assert.deepEqual(rows[0].children, []);
+	});
+
+	test('builds one child row per sub-agent tool call, ignoring regular tool calls', () => {
+		const rows = buildTurnOverviewRows([
+			turn({
+				toolCalls: [
+					{ toolName: 'view' },
+					{ toolName: 'task', isSubAgent: true, subAgentModel: 'claude-sonnet-4-6', subAgentTokens: { input: 500, output: 200 }, subAgentCost: 0.05 },
+					{ toolName: 'task', isSubAgent: true, subAgentModel: 'gpt-4o', subAgentTokens: { input: 100, output: 40 } },
+				],
+			}),
+		]);
+		assert.equal(rows[0].children.length, 2);
+		assert.deepEqual(rows[0].children[0], { toolName: 'task', model: 'claude-sonnet-4-6', input: 500, output: 200, total: 700, cost: 0.05 });
+		assert.deepEqual(rows[0].children[1], { toolName: 'task', model: 'gpt-4o', input: 100, output: 40, total: 140, cost: null });
+	});
+});
+
+describe('buildTurnChildRows', () => {
+	test('returns an empty array when the turn has no tool calls', () => {
+		assert.deepEqual(buildTurnChildRows(turn()), []);
+	});
+
+	test('defaults model to null and tokens to 0 when a sub-agent call has no usage data yet', () => {
+		const rows = buildTurnChildRows(turn({ toolCalls: [{ toolName: 'task', isSubAgent: true }] }));
+		assert.deepEqual(rows, [{ toolName: 'task', model: null, input: 0, output: 0, total: 0, cost: null }]);
 	});
 });
 


### PR DESCRIPTION
## Why

The Session Steps Overview table in the Log Viewer only showed each turn's mode/model/input/output tokens. It had no visibility into sub-agent ("child session") delegations happening within a step, and nowhere in the log viewer did it show an estimated dollar cost, so multi-model or agent-heavy sessions were hard to reason about at a glance.

## What changed

- Sub-agent/task delegations (`task`, `read_agent`, `write_agent`, `list_agents` tool calls) now render as nested `↳ 🤖` rows under their parent step, with the child's own model badge, input/output/total tokens, and estimated cost.
- Added a per-turn estimated USD cost, computed host-side via the existing `calculateEstimatedCost()` (model pricing table), surfaced as a new "Cost" column. The column only appears when at least one row actually has cost data, matching the existing pattern used for the "Cached" column.
- Fixed the sub-agent token display in the Tool Calls section, which was using raw `toLocaleString()` instead of the table's compact K/M formatting, and added its cost next to it.

## Implementation notes

- Cost is computed once, host-side, in `buildBaseLogData()` after turns are fully built (`attachTurnCosts`), so all turn-building code paths (CLI JSONL, delta JSONL, JSON sessions, ecosystem adapters) get it for free without touching each one individually.
- `turnsOverview.ts` (the dependency-free, unit-tested pure module backing this table) stays free of cost math — it only carries through the `estimatedCost`/`subAgentCost` values the host already computed, and builds the new child rows from a turn's sub-agent tool calls.
- New unit tests cover cost pass-through and child-row construction in `webview-turnsOverview.test.ts`. Verified with `check-types`, targeted unit tests, and the `check:contract`/`check:interaction` webview harnesses.