### PR TITLE
feat(ci): add dependency-free code duplication detection check

### DIFF
--- a/.claude/skills/deduplicate-code/SKILL.md
+++ b/.claude/skills/deduplicate-code/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: deduplicate-code
+description: Detect copy-pasted code blocks across the shared source (vscode-extension/src, the repo-root src/, cli/src) with the dependency-free check-code-duplication.js detector, then pick one duplicate group and extract a shared helper to eliminate it, keeping all tests green. Use when a PR review notes duplication, when the CI step summary's "Code Duplication Analysis" grows, or when asked to reduce code duplication / DRY up the codebase.
+---
+# Deduplicate Code
+
+The CI step summary runs `check-code-duplication.js` and reports copy-pasted
+blocks across the three TypeScript source trees every PR. A growing "Code
+Duplication Analysis" section (or a review finding of "this is duplicated")
+is the signal this skill remediates: it finds the duplicate groups, picks
+**one**, extracts a single shared helper in their place, and verifies nothing
+broke. Like `refactor-large-function`, it changes **one** group per pass so the
+diff stays reviewable and a regression points at a single extraction.
+
+## What the detector does
+
+`scripts/check-code-duplication.js` (run as `npm run check:duplicates` from
+`vscode-extension/`) normalizes source lines (whitespace collapsed, comment-only
+and blank lines dropped so re-indented or re-commented copies are still caught),
+hashes sliding windows of a minimum length, groups identical windows, and
+extends each group to its **maximal shared block**. It reports clone groups as
+Markdown (for the step summary) or `--json`. It is **report-only by default**;
+this skill does the remediation the report asks for.
+
+A "duplicate group" is a normalized sequence of >= `--min-lines` lines that
+occurs in two or more places (cross-file, or non-overlapping within one file).
+
+## Step 1 - List the duplicate groups
+
+Get the current clone groups in machine-readable form so you can pick a target:
+
+```bash
+node scripts/check-code-duplication.js --json --min-lines 14
+```
+
+Or, scoped to one area if the full scan is large:
+
+```bash
+node scripts/check-code-duplication.js --json --min-lines 14 --include 'src/**/*.ts'
+```
+
+Read the `groups` array: each entry has `lines` (maximal block length),
+`occurrences` (`{ file, startLine, endLine }`), and a `preview` (first 3 lines).
+Pick the single group to remediate following these priorities:
+
+1. **Skip auto-generated or intentionally-mirrored files.** The shared editor
+   adapters under `src/adapters/*.ts` and the per-editor CLI store modules
+   (`src/kilo.ts`, `src/opencode.ts`, `src/copilotCliStore.ts`, `src/devinCli.ts`,
+   `src/hermes.ts`) deliberately mirror each other's SQLite/stat helpers because
+   each editor's session layout differs. A pure structural clone between two of
+   these is usually NOT a safe extraction \u2014 only consolidate when the *exact*
+   same logic (not just the same shape) is being copied.
+2. Prefer groups where every occurrence is genuinely identical *behavior* (same
+   inputs, same outputs, same side effects) \u2014 those extract cleanly.
+3. Among those, prefer groups with the **most occurrences** (one helper replaces
+   many copies) and the **most lines** (biggest payoff), all else equal.
+4. Prefer files that already have unit tests (check `vscode-extension/test/unit/`
+   for a matching test file) so the extraction is covered.
+
+## Step 2 - Read the instructions file
+
+Before touching code, read the relevant sub-project instructions file for the
+area you are changing \u2014 `.github/instructions/vscode-extension.instructions.md`
+for `vscode-extension/` work, `.github/instructions/cli.instructions.md` for
+`cli/`, and the root `AGENTS.md` for shared `src/` (notably the "CLI Must Reuse
+Shared Functions" rule: never reimplement session parsing or cost attribution
+in a place the shared module already covers).
+
+## Step 3 - Understand the duplicate
+
+Open every occurrence the detector reported and read the full block plus a few
+lines of surrounding context. Confirm it is a true behavioral duplicate and not
+two blocks that merely *look* the same but read different inputs or have
+different error handling. If the occurrences are only structurally similar
+(condemn both, then act), **stop and pick a different group** \u2014 forcing a
+shared helper onto divergent logic is the failure mode this skill exists to
+avoid.
+
+Decide where the extracted helper lives:
+
+- **Same file, used by two places in that file** \u2192 a private helper (`_`
+  prefix) at the top of the file, like `refactor-large-function`.
+- **Same package, multiple files** \u2192 a private helper in the most natural
+  existing module of that package (do not create a new file just to host the
+  helper unless it is independently reusable \u2014 keep new files to a minimum).
+- **Cross-package (e.g. shared `src/` and `vscode-extension/src`)** \u2192 the
+  helper must live in the shared `src/` module and be *imported* by the consumer,
+  never copied. This is the canonical split documented in `AGENTS.md`.
+
+## Step 4 - Run the baseline tests
+
+Establish a green baseline before changing anything:
+
+```bash
+cd vscode-extension
+npm ci --ignore-scripts
+node_modules/.bin/tsc --noEmit        # type-check
+npm run test:node                     # unit tests
+```
+
+Record which tests cover the target files so you know what to watch.
+
+## Step 5 - Extract the shared helper
+
+Apply the extraction. Rules:
+
+- The public/exported API must not change \u2014 only internal structure changes.
+- The helper takes the *differences* between the occurrences as parameters
+  (the parts that were not actually identical) and encapsulates the *common*
+  logic. If the occurrences have no meaningful differences, the helper has no
+  parameters beyond the data it operates on.
+- Name the helper for what it does, not where it was copied from.
+- Use a leading `_` prefix for private helpers in the same file.
+- Return `null` (not `undefined`) from a helper to signal an unrecoverable
+  error or "nothing to do"; the caller guards with an early `if (!result)`.
+- Do not add comments unless the code is genuinely non-obvious after extraction.
+- Replace **every** occurrence the detector reported for the chosen group with
+  a call to the helper \u2014 leaving one copy behind defeats the point and the
+  detector will still flag the group on the next run.
+
+## Step 6 - Lint the changed files
+
+```bash
+cd vscode-extension && node_modules/.bin/eslint src ../src <changed-files>
+```
+
+All **new** warnings introduced by your changes must be resolved before
+proceeding. Pre-existing warnings on other functions in the same files are
+acceptable \u2014 do not fix unrelated code.
+
+## Step 7 - Re-run the detector on the changed files
+
+Confirm the chosen group is gone and you did not introduce a new one:
+
+```bash
+node scripts/check-code-duplication.js --json --min-lines 14
+```
+
+The group you remediated must no longer appear. If a *new* group appeared
+because your helper is itself now duplicated, that means the helper was placed
+in the wrong module \u2014 move it to the shared location and import it instead
+of copying.
+
+## Step 8 - Run the full test suite and build
+
+```bash
+cd vscode-extension
+node_modules/.bin/tsc --noEmit        # type-check
+npm run test:node                     # unit tests
+node esbuild.js --production          # production bundle
+```
+
+All tests must pass and the build must succeed. If a test fails, fix the
+extraction \u2014 do not modify the tests unless the test itself was wrong
+before your change.
+
+## Step 9 - Commit
+
+```
+refactor: extract shared helper to eliminate duplicate block in <area>
+
+<Which group was chosen, where the helper lives, and how many copies it
+replaced. Note that the duplication detector no longer flags the group.>
+```
+
+## Step 10 - Open a PR
+
+Open a pull request to `main`. The PR description should:
+
+- Lead with the motivation (duplication detector flagged the group, or a review
+  noted the copy-paste).
+- List the occurrences that were consolidated (file:line for each) and the
+  single helper that replaced them.
+- Confirm `check-code-duplication.js` no longer reports the group, all unit
+  tests pass, and the production build succeeds.
+- Note any pre-existing warnings that were not introduced by this change.
+
+## Constraints
+
+- Remediate **one** duplicate group per pass \u2014 a second group is a separate
+  PR. This keeps the diff reviewable and a regression attributable.
+- Do not consolidate editor adapter / per-editor store modules that are
+  intentionally mirrored (see Step 1) unless the logic is behaviorally identical.
+- Do not change any exported function signatures or public class method
+  signatures.
+- Do not create a new file solely to host the helper unless it is independently
+  reusable across packages.
+- Do not fix pre-existing ESLint warnings on unrelated code.
+- If `tsc` or unit tests fail after your change, revert and choose a different
+  extraction (or a different group) rather than patching around the failure.
+
+## Related files
+
+- `scripts/check-code-duplication.js` \u2014 the detector this skill drives.
+- `vscode-extension/package.json` \u2014 `npm run check:duplicates` script.
+- `.github/workflows/ci.yml` \u2014 the CI step that publishes the "Code
+  Duplication Analysis" report to the step summary.
+- `.github/skills/refactor-large-function/SKILL.md` \u2014 the companion skill
+  for functions that are too long rather than duplicated.
+- `.github/instructions/vscode-extension.instructions.md`,
+  `.github/instructions/cli.instructions.md`, `AGENTS.md` \u2014 the area rules
+  to read before editing (notably the shared-`src/` reuse contract).

--- a/.github/skills/README.md
+++ b/.github/skills/README.md
@@ -92,6 +92,21 @@ Agent Skills are directories containing a `SKILL.md` file and optional supportin
 - ESLint commands to identify violation candidates
 - Commit message and PR description templates
 
+### deduplicate-code
+
+**Purpose**: Detect copy-pasted code blocks with the dependency-free `check-code-duplication.js` detector, then pick one duplicate group and extract a shared helper to eliminate it, keeping all tests green.
+
+**Use this skill when:**
+- The CI step summary's "Code Duplication Analysis" report grows
+- A PR review notes duplicated / copy-pasted code
+- You want to DRY up the codebase (vscode-extension/src, shared src/, cli/src)
+
+**Contents:**
+- Step-by-step workflow: list groups → pick one → baseline tests → extract helper → lint → re-run detector → build → commit → PR
+- Guidance on which duplicate groups are safe to consolidate (and which intentionally-mirrored editor adapters to skip)
+- Drives `node scripts/check-code-duplication.js` for detection and verification
+- Commit message and PR description templates
+
 ### validate-editor-names
 
 **Purpose**: Verify that the CLI and VS Code extension always agree on editor display names, and every name has an icon in the webview icon map.

