### PR TITLE
Add Last 30 Days column to status bar popup stats table

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -420,6 +420,44 @@ export function tooltipSecondaryPeriod(
 	return usesLast30(tokensSetting) || usesLast30(costSetting) ? 'last30days' : 'currentMonth';
 }
 
+/** Sums per-provider costs into a total-across-all-providers figure. */
+export function defaultSumBillingGroupCosts(billingGroupCosts: Record<string, number> | undefined): number {
+	return Object.values(billingGroupCosts ?? {}).reduce((s, v) => s + v, 0);
+}
+
+/**
+ * Formats the main stats table in Markdown for the status bar hover tooltip.
+ * Renders Today, Current Month, and Last 30 Days columns side by side.
+ */
+export function formatTooltipStatsTable(
+	detailedStats: DetailedStats,
+	sumCosts: (costs: Record<string, number> | undefined) => number = defaultSumBillingGroupCosts
+): string {
+	// Trailing &nbsp; padding on "Today" and "Current Month" columns widens them a bit,
+	// giving the value columns visual breathing room without VS Code table cell CSS to lean on.
+	const pad = (cell: string) => `${cell}&nbsp;&nbsp;&nbsp;&nbsp;`;
+	// Hide decimals once the rounded display value reaches 1000+ so large totals stay readable.
+	const formatUsageValue = (n: number, fractionDigits: number, unit: string) => {
+		const rounded = Math.round(n * (10 ** fractionDigits)) / (10 ** fractionDigits);
+		const format = Math.abs(rounded) >= 1000
+			? { minimumFractionDigits: 0, maximumFractionDigits: 0 }
+			: { minimumFractionDigits: fractionDigits, maximumFractionDigits: fractionDigits };
+		return `${n.toLocaleString(undefined, format)} ${unit}`;
+	};
+	const grams = (n: number) => formatUsageValue(n, 2, 'grams');
+	const liters = (n: number) => formatUsageValue(n, 3, 'liters');
+
+	return (
+		`|  | 📅 ${l10n.t('tooltip.todayLabel')} | 📊 ${l10n.t('tooltip.currentMonthLabel')} | 📈 ${l10n.t('tooltip.last30DaysLabel')} |\n` +
+		`|:---|:---|:---|:---|\n` +
+		`| ${l10n.t('tooltip.tokensLabel')} : | ${pad(detailedStats.today.tokens.toLocaleString())} | ${pad(detailedStats.month.tokens.toLocaleString())} | ${detailedStats.last30Days.tokens.toLocaleString()} |\n` +
+		`| ${l10n.t('tooltip.copilotCostLabel')} : | ${pad(`$ ${(detailedStats.today.estimatedCostCopilot ?? 0).toFixed(2)}`)} | ${pad(`$ ${(detailedStats.month.estimatedCostCopilot ?? 0).toFixed(2)}`)} | $ ${(detailedStats.last30Days.estimatedCostCopilot ?? 0).toFixed(2)} |\n` +
+		`| ${l10n.t('tooltip.allProvidersCostLabel')} : | ${pad(`$ ${sumCosts(detailedStats.today.billingGroupCosts).toFixed(2)}`)} | ${pad(`$ ${sumCosts(detailedStats.month.billingGroupCosts).toFixed(2)}`)} | $ ${sumCosts(detailedStats.last30Days.billingGroupCosts).toFixed(2)} |\n` +
+		`| ${l10n.t('tooltip.co2Label')} : | ${pad(grams(detailedStats.today.co2))} | ${pad(grams(detailedStats.month.co2))} | ${grams(detailedStats.last30Days.co2)} |\n` +
+		`| ${l10n.t('tooltip.waterLabel')} : | ${pad(liters(detailedStats.today.waterUsage))} | ${pad(liters(detailedStats.month.waterUsage))} | ${liters(detailedStats.last30Days.waterUsage)} |\n`
+	);
+}
+
 // ── extension.ts module-level helpers ────────────────────────────────────────
 
 /** Type guard for the social platforms supported by `shareTextToSocialPlatform`. */
@@ -3624,28 +3662,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 		tooltip.supportThemeIcons = false;
 		tooltip.appendMarkdown(`#### ${l10n.t('tooltip.title')}`);
 		tooltip.appendMarkdown('\n---\n');
