### PR TITLE
Apply the 10% Copilot Auto discount to eligible cost estimates

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -46,6 +46,15 @@ The CLI reads the same local session sources as the extension, including:
 - Kiro IDE and Kiro CLI sessions
 - Other supported editor integrations wired through the shared adapter pipeline
 
+### Auto routing cost estimates
+
+VS Code Chat JSON and JSONL sessions retain request-level Auto routing attribution
+through daily, period, editor and billing-group aggregation. Copilot pricing applies
+the shared 10% discount only to the Auto-routed token subset; manual requests and
+provider pricing remain undiscounted. Debug-log token replacements retain the
+estimated Auto share per model, rather than treating the whole session as Auto.
+Older parsed-session caches are invalidated automatically to populate this metadata.
+
 ## License
 
 MIT — see [LICENSE](../LICENSE) for details.

--- a/cli/src/analysis.ts
+++ b/cli/src/analysis.ts
@@ -6,6 +6,7 @@
  * bootstrap-dependent logic lives in helpers.ts.
  */
 import { calculateEstimatedCost } from '../../src/tokenEstimation';
+import { addModelUsage, scaleModelUsage } from '../../src/statsHelpers';
 import { normalizePathForComparison, detectClaudeCodeEditorVariant } from '../../src/workspaceHelpers';
 import { getCustomProviderGroup } from '../../src/webview/shared/modelUtils';
 import { createEmptyContextRefs } from '../../src/tokenEstimation';