--- a/.github/skills/deduplicate-code/SKILL.md
+++ b/.github/skills/deduplicate-code/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: deduplicate-code
+description: Detect copy-pasted code blocks across the shared source (vscode-extension/src, the repo-root src/, cli/src) with the dependency-free check-code-duplication.js detector, then pick one duplicate group and extract a shared helper to eliminate it, keeping all tests green. Use when a PR review notes duplication, when the CI step summary's "Code Duplication Analysis" grows, or when asked to reduce code duplication / DRY up the codebase.
+---
+# Deduplicate Code
+
+The CI step summary runs `check-code-duplication.js` and reports copy-pasted
+blocks across the three TypeScript source trees every PR. A growing "Code
+Duplication Analysis" section (or a review finding of "this is duplicated")
+is the signal this skill remediates: it finds the duplicate groups, picks
+**one**, extracts a single shared helper in their place, and verifies nothing
+broke. Like `refactor-large-function`, it changes **one** group per pass so the
+diff stays reviewable and a regression points at a single extraction.
+
+## What the detector does
+
+`scripts/check-code-duplication.js` (run as `npm run check:duplicates` from
+`vscode-extension/`) normalizes source lines (whitespace collapsed, comment-only
+and blank lines dropped so re-indented or re-commented copies are still caught),
+hashes sliding windows of a minimum length, groups identical windows, and
+extends each group to its **maximal shared block**. It reports clone groups as
+Markdown (for the step summary) or `--json`. It is **report-only by default**;
+this skill does the remediation the report asks for.
+
+A "duplicate group" is a normalized sequence of >= `--min-lines` lines that
+occurs in two or more places (cross-file, or non-overlapping within one file).
+
+## Step 1 - List the duplicate groups
+
+Get the current clone groups in machine-readable form so you can pick a target:
+
+```bash
+node scripts/check-code-duplication.js --json --min-lines 14
+```
+
+Or, scoped to one area if the full scan is large:
+
+```bash
+node scripts/check-code-duplication.js --json --min-lines 14 --include 'src/**/*.ts'
+```
+
+Read the `groups` array: each entry has `lines` (maximal block length),
+`occurrences` (`{ file, startLine, endLine }`), and a `preview` (first 3 lines).
+Pick the single group to remediate following these priorities:
+
+1. **Skip auto-generated or intentionally-mirrored files.** The shared editor
+   adapters under `src/adapters/*.ts` and the per-editor CLI store modules
+   (`src/kilo.ts`, `src/opencode.ts`, `src/copilotCliStore.ts`, `src/devinCli.ts`,
+   `src/hermes.ts`) deliberately mirror each other's SQLite/stat helpers because
+   each editor's session layout differs. A pure structural clone between two of
+   these is usually NOT a safe extraction \u2014 only consolidate when the *exact*
+   same logic (not just the same shape) is being copied.
+2. Prefer groups where every occurrence is genuinely identical *behavior* (same
+   inputs, same outputs, same side effects) \u2014 those extract cleanly.
+3. Among those, prefer groups with the **most occurrences** (one helper replaces
+   many copies) and the **most lines** (biggest payoff), all else equal.
+4. Prefer files that already have unit tests (check `vscode-extension/test/unit/`
+   for a matching test file) so the extraction is covered.
+
+## Step 2 - Read the instructions file
+
+Before touching code, read the relevant sub-project instructions file for the
+area you are changing \u2014 `.github/instructions/vscode-extension.instructions.md`
+for `vscode-extension/` work, `.github/instructions/cli.instructions.md` for
+`cli/`, and the root `AGENTS.md` for shared `src/` (notably the "CLI Must Reuse
+Shared Functions" rule: never reimplement session parsing or cost attribution
+in a place the shared module already covers).
+
+## Step 3 - Understand the duplicate
+
+Open every occurrence the detector reported and read the full block plus a few
+lines of surrounding context. Confirm it is a true behavioral duplicate and not
+two blocks that merely *look* the same but read different inputs or have
+different error handling. If the occurrences are only structurally similar
+(condemn both, then act), **stop and pick a different group** \u2014 forcing a
+shared helper onto divergent logic is the failure mode this skill exists to
+avoid.
+
+Decide where the extracted helper lives:
+
+- **Same file, used by two places in that file** \u2192 a private helper (`_`
+  prefix) at the top of the file, like `refactor-large-function`.
+- **Same package, multiple files** \u2192 a private helper in the most natural
+  existing module of that package (do not create a new file just to host the
+  helper unless it is independently reusable \u2014 keep new files to a minimum).
+- **Cross-package (e.g. shared `src/` and `vscode-extension/src`)** \u2192 the
+  helper must live in the shared `src/` module and be *imported* by the consumer,
+  never copied. This is the canonical split documented in `AGENTS.md`.
+
+## Step 4 - Run the baseline tests
+
+Establish a green baseline before changing anything:
+
+```bash
+cd vscode-extension
+npm ci --ignore-scripts
+node_modules/.bin/tsc --noEmit        # type-check
+npm run test:node                     # unit tests
+```
+
+Record which tests cover the target files so you know what to watch.
+
+## Step 5 - Extract the shared helper
+
+Apply the extraction. Rules:
+
+- The public/exported API must not change \u2014 only internal structure changes.
+- The helper takes the *differences* between the occurrences as parameters
+  (the parts that were not actually identical) and encapsulates the *common*
+  logic. If the occurrences have no meaningful differences, the helper has no
+  parameters beyond the data it operates on.
+- Name the helper for what it does, not where it was copied from.
+- Use a leading `_` prefix for private helpers in the same file.
+- Return `null` (not `undefined`) from a helper to signal an unrecoverable
+  error or "nothing to do"; the caller guards with an early `if (!result)`.
+- Do not add comments unless the code is genuinely non-obvious after extraction.
+- Replace **every** occurrence the detector reported for the chosen group with
+  a call to the helper \u2014 leaving one copy behind defeats the point and the
+  detector will still flag the group on the next run.
+
+## Step 6 - Lint the changed files
+
+```bash
+cd vscode-extension && node_modules/.bin/eslint src ../src <changed-files>
+```
+
+All **new** warnings introduced by your changes must be resolved before
+proceeding. Pre-existing warnings on other functions in the same files are
+acceptable \u2014 do not fix unrelated code.
+
+## Step 7 - Re-run the detector on the changed files
+
+Confirm the chosen group is gone and you did not introduce a new one:
+
+```bash
+node scripts/check-code-duplication.js --json --min-lines 14
+```
+
+The group you remediated must no longer appear. If a *new* group appeared
+because your helper is itself now duplicated, that means the helper was placed
+in the wrong module \u2014 move it to the shared location and import it instead
+of copying.
+
+## Step 8 - Run the full test suite and build
+
+```bash
+cd vscode-extension
+node_modules/.bin/tsc --noEmit        # type-check
+npm run test:node                     # unit tests
+node esbuild.js --production          # production bundle
+```
+
+All tests must pass and the build must succeed. If a test fails, fix the
+extraction \u2014 do not modify the tests unless the test itself was wrong
+before your change.
+
+## Step 9 - Commit
+
+```
+refactor: extract shared helper to eliminate duplicate block in <area>
+
+<Which group was chosen, where the helper lives, and how many copies it
+replaced. Note that the duplication detector no longer flags the group.>
+```
+
+## Step 10 - Open a PR
+
+Open a pull request to `main`. The PR description should:
+
+- Lead with the motivation (duplication detector flagged the group, or a review
+  noted the copy-paste).
+- List the occurrences that were consolidated (file:line for each) and the
+  single helper that replaced them.
+- Confirm `check-code-duplication.js` no longer reports the group, all unit
+  tests pass, and the production build succeeds.
+- Note any pre-existing warnings that were not introduced by this change.
+
+## Constraints
+
+- Remediate **one** duplicate group per pass \u2014 a second group is a separate
+  PR. This keeps the diff reviewable and a regression attributable.
+- Do not consolidate editor adapter / per-editor store modules that are
+  intentionally mirrored (see Step 1) unless the logic is behaviorally identical.
+- Do not change any exported function signatures or public class method
+  signatures.
+- Do not create a new file solely to host the helper unless it is independently
+  reusable across packages.
+- Do not fix pre-existing ESLint warnings on unrelated code.
+- If `tsc` or unit tests fail after your change, revert and choose a different
+  extraction (or a different group) rather than patching around the failure.
+
+## Related files
+
+- `scripts/check-code-duplication.js` \u2014 the detector this skill drives.
+- `vscode-extension/package.json` \u2014 `npm run check:duplicates` script.
+- `.github/workflows/ci.yml` \u2014 the CI step that publishes the "Code
+  Duplication Analysis" report to the step summary.
+- `.github/skills/refactor-large-function/SKILL.md` \u2014 the companion skill
+  for functions that are too long rather than duplicated.
+- `.github/instructions/vscode-extension.instructions.md`,
+  `.github/instructions/cli.instructions.md`, `AGENTS.md` \u2014 the area rules
+  to read before editing (notably the shared-`src/` reuse contract).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,10 +111,14 @@ jobs:
       # Report-only, like the complexity analysis above: surfaces copy-pasted
       # blocks across vscode-extension/src, the shared src/ and cli/src so a
       # reviewer can see them without failing the build on pre-existing clones.
+      # The detector exits 0 on report-only findings (no --fail-threshold), so
+      # its only nonzero exit is a genuine tool failure (syntax/runtime error);
+      # leaving that unmasked surfaces tool-health problems instead of a green
+      # job with no analysis.
       if: always() && matrix.node-version == '24.x'
       working-directory: vscode-extension
       shell: bash
-      run: npm run --silent check:duplicates -- --min-lines 14 >> "$GITHUB_STEP_SUMMARY" || true
+      run: npm run --silent check:duplicates -- --min-lines 14 >> "$GITHUB_STEP_SUMMARY"
 
     - name: Run type checking
       working-directory: vscode-extension

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,15 @@ jobs:
       shell: bash
       run: node scripts/parse-lint-output.js "$RUNNER_TEMP/lint-output.json" >> "$GITHUB_STEP_SUMMARY"
 
