### PR TITLE
Compact log viewer summary cards; merge timeline info

### DIFF
--- a/vscode-extension/src/webview/logviewer/main.ts
+++ b/vscode-extension/src/webview/logviewer/main.ts
@@ -971,20 +971,22 @@ ${buildFileNameCard(data)}
 <div class="summary-value">${formatFileSize(data.size)}</div>
 <div class="summary-sub">Total size on disk</div>
 </div>
-<div class="summary-card">
-<div class="summary-label">🕒 Modified</div>
-<div class="summary-value" style="font-size: 14px; word-break: keep-all;">${formatDate(data.modified)}</div>
-<div class="summary-sub">Last file modification</div>
-</div>
-<div class="summary-card">
-<div class="summary-label">▶️ First Interaction</div>
-<div class="summary-value" style="font-size: 14px; word-break: keep-all;">${formatDate(data.firstInteraction)}</div>
-<div class="summary-sub">Session started</div>
-</div>
-<div class="summary-card">
-<div class="summary-label">⏹️ Last Interaction</div>
-<div class="summary-value" style="font-size: 14px; word-break: keep-all;">${formatDate(data.lastInteraction)}</div>
-<div class="summary-sub">Most recent activity</div>
+${buildTimelineCard(data)}
+</div>`;
+}
+
+/**
+ * Renders a single compact card grouping the three session timestamps
+ * (started, last activity, last file modification) as small rows instead of
+ * three separate full-sized cards.
+ */
+function buildTimelineCard(data: SessionLogData): string {
+	return `<div class="summary-card summary-card--compact">
+<div class="summary-label">🕒 Timeline</div>
+<div class="summary-compact-rows">
+<div class="summary-compact-row"><span class="summary-compact-key">▶️ Started</span><span class="summary-compact-val">${formatDate(data.firstInteraction)}</span></div>
+<div class="summary-compact-row"><span class="summary-compact-key">⏹️ Last activity</span><span class="summary-compact-val">${formatDate(data.lastInteraction)}</span></div>
+<div class="summary-compact-row"><span class="summary-compact-key">💾 Modified</span><span class="summary-compact-val">${formatDate(data.modified)}</span></div>
 </div>
 </div>`;
 }

--- a/vscode-extension/src/webview/logviewer/styles.css
+++ b/vscode-extension/src/webview/logviewer/styles.css
@@ -158,18 +158,18 @@ body {
 /* Summary cards */
 .summary-cards {
 	display: grid;
-	grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-	gap: 16px;
-	margin-bottom: 24px;
+	grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+	gap: 10px;
+	margin-bottom: 20px;
 }
 
 .summary-card {
 	background: var(--bg-secondary);
 	border: 1px solid var(--border-subtle);
-	border-radius: 12px;
-	padding: 24px 16px;
+	border-radius: 10px;
+	padding: 12px 10px;
 	text-align: center;
-	box-shadow: 0 4px 12px rgb(0, 0, 0, 0.3), 0 1px 3px rgb(0, 0, 0, 0.2);
+	box-shadow: 0 2px 6px rgb(0, 0, 0, 0.25), 0 1px 2px rgb(0, 0, 0, 0.15);
 	transition: transform 0.2s, box-shadow 0.2s;
 }
 
@@ -202,26 +202,58 @@ body {
 }
 
 .summary-label {
-	font-size: 14px;
+	font-size: 11px;
 	color: var(--text-secondary);
-	margin-bottom: 8px;
+	margin-bottom: 4px;
 	font-weight: 600;
 	text-transform: uppercase;
-	letter-spacing: 0.5px;
+	letter-spacing: 0.4px;
 }
 
 .summary-value {
-	font-size: 32px;
+	font-size: 22px;
 	font-weight: 700;
 	color: var(--link-color);
-	margin-bottom: 8px;
+	margin-bottom: 4px;
 	word-break: break-all;
 	overflow-wrap: break-word;
 	white-space: normal;
 }
 
+/* Compact variant: groups several small key/value rows (e.g. timestamps)
+   into one card instead of one full-sized card per value. */
+.summary-card--compact {
+	text-align: left;
+}
+
+.summary-compact-rows {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+}
+
+.summary-compact-row {
+	display: flex;
+	justify-content: space-between;
+	gap: 8px;
+	font-size: 11px;
+	line-height: 1.5;
+}
+
+.summary-compact-key {
+	color: var(--text-secondary);
+	white-space: nowrap;
+}
+
+.summary-compact-val {
+	color: var(--link-color);
+	font-weight: 600;
+	text-align: right;
+	overflow-wrap: break-word;
+}
+
 .summary-sub {
-	font-size: 12px;
+	font-size: 11px;
 	color: var(--text-secondary);
 	line-height: 1.5;
 }

--- a/vscode-extension/src/webview/logviewer/styles.css
+++ b/vscode-extension/src/webview/logviewer/styles.css
@@ -234,8 +234,9 @@ body {
 
 .summary-compact-row {
 	display: flex;
+	flex-wrap: wrap;
 	justify-content: space-between;
-	gap: 8px;
+	gap: 4px 8px;
 	font-size: 11px;
 	line-height: 1.5;
 }
@@ -246,10 +247,12 @@ body {
 }
 
 .summary-compact-val {
+	flex: 1 1 auto;
+	min-width: 0;
 	color: var(--link-color);
 	font-weight: 600;
 	text-align: right;
-	overflow-wrap: break-word;
+	overflow-wrap: anywhere;
 }
 
 .summary-sub {


### PR DESCRIPTION
The top summary-card row in the session log viewer took up too much vertical space (large padding, 32px value text) and had three separate cards for Modified / First Interaction / Last Interaction that all show timestamps.

This shrinks the card grid overall (padding, label/value font sizes, gap, min column width) and merges the three timestamp cards into a single compact "Timeline" card with small key/value rows (Started, Last activity, Modified). Net effect: less scrolling/real estate used at the top of the session viewer, same information.

Verified with:
- `npm run compile`
- `npm run test:node` (all pass)
- `npm run check:interaction` (logviewer panel still functions correctly)