@@ -195,19 +196,7 @@ export function aggregateIntoPeriod(period: PeriodStats, data: SessionData, frac
 	period.sessions++;
 
 	// Merge model usage proportionally
-	for (const [model, usage] of Object.entries(data.modelUsage)) {
-		if (!period.modelUsage[model]) {
-			period.modelUsage[model] = { inputTokens: 0, outputTokens: 0, sessions: 0 };
-		}
-		period.modelUsage[model].inputTokens += Math.round(usage.inputTokens * fraction);
-		period.modelUsage[model].outputTokens += Math.round(usage.outputTokens * fraction);
-		if (usage.cachedReadTokens !== undefined) {
-			period.modelUsage[model].cachedReadTokens = (period.modelUsage[model].cachedReadTokens ?? 0) + Math.round(usage.cachedReadTokens * fraction);
-		}
-		if (usage.cacheCreationTokens !== undefined) {
-			period.modelUsage[model].cacheCreationTokens = (period.modelUsage[model].cacheCreationTokens ?? 0) + Math.round(usage.cacheCreationTokens * fraction);
-		}
-	}
+	addModelUsage(period.modelUsage, scaleModelUsage(data.modelUsage, fraction));
 
 	// Track interactions proportionally for the running average
 	const interactions = Math.round(data.interactions * fraction);
@@ -378,9 +367,7 @@ export function buildChartPayload(labels: string[], days: DailyEntry[], allDaysM
 				for (const [editor, mu] of Object.entries(e.editorModelUsage)) {
 					for (const [modelId, usage] of Object.entries(mu)) {
 						if (getBillingGroup(editor, modelId) !== group) { continue; }
-						if (!grouped[modelId]) { grouped[modelId] = { inputTokens: 0, outputTokens: 0, sessions: 0 }; }
-						grouped[modelId].inputTokens += usage.inputTokens;
-						grouped[modelId].outputTokens += usage.outputTokens;
+						addModelUsage(grouped, { [modelId]: { ...usage, sessions: 0 } });
 					}
 				}
 				const pricingSource = group === 'GitHub Copilot' ? 'copilot' : 'provider';
@@ -399,9 +386,7 @@ export function buildChartPayload(labels: string[], days: DailyEntry[], allDaysM
 					for (const [editor, mu] of Object.entries(e.editorModelUsage)) {
 						for (const [modelId, usage] of Object.entries(mu)) {
 							if (getBillingGroup(editor, modelId) !== group) { continue; }
-							if (!grouped[modelId]) { grouped[modelId] = { inputTokens: 0, outputTokens: 0, sessions: 0 }; }
-							grouped[modelId].inputTokens += usage.inputTokens;
-							grouped[modelId].outputTokens += usage.outputTokens;
+							addModelUsage(grouped, { [modelId]: { ...usage, sessions: 0 } });
 						}
 					}
 					return calculateEstimatedCost(grouped, modelPricing, pricingSource);
@@ -416,17 +401,7 @@ export function buildChartPayload(labels: string[], days: DailyEntry[], allDaysM
 	const mergeEntry = (target: DailyEntry, src: DailyEntry) => {
 		target.tokens += src.tokens;
 		target.sessions += src.sessions;
-		for (const [m, u] of Object.entries(src.modelUsage)) {
-			if (!target.modelUsage[m]) { target.modelUsage[m] = { inputTokens: 0, outputTokens: 0, sessions: 0 }; }
-			target.modelUsage[m].inputTokens += u.inputTokens;
-			target.modelUsage[m].outputTokens += u.outputTokens;
-			if (u.cachedReadTokens !== undefined) {
-				target.modelUsage[m].cachedReadTokens = (target.modelUsage[m].cachedReadTokens ?? 0) + u.cachedReadTokens;
-			}
-			if (u.cacheCreationTokens !== undefined) {
-				target.modelUsage[m].cacheCreationTokens = (target.modelUsage[m].cacheCreationTokens ?? 0) + u.cacheCreationTokens;
-			}
-		}
+		addModelUsage(target.modelUsage, scaleModelUsage(src.modelUsage, 1));
 		for (const [e, u] of Object.entries(src.editorUsage)) {
 			if (!target.editorUsage[e]) { target.editorUsage[e] = { tokens: 0, sessions: 0 }; }
 			target.editorUsage[e].tokens += u.tokens;
@@ -436,11 +411,7 @@ export function buildChartPayload(labels: string[], days: DailyEntry[], allDaysM
 			if (!target.editorModelUsage) { target.editorModelUsage = {}; }
 			for (const [editor, mu] of Object.entries(src.editorModelUsage)) {
 				if (!target.editorModelUsage[editor]) { target.editorModelUsage[editor] = {}; }
-				for (const [model, u] of Object.entries(mu)) {
-					if (!target.editorModelUsage[editor][model]) { target.editorModelUsage[editor][model] = { inputTokens: 0, outputTokens: 0, sessions: 0 }; }
-					target.editorModelUsage[editor][model].inputTokens += u.inputTokens;
-					target.editorModelUsage[editor][model].outputTokens += u.outputTokens;
-				}
+				addModelUsage(target.editorModelUsage[editor], scaleModelUsage(mu, 1));
 			}
 		}
 	};

--- a/cli/src/cliCache.ts
+++ b/cli/src/cliCache.ts
@@ -11,7 +11,7 @@ import type { SessionData } from './helpers';
 import { CliCachePolicy } from '../../src/cachePolicy';
 
 /** Bump this when the SessionData shape changes to force a full re-parse. */
-const CACHE_VERSION = 5; // Read debug log tokens for agent-mode sessions
+const CACHE_VERSION = 6; // Preserve request-level Auto routing attribution
 
 /** Maximum number of entries to keep in the cache file. */
 const MAX_CACHE_ENTRIES = 2000;

--- a/cli/src/helpers.ts
+++ b/cli/src/helpers.ts
@@ -20,7 +20,7 @@ import { isJetBrainsSessionPath } from '../../src/adapters/adapterPredicates';
 import { parseJetBrainsPartition } from '../../src/jetbrains';
 import type { DetailedStats, ModelUsage, UsageAnalysisStats, WorkspaceCustomizationMatrix, TodaySessionSummary } from '../../src/types';
 import { analyzeSessionUsage, mergeUsageAnalysis, getModelUsageFromSession } from '../../src/usageAnalysis';
-import { reconcileModelUsageToActualTokens } from '../../src/statsHelpers';
+import { addModelUsage, scaleModelUsage, preserveAutoRouting, reconcileModelUsageToActualTokens } from '../../src/statsHelpers';
 import { withErrorRecovery } from '../../src/utils/errors';
 import { buildRecentSessionBuckets, type RecentSessionBucketItem } from '../../src/recentSessions';
 import * as vscodeStub from './vscode-stub';
@@ -352,7 +352,7 @@ export async function processSessionFile(filePath: string, verbose = false): Pro
 					fileModelUsage = jbResult.modelUsage;
 				} else if (jbResult.tokens > 0) {
 					const modelKey = jbResult.modelHint && jbResult.modelHint !== 'unknown' ? jbResult.modelHint : 'unknown';
-					fileModelUsage = { [modelKey]: { inputTokens: jbResult.tokens, outputTokens: 0 } };
+					fileModelUsage = { [modelKey]: { inputTokens: jbResult.tokens, outputTokens: 0, sessions: 0 } };
 				}
 			}
 
@@ -385,7 +385,11 @@ export async function processSessionFile(filePath: string, verbose = false): Pro
 			thinkingTokens = result.thinkingTokens;
 			actualTokens = result.actualTokens;
 			interactions = result.interactions;
-			fileModelUsage = result.modelUsage as ModelUsage;
+			fileModelUsage = await getModelUsageFromSession(
+				{ warn, tokenEstimators, modelPricing, ecosystems: getEcosystems() },
+				filePath,
+				content
+			);
 		}
 
 		const dailyFractions = extractDailyFractions(content, isJsonl, stats.mtime);
@@ -399,10 +403,12 @@ export async function processSessionFile(filePath: string, verbose = false): Pro
 			tokens = debugLogTokens.inputTokens + debugLogTokens.outputTokens;
 			actualTokens = tokens;
 			if (Object.keys(debugLogTokens.modelBreakdown).length > 0) {
-				fileModelUsage = {};
+				const replacement: ModelUsage = {};
 				for (const [model, bd] of Object.entries(debugLogTokens.modelBreakdown)) {
-					fileModelUsage[model] = { inputTokens: bd.inputTokens, outputTokens: bd.outputTokens, sessions: 0, ...(bd.cachedTokens > 0 ? { cachedReadTokens: bd.cachedTokens } : {}) };
+					replacement[model] = { inputTokens: bd.inputTokens, outputTokens: bd.outputTokens, sessions: 0, ...(bd.cachedTokens > 0 ? { cachedReadTokens: bd.cachedTokens } : {}) };
 				}
+				preserveAutoRouting(fileModelUsage, replacement);
+				fileModelUsage = replacement;
 			}
 		}
 
@@ -655,25 +661,14 @@ export async function calculateDailyStats(sessionFiles: string[], verbose = fals
 
 		for (const [dateKey, fraction] of Object.entries(data.dailyFractions)) {
 			const tokForDay = Math.round(displayTok * fraction);
+			const scaledUsage = scaleModelUsage(data.modelUsage, fraction);
 
 			// 30-day map: only add days within the window
 			const dailyEntry = dailyMap.get(dateKey);
 			if (dailyEntry) {
 				dailyEntry.tokens += tokForDay;
 				dailyEntry.sessions++;
-				for (const [model, usage] of Object.entries(data.modelUsage)) {
-					if (!dailyEntry.modelUsage[model]) {
-						dailyEntry.modelUsage[model] = { inputTokens: 0, outputTokens: 0, sessions: 0 };
-					}
-					dailyEntry.modelUsage[model].inputTokens += Math.round(usage.inputTokens * fraction);
-					dailyEntry.modelUsage[model].outputTokens += Math.round(usage.outputTokens * fraction);
-					if (usage.cachedReadTokens !== undefined) {
-						dailyEntry.modelUsage[model].cachedReadTokens = (dailyEntry.modelUsage[model].cachedReadTokens ?? 0) + Math.round(usage.cachedReadTokens * fraction);
-					}
-					if (usage.cacheCreationTokens !== undefined) {
-						dailyEntry.modelUsage[model].cacheCreationTokens = (dailyEntry.modelUsage[model].cacheCreationTokens ?? 0) + Math.round(usage.cacheCreationTokens * fraction);
-					}
-				}
+				addModelUsage(dailyEntry.modelUsage, scaledUsage);
 				const editor = data.editorSource;
 				if (!dailyEntry.editorUsage[editor]) {
 					dailyEntry.editorUsage[editor] = { tokens: 0, sessions: 0 };
@@ -682,11 +677,7 @@ export async function calculateDailyStats(sessionFiles: string[], verbose = fals
 				dailyEntry.editorUsage[editor].sessions++;
 				if (!dailyEntry.editorModelUsage) { dailyEntry.editorModelUsage = {}; }
 				if (!dailyEntry.editorModelUsage[editor]) { dailyEntry.editorModelUsage[editor] = {}; }
-				for (const [model, usage] of Object.entries(data.modelUsage)) {
-					if (!dailyEntry.editorModelUsage[editor][model]) { dailyEntry.editorModelUsage[editor][model] = { inputTokens: 0, outputTokens: 0, sessions: 0 }; }
-					dailyEntry.editorModelUsage[editor][model].inputTokens += Math.round(usage.inputTokens * fraction);
-					dailyEntry.editorModelUsage[editor][model].outputTokens += Math.round(usage.outputTokens * fraction);
-				}
+				addModelUsage(dailyEntry.editorModelUsage[editor], scaledUsage);
 			}
 
 			// Full history map: always add regardless of age (used for weekly/monthly charts)
@@ -696,19 +687,7 @@ export async function calculateDailyStats(sessionFiles: string[], verbose = fals
 			const allEntry = allDaysMap.get(dateKey)!;
 			allEntry.tokens += tokForDay;
 			allEntry.sessions++;
-			for (const [model, usage] of Object.entries(data.modelUsage)) {
-				if (!allEntry.modelUsage[model]) {
-					allEntry.modelUsage[model] = { inputTokens: 0, outputTokens: 0, sessions: 0 };
-				}
-				allEntry.modelUsage[model].inputTokens += Math.round(usage.inputTokens * fraction);
-				allEntry.modelUsage[model].outputTokens += Math.round(usage.outputTokens * fraction);
-				if (usage.cachedReadTokens !== undefined) {
-					allEntry.modelUsage[model].cachedReadTokens = (allEntry.modelUsage[model].cachedReadTokens ?? 0) + Math.round(usage.cachedReadTokens * fraction);
-				}
-				if (usage.cacheCreationTokens !== undefined) {
-					allEntry.modelUsage[model].cacheCreationTokens = (allEntry.modelUsage[model].cacheCreationTokens ?? 0) + Math.round(usage.cacheCreationTokens * fraction);
-				}
-			}
+			addModelUsage(allEntry.modelUsage, scaledUsage);
 			const editor = data.editorSource;
 			if (!allEntry.editorUsage[editor]) {
 				allEntry.editorUsage[editor] = { tokens: 0, sessions: 0 };
@@ -717,11 +696,7 @@ export async function calculateDailyStats(sessionFiles: string[], verbose = fals
 			allEntry.editorUsage[editor].sessions++;
 			if (!allEntry.editorModelUsage) { allEntry.editorModelUsage = {}; }
 			if (!allEntry.editorModelUsage[editor]) { allEntry.editorModelUsage[editor] = {}; }
-			for (const [model, usage] of Object.entries(data.modelUsage)) {
-				if (!allEntry.editorModelUsage[editor][model]) { allEntry.editorModelUsage[editor][model] = { inputTokens: 0, outputTokens: 0, sessions: 0 }; }
-				allEntry.editorModelUsage[editor][model].inputTokens += Math.round(usage.inputTokens * fraction);
-				allEntry.editorModelUsage[editor][model].outputTokens += Math.round(usage.outputTokens * fraction);
-			}
+			addModelUsage(allEntry.editorModelUsage[editor], scaledUsage);
 		}
 	}
 

--- a/cli/src/test/sharedLogicContract.test.ts
+++ b/cli/src/test/sharedLogicContract.test.ts
@@ -16,17 +16,19 @@
  * getModelUsageFromSession() rather than the estimator's modelUsage.
  */
 
-import test from 'node:test';
+import test, { type TestContext } from 'node:test';
 import * as assert from 'node:assert/strict';
 import * as fs from 'fs';
 import * as path from 'path';
 
-import { estimateTokensFromJsonlSession } from '../../../src/tokenEstimation';
+import { calculateEstimatedCost, estimateTokensFromJsonlSession } from '../../../src/tokenEstimation';
+import type { ModelUsage } from '../../../src/types';
 import { getModelUsageFromSession } from '../../../src/usageAnalysis';
 import tokenEstimatorsData from '../../../src/tokenEstimators.json';
 import modelPricingData from '../../../src/modelPricing.json';
 
-import { calculateUsageAnalysisStats, processSessionFile } from '../helpers';
+import { calculateDailyStats, calculateUsageAnalysisStats, processSessionFile } from '../helpers';
+import { aggregateIntoPeriod, buildChartPayload, createEmptyPeriodStats, type DailyEntry } from '../analysis';
 import { disableCache } from '../cliCache';
 
 const tokenEstimators: { [key: string]: number } = tokenEstimatorsData.estimators;
@@ -109,4 +111,166 @@ test('CLI usage analysis includes recent-session buckets for thin IDE hosts', as
 	assert.equal(stats.recentSessions?.last30.length, 1);
 	assert.equal(stats.recentSessions?.currentMonth.length, 1);
 	assert.equal(stats.recentSessions?.last7[0].filePath, FIXTURE_PATH);
+});
+
+const AUTO_MODEL = 'claude-sonnet-4.5';
+
+function mockAutoSession(t: TestContext, format: 'json' | 'jsonl', debug = false): string {
+	disableCache();
+	const today = new Date();
+	today.setHours(12, 0, 0, 0);
+	const yesterday = new Date(today);
+	yesterday.setDate(today.getDate() - 1);
+	const requests = [
+		{
+			requestId: 'auto', timestamp: yesterday.getTime(), modelId: 'copilot/auto',
+			message: { text: 'Auto request', parts: [{ text: 'Auto request' }] },
+			response: [{ kind: 'autoModeResolution', resolved: { id: AUTO_MODEL } }],
+			result: { promptTokens: 1000, outputTokens: 200 },
+		},
+		{
+			requestId: 'manual', timestamp: today.getTime(), modelId: `copilot/${AUTO_MODEL}`,
+			message: { text: 'Manual request', parts: [{ text: 'Manual request' }] },
+			response: [], result: { promptTokens: 3000, outputTokens: 600 },
+		},
+	];
+	const content = format === 'json'
+		? JSON.stringify({ requests })
+		: [
+			{ kind: 0, v: { requests: [] } },
+			...requests.map(request => ({ kind: 2, k: ['requests'], v: request })),
+		].map(event => JSON.stringify(event)).join('\n');
+	const sessionId = '11111111-1111-4111-8111-111111111111';
+	const filePath = path.join(__dirname, 'workspaceStorage', 'synthetic', 'chatSessions', `${sessionId}.${format}`);
+	const fixtureStat = fs.statSync(FIXTURE_PATH);
+	t.mock.method(fs.promises, 'stat', async (file: string) => {
+		assert.equal(file, filePath);
+		return { ...fixtureStat, mtime: today, mtimeMs: today.getTime(), size: content.length };
+	});
+	t.mock.method(fs.promises, 'readFile', async (file: string) => {
+		if (file === filePath) { return content; }
+		assert.ok(String(file).replace(/\\/g, '/').endsWith(`/debug-logs/${sessionId}/main.jsonl`));
+		if (debug) {
+			return JSON.stringify({
+				type: 'llm_request',
+				attrs: { model: AUTO_MODEL, inputTokens: 8000, outputTokens: 1600, cachedTokens: 3200 },
+			});
+		}
+		throw Object.assign(new Error('Synthetic session has no debug log'), { code: 'ENOENT' });
+	});
+	return filePath;
+}
+
+function assertAutoDiscount(usage: ModelUsage): void {
+	const { autoRouting, ...total } = usage[AUTO_MODEL];
+	assert.ok(autoRouting);
+	const undiscounted = calculateEstimatedCost({ [AUTO_MODEL]: total }, modelPricing, 'copilot');
+	const autoCost = calculateEstimatedCost({ [AUTO_MODEL]: { ...autoRouting, sessions: 0 } }, modelPricing, 'copilot');
+	assert.ok(autoCost > 0);
+	assert.ok(Math.abs(calculateEstimatedCost(usage, modelPricing, 'copilot') - (undiscounted - 0.1 * autoCost)) < 1e-12);
+	assert.equal(
+		calculateEstimatedCost(usage, modelPricing, 'provider'),
+		calculateEstimatedCost({ [AUTO_MODEL]: total }, modelPricing, 'provider'),
+		'Auto routing must not discount provider pricing'
+	);
+}
+
+for (const format of ['json', 'jsonl'] as const) {
+	test(`CLI ${format} ingestion preserves only the Auto request subset`, async t => {
+		const data = await processSessionFile(mockAutoSession(t, format));
+		assert.ok(data);
+		assert.equal(data.modelUsage[AUTO_MODEL].inputTokens, 4000);
+		assert.equal(data.modelUsage[AUTO_MODEL].outputTokens, 800);
+		assert.deepEqual(data.modelUsage[AUTO_MODEL].autoRouting, { inputTokens: 1000, outputTokens: 200 });
+		assertAutoDiscount(data.modelUsage);
+	});
+}
+
+test('CLI debug replacement preserves the estimated Auto share including cached reads', async t => {
+	const data = await processSessionFile(mockAutoSession(t, 'jsonl', true));
+	assert.ok(data);
+	assert.equal(data.actualTokens, 9600);
+	assert.deepEqual(data.modelUsage[AUTO_MODEL], {
+		inputTokens: 8000, outputTokens: 1600, cachedReadTokens: 3200, sessions: 0,
+		autoRouting: { inputTokens: 2000, outputTokens: 400, cachedReadTokens: 800 },
+	});
+	assertAutoDiscount(data.modelUsage);
+});
+
+test('CLI period aggregation scales Auto tokens without changing session counting', async t => {
+	const data = await processSessionFile(mockAutoSession(t, 'jsonl'));
+	assert.ok(data);
+	data.modelUsage[AUTO_MODEL].sessions = 7;
+	const originalUsage = structuredClone(data.modelUsage);
+	const period = createEmptyPeriodStats();
+	aggregateIntoPeriod(period, data, 0.25);
+	assert.deepEqual(period.modelUsage[AUTO_MODEL], {
+		inputTokens: 1000, outputTokens: 200, sessions: 0,
+		autoRouting: { inputTokens: 250, outputTokens: 50 },
+	});
+	aggregateIntoPeriod(period, data, 0.75);
+	assert.equal(period.sessions, 2);
+	assert.equal(period.editorUsage['VS Code'].sessions, 2);
+	assert.equal(period.modelUsage[AUTO_MODEL].sessions, 0);
+	assert.deepEqual(period.modelUsage[AUTO_MODEL].autoRouting, { inputTokens: 1000, outputTokens: 200 });
+	assert.deepEqual(data.modelUsage, originalUsage, 'aggregation must not mutate its source');
+	assertAutoDiscount(period.modelUsage);
+});
+
+interface CostPeriod {
+	totalCost: number;
+	totalSessions: number;
+	editorCostDatasets: Array<{ label: string; data: number[] }>;
+	billingGroupCostDatasets: Array<{ label: string; data: number[] }>;
+}
+
+test('CLI daily, history, weekly, monthly and billing aggregates retain Auto discounts', async t => {
+	const { labels, days, allDaysMap } = await calculateDailyStats([mockAutoSession(t, 'jsonl')]);
+	assert.equal(allDaysMap.size, 2);
+	const populatedDays = days.filter(day => day.sessions > 0);
+	assert.equal(populatedDays.length, 2);
+	for (const entry of [...populatedDays, ...allDaysMap.values()]) {
+		assert.deepEqual(entry.modelUsage[AUTO_MODEL], {
+			inputTokens: 2000, outputTokens: 400, sessions: 0,
+			autoRouting: { inputTokens: 500, outputTokens: 100 },
+		});
+		assert.deepEqual(entry.editorModelUsage?.['VS Code'], entry.modelUsage);
+		assert.equal(entry.sessions, 1);
+		assertAutoDiscount(entry.modelUsage);
+	}
+	const originalDays = structuredClone(days);
+	const payload = buildChartPayload(labels, days, allDaysMap) as { periods: Record<string, CostPeriod> };
+	const expectedCost = populatedDays.reduce((sum, day) => sum + calculateEstimatedCost(day.modelUsage, modelPricing, 'copilot'), 0);
+	for (const period of Object.values(payload.periods)) {
+		assert.ok(Math.abs(period.totalCost - expectedCost) < 1e-12);
+		assert.equal(period.totalSessions, 2);
+		assert.equal(period.editorCostDatasets.length, 1);
+		assert.equal(period.editorCostDatasets[0].label, 'VS Code');
+		assert.ok(Math.abs(period.editorCostDatasets[0].data.reduce((sum, cost) => sum + cost, 0) - expectedCost) < 1e-12);
+		assert.equal(period.billingGroupCostDatasets.length, 1);
+		assert.equal(period.billingGroupCostDatasets[0].label, 'GitHub Copilot');
+		assert.ok(Math.abs(period.billingGroupCostDatasets[0].data.reduce((sum, cost) => sum + cost, 0) - expectedCost) < 1e-12);
+	}
+	assert.deepEqual(days, originalDays);
+});
+
+test('CLI provider editor and billing costs remain undiscounted with Auto metadata', () => {
+	const usage: ModelUsage = {
+		[AUTO_MODEL]: { inputTokens: 4000, outputTokens: 800, sessions: 0, autoRouting: { inputTokens: 1000, outputTokens: 200 } },
+	};
+	const entry: DailyEntry = {
+		tokens: 4800, sessions: 1, modelUsage: usage,
+		editorUsage: { 'Claude Code': { tokens: 4800, sessions: 1 } },
+		editorModelUsage: { 'Claude Code': usage },
+	};
+	const today = new Date();
+	const key = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
+	const payload = buildChartPayload([key], [entry]) as { periods: Record<string, CostPeriod> };
+	const expectedCost = calculateEstimatedCost({ [AUTO_MODEL]: { inputTokens: 4000, outputTokens: 800, sessions: 0 } }, modelPricing, 'provider');
+	for (const period of Object.values(payload.periods)) {
+		assert.equal(period.editorCostDatasets[0].label, 'Claude Code');
+		assert.equal(period.editorCostDatasets[0].data.reduce((sum, cost) => sum + cost, 0), expectedCost);
+		assert.equal(period.billingGroupCostDatasets[0].label, 'Anthropic');
+		assert.equal(period.billingGroupCostDatasets[0].data.reduce((sum, cost) => sum + cost, 0), expectedCost);
+	}
 });

--- a/src/README.md
+++ b/src/README.md
@@ -110,6 +110,28 @@ calculateEstimatedCost(usage, pricing);             // provider/API cost (defaul
 calculateEstimatedCost(usage, pricing, 'copilot');  // GitHub Copilot AI-Credit cost
 ```
 
+**Copilot Auto routing:** estimated paid-plan AI-Credit costs apply GitHub's
+[10% Auto discount](https://code.visualstudio.com/blogs/2025/09/15/autoModelSelection)
+only to requests with an `autoModeResolution` response item or a request-level
+`modelId` of `auto` / `copilot/auto`. The resolved model supplies the rate;
+unresolved Auto stays unpriced. `ModelUsage.autoRouting` holds the eligible token
+subset (including optional cache fields), not extra usage, so manual requests
+for the same model are not discounted. Provider/API prices, provider fallbacks
+without a `copilotPricing` block, and recorded exact Copilot charges are unchanged.
+Session logs do not identify plan eligibility; these are paid-plan rate estimates,
+not a claim that a Free account incurs a charge. Premium-request counts are not
+converted into token costs by this calculation.
+
+Auto subsets survive aggregation and day allocation. When debug logs replace
+per-model tokens without a per-request routing split, the original Auto input/output
+proportions are retained as an estimate; cache tokens use the Auto input proportion.
+The Session Steps Overview uses Copilot rates for Copilot editors and provider
+rates for other editors. Sub-agents do not inherit the parent's Auto discount.
+Copilot CLI's model-change events and per-model billing/shutdown totals do not
+provide a reliable per-request Auto signal in the supported schemas; neither
+these nor JetBrains/Visual Studio heuristics receive an inferred discount.
+Other vendors' `auto` model names are not treated as Copilot routing.
+
 When a model has no `copilotPricing` block the `'copilot'` source falls back to
 the provider rates as a proxy — this means the Copilot cost is never
 *under-reported* due to a missing entry, it just won't reflect the (often

--- a/src/chartDataBuilder.ts
+++ b/src/chartDataBuilder.ts
@@ -9,7 +9,7 @@ import { TASK_CATEGORIES, type TaskCategory } from './taskClassification';
 export { COPILOT_EDITOR_NAMES } from './statsHelpers';
 
 /** Returns the pricing source to use for cost estimation for a given editor. */
-function getPricingSourceForEditor(editor: string): 'provider' | 'copilot' {
+export function getPricingSourceForEditor(editor: string): 'provider' | 'copilot' {
 	return COPILOT_EDITOR_NAMES.has(editor) ? 'copilot' : 'provider';
 }
 

--- a/src/statsHelpers.ts
+++ b/src/statsHelpers.ts
@@ -48,8 +48,7 @@ export function computeSessionDurationMs(firstInteraction: string | null | undef
 
 /**
  * Merges `source` model usage into `target` (in-place).
- * All four token fields are summed: inputTokens, outputTokens,
- * cachedReadTokens (optional), and cacheCreationTokens (optional).
+ * Sums token fields and the optional Auto-routing subset independently.
  */
 export function addModelUsage(target: ModelUsage, source: ModelUsage): void {
 for (const [model, usage] of Object.entries(source)) {
@@ -65,6 +64,10 @@ target[model].cachedReadTokens = (target[model].cachedReadTokens ?? 0) + usage.c
 if (usage.cacheCreationTokens !== undefined) {
 target[model].cacheCreationTokens = (target[model].cacheCreationTokens ?? 0) + usage.cacheCreationTokens;
 }
+if (usage.cacheCreation1hTokens !== undefined) {
+target[model].cacheCreation1hTokens = (target[model].cacheCreation1hTokens ?? 0) + usage.cacheCreation1hTokens;
+}
+mergeAutoRouting(target[model], usage);
 if (usage.thinkingTokens !== undefined) {
 target[model].thinkingTokens = (target[model].thinkingTokens ?? 0) + usage.thinkingTokens;
 }
@@ -72,6 +75,42 @@ if (usage.sessions !== undefined) {
 target[model].sessions = (target[model].sessions ?? 0) + usage.sessions;
 }
 }
+}
+
+function mergeAutoRouting(target: ModelUsage[string], source: ModelUsage[string]): void {
+	if (!source.autoRouting) { return; }
+	const subset: ModelUsage = { subset: { inputTokens: 0, outputTokens: 0, ...target.autoRouting, sessions: 0 } };
+	addModelUsage(subset, { subset: { ...source.autoRouting, sessions: 0 } });
+	const { sessions: _sessions, ...tokens } = subset.subset;
+	target.autoRouting = tokens;
+}
+
+function scaleAutoRouting(usage: ModelUsage[string], inputScale: number, outputScale: number): Pick<ModelUsage[string], 'autoRouting'> {
+	const auto = usage.autoRouting;
+	if (!auto) { return {}; }
+	return { autoRouting: {
+		inputTokens: Math.round(auto.inputTokens * inputScale),
+		outputTokens: Math.round(auto.outputTokens * outputScale),
+		...(auto.cachedReadTokens !== undefined ? { cachedReadTokens: Math.round(auto.cachedReadTokens * inputScale) } : {}),
+		...(auto.cacheCreationTokens !== undefined ? { cacheCreationTokens: Math.round(auto.cacheCreationTokens * inputScale) } : {}),
+		...(auto.cacheCreation1hTokens !== undefined ? { cacheCreation1hTokens: Math.round(auto.cacheCreation1hTokens * inputScale) } : {}),
+	} };
+}
+
+/**
+ * Keep request-derived Auto proportions when debug logs replace the token estimate.
+ * Debug model totals have no routing split: cache reads/writes inherit the estimated
+ * Auto input share, rather than discounting every request for that model.
+ */
+export function preserveAutoRouting(source: ModelUsage, replacement: ModelUsage): void {
+	for (const [model, usage] of Object.entries(replacement)) {
+		const original = source[model];
+		if (!original?.autoRouting) { continue; }
+		const inputShare = original.inputTokens > 0 ? original.autoRouting.inputTokens / original.inputTokens : 0;
+		const outputShare = original.outputTokens > 0 ? original.autoRouting.outputTokens / original.outputTokens : 0;
+		const { sessions: _sessions, ...tokens } = usage;
+		usage.autoRouting = scaleAutoRouting({ ...usage, autoRouting: tokens }, inputShare, outputShare).autoRouting;
+	}
 }
 
 /**
@@ -111,6 +150,8 @@ export function reconcileModelUsageToTotal(modelUsage: ModelUsage, targetInputTo
 			inputTokens, outputTokens,
 			...(usage.cachedReadTokens !== undefined ? { cachedReadTokens: Math.round(usage.cachedReadTokens * inputScale) } : {}),
 			...(usage.cacheCreationTokens !== undefined ? { cacheCreationTokens: Math.round(usage.cacheCreationTokens * inputScale) } : {}),
+			...(usage.cacheCreation1hTokens !== undefined ? { cacheCreation1hTokens: Math.round(usage.cacheCreation1hTokens * inputScale) } : {}),
+			...scaleAutoRouting(usage, inputScale, outputScale),
 			...(usage.sessions !== undefined ? { sessions: usage.sessions } : { sessions: 0 }),
 		};
 	}
@@ -170,7 +211,7 @@ export function sumModelUsageTokens(modelUsage: ModelUsage): number {
 }
 
 /** Scale every token field of a usage map by `fraction` (used for per-day distribution). */
-function scaleModelUsage(modelUsage: ModelUsage, fraction: number): ModelUsage {
+export function scaleModelUsage(modelUsage: ModelUsage, fraction: number): ModelUsage {
 	const scaled: ModelUsage = {};
 	for (const [model, usage] of Object.entries(modelUsage)) {
 		scaled[model] = {
@@ -178,6 +219,8 @@ function scaleModelUsage(modelUsage: ModelUsage, fraction: number): ModelUsage {
 			outputTokens: Math.round(usage.outputTokens * fraction),
 			...(usage.cachedReadTokens !== undefined ? { cachedReadTokens: Math.round(usage.cachedReadTokens * fraction) } : {}),
 			...(usage.cacheCreationTokens !== undefined ? { cacheCreationTokens: Math.round(usage.cacheCreationTokens * fraction) } : {}),
+			...(usage.cacheCreation1hTokens !== undefined ? { cacheCreation1hTokens: Math.round(usage.cacheCreation1hTokens * fraction) } : {}),
+			...scaleAutoRouting(usage, fraction, fraction),
 			sessions: 0,
 		};
 	}

--- a/src/tokenEstimation.ts
+++ b/src/tokenEstimation.ts
@@ -2,7 +2,7 @@
  * Token estimation and model-related utility functions.
  * Pure or near-pure functions extracted from CopilotTokenTracker for reusability.
  */
-import type { ModelUsage, ModelPricing, ContextReferenceUsage, TokenEstimator } from './types';
+import type { ModelUsage, ModelPricing, ContextReferenceUsage, TokenEstimator, ChatTurn } from './types';
 import { toLocalDayKey } from './utils/dayKeys';
 import type { CopilotCliOtelSessionUsage } from './copilotCliOtel';
 import { getModelLookupCandidates } from './webview/shared/modelUtils';
@@ -10,6 +10,7 @@ import { getModelLookupCandidates } from './webview/shared/modelUtils';
 /** Minimum request shape needed by getModelFromRequest. */
 interface ModelRequestSource {
 	modelId?: string;
+	response?: unknown[];
 	result?: {
 		metadata?: { modelId?: string };
 		details?: string;
@@ -1039,15 +1040,6 @@ function getDisplayNameLookup(modelPricing: { [key: string]: ModelPricing }): { 
 	return cached;
 }
 
-/** Find the model ID for a request by matching display names against its details string. Returns null if not found. */
-function _gmfrFindByDisplayName(details: string, modelPricing: { [key: string]: ModelPricing }): string | null {
-	const { map, sortedNames } = getDisplayNameLookup(modelPricing);
-	for (const displayName of sortedNames) {
-		if (details.includes(displayName)) { return map[displayName]; }
-	}
-	return null;
-}
-
 function _gmrMatchDisplayName(details: string, modelPricing: { [key: string]: ModelPricing }): string | null {
 	const { map, sortedNames } = getDisplayNameLookup(modelPricing);
 	for (const displayName of sortedNames) {
@@ -1056,24 +1048,40 @@ function _gmrMatchDisplayName(details: string, modelPricing: { [key: string]: Mo
 	return null;
 }
 
-export function getModelFromRequest(request: ModelRequestSource, modelPricing: { [key: string]: ModelPricing } = {}): string {
-	if (request.modelId) { return request.modelId.replace(/^copilot\//, ''); }
-	if (request.result?.metadata?.modelId) { return request.result.metadata.modelId.replace(/^copilot\//, ''); }
+function isAutoModel(model: string | undefined): boolean {
+	return model === 'auto' || model === 'copilot/auto';
+}
+
+function getAutoResolution(request: ModelRequestSource): string | undefined {
+	if (!Array.isArray(request.response)) { return undefined; }
+	for (const item of request.response) {
+		if (!item || typeof item !== 'object' || !('kind' in item) || item.kind !== 'autoModeResolution') { continue; }
+		if (!('resolved' in item) || !item.resolved || typeof item.resolved !== 'object') { continue; }
+		if ('id' in item.resolved && typeof item.resolved.id === 'string' && item.resolved.id && !isAutoModel(item.resolved.id)) {
+			return item.resolved.id.replace(/^copilot\//, '');
+		}
+	}
+	return undefined;
+}
+
+/** Only explicit request-level evidence qualifies; a session picker can change between turns. */
+export function isCopilotAutoRequest(request: ModelRequestSource): boolean {
+	return isAutoModel(request.modelId) || isAutoModel(request.result?.metadata?.modelId)
+		|| (Array.isArray(request.response) && request.response.some(item => !!item && typeof item === 'object' && 'kind' in item && item.kind === 'autoModeResolution'));
+}
+
+export function getModelFromRequest(request: ModelRequestSource, modelPricing: { [key: string]: ModelPricing } = {}, fallbackModel = 'gpt-4'): string {
+	const resolved = getAutoResolution(request);
+	if (resolved) { return resolved; }
+	const candidates = [request.modelId, request.result?.metadata?.modelId];
+	const explicit = candidates.find(model => model && !isAutoModel(model));
+	if (explicit) { return explicit.replace(/^copilot\//, ''); }
 	if (request.result?.details) {
 		const matched = _gmrMatchDisplayName(request.result.details, modelPricing);
 		if (matched) { return matched; }
 	}
-
-	if (request.result?.metadata?.modelId) {
-		return request.result.metadata.modelId.replace(/^copilot\//, '');
-	}
-
-	if (request.result?.details) {
-		const found = _gmfrFindByDisplayName(request.result.details, modelPricing);
-		if (found) { return found; }
-	}
-
-	return 'gpt-4'; // default
+	if (isCopilotAutoRequest(request)) { return 'auto'; }
+	return fallbackModel;
 }
 
 /**
@@ -1356,9 +1364,45 @@ export function calculateEstimatedCost(
 		const outputCost = (usage.outputTokens / 1_000_000) * pricing.outputCostPerMillion;
 
 		totalCost += uncachedInputCost + cachedReadCost + cacheCreation5mCost + cacheCreation1hCost + outputCost;
+		totalCost -= copilotAutoDiscount(model, usage, baseEntry, pricingSource);
 	}
 
 	return totalCost;
+}
+
+function copilotAutoDiscount(model: string, usage: ModelUsage[string], pricing: ModelPricing, source: 'provider' | 'copilot'): number {
+	if (source !== 'copilot' || !pricing.copilotPricing || !usage.autoRouting) { return 0; }
+	// Provider fallbacks and recorded exact charges are not Copilot rate estimates.
+	return 0.1 * calculateEstimatedCost(
+		{ [model]: { ...usage.autoRouting, sessions: 0 } },
+		{ [model]: pricing.copilotPricing },
+		'provider',
+	);
+}
+
+function attachSubAgentCosts(turn: ChatTurn, modelPricing: Record<string, ModelPricing>, pricingSource: 'provider' | 'copilot'): void {
+	for (const tc of turn.toolCalls) {
+		if (!tc.isSubAgent || !tc.subAgentModel || !tc.subAgentTokens) { continue; }
+		const cost = calculateEstimatedCost({
+			[tc.subAgentModel]: { inputTokens: tc.subAgentTokens.input, outputTokens: tc.subAgentTokens.output, sessions: 1 },
+		}, modelPricing, pricingSource);
+		if (cost > 0) { tc.subAgentCost = cost; }
+	}
+}
+
+/** Attach estimates only; recorded exact billing is handled separately by the caller. */
+export function attachEstimatedTurnCosts(turns: ChatTurn[], modelPricing: Record<string, ModelPricing>, pricingSource: 'provider' | 'copilot'): void {
+	for (const turn of turns) {
+		const inputTokens = turn.actualUsage?.promptTokens ?? turn.inputTokensEstimate;
+		const outputTokens = turn.actualUsage?.completionTokens ?? turn.outputTokensEstimate;
+		if (turn.model && (inputTokens > 0 || outputTokens > 0)) {
+			const usage = { inputTokens, outputTokens, sessions: 1,
+				...(turn.autoRouted ? { autoRouting: { inputTokens, outputTokens } } : {}) };
+			const cost = calculateEstimatedCost({ [turn.model]: usage }, modelPricing, pricingSource);
+			if (cost > 0) { turn.estimatedCost = cost; }
+		}
+		attachSubAgentCosts(turn, modelPricing, pricingSource);
+	}
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,6 +39,8 @@ export interface ModelUsage {
      */
     cacheCreation1hTokens?: number;
     thinkingTokens?: number;
+    /** Token subset from explicitly Auto-routed Copilot requests (not additional usage). */
+    autoRouting?: Omit<ModelUsage[string], 'sessions' | 'autoRouting'>;
     /** Number of sessions that used this model in the aggregated period. */
     sessions: number;
   };
@@ -1231,6 +1233,8 @@ export interface ChatTurn {
   userMessage: string;
   assistantResponse: string;
   model: string | null;
+  /** Explicit per-request Copilot Auto selection; never inferred from a session's final picker. */
+  autoRouted?: boolean;
   toolCalls: { toolName: string; arguments?: string; result?: string; isSubAgent?: boolean; subAgentModel?: string; subAgentTokens?: { input: number; output: number }; subAgentCost?: number }[];
   contextReferences: ContextReferenceUsage;
   mcpTools: { server: string; tool: string }[];

--- a/src/usageAnalysis.ts
+++ b/src/usageAnalysis.ts
@@ -43,6 +43,7 @@ import {
 	isJsonlContent,
 	isUuidPointerFile,
 	getModelFromRequest,
+	isCopilotAutoRequest,
 	getModelTier,
 	getModelCostBucket,
 	estimateTokensFromText,
@@ -2904,20 +2905,15 @@ function _gmusEstimateDeltaRequestTokens(request: SessionRequestRaw, requestMode
 /** Process a single delta-format request, extracting or estimating token usage. */
 function _gmusProcessDeltaRequest(request: SessionRequestRaw, defaultModel: string, modelUsage: ModelUsage, deps: GmusDeps): void {
 	if (!request.requestId) { return; }
-	let requestModel = defaultModel;
-	if (request.modelId) {
-		requestModel = request.modelId.replace(/^copilot\//, '');
-	} else if (request.result?.metadata?.modelId) {
-		requestModel = request.result.metadata.modelId.replace(/^copilot\//, '');
-	} else if (request.result?.details) {
-		requestModel = getModelFromRequest(request, deps.modelPricing);
-	}
+	const requestModel = getModelFromRequest(request, deps.modelPricing, defaultModel);
 	// Untrusted `modelId` string from parsed session JSON — see protoGuard.ts.
 	if (isUnsafeObjectKey(requestModel)) { return; }
 	if (!modelUsage[requestModel]) { modelUsage[requestModel] = { inputTokens: 0, outputTokens: 0, sessions: 0 }; }
+	const before = { ...modelUsage[requestModel] };
 	if (!tryExtractExactTokenUsage(request, requestModel, modelUsage)) {
 		_gmusEstimateDeltaRequestTokens(request, requestModel, modelUsage, deps);
 	}
+	recordAutoRequestUsage(request, modelUsage[requestModel], before);
 	if (request.response && Array.isArray(request.response)) {
 		accumulateSubAgentTokenUsage(request.response as ResponseItemRaw[], requestModel, modelUsage, deps.tokenEstimators);
 	}
@@ -2933,19 +2929,20 @@ function _gmusProcessDeltaRequests(state: GmusJsonlState, modelUsage: ModelUsage
 }
 
 /** Apply regex-based fallback extraction to fill in any requests that reconstruction missed. */
-function _gmusDeltaFallbackExtraction(lines: string[], state: GmusJsonlState, modelUsage: ModelUsage): void {
+function _gmusDeltaFallbackExtraction(lines: string[], state: GmusJsonlState, modelUsage: ModelUsage, deps: GmusDeps): void {
 	const rawModelUsage = extractPerRequestUsageFromRawLines(lines);
 	for (const [reqIdx, extracted] of rawModelUsage) {
 		const request = state.sessionState.requests?.[reqIdx] as SessionRequestRaw | undefined;
 		if (!request) { continue; }
 		if (request.result?.usage || (typeof request.result?.promptTokens === 'number') || (request.result?.metadata && typeof request.result.metadata.promptTokens === 'number')) { continue; }
-		let requestModel = state.defaultModel;
-		if (request.modelId) { requestModel = request.modelId.replace(/^copilot\//, ''); }
+		const requestModel = getModelFromRequest(request, deps.modelPricing, state.defaultModel);
 		// Untrusted `modelId` string from parsed session JSON — see protoGuard.ts.
 		if (isUnsafeObjectKey(requestModel)) { continue; }
 		if (!modelUsage[requestModel]) { modelUsage[requestModel] = { inputTokens: 0, outputTokens: 0, sessions: 0 }; }
+		const before = { ...modelUsage[requestModel] };
 		modelUsage[requestModel].inputTokens += extracted.promptTokens;
 		modelUsage[requestModel].outputTokens += extracted.outputTokens;
+		recordAutoRequestUsage(request, modelUsage[requestModel], before);
 	}
 }
 
@@ -2967,7 +2964,7 @@ function _gmusProcessJsonlContent(lines: string[], modelUsage: ModelUsage, deps:
 	if (!state.isDeltaBased && state.cliShutdownModelUsage) { return state.cliShutdownModelUsage; }
 	if (!state.isDeltaBased && state.cliRealOutputByModel) { return _gmusBuildEstimatedCliUsage(state, modelUsage); }
 	_gmusProcessDeltaRequests(state, modelUsage, deps);
-	_gmusDeltaFallbackExtraction(lines, state, modelUsage);
+	_gmusDeltaFallbackExtraction(lines, state, modelUsage, deps);
 	return null;
 }
 
@@ -2986,13 +2983,24 @@ function _gmusProcessJsonRequestEstimate(request: SessionRequestRaw, model: stri
 	}
 }
 
+/** Record the parent's eligible token delta before adding any sub-agent usage. */
+function recordAutoRequestUsage(request: SessionRequestRaw, usage: ModelUsage[string], before: ModelUsage[string]): void {
+	if (!isCopilotAutoRequest(request)) { return; }
+	usage.autoRouting = {
+		inputTokens: (usage.autoRouting?.inputTokens ?? 0) + usage.inputTokens - before.inputTokens,
+		outputTokens: (usage.autoRouting?.outputTokens ?? 0) + usage.outputTokens - before.outputTokens,
+	};
+}
+
 /** Process a single JSON-format session request, accumulating its token usage. */
 function _gmusProcessJsonRequest(request: SessionRequestRaw, modelUsage: ModelUsage, deps: GmusDeps): void {
 	const model = getModelFromRequest(request, deps.modelPricing);
 	// Untrusted `model` string from parsed session JSON — see protoGuard.ts.
 	if (isUnsafeObjectKey(model)) { return; }
 	if (!modelUsage[model]) { modelUsage[model] = { inputTokens: 0, outputTokens: 0, sessions: 0 }; }
+	const before = { ...modelUsage[model] };
 	if (!tryExtractExactTokenUsage(request, model, modelUsage)) { _gmusProcessJsonRequestEstimate(request, model, modelUsage, deps); }
+	recordAutoRequestUsage(request, modelUsage[model], before);
 	if (request.response && Array.isArray(request.response)) {
 		accumulateSubAgentTokenUsage(request.response as ResponseItemRaw[], model, modelUsage, deps.tokenEstimators);
 	}

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -163,6 +163,8 @@ import {
   estimateTokensFromJsonlSession as _estimateTokensFromJsonlSession,
   extractPerRequestUsageFromRawLines as _extractPerRequestUsageFromRawLines,
   getModelFromRequest as _getModelFromRequest,
+  isCopilotAutoRequest,
+  attachEstimatedTurnCosts,
   isJsonlContent as _isJsonlContent,
   isUuidPointerFile as _isUuidPointerFile,
   applyDelta as _applyDelta,
@@ -266,7 +268,7 @@ import {
 } from '../../src/workspaceHelpers';
 
 // --- Chart building ---
-import { buildChartData as _buildChartData, getBillingGroup, getPricingSourceForBillingGroup } from '../../src/chartDataBuilder';
+import { buildChartData as _buildChartData, getBillingGroup, getPricingSourceForBillingGroup, getPricingSourceForEditor } from '../../src/chartDataBuilder';
 
 // --- Time-to-first-token analysis ---
 import { buildTtftBuckets as _buildTtftBuckets, buildTtftModelSeries as _buildTtftModelSeries, type TtftGranularity } from '../../src/ttftAnalysis';
@@ -286,6 +288,7 @@ import { classifySessionTask, buildClassificationInputFromUsageAnalysis, countDe
 
 // --- Stats helpers ---
 import { addModelUsage, addEditorUsage, addLanguageUsage, computeUtcDateRanges, aggregatePeriodStats, makePeriodAccumulator, computeSessionTotalTokens, computeSessionDurationMs, reconcileModelUsageToTotal, reconcileModelUsageToActualTokens, distributeModelUsageToDays, computeFallbackDailyRollup as _computeFallbackDailyRollup, type SessionAggregateInput } from '../../src/statsHelpers';
+import { scaleModelUsage, preserveAutoRouting } from '../../src/statsHelpers';
 
 // --- GitHub & agent sessions ---
 import {
@@ -554,10 +557,8 @@ function isUsageAnalysisTab(tab: string): tab is UsageAnalysisTab {
 
 class CopilotTokenTracker implements vscode.Disposable {
 	// Cache version - increment this when making changes that require cache invalidation.
-	// Correction detection now requires corroboration for agent-self-correction moments and
-	// adds intensity/escalation fields to user-correction moments — old cached moments were
-	// computed under the previous (uncorroborated) logic and lack these fields.
-	private static readonly CACHE_VERSION = 71;
+	// Rebuild model usage with the per-request Auto-routing subset used by Copilot estimates.
+	private static readonly CACHE_VERSION = 72;
 	/** Initial stats should not wait indefinitely for one inaccessible or stalled session. */
 	private static readonly SESSION_PRELOAD_TIMEOUT_MS = 15_000;
 	// Maximum length for displaying workspace IDs in diagnostics/customization matrix
@@ -6333,11 +6334,7 @@ private computeFallbackDailyRollup(
 	} catch { /* ignore */ }
 }
 	private scaledModelUsage(modelUsage: ModelUsage, fraction: number): ModelUsage {
-		const dayModelUsage: ModelUsage = {};
-		for (const [model, usage] of Object.entries(modelUsage)) {
-			dayModelUsage[model] = { inputTokens: Math.round(usage.inputTokens * fraction), outputTokens: Math.round(usage.outputTokens * fraction), ...(usage.cachedReadTokens !== undefined ? { cachedReadTokens: Math.round(usage.cachedReadTokens * fraction) } : {}), ...(usage.cacheCreationTokens !== undefined ? { cacheCreationTokens: Math.round(usage.cacheCreationTokens * fraction) } : {}), sessions: 0 };
-		}
-		return dayModelUsage;
+		return scaleModelUsage(modelUsage, fraction);
 	}
 
 	private resolveAndApplyDebugLog(
@@ -6384,6 +6381,7 @@ private computeFallbackDailyRollup(
 		for (const [model, bd] of Object.entries(debugLogTokens.modelBreakdown)) {
 			breakdownUsage[model] = { inputTokens: bd.inputTokens, outputTokens: bd.outputTokens, ...(bd.cachedTokens > 0 ? { cachedReadTokens: bd.cachedTokens } : {}), sessions: 0 };
 		}
+		preserveAutoRouting(modelUsage, breakdownUsage);
 		// Reconcile against the debug log's own totals even when the breakdown is
 		// missing or partial (e.g. some requests lack a `model` attribute), so
 		// Input+Output never drifts from Total — see reconcileModelUsageToTotal.
@@ -7003,7 +7001,7 @@ private computeFallbackDailyRollup(
 				'For accurate billing data, check the Cursor dashboard at cursor.com/settings.',
 			],
 		} : undefined;
-		this.attachTurnCosts(turns);
+		attachEstimatedTurnCosts(turns, this.modelPricing, getPricingSourceForEditor(editorName));
 		return {
 			file: details.file, title: details.title || null, editorSource: details.editorSource,
 			editorName, size: details.size, modified: details.modified, interactions: details.interactions,
@@ -7064,13 +7062,14 @@ private computeFallbackDailyRollup(
 		const contextRefs = this.createEmptyContextRefs();
 		const userMessage = request.message?.text || '';
 		this.analyzeRequestContext(request, contextRefs);
-		const requestModel = request.modelId || currentModel || this.getModelFromRequest(request) || 'gpt-4';
+		const requestModel = _getModelFromRequest(request, this.modelPricing, currentModel || 'gpt-4');
 		const { responseText, thinkingText, toolCalls, mcpTools } = this.extractResponseData(request.response || []);
 		const actualUsage = this.extractActualUsageFromRequest(request, rawUsageFallback, i);
 		return {
 			turnNumber: i + 1,
 			timestamp: request.timestamp ? new Date(request.timestamp).toISOString() : null,
 			mode: sessionMode, userMessage, assistantResponse: responseText, model: requestModel,
+			autoRouted: isCopilotAutoRequest(request),
 			toolCalls, contextReferences: contextRefs, mcpTools,
 			inputTokensEstimate: this.estimateTokensFromText(userMessage, requestModel),
 			outputTokensEstimate: this.estimateTokensFromText(responseText, requestModel),
@@ -7301,6 +7300,8 @@ private computeFallbackDailyRollup(
 		return {
 			turnNumber, timestamp: request.timestamp || request.ts || request.result?.timestamp || null,
 			mode: requestMode, userMessage, assistantResponse, model, toolCalls, contextReferences: contextRefs, mcpTools,
+			autoRouted: isCopilotAutoRequest(request),
+			actualUsage: this.extractActualUsageFromRequest(request, new Map(), turnNumber - 1),
 			inputTokensEstimate: this.estimateTokensFromText(userMessage, model),
 			outputTokensEstimate: this.estimateTokensFromText(assistantResponse, model),
 			thinkingTokensEstimate: this.estimateTokensFromText(thinkingText, model)
@@ -7370,31 +7371,6 @@ private computeFallbackDailyRollup(
 		return _calculateEstimatedCost(modelUsage, this.modelPricing, pricingSource);
 	}
 
-	/**
-	 * Post-processes already-built `turns` with estimated USD costs, for the log viewer's
-	 * Session Steps Overview table: one cost per turn (its own model call — actual usage
-	 * tokens when available, otherwise the text-based estimate) and one per sub-agent/child
-	 * tool call (using its own `subAgentModel` + `subAgentTokens`). Mutates `turns` in place.
-	 * Silently leaves `estimatedCost`/`subAgentCost` unset when the model is unknown or has
-	 * no pricing entry (`calculateEstimatedCost` returns 0 for those, which we treat as "no cost").
-	 */
-	private attachTurnCosts(turns: ChatTurn[]): void {
-		for (const turn of turns) {
-			const input = turn.actualUsage ? turn.actualUsage.promptTokens : turn.inputTokensEstimate;
-			const output = turn.actualUsage ? turn.actualUsage.completionTokens : turn.outputTokensEstimate;
-			if (turn.model && (input > 0 || output > 0)) {
-				const cost = this.calculateEstimatedCost({ [turn.model]: { inputTokens: input, outputTokens: output, sessions: 1 } });
-				if (cost > 0) { turn.estimatedCost = cost; }
-			}
-			for (const tc of turn.toolCalls) {
-				if (!tc.isSubAgent || !tc.subAgentModel || !tc.subAgentTokens) { continue; }
-				const cost = this.calculateEstimatedCost({
-					[tc.subAgentModel]: { inputTokens: tc.subAgentTokens.input, outputTokens: tc.subAgentTokens.output, sessions: 1 },
-				});
-				if (cost > 0) { tc.subAgentCost = cost; }
-			}
-		}
-	}
 
 
 
@@ -10697,12 +10673,7 @@ ${this.getLoadingHtmlBody(nonce, iconUri.toString(), startedAtMs)}
   /** Merge one file's per-model usage entries into the running aggregate. */
   private static mergeModelUsageEntry(aggregated: ModelUsage, model: string, usage: ModelUsage[ModelId]): void {
     if (!aggregated[model]) { aggregated[model] = { inputTokens: 0, outputTokens: 0, cachedReadTokens: 0, cacheCreationTokens: 0, cacheCreation1hTokens: 0, sessions: 0 }; }
-    const agg = aggregated[model];
-    agg.inputTokens += usage.inputTokens || 0;
-    agg.outputTokens += usage.outputTokens || 0;
-    agg.cachedReadTokens = (agg.cachedReadTokens || 0) + (usage.cachedReadTokens || 0);
-    agg.cacheCreationTokens = (agg.cacheCreationTokens || 0) + (usage.cacheCreationTokens || 0);
-    agg.cacheCreation1hTokens = (agg.cacheCreation1hTokens || 0) + (usage.cacheCreation1hTokens || 0);
+    addModelUsage(aggregated, { [model]: { ...usage, sessions: 0 } });
   }
 
   /** Aggregate per-model usage (and per-model session counts) across a set of session files with modelUsage data. */

--- a/vscode-extension/test/unit/statsHelpers.test.ts
+++ b/vscode-extension/test/unit/statsHelpers.test.ts
@@ -17,6 +17,27 @@ type SessionAggregateInput,
 type UtcDateRanges,
 } from '../../../src/statsHelpers';
 import type { ModelUsage, EditorUsage, SessionFileCache, DailyRollupEntry } from '../../../src/types';
+import { scaleModelUsage, preserveAutoRouting } from '../../../src/statsHelpers';
+import { calculateEstimatedCost } from '../../../src/tokenEstimation';
+
+test('Auto subsets survive merging, scaling, reconciliation and debug-log replacement', () => {
+	const source: ModelUsage = { model: { inputTokens: 100, outputTokens: 40, sessions: 1,
+		autoRouting: { inputTokens: 40, outputTokens: 20 } } };
+	const target: ModelUsage = {};
+	addModelUsage(target, source);
+	addModelUsage(target, source);
+	addModelUsage(target, { model: { inputTokens: 100, outputTokens: 20, sessions: 1 } });
+	assert.deepEqual(target.model.autoRouting, { inputTokens: 80, outputTokens: 40 });
+	assert.deepEqual(source.model.autoRouting, { inputTokens: 40, outputTokens: 20 });
+	assert.deepEqual(scaleModelUsage(target, 0.5).model.autoRouting, { inputTokens: 40, outputTokens: 20 });
+	assert.deepEqual(reconcileModelUsageToTotal(target, 600, 300).model.autoRouting, { inputTokens: 160, outputTokens: 120 });
+	const replacement: ModelUsage = { model: { inputTokens: 1_000_000, outputTokens: 1_000_000, cachedReadTokens: 500_000, sessions: 0 } };
+	preserveAutoRouting(source, replacement);
+	assert.deepEqual(replacement.model.autoRouting, { inputTokens: 400_000, outputTokens: 500_000, cachedReadTokens: 200_000 });
+	const pricing = { model: { inputCostPerMillion: 20, outputCostPerMillion: 40,
+		copilotPricing: { inputCostPerMillion: 2, outputCostPerMillion: 4, cachedInputCostPerMillion: 0.2 } } };
+	assert.ok(Math.abs(calculateEstimatedCost(replacement, pricing, 'copilot') - 4.856) < 1e-12);
+});
 
 // ── Helper factory ───────────────────────────────────────────────────────────
 

--- a/vscode-extension/test/unit/tokenEstimation.test.ts
+++ b/vscode-extension/test/unit/tokenEstimation.test.ts
@@ -2,6 +2,83 @@ import test from 'node:test';
 import * as assert from 'node:assert/strict';
 
 import { extractSubAgentData, normalizeDisplayModelName, extractResponseItemText } from '../../../src/tokenEstimation';
+import { isCopilotAutoRequest, attachEstimatedTurnCosts } from '../../../src/tokenEstimation';
+import type { ChatTurn, ModelUsage } from '../../../src/types';
+import { getPricingSourceForEditor } from '../../../src/chartDataBuilder';
+
+const autoPricing = { 'gpt-4o': {
+	inputCostPerMillion: 20, outputCostPerMillion: 40, cachedInputCostPerMillion: 1,
+	copilotPricing: { inputCostPerMillion: 2, outputCostPerMillion: 4 },
+} };
+
+test('Auto discount: only the eligible Copilot token subset gets 10% off', () => {
+	const manual = { inputTokens: 1_000_000, outputTokens: 1_000_000, sessions: 1 };
+	const auto = { ...manual, autoRouting: { inputTokens: 1_000_000, outputTokens: 1_000_000 } };
+	assert.equal(calculateEstimatedCost({ 'gpt-4o': auto }, autoPricing, 'copilot'), 5.4);
+	assert.equal(calculateEstimatedCost({ 'gpt-4o': manual }, autoPricing, 'copilot'), 6);
+	assert.equal(calculateEstimatedCost({ 'gpt-4o': auto }, autoPricing, 'provider'), 60);
+	const mixed = { ...auto, inputTokens: 2_000_000, outputTokens: 3_000_000 };
+	assert.equal(calculateEstimatedCost({ 'gpt-4o': mixed }, autoPricing, 'copilot'), 15.4);
+	assert.equal(calculateEstimatedCost({ 'gpt-4o': mixed }, autoPricing), 160);
+	assert.equal(calculateEstimatedCost({ 'gpt-4o': auto }, { 'gpt-4o': { inputCostPerMillion: 20, outputCostPerMillion: 40 } }, 'copilot'), 60);
+});
+
+test('Auto discount: cache subset uses only Copilot rates and their fallbacks', () => {
+	const tokens = { inputTokens: 1_000_000, outputTokens: 1_000_000, cachedReadTokens: 500_000 };
+	const usage = { 'gpt-4o': { ...tokens, autoRouting: tokens, sessions: 1 } };
+	// Copilot has no cache rate: use its $2 input rate, not the provider's $1 cache rate.
+	assert.equal(calculateEstimatedCost(usage, autoPricing, 'copilot'), 5.4);
+	const pricing = { 'gpt-4o': { ...autoPricing['gpt-4o'], copilotPricing: {
+		inputCostPerMillion: 2, outputCostPerMillion: 4, cachedInputCostPerMillion: 0.2,
+		cacheCreationCostPerMillion: 3, cacheCreation1hCostPerMillion: 5,
+	} } };
+	const cached = { ...tokens, cacheCreationTokens: 200_000, cacheCreation1hTokens: 100_000 };
+	const autoUsage: ModelUsage = { 'gpt-4o': { ...cached, autoRouting: cached, sessions: 1 } };
+	assert.ok(Math.abs(calculateEstimatedCost(autoUsage, pricing, 'copilot') - 5.5 * 0.9) < 1e-12);
+});
+
+test('Auto detection and resolution use request evidence, not unrelated auto strings', () => {
+	for (const modelId of ['auto', 'copilot/auto']) {
+		const request = { modelId, result: { metadata: { modelId: 'gpt-4o' } } };
+		assert.equal(isCopilotAutoRequest(request), true);
+		assert.equal(getModelFromRequest(request), 'gpt-4o');
+	}
+	const response = [{ kind: 'autoModeResolution', resolved: { id: 'copilot/gpt-4o', name: 'GPT-4o' } }];
+	assert.equal(isCopilotAutoRequest({ response }), true);
+	assert.equal(getModelFromRequest({ response }), 'gpt-4o');
+	assert.equal(getModelFromRequest({ modelId: 'auto' }), 'auto');
+	assert.equal(isCopilotAutoRequest({ modelId: 'customendpoint/kiro/auto' }), false);
+	assert.equal(isCopilotAutoRequest({ modelId: 'gpt-4o' }), false);
+	assert.equal(isCopilotAutoRequest({ response: [null, {}, { kind: 'markdownContent', value: 'auto' }] }), false);
+	assert.equal(getModelFromRequest({ response: [{ kind: 'autoModeResolution', resolved: null }] }), 'auto');
+});
+
+test('Steps Overview costs: Auto actual usage discounted, manual/provider and child calls unchanged', () => {
+	const makeTurn = (autoRouted: boolean): ChatTurn => ({
+		turnNumber: 1, timestamp: null, mode: 'agent', userMessage: '', assistantResponse: '',
+		model: 'gpt-4o', autoRouted, contextReferences: createEmptyContextRefs(), mcpTools: [],
+		inputTokensEstimate: 1, outputTokensEstimate: 1, thinkingTokensEstimate: 0,
+		actualUsage: { promptTokens: 1_000_000, completionTokens: 1_000_000 },
+		toolCalls: [{ toolName: 'runSubagent', isSubAgent: true, subAgentModel: 'gpt-4o', subAgentTokens: { input: 1_000_000, output: 1_000_000 } }],
+	});
+	const turns = [makeTurn(true), makeTurn(false)];
+	attachEstimatedTurnCosts(turns, autoPricing, getPricingSourceForEditor('VS Code'));
+	assert.equal(turns[0].estimatedCost, 5.4);
+	assert.equal(turns[1].estimatedCost, 6);
+	assert.equal(turns[0].toolCalls[0].subAgentCost, 6);
+	const provider = makeTurn(true);
+	attachEstimatedTurnCosts([provider], autoPricing, getPricingSourceForEditor('Claude Code'));
+	assert.equal(provider.estimatedCost, 60);
+	const estimated = makeTurn(true);
+	delete estimated.actualUsage;
+	estimated.inputTokensEstimate = 1_000_000;
+	estimated.outputTokensEstimate = 1_000_000;
+	attachEstimatedTurnCosts([estimated], autoPricing, 'copilot');
+	assert.equal(estimated.estimatedCost, 5.4);
+	const unknown = { ...makeTurn(true), model: 'auto' };
+	attachEstimatedTurnCosts([unknown], autoPricing, 'copilot');
+	assert.equal(unknown.estimatedCost, undefined);
+});
 
 test('normalizeDisplayModelName: lowercases and replaces spaces with hyphens', () => {
 	assert.equal(normalizeDisplayModelName('Claude Haiku 4.5'), 'claude-haiku-4.5');

--- a/vscode-extension/test/unit/usageAnalysis.test.ts
+++ b/vscode-extension/test/unit/usageAnalysis.test.ts
@@ -23,6 +23,7 @@ import {
     type UsageAnalysisDeps,
 } from '../../../src/usageAnalysis';
 import { createEmptyTaskClassificationResult } from '../../../src/taskClassification';
+import { calculateEstimatedCost } from '../../../src/tokenEstimation';
 import type {
     UsageAnalysisPeriod,
     SessionUsageAnalysis,
@@ -32,6 +33,52 @@ import type {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+test('Auto usage: JSON and delta sessions retain mixed per-request routing without discounting subagents', async () => {
+	const requests = [
+		{ requestId: 'auto', modelId: 'copilot/auto',
+			result: { promptTokens: 1_000_000, outputTokens: 500_000 },
+			response: [
+				{ kind: 'autoModeResolution', resolved: { id: 'gpt-4o', name: 'GPT-4o' } },
+				{ kind: 'toolInvocationSerialized', toolSpecificData: { kind: 'subagent', modelName: 'gpt-4o', prompt: 'abcd', result: 'efgh' } },
+			] },
+		{ requestId: 'manual', modelId: 'gpt-4o', result: { usage: { promptTokens: 2_000_000, completionTokens: 1_000_000 } } },
+		{ requestId: 'metadata-auto', modelId: 'auto', result: { metadata: { modelId: 'gpt-4o', promptTokens: 100, outputTokens: 50 } } },
+	];
+	const deps = { warn: (message: string) => assert.fail(message), ecosystems: [], tokenEstimators: { 'gpt-4o': 0.25 },
+		modelPricing: { 'gpt-4o': { inputCostPerMillion: 20, outputCostPerMillion: 40, copilotPricing: { inputCostPerMillion: 2, outputCostPerMillion: 4 } } } };
+	const session = { requests, selectedModel: { identifier: 'copilot/auto' } };
+	for (const [file, content] of [
+		['mixed.json', JSON.stringify(session)],
+		['mixed.jsonl', JSON.stringify({ kind: 0, v: session })],
+	]) {
+		const usage = await getModelUsageFromSession(deps, file, content);
+		assert.deepEqual(usage['gpt-4o'].autoRouting, { inputTokens: 1_000_100, outputTokens: 500_050 });
+		assert.equal(usage['gpt-4o'].inputTokens, 3_000_101);
+		assert.equal(usage['gpt-4o'].outputTokens, 1_500_051);
+		const provider = calculateEstimatedCost(usage, deps.modelPricing);
+		const copilot = calculateEstimatedCost(usage, deps.modelPricing, 'copilot');
+		assert.ok(Math.abs(copilot - (provider / 10 - 0.40004)) < 1e-10);
+	}
+});
+
+test('Auto usage: marker-only estimates work but session picker and CLI model changes do not imply discounts', async () => {
+	const deps = { warn: (message: string) => assert.fail(message), ecosystems: [], tokenEstimators: { 'gpt-4o': 0.25 }, modelPricing: {} };
+	const request = { requestId: '1', message: { text: 'abcd', parts: [{ text: 'abcd' }] },
+		response: [{ kind: 'autoModeResolution', resolved: { id: 'gpt-4o' } }, { kind: 'markdownContent', value: 'efgh' }] };
+	const usage = await getModelUsageFromSession(deps, 'estimate.json', JSON.stringify({ requests: [request] }));
+	assert.deepEqual(usage['gpt-4o'].autoRouting, { inputTokens: 1, outputTokens: 1 });
+	const manual = await getModelUsageFromSession(deps, 'manual.json', JSON.stringify({
+		selectedModel: { identifier: 'copilot/auto' }, requests: [{ modelId: 'gpt-4o', result: { promptTokens: 10, outputTokens: 5 } }],
+	}));
+	assert.equal(manual['gpt-4o'].autoRouting, undefined);
+	const cli = await getModelUsageFromSession(deps, 'cli.jsonl', [
+		{ type: 'session.start', data: { selectedModel: 'auto' } },
+		{ type: 'session.model_change', data: { newModel: 'gpt-4o' } },
+		{ type: 'session.shutdown', data: { modelMetrics: { 'gpt-4o': { usage: { inputTokens: 10, outputTokens: 5 } } } } },
+	].map(event => JSON.stringify(event)).join('\n'));
+	assert.equal(cli['gpt-4o'].autoRouting, undefined);
+});
 
 function emptyRefs(): ContextReferenceUsage {
     return {


### PR DESCRIPTION
## Summary

- Detect Copilot Auto routing per VS Code Chat request from `autoModeResolution` or raw `auto` / `copilot/auto` model IDs, retaining the resolved model for pricing.
- Track eligible tokens as a nested `ModelUsage.autoRouting` subset, so mixed Auto/manual usage for the same model receives the discount only on the Auto portion. Apply 0.9x only to `copilotPricing` AI-Credit estimates; provider/API estimates, provider-rate fallbacks, and recorded exact Copilot charges remain unchanged.
- Preserve the subset through shared aggregation, scaling, debug-log replacement, and CLI ingestion/rollups. Invalidate extension and CLI caches.
- Move Steps Overview cost attachment into shared code and select rates by editor. Copilot editors now use Copilot rates; non-Copilot editors retain provider rates. Sub-agents do not inherit a parent's Auto discount.

## Boundaries and assumptions

- These are paid-plan rate estimates: session logs do not identify plan eligibility. This does not infer charges for Free accounts or convert premium-request counts to token costs.
- A session's final model picker is not evidence that every request used Auto. Unresolved Auto remains unpriced.
- Supported Copilot CLI billing/shutdown schemas, JetBrains logs, and Visual Studio data do not supply a reliable per-request Auto marker; no heuristic discount is applied to those sources. Other vendors' Auto routing is not Copilot routing.
- Where debug logs replace model totals without a routing split, retain the request-derived Auto input/output proportions as estimates; allocate cache tokens using the Auto input share. This limitation is documented.
- Built independently from `main` at `86dab958`, not from #2047. The minimal shared model-resolution/turn-builder changes overlap that open PR and may require reconciliation when either is merged.

## Verification

- `vscode-extension`: `npm run compile` passed.
- `vscode-extension`: `npm run validate` passed type-check/build; ESLint reports 25 pre-existing warnings and no errors. Compared all changed production files against their `main` versions using ESLint: **no new lint findings**.
- Required targeted suites passed: tokenEstimation, usageAnalysis, statsHelpers, webview-turnsOverview, and extension (**622 tests**).
- `vscode-extension`: `npm run test:node` passed all **136 test files**, including pricing, usage, chart/aggregation, parser, and log-viewer coverage.
- CLI build and type-check passed; all **11 shared-logic contract tests** passed.
- New tests cover Auto versus manual costs, mixed usage, unchanged provider/fallback rates, cache pricing and fallback rates, JSON/delta attribution, sub-agent exclusion, editor-aware turn estimates, debug reconciliation, and CLI propagation.
- `git diff --check` passed; commit `046dc622` has a valid signature.

Reference: https://code.visualstudio.com/blogs/2025/09/15/autoModelSelection