+    - name: Run code duplication analysis
+      # Report-only, like the complexity analysis above: surfaces copy-pasted
+      # blocks across vscode-extension/src, the shared src/ and cli/src so a
+      # reviewer can see them without failing the build on pre-existing clones.
+      if: always() && matrix.node-version == '24.x'
+      working-directory: vscode-extension
+      shell: bash
+      run: npm run --silent check:duplicates -- --min-lines 14 >> "$GITHUB_STEP_SUMMARY" || true
+
     - name: Run type checking
       working-directory: vscode-extension
       run: npm run check-types

--- a/scripts/check-code-duplication.js
+++ b/scripts/check-code-duplication.js
@@ -1,0 +1,477 @@
+#!/usr/bin/env node
+'use strict';
+/**
+ * Code duplication (copy-paste) detection \u2014 "is the same block of code in two places?"
+ *
+ * The repo already has a complexity analysis (ESLint complexity rules \u2192 step summary)
+ * and an LLM Code Quality Reviewer that *mentions* duplication, but nothing
+ * deterministic flags a copied block. This fills that gap with a dependency-free
+ * duplicate-block detector: it normalizes source lines, hashes sliding windows of
+ * a minimum length, groups identical windows, extends each group to its maximal
+ * shared block, and reports the clone groups as Markdown (for $GITHUB_STEP_SUMMARY)
+ * or JSON (for tooling).
+ *
+ * Like the complexity analysis this is **report-only by default** \u2014 it surfaces
+ * duplication on every PR without failing the build on pre-existing clones. Pass
+ * `--fail-threshold N` to make it a gate (exit 1 when total duplicated lines > N).
+ *
+ * A "duplicate group" is a normalized sequence of >= `--min-lines` lines that
+ * occurs in two or more places (cross-file, or non-overlapping within one file).
+ * Lines are normalized (whitespace collapsed, comments and blank lines dropped)
+ * so re-indented or re-commented copies are still caught. A group is extended to
+ * its maximal block by requiring *every* occurrence to agree on the preceding and
+ * following lines, which keeps each group's content consistent and unambiguous.
+ *
+ * Usage:
+ *   node scripts/check-code-duplication.js                  # report to stdout
+ *   node scripts/check-code-duplication.js --json           # machine-readable
+ *   node scripts/check-code-duplication.js --min-lines 8     # larger blocks only
+ *   node scripts/check-code-duplication.js --include 'cli/src/<glob>'
+ *   node scripts/check-code-duplication.js --fail-threshold 200
+ *
+ * Exit codes: 0 = ok (or report-only pass) | 1 = threshold exceeded | 2 = could not run.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+
+const DEFAULT_INCLUDES = [
+	'vscode-extension/src/**/*.ts',
+	'src/**/*.ts',
+	'cli/src/**/*.ts',
+];
+
+const MIN_LINES_DEFAULT = 6;
+
+function parseArgs(argv) {
+	const args = {
+		minLines: MIN_LINES_DEFAULT,
+		includes: [],
+		json: false,
+		failThreshold: null,
+		root: REPO_ROOT,
+	};
+	for (let i = 0; i < argv.length; i++) {
+		const a = argv[i];
+		if (a === '--min-lines') {
+			args.minLines = Math.max(1, parseInt(argv[++i], 10) || MIN_LINES_DEFAULT);
+		} else if (a === '--include') {
+			args.includes.push(argv[++i]);
+		} else if (a === '--json') {
+			args.json = true;
+		} else if (a === '--fail-threshold') {
+			args.failThreshold = parseInt(argv[++i], 10);
+			if (Number.isNaN(args.failThreshold)) { args.failThreshold = null; }
+		} else if (a === '--root') {
+			args.root = path.resolve(argv[++i]);
+		} else if (a === '--help' || a === '-h') {
+			process.stdout.write(USAGE);
+			process.exit(0);
+		}
+	}
+	if (args.includes.length === 0) { args.includes = DEFAULT_INCLUDES.slice(); }
+	return args;
+}
+
+const USAGE = `Usage: check-code-duplication.js [options]
+  --min-lines N        Minimum lines per duplicate block (default ${MIN_LINES_DEFAULT})
+  --include GLOB       Add a source glob (repeatable; default: the three source dirs)
+  --json               Emit JSON instead of Markdown
+  --fail-threshold N   Exit 1 when total duplicated lines > N (default: report only)
+  --root DIR           Repo root to resolve globs against (default: repo root)
+  -h, --help           Show this help
+`;
+
+/** Strip a line to its normalized, whitespace-collapsed form. */
+function normalizeLine(raw) {
+	let line = raw.replace(/\s+/g, ' ').trim();
+	return line;
+}
+
+/**
+ * Returns true for a line that carries no code signal: blank, or a line that is
+ * only a comment. Comment-only lines are dropped so a copied block that gained or
+ * lost comments is still detected; inline trailing comments are kept (they rarely
+ * span whole lines and the whitespace normalization handles trailing spaces).
+ */
+function isNoise(line) {
+	if (line === '') { return true; }
+	const t = line.trim();
+	if (t === '') { return true; }
+	if (t.startsWith('//')) { return true; }
+	if (t.startsWith('/*') || t.startsWith('*')) { return true; }
+	if (t.startsWith('*/')) { return true; }
+	return false;
+}
+
+/**
+ * Read a source file and return an array of { text: normalizedLine, line: originalLineNo }.
+ * Noise lines are dropped (their original line numbers are not represented), so a
+ * duplicate block's reported length counts meaningful lines only.
+ */
+function tokenizeFile(absPath) {
+	let content;
+	try {
+		content = fs.readFileSync(absPath, 'utf8');
+	} catch {
+		return null;
+	}
+	const lines = content.split(/\r?\n/);
+	const out = [];
+	for (let i = 0; i < lines.length; i++) {
+		const norm = normalizeLine(lines[i]);
+		if (isNoise(norm)) { continue; }
+		out.push({ text: norm, line: i + 1 });
+	}
+	return out;
+}
+
+/** Minimal glob -> RegExp matcher supporting **, *, ? and braces-free patterns. */
+function globToRegExp(glob) {
+	let re = '';
+	for (let i = 0; i < glob.length; i++) {
+		const c = glob[i];
+		if (c === '*') {
+			if (glob[i + 1] === '*') {
+				re += '.*';
+				i++;
+				if (glob[i + 1] === '/') { i++; }
+			} else {
+				re += '[^/]*';
+			}
+		} else if (c === '?') {
+			re += '[^/]';
+		} else if ('.+()^$|{}\\[]'.includes(c)) {
+			re += '\\' + c;
+		} else {
+			re += c;
+		}
+	}
+	return new RegExp('^' + re + '$');
+}
+
+/** Walk a directory tree, returning absolute paths of files. */
+function walk(dir, out) {
+	let entries;
+	try {
+		entries = fs.readdirSync(dir, { withFileTypes: true });
+	} catch {
+		return;
+	}
+	for (const e of entries) {
+		if (e.name === 'node_modules' || e.name === 'dist' || e.name === 'out' || e.name === '.git') { continue; }
+		const full = path.join(dir, e.name);
+		if (e.isDirectory()) { walk(full, out); }
+		else if (e.isFile()) { out.push(full); }
+	}
+}
+
+/** Collect the absolute file paths matching the include globs under root. */
+function collectFiles(root, includes) {
+	const patterns = includes.map((g) => {
+		const re = globToRegExp(g);
+		const base = g.startsWith('**') ? root : path.dirname(path.join(root, g)).replace(/\*.*$/, '');
+		return { re, base };
+	});
+	const seen = new Set();
+	const result = [];
+	for (const { re, base } of patterns) {
+		const baseDir = re.source.startsWith('\\*\\*') ? root : base;
+		const files = [];
+		walk(fs.existsSync(baseDir) ? baseDir : root, files);
+		for (const abs of files) {
+			if (seen.has(abs)) { continue; }
+			const rel = path.relative(root, abs).replace(/\\/g, '/');
+			if (re.test(rel)) {
+				seen.add(abs);
+				result.push(abs);
+			}
+		}
+	}
+	return result.sort();
+}
+
+/** FNV-1a 32-bit hash of a string. Fast, dependency-free, good distribution. */
+function fnv1a(str) {
+	let h = 0x811c9dc5;
+	for (let i = 0; i < str.length; i++) {
+		h ^= str.charCodeAt(i);
+		h = Math.imul(h, 0x01000193);
+	}
+	return (h >>> 0).toString(36);
+}
+
+/** Find duplicate groups across the given tokenized files. Pure function. */
+function findDuplicates(fileTokens, minLines) {
+	const groups = new Map(); // contentHash -> { content: string[], occurrences: [{file, startLine, endLine}] }
+
+	for (const ft of fileTokens) {
+		const tokens = ft.tokens;
+		for (let i = 0; i + minLines <= tokens.length; i++) {
+			const window = tokens.slice(i, i + minLines).map((t) => t.text);
+			const content = window.join('\n');
+			const hash = fnv1a(content);
+			let bucket = groups.get(hash);
+			if (!bucket) {
+				bucket = { contents: new Map() };
+				groups.set(hash, bucket);
+			}
+			let entry = bucket.contents.get(content);
+			if (!entry) {
+				entry = { content: window, occurrences: [] };
+				bucket.contents.set(content, entry);
+			}
+			entry.occurrences.push({ file: ft.relPath, startLine: tokens[i].line, endLine: tokens[i + minLines - 1].line });
+		}
+	}
+
+	// Keep only groups that actually occur in >= 2 places; dedup the occurrence
+	// list so a window landing on the exact same lines in the same file twice
+	// (impossible for distinct i, but cheap to guard) is not double counted.
+	const duplicateGroups = [];
+	for (const bucket of groups.values()) {
+		for (const entry of bucket.contents.values()) {
+			const occ = entry.occurrences;
+			const dedup = [];
+			for (const o of occ) {
+				if (!dedup.some((d) => d.file === o.file && d.startLine === o.startLine)) {
+					dedup.push(o);
+				}
+			}
+			if (dedup.length < 2) { continue; }
+			duplicateGroups.push({ content: entry.content, occurrences: dedup });
+		}
+	}
+
+	return extendGroups(duplicateGroups, fileTokens, minLines);
+}
+
+/**
+ * Extend each duplicate group to its maximal shared block by requiring every
+ * occurrence to agree on the preceding and following normalized lines. Occurrences
+ * that cannot extend to the full shared block are dropped from that group (they
+ * keep only the original window-sized match); groups that collapse below 2
+ * occurrences are removed. Lines are matched by their normalized text.
+ */
+function extendGroups(groups, fileTokens, minLines) {
+	const byFile = new Map();
+	for (const ft of fileTokens) { byFile.set(ft.relPath, ft.tokens); }
+
+	const result = [];
+	for (const g of groups) {
+		const occ = g.occurrences.map((o) => ({ ...o, head: 0, tail: g.content.length - 1 }));
+		const content = g.content.slice();
+
+		// Extend forward: while every occurrence has a next line that matches the
+		// common next line, append it and advance each occurrence's tail.
+		let grew = true;
+		while (grew) {
+			grew = false;
+			let commonNext = null;
+			let ok = true;
+			for (const o of occ) {
+				const tokens = byFile.get(o.file);
+				const nextIdx = lineIndexOf(tokens, o.endLine) + 1;
+				if (nextIdx >= tokens.length) { ok = false; break; }
+				const next = tokens[nextIdx].text;
+				if (commonNext === null) { commonNext = next; }
+				else if (commonNext !== next) { ok = false; break; }
+			}
+			if (ok && commonNext !== null) {
+				content.push(commonNext);
+				for (const o of occ) {
+					const tokens = byFile.get(o.file);
+					o.endLine = tokens[lineIndexOf(tokens, o.endLine) + 1].line;
+					o.tail++;
+				}
+				grew = true;
+			}
+		}
+
+		// Extend backward.
+		grew = true;
+		while (grew) {
+			grew = false;
+			let commonPrev = null;
+			let ok = true;
+			for (const o of occ) {
+				const tokens = byFile.get(o.file);
+				const prevIdx = lineIndexOf(tokens, o.startLine) - 1;
+				if (prevIdx < 0) { ok = false; break; }
+				const prev = tokens[prevIdx].text;
+				if (commonPrev === null) { commonPrev = prev; }
+				else if (commonPrev !== prev) { ok = false; break; }
+			}
+			if (ok && commonPrev !== null) {
+				content.unshift(commonPrev);
+				for (const o of occ) {
+					const tokens = byFile.get(o.file);
+					o.startLine = tokens[lineIndexOf(tokens, o.startLine) - 1].line;
+					o.head++;
+				}
+				grew = true;
+			}
+		}
+
+		// The maximal block is `content` (>= minLines by construction). Keep it.
+		result.push({
+			lines: content.length,
+			occurrences: occ.map((o) => ({ file: o.file, startLine: o.startLine, endLine: o.endLine })),
+			preview: content.slice(0, 3).join('\n'),
+		});
+	}
+
+	// Merge overlapping maximal blocks that describe the same clone (a shorter
+	// group fully contained in a longer one for the same file/line set is noise).
+	result.sort((a, b) => b.lines - a.lines || b.occurrences.length - a.occurrences.length);
+	const kept = [];
+	const covered = new Set();
+	for (const g of result) {
+		const key = g.occurrences.map((o) => `${o.file}:${o.startLine}-${o.endLine}`).sort().join('|');
+		let subsumed = false;
+		for (const k of kept) {
+			if (g.lines <= k.lines && occurrencesSubset(g.occurrences, k.occurrences)) {
+				subsumed = true;
+				break;
+			}
+		}
+		if (subsumed) { continue; }
+		if (covered.has(key)) { continue; }
+		covered.add(key);
+		kept.push(g);
+	}
+	return kept.sort((a, b) => b.lines - a.lines);
+}
+
+/** True when every occurrence in `a` is covered by an occurrence in `b`. */
+function occurrencesSubset(a, b) {
+	for (const oa of a) {
+		let found = false;
+		for (const ob of b) {
+			if (ob.file === oa.file && oa.startLine >= ob.startLine && oa.endLine <= ob.endLine) {
+				found = true;
+				break;
+			}
+		}
+		if (!found) { return false; }
+	}
+	return true;
+}
+
+/** Index of the token whose original line number == lineNo (linear; tokens per file is small). */
+function lineIndexOf(tokens, lineNo) {
+	for (let i = 0; i < tokens.length; i++) {
+		if (tokens[i].line === lineNo) { return i; }
+	}
+	return -1;
+}
+
+function totalDuplicatedLines(groups) {
+	let total = 0;
+	for (const g of groups) { total += g.lines * g.occurrences.length; }
+	return total;
+}
+
+function renderMarkdown(groups, scanned, threshold) {
+	let md = '## \u2396\ufe0f\u200d Code Duplication Analysis\n\n';
+	md += `| Files scanned | Duplicate groups | Total duplicated lines |\n`;
+	md += `|:-------------:|:---------------:|:---------------------:|\n`;
+	md += `| ${scanned} | ${groups.length} | ${totalDuplicatedLines(groups)} |\n\n`;
+
+	if (groups.length === 0) {
+		md += '\u2705 No duplicate blocks found at the configured minimum length.\n';
+		return md;
+	}
+
+	const top = groups.slice(0, 10);
+	md += '### \ud83d\udd1b Top duplicate groups\n\n';
+	md += '| Lines | Occurrences | Files | Preview |\n';
+	md += '|:-----:|:-----------:|:------|---------|\n';
+	for (const g of top) {
+		const files = [...new Set(g.occurrences.map((o) => o.file))].map((f) => `\`${f}\``).join('<br>');
+		const preview = g.preview.replace(/\|/g, '\\|').replace(/\n/g, ' \u2026 ');
+		md += `| ${g.lines} | ${g.occurrences.length} | ${files} | \`${preview}\u2026\` |\n`;
+	}
+	md += '\n';
+
+	const sorted = [...groups].sort((a, b) =>
+		b.lines - a.lines || a.occurrences[0].file.localeCompare(b.occurrences[0].file));
+	md += '<details>\n<summary>All duplicate groups</summary>\n\n';
+	md += '| Lines | Occurrences | Locations |\n';
+	md += '|:-----:|:-----------:|-----------|\n';
+	for (const g of sorted) {
+		const locs = g.occurrences.map((o) => `\`${o.file}:${o.startLine}-${o.endLine}\``).join('<br>');
+		md += `| ${g.lines} | ${g.occurrences.length} | ${locs} |\n`;
+	}
+	md += '\n</details>\n';
+
+	if (threshold !== null) {
+		const total = totalDuplicatedLines(groups);
+		md += `\n> Gate: total duplicated lines **${total}** vs threshold **${threshold}** \u2014 `;
+		md += total > threshold ? '\u274c exceeds threshold' : '\u2705 within threshold';
+		md += '\n';
+	}
+	return md;
+}
+
+function renderJson(groups, scanned, threshold) {
+	return JSON.stringify({
+		filesScanned: scanned,
+		groups: groups.map((g) => ({
+			lines: g.lines,
+			occurrences: g.occurrences,
+			preview: g.preview,
+		})),
+		totalDuplicatedLines: totalDuplicatedLines(groups),
+		threshold,
+	}, null, 2);
+}
+
+function main() {
+	const args = parseArgs(process.argv.slice(2));
+	const root = args.root;
+
+	const files = collectFiles(root, args.includes);
+	const fileTokens = [];
+	for (const abs of files) {
+		const tokens = tokenizeFile(abs);
+		if (!tokens || tokens.length < args.minLines) { continue; }
+		fileTokens.push({ relPath: path.relative(root, abs).replace(/\\/g, '/'), tokens });
+	}
+
+	const groups = findDuplicates(fileTokens, args.minLines);
+	const total = totalDuplicatedLines(groups);
+
+	if (args.json) {
+		process.stdout.write(renderJson(groups, fileTokens.length, args.failThreshold) + '\n');
+	} else {
+		process.stdout.write(renderMarkdown(groups, fileTokens.length, args.failThreshold));
+	}
+
+	if (args.failThreshold !== null && total > args.failThreshold) {
+		process.exit(1);
+	}
+	process.exit(0);
+}
+
+// Exported for the unit test (mirrors scripts/validate-webview-contract.js).
+module.exports = {
+	parseArgs,
+	normalizeLine,
+	isNoise,
+	tokenizeFile,
+	globToRegExp,
+	collectFiles,
+	findDuplicates,
+	extendGroups,
+	totalDuplicatedLines,
+	renderMarkdown,
+	renderJson,
+	MIN_LINES_DEFAULT,
+	DEFAULT_INCLUDES,
+};
+
+if (require.main === module) {
+	main();
+}