-		const secondaryPeriod = tooltipSecondaryPeriod(this.getStatusBarShowTokensSetting(), this.getStatusBarShowCostSetting());
-		const secondaryStats = secondaryPeriod === 'currentMonth' ? detailedStats.month : detailedStats.last30Days;
-		const secondaryLabel = secondaryPeriod === 'currentMonth' ? l10n.t('tooltip.currentMonthLabel') : l10n.t('tooltip.last30DaysLabel');
-		// Trailing &nbsp; padding on the "Today" column widens it a bit, giving the two
-		// value columns visual breathing room without VS Code table cell CSS to lean on.
-		const pad = (cell: string) => `${cell}&nbsp;&nbsp;&nbsp;&nbsp;`;
-		// Hide decimals once the rounded display value reaches 1000+ so large totals stay readable.
-		const formatUsageValue = (n: number, fractionDigits: number, unit: string) => {
-			const rounded = Math.round(n * (10 ** fractionDigits)) / (10 ** fractionDigits);
-			const format = Math.abs(rounded) >= 1000
-				? { minimumFractionDigits: 0, maximumFractionDigits: 0 }
-				: { minimumFractionDigits: fractionDigits, maximumFractionDigits: fractionDigits };
-			return `${n.toLocaleString(undefined, format)} ${unit}`;
-		};
-		const grams = (n: number) => formatUsageValue(n, 2, 'grams');
-		const liters = (n: number) => formatUsageValue(n, 3, 'liters');
-		tooltip.appendMarkdown(`|  | 📅 ${l10n.t('tooltip.todayLabel')} | 📊 ${secondaryLabel} |\n|:---|:---|:---|\n`);
-		tooltip.appendMarkdown(`| ${l10n.t('tooltip.tokensLabel')} : | ${pad(detailedStats.today.tokens.toLocaleString())} | ${secondaryStats.tokens.toLocaleString()} |\n`);
-		tooltip.appendMarkdown(`| ${l10n.t('tooltip.copilotCostLabel')} : | ${pad(`$ ${(detailedStats.today.estimatedCostCopilot ?? 0).toFixed(2)}`)} | $ ${(secondaryStats.estimatedCostCopilot ?? 0).toFixed(2)} |\n`);
-		tooltip.appendMarkdown(`| ${l10n.t('tooltip.allProvidersCostLabel')} : | ${pad(`$ ${this.sumBillingGroupCosts(detailedStats.today.billingGroupCosts).toFixed(2)}`)} | $ ${this.sumBillingGroupCosts(secondaryStats.billingGroupCosts).toFixed(2)} |\n`);
-		tooltip.appendMarkdown(`| ${l10n.t('tooltip.co2Label')} : | ${pad(grams(detailedStats.today.co2))} | ${grams(secondaryStats.co2)} |\n`);
-		tooltip.appendMarkdown(`| ${l10n.t('tooltip.waterLabel')} : | ${pad(liters(detailedStats.today.waterUsage))} | ${liters(secondaryStats.waterUsage)} |\n`);
+		tooltip.appendMarkdown(formatTooltipStatsTable(detailedStats, (costs) => this.sumBillingGroupCosts(costs)));
 		tooltip.appendMarkdown('\n---\n');
 		this.appendProviderCostSection(tooltip, detailedStats);
 		return tooltip;
