### PR TITLE
Fix Cost column missing in Session Steps Overview for Auto-routed models

### DIFF
--- a/src/tokenEstimation.ts
+++ b/src/tokenEstimation.ts
@@ -14,6 +14,8 @@ interface ModelRequestSource {
 		metadata?: { modelId?: string };
 		details?: string;
 	};
+	/** Response stream items — scanned for an `autoModeResolution` entry (see `_findAutoModeResolvedModel`). */
+	response?: unknown[];
 }
 
 /** Shape of a single delta event line in a JSONL session file. */
@@ -1056,8 +1058,36 @@ function _gmrMatchDisplayName(details: string, modelPricing: { [key: string]: Mo
 	return null;
 }
 
+/**
+ * When Copilot's "Auto" model routing is used, `request.modelId` (and
+ * `result.metadata.modelId`) only ever record the generic `"auto"` /
+ * `"copilot/auto"` id — the actual model Auto picked for that turn is reported
+ * separately, as an `autoModeResolution` item in the response stream:
+ * `{ kind: 'autoModeResolution', resolved: { id, name } }`. Without resolving
+ * this, cost/tier lookups treat "auto" as an unpriced model id, silently
+ * showing $0/no cost for every Auto-routed turn. Returns null when no such
+ * item is present (e.g. non-Auto requests, or older sessions predating it).
+ */
+function _findAutoModeResolvedModel(response: unknown[] | undefined): string | null {
+	if (!Array.isArray(response)) { return null; }
+	for (const item of response) {
+		if (item && typeof item === 'object' && (item as { kind?: string }).kind === 'autoModeResolution') {
+			const id = (item as { resolved?: { id?: string } }).resolved?.id;
+			if (typeof id === 'string' && id) { return id; }
+		}
+	}
+	return null;
+}
+
 export function getModelFromRequest(request: ModelRequestSource, modelPricing: { [key: string]: ModelPricing } = {}): string {
-	if (request.modelId) { return request.modelId.replace(/^copilot\//, ''); }
+	if (request.modelId) {
+		const stripped = request.modelId.replace(/^copilot\//, '');
+		if (stripped === 'auto') {
+			const resolved = _findAutoModeResolvedModel(request.response);
+			if (resolved) { return resolved; }
+		}
+		return stripped;
+	}
 	if (request.result?.metadata?.modelId) { return request.result.metadata.modelId.replace(/^copilot\//, ''); }
 	if (request.result?.details) {
 		const matched = _gmrMatchDisplayName(request.result.details, modelPricing);

--- a/src/tokenEstimation.ts
+++ b/src/tokenEstimation.ts
@@ -1042,14 +1042,6 @@ function getDisplayNameLookup(modelPricing: { [key: string]: ModelPricing }): { 
 }
 
 /** Find the model ID for a request by matching display names against its details string. Returns null if not found. */
-function _gmfrFindByDisplayName(details: string, modelPricing: { [key: string]: ModelPricing }): string | null {
-	const { map, sortedNames } = getDisplayNameLookup(modelPricing);
-	for (const displayName of sortedNames) {
-		if (details.includes(displayName)) { return map[displayName]; }
-	}
-	return null;
-}
-
 function _gmrMatchDisplayName(details: string, modelPricing: { [key: string]: ModelPricing }): string | null {
 	const { map, sortedNames } = getDisplayNameLookup(modelPricing);
 	for (const displayName of sortedNames) {
@@ -1080,28 +1072,22 @@ function _findAutoModeResolvedModel(response: unknown[] | undefined): string | n
 }
 
 export function getModelFromRequest(request: ModelRequestSource, modelPricing: { [key: string]: ModelPricing } = {}): string {
-	if (request.modelId) {
-		const stripped = request.modelId.replace(/^copilot\//, '');
-		if (stripped === 'auto') {
-			const resolved = _findAutoModeResolvedModel(request.response);
-			if (resolved) { return resolved; }
-		}
-		return stripped;
+	const rawModelId = request.modelId
+		? request.modelId.replace(/^copilot\//, '')
+		: (request.result?.metadata?.modelId ? request.result.metadata.modelId.replace(/^copilot\//, '') : null);
+	if (rawModelId && rawModelId !== 'auto') { return rawModelId; }
+	if (rawModelId === 'auto') {
+		// Auto routing: the raw id is a generic placeholder — try to resolve the
+		// model actually picked for this turn before falling back to the "auto"
+		// sentinel itself (never silently substitute an unrelated model here).
+		const resolved = _findAutoModeResolvedModel(request.response);
+		if (resolved) { return resolved; }
 	}
-	if (request.result?.metadata?.modelId) { return request.result.metadata.modelId.replace(/^copilot\//, ''); }
 	if (request.result?.details) {
 		const matched = _gmrMatchDisplayName(request.result.details, modelPricing);
 		if (matched) { return matched; }
 	}
-
-	if (request.result?.metadata?.modelId) {
-		return request.result.metadata.modelId.replace(/^copilot\//, '');
-	}
-
-	if (request.result?.details) {
-		const found = _gmfrFindByDisplayName(request.result.details, modelPricing);
-		if (found) { return found; }
-	}
+	if (rawModelId === 'auto') { return rawModelId; }
 
 	return 'gpt-4'; // default
 }

--- a/src/usageAnalysis.ts
+++ b/src/usageAnalysis.ts
@@ -2904,14 +2904,13 @@ function _gmusEstimateDeltaRequestTokens(request: SessionRequestRaw, requestMode
 /** Process a single delta-format request, extracting or estimating token usage. */
 function _gmusProcessDeltaRequest(request: SessionRequestRaw, defaultModel: string, modelUsage: ModelUsage, deps: GmusDeps): void {
 	if (!request.requestId) { return; }
-	let requestModel = defaultModel;
-	if (request.modelId) {
-		requestModel = request.modelId.replace(/^copilot\//, '');
-	} else if (request.result?.metadata?.modelId) {
-		requestModel = request.result.metadata.modelId.replace(/^copilot\//, '');
-	} else if (request.result?.details) {
-		requestModel = getModelFromRequest(request, deps.modelPricing);
-	}
+	// Route through the shared resolver whenever the request carries its own model
+	// info, so Auto-routed requests (modelId "auto"/"copilot/auto") resolve to the
+	// actually-picked model via the response's `autoModeResolution` item instead of
+	// being attributed to the unpriced "auto" id. Falls back to the session-level
+	// `defaultModel` only when the request has no model info of its own at all.
+	const hasOwnModelInfo = !!(request.modelId || request.result?.metadata?.modelId || request.result?.details);
+	const requestModel = hasOwnModelInfo ? getModelFromRequest(request, deps.modelPricing) : defaultModel;
 	// Untrusted `modelId` string from parsed session JSON — see protoGuard.ts.
 	if (isUnsafeObjectKey(requestModel)) { return; }
 	if (!modelUsage[requestModel]) { modelUsage[requestModel] = { inputTokens: 0, outputTokens: 0, sessions: 0 }; }

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -7064,7 +7064,7 @@ private computeFallbackDailyRollup(
 		const contextRefs = this.createEmptyContextRefs();
 		const userMessage = request.message?.text || '';
 		this.analyzeRequestContext(request, contextRefs);
-		const requestModel = request.modelId || currentModel || this.getModelFromRequest(request) || 'gpt-4';
+		const requestModel = this.resolveDeltaTurnModel(request, currentModel);
 		const { responseText, thinkingText, toolCalls, mcpTools } = this.extractResponseData(request.response || []);
 		const actualUsage = this.extractActualUsageFromRequest(request, rawUsageFallback, i);
 		return {
@@ -7077,6 +7077,22 @@ private computeFallbackDailyRollup(
 			thinkingTokensEstimate: this.estimateTokensFromText(thinkingText, requestModel),
 			actualUsage, thinkingEffort: effortByRequestId.get(request.requestId)
 		};
+	}
+
+	/**
+	 * Resolves the model actually used for one delta-format turn. `request.modelId`
+	 * is only the generic `"auto"`/`"copilot/auto"` id when Copilot's Auto routing
+	 * was used — the real per-turn model is only recoverable via `getModelFromRequest`
+	 * (which reads the response stream's `autoModeResolution` item). Preferring a raw
+	 * `"auto"` modelId here would otherwise price every Auto-routed turn as an unknown
+	 * model, silently dropping its cost from the Session Steps Overview table.
+	 */
+	private resolveDeltaTurnModel(request: any, currentModel: string | null): string {
+		const rawModelId = request.modelId ? String(request.modelId).replace(/^copilot\//, '') : null;
+		if (rawModelId && rawModelId !== 'auto') { return rawModelId; }
+		const resolved = this.getModelFromRequest(request);
+		if (resolved && resolved !== 'auto') { return resolved; }
+		return currentModel || rawModelId || 'gpt-4';
 	}
 
 	private extractActualUsageFromRequest(request: any, rawUsageFallback: Map<number, { promptTokens: number; outputTokens: number }>, index: number): ActualUsage | undefined {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -7086,13 +7086,23 @@ private computeFallbackDailyRollup(
 	 * (which reads the response stream's `autoModeResolution` item). Preferring a raw
 	 * `"auto"` modelId here would otherwise price every Auto-routed turn as an unknown
 	 * model, silently dropping its cost from the Session Steps Overview table.
+	 *
+	 * When a turn is explicitly Auto-routed but its response has no `autoModeResolution`
+	 * item (e.g. an older session predating that field), the `"auto"` sentinel is kept
+	 * as-is rather than falling back to `currentModel` — the session's selected model can
+	 * differ from whatever Auto actually picked, and substituting it would silently
+	 * mislabel/misprice the turn.
 	 */
 	private resolveDeltaTurnModel(request: any, currentModel: string | null): string {
 		const rawModelId = request.modelId ? String(request.modelId).replace(/^copilot\//, '') : null;
 		if (rawModelId && rawModelId !== 'auto') { return rawModelId; }
+		if (rawModelId === 'auto') {
+			const resolved = this.getModelFromRequest(request);
+			return (resolved && resolved !== 'auto') ? resolved : 'auto';
+		}
 		const resolved = this.getModelFromRequest(request);
-		if (resolved && resolved !== 'auto') { return resolved; }
-		return currentModel || rawModelId || 'gpt-4';
+		if (resolved && resolved !== 'auto' && resolved !== 'gpt-4') { return resolved; }
+		return currentModel || resolved || 'gpt-4';
 	}
 
 	private extractActualUsageFromRequest(request: any, rawUsageFallback: Map<number, { promptTokens: number; outputTokens: number }>, index: number): ActualUsage | undefined {

--- a/vscode-extension/test/unit/tokenEstimation.test.ts
+++ b/vscode-extension/test/unit/tokenEstimation.test.ts
@@ -1498,6 +1498,35 @@ test('getModelFromRequest: strips copilot/ prefix from result.metadata.modelId',
         assert.equal(getModelFromRequest(req), 'claude-sonnet-4.5');
 });
 
+// ── getModelFromRequest: Auto-mode resolution ───────────────────────────────
+// Copilot's "Auto" routing only records "auto"/"copilot/auto" as modelId; the
+// model actually picked for that turn is reported later as an
+// `autoModeResolution` item in the response stream. Without resolving this,
+// "auto" is treated as an unpriced model, silently dropping the turn's cost.
+
+test('getModelFromRequest: resolves the real model from an autoModeResolution response item', () => {
+        const req = {
+                modelId: 'copilot/auto',
+                response: [
+                        { kind: 'autoModeResolution', resolved: { id: 'mai-code-1.1-flash', name: 'MAI-Code-1.1-Flash' } },
+                ],
+        };
+        assert.equal(getModelFromRequest(req), 'mai-code-1.1-flash');
+});
+
+test('getModelFromRequest: falls back to "auto" when no autoModeResolution item is present', () => {
+        assert.equal(getModelFromRequest({ modelId: 'auto' }), 'auto');
+        assert.equal(getModelFromRequest({ modelId: 'copilot/auto', response: [] }), 'auto');
+});
+
+test('getModelFromRequest: non-auto modelId is unaffected by a response array', () => {
+        const req = {
+                modelId: 'copilot/gpt-4o',
+                response: [{ kind: 'autoModeResolution', resolved: { id: 'claude-sonnet-4.5' } }],
+        };
+        assert.equal(getModelFromRequest(req), 'gpt-4o');
+});
+
 // ── selectTokenEstimationStrategy: format detection limit ──────────────────
 
 test('selectTokenEstimationStrategy: format detection stops after FORMAT_DETECTION_LINE_LIMIT non-empty lines', () => {

--- a/vscode-extension/test/unit/tokenEstimation.test.ts
+++ b/vscode-extension/test/unit/tokenEstimation.test.ts
@@ -1527,6 +1527,14 @@ test('getModelFromRequest: non-auto modelId is unaffected by a response array', 
         assert.equal(getModelFromRequest(req), 'gpt-4o');
 });
 
+test('getModelFromRequest: resolves auto from result.metadata.modelId (metadata-only shape) too', () => {
+        const req = {
+                result: { metadata: { modelId: 'copilot/auto' } },
+                response: [{ kind: 'autoModeResolution', resolved: { id: 'gpt-5.4' } }],
+        };
+        assert.equal(getModelFromRequest(req), 'gpt-5.4');
+});
+
 // ── selectTokenEstimationStrategy: format detection limit ──────────────────
 
 test('selectTokenEstimationStrategy: format detection stops after FORMAT_DETECTION_LINE_LIMIT non-empty lines', () => {


### PR DESCRIPTION
## Problem
The Session Steps Overview table (shown above the chat turns list in the log viewer) already had a Cost column, but it was hidden entirely for sessions using Copilot Chat's **Auto** model routing.

## Root cause
`request.modelId` is only the generic `"auto"` / `"copilot/auto"` id when Auto routing is used. The model Auto actually picked for that turn is reported separately, as an `autoModeResolution` item in the response stream (`{ kind: 'autoModeResolution', resolved: { id, name } }`). Since `"auto"` has no pricing entry, `attachTurnCosts` silently computed `$0`/no cost for every Auto-routed turn, so `hasCost` was `false` and the whole Cost column was hidden.

## Fix
- `getModelFromRequest()` (shared, `src/tokenEstimation.ts`) now resolves the real model from the response's `autoModeResolution` item when the raw modelId is `"auto"`.
- `buildDeltaTurn()` in the VS Code extension now goes through that same resolution instead of trusting a raw `"auto"` modelId directly (it previously short-circuited before `getModelFromRequest` was even consulted).

This also fixes the Model badge showing "Auto" instead of the actual model for these turns, and improves cost attribution accuracy for any other feature relying on `getModelFromRequest`/`getModelFromSession`-style attribution for Auto-routed sessions.

## Testing
- Added unit tests in `vscode-extension/test/unit/tokenEstimation.test.ts` covering: resolution via `autoModeResolution`, fallback to `"auto"` when absent, and no effect on non-auto modelIds.
- `npm run compile` succeeds.
- `tokenEstimation.test.js`, `sessionParser.test.js`, `usageAnalysis.test.js` all pass (246/246 + existing suites, no regressions).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>