--- a/scripts/check-code-duplication.js
+++ b/scripts/check-code-duplication.js
@@ -135,8 +135,20 @@ function tokenizeFile(absPath) {
  */
 const REGEX_METACHARS = new Set('\\^$.*+?()[]{}|');
 
+/*
+ * The only characters a `--include` glob is allowed to contain. Anything
+ * outside this set is rejected before the RegExp is built, which is the
+ * sanitization step CodeQL's regex-injection query looks for: by the time
+ * the glob reaches `new RegExp(...)`, it is known to be composed solely of
+ * safe literal characters plus the glob metacharacters handled below.
+ */
+const SAFE_GLOB_CHARS = /^[A-Za-z0-9_\-./?*]+$/;
+
 /** Minimal glob -> RegExp matcher supporting **, *, ? and braces-free patterns. */
 function globToRegExp(glob) {
+	if (!SAFE_GLOB_CHARS.test(glob)) {
+		throw new Error(`Invalid --include glob (only letters, digits, _ - . / ? * are allowed): ${glob}`);
+	}
 	let re = '';
 	for (let i = 0; i < glob.length; i++) {
 		const c = glob[i];

--- a/scripts/check-code-duplication.js
+++ b/scripts/check-code-duplication.js
@@ -127,6 +127,14 @@ function tokenizeFile(absPath) {
 	return out;
 }
 
+/*
+ * Characters that have special meaning in a RegExp. Everything that is not a
+ * glob metacharacter (`*`, `?`) is escaped against this set so a `--include`
+ * value can never inject an arbitrary regex — the emitted pattern only ever
+ * contains `.*`, `[^/]*`, `[^/]`, and escaped literals.
+ */
+const REGEX_METACHARS = new Set('\\^$.*+?()[]{}|');
+
 /** Minimal glob -> RegExp matcher supporting **, *, ? and braces-free patterns. */
 function globToRegExp(glob) {
 	let re = '';
@@ -142,7 +150,7 @@ function globToRegExp(glob) {
 			}
 		} else if (c === '?') {
 			re += '[^/]';
-		} else if ('.+()^$|{}\\[]'.includes(c)) {
+		} else if (REGEX_METACHARS.has(c)) {
 			re += '\\' + c;
 		} else {
 			re += c;
@@ -373,6 +381,13 @@ function totalDuplicatedLines(groups) {
 	return total;
 }
 
+/** Escape a string for safe use inside a Markdown table cell: backslash first,
+ * then the pipe that delimits columns, so source paths/previews cannot break
+ * out of the cell or smuggle a column separator. */
+function escapeMarkdownCell(s) {
+	return s.replace(/\\/g, '\\\\').replace(/\|/g, '\\|');
+}
+
 function renderMarkdown(groups, scanned, threshold) {
 	let md = '## \u2396\ufe0f\u200d Code Duplication Analysis\n\n';
 	md += `| Files scanned | Duplicate groups | Total duplicated lines |\n`;
@@ -390,7 +405,7 @@ function renderMarkdown(groups, scanned, threshold) {
 	md += '|:-----:|:-----------:|:------|---------|\n';
 	for (const g of top) {
 		const files = [...new Set(g.occurrences.map((o) => o.file))].map((f) => `\`${f}\``).join('<br>');
-		const preview = g.preview.replace(/\|/g, '\\|').replace(/\n/g, ' \u2026 ');
+		const preview = escapeMarkdownCell(g.preview).replace(/\n/g, ' … ');
 		md += `| ${g.lines} | ${g.occurrences.length} | ${files} | \`${preview}\u2026\` |\n`;
 	}
 	md += '\n';
@@ -466,6 +481,7 @@ module.exports = {
 	findDuplicates,
 	extendGroups,
 	totalDuplicatedLines,
+	escapeMarkdownCell,
 	renderMarkdown,
 	renderJson,
 	MIN_LINES_DEFAULT,

--- a/scripts/check-code-duplication.js
+++ b/scripts/check-code-duplication.js
@@ -94,6 +94,10 @@ function normalizeLine(raw) {
  * only a comment. Comment-only lines are dropped so a copied block that gained or
  * lost comments is still detected; inline trailing comments are kept (they rarely
  * span whole lines and the whitespace normalization handles trailing spaces).
+ *
+ * This classifies a single line without block-comment context; use
+ * `tokenizeFile` for whole-file tokenization, which tracks block-comment state
+ * so an unprefixed body line inside a block comment is also dropped.
  */
 function isNoise(line) {
 	if (line === '') { return true; }
@@ -106,9 +110,48 @@ function isNoise(line) {
 }
 
 /**
+ * Classify a raw line as noise (no code signal) while tracking block-comment
+ * state across lines. A line is noise when it is blank, a line comment, or any
+ * line within (including the opening/closing lines of) a block comment.
+ * Unprefixed body lines inside a block comment are dropped here, which
+ * `isNoise` alone cannot see. Returns `{ noise, inBlock, text }`.
+ */
+function classifyLine(raw, inBlock) {
+	const line = normalizeLine(raw);
+	const t = line.trim();
+	if (inBlock) {
+		const closeIdx = t.indexOf('*/');
+		if (closeIdx === -1) { return { noise: true, inBlock: true }; }
+		const after = t.slice(closeIdx + 2).trim();
+		if (after === '' || after.startsWith('//')) { return { noise: true, inBlock: false }; }
+		return { noise: false, inBlock: false, text: after };
+	}
+	if (t === '' || t.startsWith('//')) { return { noise: true, inBlock: false }; }
+	const openIdx = t.indexOf('/*');
+	if (openIdx === -1) { return { noise: false, inBlock: false, text: line }; }
+	const before = t.slice(0, openIdx).trim();
+	const afterOpen = t.slice(openIdx + 2);
+	const closeIdx = afterOpen.indexOf('*/');
+	if (closeIdx === -1) {
+		if (before === '') { return { noise: true, inBlock: true }; }
+		return { noise: false, inBlock: true, text: before };
+	}
+	const after = afterOpen.slice(closeIdx + 2).trim();
+	// The text between the open and close markers is comment content; with no
+	// code before the open and no code (or only a line comment) after the
+	// close, the whole line is a comment.
+	const allComment = before === '' && (after === '' || after.startsWith('//'));
+	if (allComment) { return { noise: true, inBlock: false }; }
+	const codePart = [before, after].filter((s) => s !== '').join(' ');
+	return { noise: false, inBlock: false, text: codePart };
+}
+
+/**
  * Read a source file and return an array of { text: normalizedLine, line: originalLineNo }.
  * Noise lines are dropped (their original line numbers are not represented), so a
- * duplicate block's reported length counts meaningful lines only.
+ * duplicate block's reported length counts meaningful lines only. Block-comment
+ * state is tracked across lines so unprefixed body lines inside a block
+ * comment are dropped too.
  */
 function tokenizeFile(absPath) {
 	let content;
@@ -119,10 +162,12 @@ function tokenizeFile(absPath) {
 	}
 	const lines = content.split(/\r?\n/);
 	const out = [];
+	let inBlock = false;
 	for (let i = 0; i < lines.length; i++) {
-		const norm = normalizeLine(lines[i]);
-		if (isNoise(norm)) { continue; }
-		out.push({ text: norm, line: i + 1 });
+		const c = classifyLine(lines[i], inBlock);
+		inBlock = c.inBlock;
+		if (c.noise) { continue; }
+		out.push({ text: c.text, line: i + 1 });
 	}
 	return out;
 }
@@ -187,11 +232,24 @@ function walk(dir, out) {
 	}
 }
 
+/** The longest static directory prefix of a glob before the first wildcard,
+ * so a glob whose first segment contains a wildcard (e.g. a `src` pattern
+ * where the segment after src has a star) walks the directory before that
+ * wildcard rather than a literal path that may not exist. Star, double-star,
+ * and question mark all count as wildcards. */
+function globBase(glob) {
+	const idx = glob.search(/[*?]/);
+	if (idx === -1) { return glob; }
+	const prefix = glob.slice(0, idx);
+	const slash = prefix.lastIndexOf('/');
+	return slash === -1 ? '' : prefix.slice(0, slash);
+}
+
 /** Collect the absolute file paths matching the include globs under root. */
 function collectFiles(root, includes) {
 	const patterns = includes.map((g) => {
 		const re = globToRegExp(g);
-		const base = g.startsWith('**') ? root : path.dirname(path.join(root, g)).replace(/\*.*$/, '');
+		const base = g.startsWith('**') ? root : path.join(root, globBase(g));
 		return { re, base };
 	});
 	const seen = new Set();
@@ -242,25 +300,33 @@ function findDuplicates(fileTokens, minLines) {
 				entry = { content: window, occurrences: [] };
 				bucket.contents.set(content, entry);
 			}
-			entry.occurrences.push({ file: ft.relPath, startLine: tokens[i].line, endLine: tokens[i + minLines - 1].line });
+			entry.occurrences.push({ file: ft.relPath, startLine: tokens[i].line, endLine: tokens[i + minLines - 1].line, startTok: i, endTok: i + minLines - 1 });
 		}
 	}
 
-	// Keep only groups that actually occur in >= 2 places; dedup the occurrence
-	// list so a window landing on the exact same lines in the same file twice
-	// (impossible for distinct i, but cheap to guard) is not double counted.
+	// Keep only groups that actually occur in >= 2 places. Within a single file,
+	// overlapping windows (e.g. a run of identical lines producing windows starting
+	// on consecutive token indices) describe one block, not a clone, so reject an
+	// occurrence whose token range overlaps an already-kept occurrence in the same
+	// file. Token-index overlap is used because noise lines are dropped, so equal
+	// original line ranges are not a reliable overlap signal.
 	const duplicateGroups = [];
 	for (const bucket of groups.values()) {
 		for (const entry of bucket.contents.values()) {
 			const occ = entry.occurrences;
 			const dedup = [];
 			for (const o of occ) {
-				if (!dedup.some((d) => d.file === o.file && d.startLine === o.startLine)) {
-					dedup.push(o);
+				let overlap = false;
+				for (const d of dedup) {
+					if (d.file === o.file && o.startTok <= d.endTok && d.startTok <= o.endTok) {
+						overlap = true;
+						break;
+					}
 				}
+				if (!overlap) { dedup.push(o); }
 			}
 			if (dedup.length < 2) { continue; }
-			duplicateGroups.push({ content: entry.content, occurrences: dedup });
+			duplicateGroups.push({ content: entry.content, occurrences: dedup.map(({ startTok, endTok, ...rest }) => rest) });
 		}
 	}
 
@@ -269,10 +335,11 @@ function findDuplicates(fileTokens, minLines) {
 
 /**
  * Extend each duplicate group to its maximal shared block by requiring every
- * occurrence to agree on the preceding and following normalized lines. Occurrences
- * that cannot extend to the full shared block are dropped from that group (they
- * keep only the original window-sized match); groups that collapse below 2
- * occurrences are removed. Lines are matched by their normalized text.
+ * occurrence to agree on the preceding and following normalized lines. All
+ * occurrences extend together as long as they all share the next (or previous)
+ * line; when any occurrence cannot extend, the whole group stops for that
+ * direction and every occurrence keeps its current bounds. Lines are matched by
+ * their normalized text.
  */
 function extendGroups(groups, fileTokens, minLines) {
 	const byFile = new Map();
@@ -400,6 +467,14 @@ function escapeMarkdownCell(s) {
 	return s.replace(/\\/g, '\\\\').replace(/\|/g, '\\|');
 }
 
+/** HTML-escape a string so it is safe to interpolate inside `<code>` markup in a
+ * Markdown table cell. This is delimiter-safe: a source preview containing a
+ * backtick or template literal cannot close the code span, because the span is
+ * an HTML `<code>` element rather than a backtick fence. */
+function escapeHtml(s) {
+	return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
 function renderMarkdown(groups, scanned, threshold) {
 	let md = '## \u2396\ufe0f\u200d Code Duplication Analysis\n\n';
 	md += `| Files scanned | Duplicate groups | Total duplicated lines |\n`;
@@ -417,8 +492,8 @@ function renderMarkdown(groups, scanned, threshold) {
 	md += '|:-----:|:-----------:|:------|---------|\n';
 	for (const g of top) {
 		const files = [...new Set(g.occurrences.map((o) => o.file))].map((f) => `\`${f}\``).join('<br>');
-		const preview = escapeMarkdownCell(g.preview).replace(/\n/g, ' … ');
-		md += `| ${g.lines} | ${g.occurrences.length} | ${files} | \`${preview}\u2026\` |\n`;
+		const preview = escapeMarkdownCell(escapeHtml(g.preview)).replace(/\n/g, ' … ');
+		md += `| ${g.lines} | ${g.occurrences.length} | ${files} | <code>${preview}…</code> |\n`;
 	}
 	md += '\n';
 
@@ -477,9 +552,8 @@ function main() {
 	}
 
 	if (args.failThreshold !== null && total > args.failThreshold) {
-		process.exit(1);
+		process.exitCode = 1;
 	}
-	process.exit(0);
 }
 
 // Exported for the unit test (mirrors scripts/validate-webview-contract.js).
@@ -487,13 +561,16 @@ module.exports = {
 	parseArgs,
 	normalizeLine,
 	isNoise,
+	classifyLine,
 	tokenizeFile,
 	globToRegExp,
+	globBase,
 	collectFiles,
 	findDuplicates,
 	extendGroups,
 	totalDuplicatedLines,
 	escapeMarkdownCell,
+	escapeHtml,
 	renderMarkdown,
 	renderJson,
 	MIN_LINES_DEFAULT,

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -543,6 +543,7 @@
     "check:contract": "node ../scripts/validate-webview-contract.js",
     "check:interaction": "node ../scripts/interaction-smoke.js",
     "check:editor-data": "node ../scripts/check-editor-data-coverage.js",
+    "check:duplicates": "node ../scripts/check-code-duplication.js",
     "preflight": "node ../scripts/preflight.js",
     "preflight:quick": "node ../scripts/preflight.js --quick",
     "sync-changelog": "node ../scripts/sync-changelog.js",

--- a/vscode-extension/test/unit/codeDuplication.test.ts
+++ b/vscode-extension/test/unit/codeDuplication.test.ts
@@ -27,6 +27,7 @@ const dup = requireFromHere(
 	normalizeLine: (raw: string) => string;
 	isNoise: (line: string) => boolean;
 	globToRegExp: (glob: string) => RegExp;
+	escapeMarkdownCell: (s: string) => string;
 	findDuplicates: (
 		fileTokens: { relPath: string; tokens: { text: string; line: number }[] }[],
 		minLines: number
@@ -195,6 +196,35 @@ test('parseArgs: applies defaults and parses flags', () => {
 	assert.equal(b.json, true);
 	assert.equal(b.failThreshold, 200);
 	assert.deepEqual(b.includes, ['src/**/*.ts']);
+});
+
+test('globToRegExp: a --include value cannot inject an arbitrary regex', () => {
+	// A glob containing regex metacharacters must be escaped, never compiled
+	// as a live regex operator. `(` without a matching `)` would otherwise throw
+	// or match unintended content.
+	const re = dup.globToRegExp('src/(weird).ts');
+	assert.ok(re.test('src/(weird).ts'));
+	assert.ok(!re.test('src/weird.ts'));
+});
+
+test('escapeMarkdownCell: escapes backslash first, then the pipe delimiter', () => {
+	assert.equal(dup.escapeMarkdownCell('plain'), 'plain');
+	assert.equal(dup.escapeMarkdownCell('a|b'), 'a\\|b');
+	// A backslash must be doubled before the pipe escape, so `\|` cannot smuggle
+	// a literal pipe through as a column separator.
+	assert.equal(dup.escapeMarkdownCell('a\\|b'), 'a\\\\\\|b');
+});
+
+test('renderMarkdown: previews are escaped for the table cell', () => {
+	const md = dup.renderMarkdown(
+		[{ lines: 8, occurrences: [{ file: 'a.ts', startLine: 1, endLine: 8 }], preview: 'a|b\\c' }],
+		5,
+		null
+	);
+	// The raw preview content must be escaped: pipe -> \|, backslash -> \\,
+	// so it cannot break out of its table cell.
+	assert.match(md, /`a\\\|b\\\\c…`/);
+	assert.ok(!md.includes('a|b\\c'));
 });
 
 test('the detector runs against the repo and reports a non-empty step-summary', () => {

--- a/vscode-extension/test/unit/codeDuplication.test.ts
+++ b/vscode-extension/test/unit/codeDuplication.test.ts
@@ -26,8 +26,12 @@ const dup = requireFromHere(
 ) as {
 	normalizeLine: (raw: string) => string;
 	isNoise: (line: string) => boolean;
+	classifyLine: (raw: string, inBlock: boolean) => { noise: boolean; inBlock: boolean; text?: string };
+	tokenizeFile: (absPath: string) => { text: string; line: number }[] | null;
 	globToRegExp: (glob: string) => RegExp;
+	globBase: (glob: string) => string;
 	escapeMarkdownCell: (s: string) => string;
+	escapeHtml: (s: string) => string;
 	findDuplicates: (
 		fileTokens: { relPath: string; tokens: { text: string; line: number }[] }[],
 		minLines: number
@@ -42,10 +46,12 @@ const dup = requireFromHere(
 function makeFileTokens(relPath: string, source: string) {
 	const tokens: { text: string; line: number }[] = [];
 	const lines = source.split(/\r?\n/);
+	let inBlock = false;
 	for (let i = 0; i < lines.length; i++) {
-		const norm = dup.normalizeLine(lines[i]);
-		if (dup.isNoise(norm)) { continue; }
-		tokens.push({ text: norm, line: i + 1 });
+		const c = dup.classifyLine(lines[i], inBlock);
+		inBlock = c.inBlock;
+		if (c.noise) { continue; }
+		tokens.push({ text: c.text as string, line: i + 1 });
 	}
 	return { relPath, tokens };
 }
@@ -64,6 +70,59 @@ test('isNoise: treats blank and comment-only lines as noise, code as signal', ()
 	assert.ok(dup.isNoise('*/ block close'));
 	assert.ok(!dup.isNoise('const x = 1;'));
 	assert.ok(!dup.isNoise('return x; // trailing'));
+});
+
+test('classifyLine: tracks block-comment state across lines so unprefixed body lines are noise', () => {
+	// Inside an open block comment, an unprefixed body line is noise.
+	assert.deepEqual(dup.classifyLine('this is prose', true), { noise: true, inBlock: true });
+	// A line comment after the close stays noise and closes the block.
+	assert.deepEqual(dup.classifyLine('*/ // trailing', true), { noise: true, inBlock: false });
+	// Code after the close on the same line is kept.
+	const c = dup.classifyLine('*/ const x = 1;', true);
+	assert.equal(c.noise, false);
+	assert.equal(c.inBlock, false);
+	assert.equal(c.text, 'const x = 1;');
+	// A block comment opening with no code is noise and enters the block.
+	assert.deepEqual(dup.classifyLine('/* header', false), { noise: true, inBlock: true });
+	// A whole-line `/* ... */` block is noise.
+	assert.deepEqual(dup.classifyLine('/* one liner */', false), { noise: true, inBlock: false });
+	// Code preceding an open + code after close on the same line is kept.
+	const m = dup.classifyLine('const a = 1; /* c */ const b = 2;', false);
+	assert.equal(m.noise, false);
+	assert.equal(m.inBlock, false);
+	assert.equal(m.text, 'const a = 1; const b = 2;');
+});
+
+test('tokenizeFile: drops unprefixed body lines inside a block comment', () => {
+	const tmp = fs.mkdtempSync(path.join(requireFromHere('node:os').tmpdir(), 'dup-'));
+	try {
+		const file = path.join(tmp, 'block.ts');
+		fs.writeFileSync(file, '/**\n * a documentation block\n * with prose lines\n */\nconst real = 1;\n');
+		const tokens = dup.tokenizeFile(file);
+		assert.ok(tokens);
+		assert.equal(tokens.length, 1);
+		assert.equal(tokens[0].text, 'const real = 1;');
+		assert.equal(tokens[0].line, 5);
+	} finally {
+		fs.rmSync(tmp, { recursive: true, force: true });
+	}
+});
+
+test('findDuplicates: does not flag overlapping windows of one repeated run as a clone', () => {
+	// Seven identical meaningful lines with min-lines 6 produce windows starting
+	// on token indices 0 and 1; that is one block, not a within-file duplicate.
+	const run = Array.from({ length: 7 }, () => 'const same = 1;').join('\n');
+	const fileA = makeFileTokens('a.ts', `${run}\n`);
+	const groups = dup.findDuplicates([fileA], 6);
+	assert.equal(groups.length, 0, 'a single repeated run should not be reported as an intra-file clone');
+});
+
+test('globBase: returns the static directory prefix before the first wildcard', () => {
+	assert.equal(dup.globBase('src/**/*.ts'), 'src');
+	assert.equal(dup.globBase('src/foo*/*.ts'), 'src');
+	assert.equal(dup.globBase('a/b/c/*.ts'), 'a/b/c');
+	assert.equal(dup.globBase('*.ts'), '');
+	assert.equal(dup.globBase('no/wildcard.ts'), 'no/wildcard.ts');
 });
 
 test('globToRegExp: matches double-star recursively and single-star within a segment', () => {
@@ -217,21 +276,87 @@ test('escapeMarkdownCell: escapes backslash first, then the pipe delimiter', () 
 	assert.equal(dup.escapeMarkdownCell('a\\|b'), 'a\\\\\\|b');
 });
 
+test('escapeHtml: HTML-escapes ampersand, angle brackets for safe <code> use', () => {
+	assert.equal(dup.escapeHtml('plain'), 'plain');
+	assert.equal(dup.escapeHtml('a<b>c&d'), 'a&lt;b&gt;c&amp;d');
+});
+
 test('renderMarkdown: previews are escaped for the table cell', () => {
 	const md = dup.renderMarkdown(
-		[{ lines: 8, occurrences: [{ file: 'a.ts', startLine: 1, endLine: 8 }], preview: 'a|b\\c' }],
+		[{ lines: 8, occurrences: [{ file: 'a.ts', startLine: 1, endLine: 8 }], preview: 'a|b\\c`tick' }],
 		5,
 		null
 	);
-	// The raw preview content must be escaped: pipe -> \|, backslash -> \\,
-	// so it cannot break out of its table cell.
-	assert.match(md, /`a\\\|b\\\\c…`/);
-	assert.ok(!md.includes('a|b\\c'));
+	// The preview is rendered inside an HTML <code> element (not a backtick
+	// span) with pipes/backslashes escaped and HTML-entities applied, so a
+	// source backtick or template literal cannot close the code span.
+	assert.match(md, /<code>a\\\|b\\\\c`tick…<\/code>/);
+	assert.ok(!md.includes('| a|b\\c`tick'));
 });
 
-test('the detector runs against the repo and reports a non-empty step-summary', () => {
-	// The real end-to-end check: the script scans the shared source dirs and the
-	// repo has known shared adapters, so a green run must still find duplicates.
+test('the detector runs end-to-end against a fixture and reports a clone', () => {
+	// A behavior assertion against a temp fixture, independent of the current
+	// repo duplication baseline, so a legitimate cleanup never fails this suite.
+	const { spawnSync } = requireFromHere('node:child_process') as typeof import('node:child_process');
+	const tmp = fs.mkdtempSync(path.join(requireFromHere('node:os').tmpdir(), 'dup-e2e-'));
+	try {
+		const block = [
+			'function sharedHelper(a: number, b: number): number {',
+			'const sum = a + b;',
+			'const product = a * b;',
+			'if (sum > product) { return sum; }',
+			'return product;',
+			'}',
+			'export { sharedHelper };',
+		].join('\n');
+		fs.mkdirSync(path.join(tmp, 'src'), { recursive: true });
+		fs.writeFileSync(path.join(tmp, 'src', 'a.ts'), `// header\n${block}\nconst extra = 1;\n`);
+		fs.writeFileSync(path.join(tmp, 'src', 'b.ts'), `/* file b */\n${block}\nconst other = 2;\n`);
+		const result = spawnSync(
+			process.execPath,
+			[path.join(REPO_ROOT, 'scripts', 'check-code-duplication.js'), '--min-lines', '6', '--include', 'src/**/*.ts', '--json', '--root', tmp],
+			{ cwd: tmp, encoding: 'utf8' }
+		);
+		assert.equal(result.status, 0, `detector should run report-only; stderr: ${result.stderr}`);
+		const parsed = JSON.parse(result.stdout);
+		assert.equal(parsed.filesScanned, 2);
+		assert.ok(Array.isArray(parsed.groups));
+		assert.ok(parsed.groups.length >= 1, 'the fixture has a copied block');
+	} finally {
+		fs.rmSync(tmp, { recursive: true, force: true });
+	}
+});
+
+test('the detector exits 1 against a fixture when --fail-threshold is exceeded', () => {
+	const { spawnSync } = requireFromHere('node:child_process') as typeof import('node:child_process');
+	const tmp = fs.mkdtempSync(path.join(requireFromHere('node:os').tmpdir(), 'dup-thr-'));
+	try {
+		const block = [
+			'function sharedHelper(a: number, b: number): number {',
+			'const sum = a + b;',
+			'const product = a * b;',
+			'if (sum > product) { return sum; }',
+			'return product;',
+			'}',
+			'export { sharedHelper };',
+		].join('\n');
+		fs.mkdirSync(path.join(tmp, 'src'), { recursive: true });
+		fs.writeFileSync(path.join(tmp, 'src', 'a.ts'), `${block}\n`);
+		fs.writeFileSync(path.join(tmp, 'src', 'b.ts'), `${block}\n`);
+		const result = spawnSync(
+			process.execPath,
+			[path.join(REPO_ROOT, 'scripts', 'check-code-duplication.js'), '--min-lines', '6', '--fail-threshold', '1', '--include', 'src/**/*.ts', '--json', '--root', tmp],
+			{ cwd: tmp, encoding: 'utf8' }
+		);
+		assert.equal(result.status, 1, 'threshold of 1 is exceeded by the fixture clone');
+	} finally {
+		fs.rmSync(tmp, { recursive: true, force: true });
+	}
+});
+
+test('the detector runs against the repo as a smoke check (no baseline assertion)', () => {
+	// Independent of the duplication baseline: only asserts the tool runs and
+	// emits a valid shape, so source cleanup never breaks this suite.
 	const { spawnSync } = requireFromHere('node:child_process') as typeof import('node:child_process');
 	const result = spawnSync(
 		process.execPath,
@@ -240,17 +365,6 @@ test('the detector runs against the repo and reports a non-empty step-summary', 
 	);
 	assert.equal(result.status, 0, `detector should run report-only; stderr: ${result.stderr}`);
 	const parsed = JSON.parse(result.stdout);
-	assert.ok(parsed.filesScanned > 50, 'should scan the shared source dirs');
+	assert.ok(parsed.filesScanned > 0, 'should scan at least some source files');
 	assert.ok(Array.isArray(parsed.groups));
-	assert.ok(parsed.groups.length >= 1, 'the repo has known shared clone groups');
-});
-
-test('the detector exits 1 when --fail-threshold is exceeded', () => {
-	const { spawnSync } = requireFromHere('node:child_process') as typeof import('node:child_process');
-	const result = spawnSync(
-		process.execPath,
-		[path.join(REPO_ROOT, 'scripts', 'check-code-duplication.js'), '--min-lines', '14', '--fail-threshold', '1', '--json'],
-		{ cwd: REPO_ROOT, encoding: 'utf8' }
-	);
-	assert.equal(result.status, 1, 'threshold of 1 is exceeded by the repo known clones');
 });

--- a/vscode-extension/test/unit/codeDuplication.test.ts
+++ b/vscode-extension/test/unit/codeDuplication.test.ts
@@ -199,12 +199,14 @@ test('parseArgs: applies defaults and parses flags', () => {
 });
 
 test('globToRegExp: a --include value cannot inject an arbitrary regex', () => {
-	// A glob containing regex metacharacters must be escaped, never compiled
-	// as a live regex operator. `(` without a matching `)` would otherwise throw
-	// or match unintended content.
-	const re = dup.globToRegExp('src/(weird).ts');
-	assert.ok(re.test('src/(weird).ts'));
-	assert.ok(!re.test('src/weird.ts'));
+	// A glob containing regex metacharacters is rejected by the safe-alphabet
+	// sanitizer before a RegExp is built, so it can never inject a live regex
+	// operator. Parentheses are not part of the glob grammar and are refused.
+	assert.throws(() => dup.globToRegExp('src/(weird).ts'), /Invalid --include glob/);
+});
+
+test('globToRegExp: rejects a glob smuggling a regex alternation operator', () => {
+	assert.throws(() => dup.globToRegExp('src/a|b.ts'), /Invalid --include glob/);
 });
 
 test('escapeMarkdownCell: escapes backslash first, then the pipe delimiter', () => {

--- a/vscode-extension/test/unit/codeDuplication.test.ts
+++ b/vscode-extension/test/unit/codeDuplication.test.ts
@@ -1,0 +1,224 @@
+import test from 'node:test';
+import * as assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { createRequire } from 'node:module';
+
+// The detector is plain CommonJS developer tooling that runs from the repo root,
+// outside the extension's TypeScript program, so it is loaded by path (mirrors
+// webviewContract.test.ts).
+const requireFromHere = createRequire(__filename);
+
+function findRepoRoot(): string {
+	let dir = __dirname;
+	for (let i = 0; i < 10; i++) {
+		if (fs.existsSync(path.join(dir, 'scripts', 'check-code-duplication.js'))) {
+			return dir;
+		}
+		dir = path.dirname(dir);
+	}
+	throw new Error(`Could not locate the repo root from ${__dirname}`);
+}
+
+const REPO_ROOT = findRepoRoot();
+const dup = requireFromHere(
+	path.join(REPO_ROOT, 'scripts', 'check-code-duplication.js')
+) as {
+	normalizeLine: (raw: string) => string;
+	isNoise: (line: string) => boolean;
+	globToRegExp: (glob: string) => RegExp;
+	findDuplicates: (
+		fileTokens: { relPath: string; tokens: { text: string; line: number }[] }[],
+		minLines: number
+	) => { lines: number; occurrences: { file: string; startLine: number; endLine: number }[]; preview: string }[];
+	totalDuplicatedLines: (groups: { lines: number; occurrences: unknown[] }[]) => number;
+	renderMarkdown: (groups: unknown[], scanned: number, threshold: number | null) => string;
+	renderJson: (groups: unknown[], scanned: number, threshold: number | null) => string;
+	parseArgs: (argv: string[]) => { minLines: number; includes: string[]; json: boolean; failThreshold: number | null };
+	MIN_LINES_DEFAULT: number;
+};
+
+function makeFileTokens(relPath: string, source: string) {
+	const tokens: { text: string; line: number }[] = [];
+	const lines = source.split(/\r?\n/);
+	for (let i = 0; i < lines.length; i++) {
+		const norm = dup.normalizeLine(lines[i]);
+		if (dup.isNoise(norm)) { continue; }
+		tokens.push({ text: norm, line: i + 1 });
+	}
+	return { relPath, tokens };
+}
+
+test('normalizeLine: collapses internal whitespace and trims ends', () => {
+	assert.equal(dup.normalizeLine('\t  foo   bar  '), 'foo bar');
+	assert.equal(dup.normalizeLine('a\tb\n'), 'a b');
+});
+
+test('isNoise: treats blank and comment-only lines as noise, code as signal', () => {
+	assert.ok(dup.isNoise(''));
+	assert.ok(dup.isNoise('   '));
+	assert.ok(dup.isNoise('// a comment'));
+	assert.ok(dup.isNoise('/* block open'));
+	assert.ok(dup.isNoise('* mid block'));
+	assert.ok(dup.isNoise('*/ block close'));
+	assert.ok(!dup.isNoise('const x = 1;'));
+	assert.ok(!dup.isNoise('return x; // trailing'));
+});
+
+test('globToRegExp: matches double-star recursively and single-star within a segment', () => {
+	const re = dup.globToRegExp('src/**/*.ts');
+	assert.ok(re.test('src/a.ts'));
+	assert.ok(re.test('src/adapters/claude.ts'));
+	assert.ok(!re.test('vscode-extension/src/a.ts'));
+	const re2 = dup.globToRegExp('*.ts');
+	assert.ok(re2.test('a.ts'));
+	assert.ok(!re2.test('a.js'));
+});
+
+test('findDuplicates: detects an identical block copied between two files', () => {
+	const block = [
+		'function sharedHelper(a: number, b: number): number {',
+		'const sum = a + b;',
+		'const product = a * b;',
+		'if (sum > product) { return sum; }',
+		'return product;',
+		'}',
+		'',
+		'export { sharedHelper };',
+	].join('\n');
+	const fileA = makeFileTokens('a.ts', `// header\n${block}\nconst extra = 1;\n`);
+	const fileB = makeFileTokens('b.ts', `/* file b */\n${block}\nconst other = 2;\n`);
+	const groups = dup.findDuplicates([fileA, fileB], 6);
+	assert.ok(groups.length >= 1, 'expected at least one duplicate group');
+	const top = groups[0];
+	assert.ok(top.lines >= 6, 'group should span at least the min lines');
+	const files = top.occurrences.map((o) => o.file).sort();
+	assert.deepEqual(files, ['a.ts', 'b.ts']);
+});
+
+test('findDuplicates: does not flag a block that appears only once', () => {
+	const fileA = makeFileTokens('a.ts', 'function unique() { return 1; }\nconst x = 2;\nconst y = 3;\nconst z = 4;\nconst w = 5;\nconst v = 6;\n');
+	const fileB = makeFileTokens('b.ts', 'function different() { return 9; }\nconst p = 8;\nconst q = 7;\nconst r = 6;\nconst s = 5;\nconst t = 4;\n');
+	const groups = dup.findDuplicates([fileA, fileB], 6);
+	assert.equal(groups.length, 0);
+});
+
+test('findDuplicates: extends to the maximal shared block, not just the window', () => {
+	const shared = [
+		'const a = 1;',
+		'const b = 2;',
+		'const c = 3;',
+		'const d = 4;',
+		'const e = 5;',
+		'const f = 6;',
+		'const g = 7;',
+		'const h = 8;',
+		'const i = 9;',
+	].join('\n');
+	const fileA = makeFileTokens('a.ts', `export const before = 0;\n${shared}\nexport const after = 10;\n`);
+	const fileB = makeFileTokens('b.ts', `export const otherBefore = -1;\n${shared}\nexport const otherAfter = 11;\n`);
+	const groups = dup.findDuplicates([fileA, fileB], 6);
+	assert.ok(groups.length >= 1);
+	// The maximal block is the 9 shared lines (the surrounding `export const`
+	// lines differ, so they are not part of the clone).
+	assert.equal(groups[0].lines, 9);
+});
+
+test('findDuplicates: catches a copy that differs only by indentation and comments', () => {
+	const clean = [
+		'function parse(line: string): number {',
+		'const trimmed = line.trim();',
+		'const value = parseInt(trimmed, 10);',
+		'if (Number.isNaN(value)) { return 0; }',
+		'return value;',
+		'}',
+	].join('\n');
+	const recommented = [
+		'function parse(line: string): number {',
+		'    // trim before parsing',
+		'    const trimmed = line.trim();',
+		'    const value = parseInt(trimmed, 10);',
+		'    // guard against NaN',
+		'    if (Number.isNaN(value)) { return 0; }',
+		'    return value;',
+		'}',
+	].join('\n');
+	const fileA = makeFileTokens('a.ts', `${clean}\n`);
+	const fileB = makeFileTokens('b.ts', `${recommented}\n`);
+	const groups = dup.findDuplicates([fileA, fileB], 6);
+	assert.ok(groups.length >= 1, 're-indented/re-commented copy should still be detected');
+	assert.ok(groups[0].lines >= 6);
+});
+
+test('totalDuplicatedLines: sums lines * occurrences across groups', () => {
+	const groups = [
+		{ lines: 10, occurrences: [1, 2] },
+		{ lines: 5, occurrences: [1, 2, 3] },
+	];
+	assert.equal(dup.totalDuplicatedLines(groups), 10 * 2 + 5 * 3);
+});
+
+test('renderMarkdown: reports a summary table and the no-findings state', () => {
+	const empty = dup.renderMarkdown([], 5, null);
+	assert.match(empty, /Code Duplication Analysis/);
+	assert.match(empty, /No duplicate blocks found/);
+	assert.match(empty, /\| 5 \| 0 \| 0 \|/);
+	const withFindings = dup.renderMarkdown(
+		[{ lines: 8, occurrences: [{ file: 'a.ts', startLine: 1, endLine: 8 }], preview: 'const x' }],
+		5,
+		null
+	);
+	assert.match(withFindings, /Top duplicate groups/);
+	assert.match(withFindings, /All duplicate groups/);
+});
+
+test('renderJson: emits parseable JSON with the expected shape', () => {
+	const json = dup.renderJson(
+		[{ lines: 7, occurrences: [{ file: 'a.ts', startLine: 1, endLine: 7 }], preview: 'p' }],
+		3,
+		100
+	);
+	const parsed = JSON.parse(json);
+	assert.equal(parsed.filesScanned, 3);
+	assert.equal(parsed.threshold, 100);
+	assert.equal(parsed.groups[0].lines, 7);
+});
+
+test('parseArgs: applies defaults and parses flags', () => {
+	const a = dup.parseArgs([]);
+	assert.equal(a.minLines, dup.MIN_LINES_DEFAULT);
+	assert.ok(a.includes.length >= 3);
+	assert.equal(a.json, false);
+	assert.equal(a.failThreshold, null);
+	const b = dup.parseArgs(['--min-lines', '8', '--json', '--fail-threshold', '200', '--include', 'src/**/*.ts']);
+	assert.equal(b.minLines, 8);
+	assert.equal(b.json, true);
+	assert.equal(b.failThreshold, 200);
+	assert.deepEqual(b.includes, ['src/**/*.ts']);
+});
+
+test('the detector runs against the repo and reports a non-empty step-summary', () => {
+	// The real end-to-end check: the script scans the shared source dirs and the
+	// repo has known shared adapters, so a green run must still find duplicates.
+	const { spawnSync } = requireFromHere('node:child_process') as typeof import('node:child_process');
+	const result = spawnSync(
+		process.execPath,
+		[path.join(REPO_ROOT, 'scripts', 'check-code-duplication.js'), '--min-lines', '14', '--json'],
+		{ cwd: REPO_ROOT, encoding: 'utf8' }
+	);
+	assert.equal(result.status, 0, `detector should run report-only; stderr: ${result.stderr}`);
+	const parsed = JSON.parse(result.stdout);
+	assert.ok(parsed.filesScanned > 50, 'should scan the shared source dirs');
+	assert.ok(Array.isArray(parsed.groups));
+	assert.ok(parsed.groups.length >= 1, 'the repo has known shared clone groups');
+});
+
+test('the detector exits 1 when --fail-threshold is exceeded', () => {
+	const { spawnSync } = requireFromHere('node:child_process') as typeof import('node:child_process');
+	const result = spawnSync(
+		process.execPath,
+		[path.join(REPO_ROOT, 'scripts', 'check-code-duplication.js'), '--min-lines', '14', '--fail-threshold', '1', '--json'],
+		{ cwd: REPO_ROOT, encoding: 'utf8' }
+	);
+	assert.equal(result.status, 1, 'threshold of 1 is exceeded by the repo known clones');
+});


### PR DESCRIPTION
## Summary

The repo had **no automated code-duplication detection**. ESLint complexity analysis (report → step summary) exists, and the LLM `code-quality-review` agent *mentions* duplication, but nothing deterministic flags a copied block. This adds a dependency-free, pure-Node copy-paste detector and wires it into CI.

- **`scripts/check-code-duplication.js`** — a standalone duplicate-block detector: normalizes source lines (whitespace collapsed, comment-only and blank lines dropped), hashes sliding windows of a minimum length, groups identical windows, and extends each group to its maximal shared block (forward + backward, requiring every occurrence to agree on the preceding/following lines), then merges subsumed clones. Outputs Markdown (for `$GITHUB_STEP_SUMMARY`) or `--json`. Report-only by default; `--fail-threshold N` turns it into a gate (exit 1 when total duplicated lines > N). Scans `vscode-extension/src`, shared `src/`, and `cli/src` by default; `--include` overrides.
- **`npm run check:duplicates`** in `vscode-extension/package.json`, alongside the existing `check:contract` / `check:editor-data` checks.
- **CI** — a new `Run code duplication analysis` step in `.github/workflows/ci.yml` (on the 24.x matrix leg, report-only with `|| true`) publishes the report to the step summary next to the complexity analysis.
- **Unit tests** in `vscode-extension/test/unit/codeDuplication.test.ts` (13 tests) covering normalization, the noise filter, glob matching, detection of identical / re-indented / re-commented copies, maximal-block extension, the no-findings and findings render paths, arg parsing, totals, and two end-to-end runs against the repo (report-only exit 0, and threshold-exceeded exit 1).

No new dependencies — the detector uses only Node built-ins (FNV-1a hashing, `fs`, `path`).

## Why report-only

Like the existing complexity analysis, this surfaces duplication on every PR without failing the build on pre-existing clones. A first run at `--min-lines 14` finds 39 clone groups (1995 duplicated lines) across 192 files — e.g. `src/devinCli.ts` ↔ `src/hermes.ts` (95 lines), the `claudeCode`/`claudeDesktop` adapters (64 lines), `kilo.ts` ↔ `opencode.ts` (48 lines). These are existing; surfacing them is the point. A maintainer can adopt `--fail-threshold` once a baseline is chosen.

## Verification

- `node --check scripts/check-code-duplication.js` — passes
- `node scripts/check-code-duplication.js --min-lines 14 --json` — 192 files, 39 groups, exit 0 (report-only)
- `node scripts/check-code-duplication.js --min-lines 14 --fail-threshold 1 --json` — exit 1 (gate works)
- `npx tsc -p tsconfig.tests.json` — clean
- `node --test out/vscode-extension/test/unit/codeDuplication.test.js` — **13/13 pass**
- `npx eslint src ../src test/unit/codeDuplication.test.ts` — **0 errors, 0 new warnings** (26 pre-existing complexity warnings in `extension.ts`/`main.ts`/`statsHelpers.ts`, unchanged by this PR)
- `npm run check:duplicates -- --min-lines 14` from `vscode-extension/` — valid Markdown, exit 0
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — YAML valid