@@ -3653,7 +3670,7 @@ class CopilotTokenTracker implements vscode.Disposable {
 
 	/** Sums per-provider costs into a total-across-all-providers figure. */
 	private sumBillingGroupCosts(billingGroupCosts: Record<string, number> | undefined): number {
-		return Object.values(billingGroupCosts ?? {}).reduce((s, v) => s + v, 0);
+		return defaultSumBillingGroupCosts(billingGroupCosts);
 	}
 
 	/** Builds and appends the cost sections: a GitHub Copilot budget gauge on top (spend vs.

--- a/vscode-extension/test/unit/extension-tooltipPeriod.test.ts
+++ b/vscode-extension/test/unit/extension-tooltipPeriod.test.ts
@@ -1,7 +1,150 @@
 import test from 'node:test';
 import * as assert from 'node:assert/strict';
 
-import { tooltipSecondaryPeriod, type StatusBarDisplaySetting } from '../../src/extension';
+import {
+	tooltipSecondaryPeriod,
+	formatTooltipStatsTable,
+	type StatusBarDisplaySetting
+} from '../../src/extension';
+import type { DetailedStats, PeriodStats } from '../../../src/types';
+
+function createPeriodStats(overrides: Partial<PeriodStats> = {}): PeriodStats {
+	return {
+		tokens: 0,
+		thinkingTokens: 0,
+		estimatedTokens: 0,
+		actualTokens: 0,
+		sessions: 0,
+		avgInteractionsPerSession: 0,
+		avgTokensPerSession: 0,
+		modelUsage: {},
+		editorUsage: {},
+		co2: 0,
+		treesEquivalent: 0,
+		waterUsage: 0,
+		estimatedCost: 0,
+		...overrides,
+	};
+}
+
+function createDetailedStats(overrides: {
+	today?: Partial<PeriodStats>;
+	month?: Partial<PeriodStats>;
+	lastMonth?: Partial<PeriodStats>;
+	last30Days?: Partial<PeriodStats>;
+} = {}): DetailedStats {
+	return {
+		today: createPeriodStats(overrides.today),
+		month: createPeriodStats(overrides.month),
+		lastMonth: createPeriodStats(overrides.lastMonth),
+		last30Days: createPeriodStats(overrides.last30Days),
+		lastUpdated: new Date()
+	};
+}
+
+function formatExpectedUsage(n: number, fractionDigits: number, unit: string): string {
+	const rounded = Math.round(n * (10 ** fractionDigits)) / (10 ** fractionDigits);
+	const format = Math.abs(rounded) >= 1000
+		? { minimumFractionDigits: 0, maximumFractionDigits: 0 }
+		: { minimumFractionDigits: fractionDigits, maximumFractionDigits: fractionDigits };
+	return `${n.toLocaleString(undefined, format)} ${unit}`;
+}
+
+test('formatTooltipStatsTable renders 3 columns: Today, Current Month, and Last 30 Days', () => {
+	const stats = createDetailedStats({
+		today: {
+			tokens: 44042172,
+			estimatedCostCopilot: 20.54,
+			billingGroupCosts: { 'GitHub Copilot': 20.54, 'Anthropic': 19.85 },
+			co2: 8808,
+			waterUsage: 13213
+		},
+		month: {
+			tokens: 656117347,
+			estimatedCostCopilot: 221.94,
+			billingGroupCosts: { 'GitHub Copilot': 221.94, 'Anthropic': 64.87 },
+			co2: 131223,
+			waterUsage: 196835
+		},
+		last30Days: {
+			tokens: 712000000,
+			estimatedCostCopilot: 245.50,
+			billingGroupCosts: { 'GitHub Copilot': 245.50, 'Anthropic': 70.00 },
+			co2: 142000,
+			waterUsage: 213000
+		}
+	});
+
+	const markdown = formatTooltipStatsTable(stats);
+
+	// Check table header and 4-column alignment
+	assert.ok(markdown.includes('|  | 📅 Today | 📊 Current Month | 📈 Last 30 Days |'));
+	assert.ok(markdown.includes('|:---|:---|:---|:---|'));
+
+	// Check Tokens row
+	const tToday = (44042172).toLocaleString();
+	const tMonth = (656117347).toLocaleString();
+	const t30Days = (712000000).toLocaleString();
+	assert.ok(markdown.includes(`| Tokens : | ${tToday}&nbsp;&nbsp;&nbsp;&nbsp; | ${tMonth}&nbsp;&nbsp;&nbsp;&nbsp; | ${t30Days} |`));
+
+	// Check GitHub Copilot cost row
+	assert.ok(markdown.includes('| GitHub Copilot cost : | $ 20.54&nbsp;&nbsp;&nbsp;&nbsp; | $ 221.94&nbsp;&nbsp;&nbsp;&nbsp; | $ 245.50 |'));
+
+	// Check All providers cost row (summed)
+	assert.ok(markdown.includes('| All providers cost : | $ 40.39&nbsp;&nbsp;&nbsp;&nbsp; | $ 286.81&nbsp;&nbsp;&nbsp;&nbsp; | $ 315.50 |'));
+
+	// Check CO2 estimated row (>= 1000 hides decimals)
+	const co2Today = formatExpectedUsage(8808, 2, 'grams');
+	const co2Month = formatExpectedUsage(131223, 2, 'grams');
+	const co230Days = formatExpectedUsage(142000, 2, 'grams');
+	assert.ok(markdown.includes(`| CO₂ estimated : | ${co2Today}&nbsp;&nbsp;&nbsp;&nbsp; | ${co2Month}&nbsp;&nbsp;&nbsp;&nbsp; | ${co230Days} |`));
+
+	// Check Water estimated row (>= 1000 hides decimals)
+	const waterToday = formatExpectedUsage(13213, 3, 'liters');
+	const waterMonth = formatExpectedUsage(196835, 3, 'liters');
+	const water30Days = formatExpectedUsage(213000, 3, 'liters');
+	assert.ok(markdown.includes(`| Water estimated : | ${waterToday}&nbsp;&nbsp;&nbsp;&nbsp; | ${waterMonth}&nbsp;&nbsp;&nbsp;&nbsp; | ${water30Days} |`));
+});
+
+test('formatTooltipStatsTable formats small CO2 and water values with decimals', () => {
+	const stats = createDetailedStats({
+		today: { co2: 12.345, waterUsage: 0.123 },
+		month: { co2: 99.5, waterUsage: 5.678 },
+		last30Days: { co2: 150.25, waterUsage: 12.345 }
+	});
+
+	const markdown = formatTooltipStatsTable(stats);
+
+	const co2Today = formatExpectedUsage(12.345, 2, 'grams');
+	const co2Month = formatExpectedUsage(99.5, 2, 'grams');
+	const co230Days = formatExpectedUsage(150.25, 2, 'grams');
+	assert.ok(markdown.includes(`| CO₂ estimated : | ${co2Today}&nbsp;&nbsp;&nbsp;&nbsp; | ${co2Month}&nbsp;&nbsp;&nbsp;&nbsp; | ${co230Days} |`));
+
+	const waterToday = formatExpectedUsage(0.123, 3, 'liters');
+	const waterMonth = formatExpectedUsage(5.678, 3, 'liters');
+	const water30Days = formatExpectedUsage(12.345, 3, 'liters');
+	assert.ok(markdown.includes(`| Water estimated : | ${waterToday}&nbsp;&nbsp;&nbsp;&nbsp; | ${waterMonth}&nbsp;&nbsp;&nbsp;&nbsp; | ${water30Days} |`));
+});
+
+test('formatTooltipStatsTable hides decimals when value rounds to 1000+', () => {
+	const stats = createDetailedStats({
+		today: { co2: 999.996, waterUsage: 999.9996 },
+		month: { co2: 1000, waterUsage: 1000 },
+		last30Days: { co2: 1001, waterUsage: 1001 }
+	});
+
+	const markdown = formatTooltipStatsTable(stats);
+
+	const co2Today = formatExpectedUsage(999.996, 2, 'grams');
+	const co2Month = formatExpectedUsage(1000, 2, 'grams');
+	const co230Days = formatExpectedUsage(1001, 2, 'grams');
+	assert.ok(markdown.includes(`| CO₂ estimated : | ${co2Today}&nbsp;&nbsp;&nbsp;&nbsp; | ${co2Month}&nbsp;&nbsp;&nbsp;&nbsp; | ${co230Days} |`));
+
+	const waterToday = formatExpectedUsage(999.9996, 3, 'liters');
+	const waterMonth = formatExpectedUsage(1000, 3, 'liters');
+	const water30Days = formatExpectedUsage(1001, 3, 'liters');
+	assert.ok(markdown.includes(`| Water estimated : | ${waterToday}&nbsp;&nbsp;&nbsp;&nbsp; | ${waterMonth}&nbsp;&nbsp;&nbsp;&nbsp; | ${water30Days} |`));
+});
 
 test('tooltipSecondaryPeriod: default both/none shows last30days', () => {
 	assert.equal(tooltipSecondaryPeriod('both', 'none'), 'last30days');

--- a/vscode-extension/test/unit/vscode-shim-register.ts
+++ b/vscode-extension/test/unit/vscode-shim-register.ts
@@ -332,6 +332,23 @@ function attachMock(target: any): void {
 		'aiEngineeringFluency.runLocalViewRegression',
 		'aiEngineeringFluency.generateDiagnosticReport'
 	]);
+
+	target.MarkdownString = target.MarkdownString ?? class MarkdownString {
+		value: string;
+		isTrusted: boolean = false;
+		supportThemeIcons: boolean = false;
+		constructor(value?: string) {
+			this.value = value ?? '';
+		}
+		appendMarkdown(value: string): any {
+			this.value += value;
+			return this;
+		}
+		appendText(value: string): any {
+			this.value += value;
+			return this;
+		}
+	};
 }
 
 const vscodeStub: any = {};


### PR DESCRIPTION
## Motivation

Previously, the VS Code extension's status bar hover tooltip showed a 2-column stats table with "Today" and a toggled secondary period (either "Current Month" or "Last 30 Days"). There is sufficient horizontal room in the tooltip table to display both "Current Month" and "Last 30 Days" alongside "Today", providing immediate visibility into daily, calendar-month, and trailing 30-day token usage, costs, and environmental metrics.

## Summary of Changes

- **3-column stats table**: Updated status bar tooltip table generation to render `📅 Today`, `📊 Current Month`, and `📈 Last 30 Days` side by side.
- **Extracted helper function**: Added and exported `formatTooltipStatsTable` in `vscode-extension/src/extension.ts` to keep tooltip markdown generation modular and cleanly testable.
- **Metric formatting**: Preserved existing number formatting, currency displays, and decimal-suppression boundaries (e.g. >= 1,000 grams/liters).
- **Test coverage**: Added unit tests in `vscode-extension/test/unit/extension-tooltipPeriod.test.ts` asserting 4-column structure, header alignment, row metrics, and decimal formatting. Added `MarkdownString` mock in `vscode-shim-register.ts`.
- **Compatibility**: Maintained `tooltipSecondaryPeriod` export for backward compatibility.

## Validation

- Ran `npm run test:node` (all unit tests passed, including `extension-tooltipPeriod.test.ts`).
- Ran `npm run validate` (type-check, ESLint, esbuild) with 0 errors.
- Ran `npm run check:contract` (all webview contracts verified).