### PR TITLE
Show HydraFusion leg costs in dollars, link legs to Session Steps Overview

### DIFF
--- a/.github/skills/visual-view-diff/fixtures/logviewer.json
+++ b/.github/skills/visual-view-diff/fixtures/logviewer.json
@@ -173,7 +173,7 @@
               "aiu": 11.429228
             },
             "isFinalSource": false,
-            "completedAt": "2026-09-11T09:15:02.400Z"
+            "completedAt": "2026-03-14T09:14:02.400Z"
           },
           {
             "phaseId": "fusion-a1b2c3d4:judge",
@@ -193,7 +193,7 @@
               "aiu": 0.6076
             },
             "isFinalSource": false,
-            "completedAt": "2026-09-11T09:15:03.600Z"
+            "completedAt": "2026-03-14T09:14:03.600Z"
           },
           {
             "phaseId": "fusion-a1b2c3d4:repair",
@@ -213,7 +213,7 @@
               "aiu": 180.21224
             },
             "isFinalSource": true,
-            "completedAt": "2026-09-11T09:15:06.000Z"
+            "completedAt": "2026-03-14T09:14:06.000Z"
           }
         ],
         "handoffs": [
@@ -231,8 +231,8 @@
         "aiu": 192.249068,
         "reviewAiu": 12.036828,
         "durationMs": 292424,
-        "startedAt": "2026-09-11T09:15:01.200Z",
-        "completedAt": "2026-09-11T09:15:07.200Z",
+        "startedAt": "2026-03-14T09:14:01.200Z",
+        "completedAt": "2026-03-14T09:14:07.200Z",
         "isCompound": true
       },
       {
@@ -271,7 +271,7 @@
               "aiu": 248.10442
             },
             "isFinalSource": true,
-            "completedAt": "2026-09-11T09:15:09.600Z"
+            "completedAt": "2026-03-14T09:18:02.400Z"
           },
           {
             "phaseId": "fusion-e5f6a7b8:critic",
@@ -291,7 +291,7 @@
               "aiu": 1.2841
             },
             "isFinalSource": false,
-            "completedAt": "2026-09-11T09:15:10.800Z"
+            "completedAt": "2026-03-14T09:18:03.600Z"
           }
         ],
         "handoffs": [],
@@ -303,8 +303,8 @@
         "aiu": 249.38852,
         "reviewAiu": 1.2841,
         "durationMs": 193044,
-        "startedAt": "2026-09-11T09:15:08.400Z",
-        "completedAt": "2026-09-11T09:15:12.000Z",
+        "startedAt": "2026-03-14T09:18:01.200Z",
+        "completedAt": "2026-03-14T09:18:04.800Z",
         "isCompound": true
       },
       {
@@ -341,7 +341,7 @@
               "aiu": 14.720411
             },
             "isFinalSource": true,
-            "completedAt": "2026-09-11T09:15:14.400Z"
+            "completedAt": "2026-03-14T09:22:02.400Z"
           }
         ],
         "handoffs": [],
@@ -353,8 +353,8 @@
         "aiu": 14.720411,
         "reviewAiu": 0,
         "durationMs": 22509,
-        "startedAt": "2026-09-11T09:15:13.200Z",
-        "completedAt": "2026-09-11T09:15:15.600Z",
+        "startedAt": "2026-03-14T09:22:01.200Z",
+        "completedAt": "2026-03-14T09:22:03.600Z",
         "isCompound": false
       }
     ],

--- a/src/hydrafusion.ts
+++ b/src/hydrafusion.ts
@@ -541,6 +541,20 @@ export function analyzeHydraFusionSession(content: string): HydraFusionSummary |
  * the corresponding entries out of the map rather than guessing; callers get an
  * empty map, not a wrong one.
  *
+ * Known limitation: this correlates by timestamp proximity because neither event
+ * stream carries a shared identifier — `user.message` (which becomes a `ChatTurn`)
+ * has none, and `session.fusion_resolved`'s own `turnId` has nothing on the chat
+ * side to match against. So if the chat turn that actually triggered a fusion
+ * resolution is missing from `chatTurns` entirely (e.g. it was dropped during
+ * turn extraction upstream, not a case this function can detect), that fusion
+ * turn's legs attach to whichever earlier chat turn happens to precede it instead
+ * — a real turn just never routed through HydraFusion is handled correctly (see
+ * the "skips a chat turn a non-fusion model handled" test), but a turn missing
+ * outright is not distinguishable from one. Fixing that would mean threading a
+ * shared id (e.g. `assistant.turn_start`/`turn_end`'s `turnId`) through `ChatTurn`
+ * itself, which is a larger change to the canonical turn model shared by every
+ * consumer — out of scope for what is otherwise a display-only feature.
+ *
  * @returns Map from fusion turn index (into `hydraTurns`) to the matching chat
  *   turn's `turnNumber`.
  */

--- a/src/hydrafusion.ts
+++ b/src/hydrafusion.ts
@@ -232,6 +232,19 @@ export function nanoAiuToAiu(nanoAiu: unknown): number {
 	return asNumber(nanoAiu) / NANO_AIU_PER_AIU;
 }
 
+/**
+ * AI credits convert to USD at a fixed, documented rate — see `monthlyAiCreditsUsd`
+ * in `vscode-extension/src/copilotPlans.json`: "1 AI credit = $0.01". This is GitHub's
+ * own conversion, not an estimate, so it applies uniformly regardless of which model
+ * served a leg.
+ */
+const USD_PER_AIU = 0.01;
+
+/** Converts AIU credits (already divided from nano-AIU) into a USD amount for display. */
+export function aiuToUsd(aiu: number): number {
+	return aiu * USD_PER_AIU;
+}
+
 function parseUsage(raw: unknown): HydraFusionUsage {
 	const u = asRecord(raw) ?? {};
 	return {
@@ -510,4 +523,45 @@ export function analyzeHydraFusionSession(content: string): HydraFusionSummary |
 		degradedTurns: turns.filter(t => t.degradedReason !== null).length,
 		syntheticModel,
 	};
+}
+
+/**
+ * Correlates each fusion turn with the chat turn (`ChatTurn.turnNumber`) whose user
+ * prompt triggered it, so per-leg detail can be shown inline in the generic turns
+ * table instead of only in the dedicated HydraFusion section.
+ *
+ * Both sequences are chronologically ordered — chat turns by `turnNumber`, fusion
+ * turns by the order the router resolved them — so a single forward merge suffices:
+ * for each fusion turn, advance through chat turns while their timestamp is at or
+ * before the fusion turn's routing decision (`startedAt`). The last chat turn
+ * advanced past is the one whose prompt the router was resolving; turns the router
+ * never got to (a later prompt, or one where routing was skipped) are left unmatched.
+ *
+ * A missing timestamp on either side — or a session with no fusion turns — leaves
+ * the corresponding entries out of the map rather than guessing; callers get an
+ * empty map, not a wrong one.
+ *
+ * @returns Map from fusion turn index (into `hydraTurns`) to the matching chat
+ *   turn's `turnNumber`.
+ */
+export function matchHydraFusionTurnsToChatTurns(
+	chatTurns: { turnNumber: number; timestamp: string | null }[],
+	hydraTurns: HydraFusionTurn[],
+): Map<number, number> {
+	const matches = new Map<number, number>();
+	let chatIndex = 0;
+	for (let h = 0; h < hydraTurns.length; h++) {
+		const startedAt = hydraTurns[h].startedAt ? Date.parse(hydraTurns[h].startedAt!) : NaN;
+		if (Number.isNaN(startedAt)) { continue; }
+
+		let matchedTurnNumber: number | null = null;
+		while (chatIndex < chatTurns.length) {
+			const ts = chatTurns[chatIndex].timestamp ? Date.parse(chatTurns[chatIndex].timestamp!) : NaN;
+			if (Number.isNaN(ts) || ts > startedAt) { break; }
+			matchedTurnNumber = chatTurns[chatIndex].turnNumber;
+			chatIndex++;
+		}
+		if (matchedTurnNumber !== null) { matches.set(h, matchedTurnNumber); }
+	}
+	return matches;
 }

--- a/src/hydrafusion.ts
+++ b/src/hydrafusion.ts
@@ -30,6 +30,8 @@
  * https://github.com/samueltauil/hydrafusion-traces (docs/SPIKE.md).
  */
 
+import { NANO_AIU_TO_DOLLARS } from './tokenEstimation';
+
 /** Nano-AIU per AIU — the CLI reports credits scaled by 1e9 to keep them integral. */
 const NANO_AIU_PER_AIU = 1_000_000_000;
 
@@ -233,16 +235,19 @@ export function nanoAiuToAiu(nanoAiu: unknown): number {
 }
 
 /**
- * AI credits convert to USD at a fixed, documented rate — see `monthlyAiCreditsUsd`
- * in `vscode-extension/src/copilotPlans.json`: "1 AI credit = $0.01". This is GitHub's
- * own conversion, not an estimate, so it applies uniformly regardless of which model
- * served a leg.
+ * AIU-to-USD rate, derived from the repo's one canonical nano-AIU-to-dollars rate
+ * (`NANO_AIU_TO_DOLLARS` in `tokenEstimation.ts`, applied elsewhere to
+ * `session.shutdown.totalNanoAiu`) rather than a second hard-coded constant here.
+ * `NANO_AIU_PER_AIU * NANO_AIU_TO_DOLLARS` is the same $0.01-per-credit rate GitHub
+ * documents in `copilotPlans.json`'s `monthlyAiCreditsUsd` note ("1 AI credit =
+ * $0.01") — computed once as its own factor, rather than inline in `aiuToUsd` below,
+ * so the multiplication order doesn't reintroduce floating-point noise per call.
  */
-const USD_PER_AIU = 0.01;
+const AIU_TO_USD_RATE = NANO_AIU_PER_AIU * NANO_AIU_TO_DOLLARS;
 
 /** Converts AIU credits (already divided from nano-AIU) into a USD amount for display. */
 export function aiuToUsd(aiu: number): number {
-	return aiu * USD_PER_AIU;
+	return aiu * AIU_TO_USD_RATE;
 }
 
 function parseUsage(raw: unknown): HydraFusionUsage {
@@ -571,7 +576,11 @@ export function matchHydraFusionTurnsToChatTurns(
 		let matchedTurnNumber: number | null = null;
 		while (chatIndex < chatTurns.length) {
 			const ts = chatTurns[chatIndex].timestamp ? Date.parse(chatTurns[chatIndex].timestamp!) : NaN;
-			if (Number.isNaN(ts) || ts > startedAt) { break; }
+			// An unusable timestamp can never be a match for *any* fusion turn, but it must not
+			// get stuck as the loop's position either — skip it permanently so later, well-formed
+			// chat turns stay reachable by this and every subsequent fusion turn.
+			if (Number.isNaN(ts)) { chatIndex++; continue; }
+			if (ts > startedAt) { break; }
 			matchedTurnNumber = chatTurns[chatIndex].turnNumber;
 			chatIndex++;
 		}

--- a/vscode-extension/src/webview/logviewer/hydraFusionSection.ts
+++ b/vscode-extension/src/webview/logviewer/hydraFusionSection.ts
@@ -267,13 +267,16 @@ export function renderLegsTable(phases: HydraFusionPhase[]): string {
  *   when `matchHydraFusionTurnsToChatTurns` could place this turn — renders a link
  *   that scrolls to and expands that row so the same leg detail can be reached from
  *   either place. `null` when no match was found (e.g. the chat turn carries no
- *   timestamp), in which case the link is simply omitted.
+ *   timestamp), in which case the link is simply omitted — as it also is when the
+ *   turn has no completed phases yet (an in-flight turn): the overview row has
+ *   nothing to expand, so a link there would promise detail it can't deliver.
  */
 export function renderTurnRow(turn: HydraFusionTurn, index: number, chatTurnNumber: number | null = null): string {
 	const plan = turn.plannedPhases.length > 0 ? turn.plannedPhases.join(' › ') : null;
 	const skipped = plan && turn.plannedPhases.length > turn.phases.length
 		? ` (${turn.plannedPhases.length - turn.phases.length} planned leg${turn.plannedPhases.length - turn.phases.length === 1 ? '' : 's'} never ran)`
 		: '';
+	const canJumpToStep = chatTurnNumber !== null && turn.phases.length > 0;
 
 	return `<details class="hydra-turn">
 <summary class="hydra-turn-summary">
@@ -284,7 +287,7 @@ export function renderTurnRow(turn: HydraFusionTurn, index: number, chatTurnNumb
 <span title="Credits for this turn"><strong>${escapeHtml(formatFusionCost(turn.aiu))}</strong></span>
 <span title="Wall-clock time for the whole turn">${escapeHtml(formatFusionDuration(turn.durationMs))}</span>
 <span title="Router hops in this turn">${turn.phases.length} leg${turn.phases.length === 1 ? '' : 's'}</span>
-${chatTurnNumber !== null ? `<span class="hydra-jump-to-step" data-turn="${chatTurnNumber}" title="Jump to step #${chatTurnNumber} in the Session Steps Overview below" role="button" tabindex="0">⤵ step #${chatTurnNumber}</span>` : ''}
+${canJumpToStep ? `<span class="hydra-jump-to-step" data-turn="${chatTurnNumber}" title="Jump to step #${chatTurnNumber} in the Session Steps Overview below" role="button" tabindex="0">⤵ step #${chatTurnNumber}</span>` : ''}
 </span>
 </summary>
 <div class="hydra-turn-body">

--- a/vscode-extension/src/webview/logviewer/hydraFusionSection.ts
+++ b/vscode-extension/src/webview/logviewer/hydraFusionSection.ts
@@ -9,7 +9,8 @@
 // @security every model id, pattern, verdict and phase kind originates from the session
 // file and is therefore untrusted; all of them go through `escapeHtml` before rendering.
 
-import { escapeHtml, formatCompact, formatFixed, formatPercent } from '../shared/formatUtils';
+import { escapeHtml, formatCompact, formatCost, formatPercent } from '../shared/formatUtils';
+import { aiuToUsd } from '../../../../src/hydrafusion';
 import type {
 	HydraFusionPhase,
 	HydraFusionSummary,
@@ -45,14 +46,9 @@ function patternTitle(pattern: string): string {
 	return PATTERN_META[pattern]?.title ?? 'Routing pattern reported by the CLI';
 }
 
-/**
- * Formats AI credit units for display.
- *
- * Small turns routinely cost well under one credit, so two decimals are kept until the
- * number is large enough that they stop carrying information.
- */
-export function formatAiu(value: number): string {
-	return formatFixed(value, Math.abs(value) >= 100 ? 1 : 2);
+/** Formats AIU credits as the USD cost shown everywhere else in the app. */
+export function formatFusionCost(aiu: number): string {
+	return formatCost(aiuToUsd(aiu));
 }
 
 /**
@@ -105,14 +101,14 @@ function renderHeadlineCards(summary: HydraFusionSummary): string {
 
 	cards.push(renderCard(
 		'🔍', 'Review share', formatPercent(summary.reviewSharePercent),
-		`${formatAiu(summary.reviewAiu)} of ${formatAiu(summary.totalAiu)} AIU`,
+		`${formatFusionCost(summary.reviewAiu)} of ${formatFusionCost(summary.totalAiu)}`,
 		'Share of the bill spent on legs that did not supply the final answer — reviews and superseded drafts. Those legs still sit in the final leg\'s context, so this is the cost of review rather than waste.',
 	));
 
 	cards.push(renderCard(
-		'💳', 'Credits', `${formatAiu(summary.totalAiu)} AIU`,
+		'💳', 'Credits', formatFusionCost(summary.totalAiu),
 		`${summary.totalLegs} legs · ${summary.totalRequestCount} inference calls`,
-		'AI credit units reported by the CLI itself, summed from each turn\'s rollup. Legs are router hops; inference calls are model round trips across all of them.',
+		'Cost of the AI credits the CLI itself reported (1 credit = $0.01), summed from each turn\'s rollup. Legs are router hops; inference calls are model round trips across all of them.',
 	));
 
 	cards.push(renderCard(
@@ -145,7 +141,7 @@ function renderHeadlineCards(summary: HydraFusionSummary): string {
 /** The pattern mix as pills — which execution shapes the router chose, and what each cost. */
 function renderPatternPills(summary: HydraFusionSummary): string {
 	const pills = summary.patternCounts.map(p => `<span class="hydra-pattern-pill ${patternClass(p.pattern)}" title="${escapeHtml(patternTitle(p.pattern))}">
-${escapeHtml(p.pattern)} <strong>${p.turns}</strong> <span class="hydra-pattern-pill-aiu">${escapeHtml(formatAiu(p.aiu))} AIU</span>
+${escapeHtml(p.pattern)} <strong>${p.turns}</strong> <span class="hydra-pattern-pill-aiu">${escapeHtml(formatFusionCost(p.aiu))}</span>
 </span>`).join('');
 	return `<div class="hydra-pattern-row"><span class="hydra-pattern-row-label">Patterns chosen</span>${pills}</div>`;
 }
@@ -157,7 +153,7 @@ function renderModelTable(summary: HydraFusionSummary): string {
 <td class="hydra-model-cell"><span class="hydra-model-name">${escapeHtml(m.model)}</span></td>
 <td class="hydra-num">${m.legs}</td>
 <td class="hydra-num" title="Turns where this model supplied the answer you saw">${m.finalAnswers}</td>
-<td class="hydra-num"><strong>${escapeHtml(formatAiu(m.aiu))}</strong></td>
+<td class="hydra-num"><strong>${escapeHtml(formatFusionCost(m.aiu))}</strong></td>
 <td class="hydra-bar-cell"><span class="hydra-bar" style="width:${barWidthPercent(m.aiu, maxAiu).toFixed(1)}%"></span></td>
 <td class="hydra-num">${formatCompact(m.inputTokens)}</td>
 <td class="hydra-num">${formatCompact(m.outputTokens)}</td>
@@ -171,7 +167,7 @@ function renderModelTable(summary: HydraFusionSummary): string {
 <th scope="col">Model</th>
 <th scope="col" title="Router hops this model served">Legs</th>
 <th scope="col" title="Turns where this model produced the final answer">Answers</th>
-<th scope="col">AIU</th>
+<th scope="col">Cost</th>
 <th scope="col"><span class="hydra-sr-only">Share of credits</span></th>
 <th scope="col">Input</th>
 <th scope="col">Output</th>
@@ -189,7 +185,7 @@ function renderPhaseLedger(summary: HydraFusionSummary): string {
 		return `<tr>
 <td><span class="hydra-phase-badge ${meta.cssClass}">${meta.icon} ${escapeHtml(p.kind)}</span></td>
 <td class="hydra-num">${p.legs}</td>
-<td class="hydra-num"><strong>${escapeHtml(formatAiu(p.aiu))}</strong></td>
+<td class="hydra-num"><strong>${escapeHtml(formatFusionCost(p.aiu))}</strong></td>
 <td class="hydra-bar-cell"><span class="hydra-bar ${meta.cssClass}" style="width:${barWidthPercent(p.aiu, maxAiu).toFixed(1)}%"></span></td>
 </tr>`;
 	}).join('');
@@ -201,7 +197,7 @@ function renderPhaseLedger(summary: HydraFusionSummary): string {
 <thead><tr>
 <th scope="col">Phase</th>
 <th scope="col">Legs</th>
-<th scope="col">AIU</th>
+<th scope="col">Cost</th>
 <th scope="col"><span class="hydra-sr-only">Share of credits</span></th>
 </tr></thead>
 <tbody>${rows}</tbody>
@@ -216,7 +212,7 @@ function renderModelChain(turn: HydraFusionTurn): string {
 			: p.verdict === 'accept' ? '<span class="hydra-verdict-accept" title="Judge accepted this draft">✓</span>'
 			: '';
 		const finalMark = p.isFinalSource ? '<span class="hydra-final-dot" title="This leg produced the answer you saw">●</span>' : '';
-		return `<span class="hydra-chain-item ${phaseMeta(p.kind).cssClass}" title="${escapeHtml(`${p.kind} · ${p.model} · ${formatAiu(p.usage.aiu)} AIU`)}">${escapeHtml(p.model)}${verdictMark}${finalMark}</span>`;
+		return `<span class="hydra-chain-item ${phaseMeta(p.kind).cssClass}" title="${escapeHtml(`${p.kind} · ${p.model} · ${formatFusionCost(p.usage.aiu)}`)}">${escapeHtml(p.model)}${verdictMark}${finalMark}</span>`;
 	}).join('<span class="hydra-chain-arrow">→</span>');
 }
 
@@ -235,14 +231,45 @@ function renderLegRow(phase: HydraFusionPhase, maxDurationMs: number): string {
 <td class="hydra-num">${phase.usage.requestCount}</td>
 <td class="hydra-num">${formatCompact(phase.usage.inputTokens)}</td>
 <td class="hydra-num">${formatCompact(phase.usage.outputTokens)}</td>
-<td class="hydra-num"><strong>${escapeHtml(formatAiu(phase.usage.aiu))}</strong></td>
+<td class="hydra-num"><strong>${escapeHtml(formatFusionCost(phase.usage.aiu))}</strong></td>
 </tr>`;
 }
 
-/** One collapsed turn row that expands into its leg-by-leg waterfall. */
-export function renderTurnRow(turn: HydraFusionTurn, index: number): string {
-	const maxDurationMs = Math.max(...turn.phases.map(p => p.durationMs), 0);
-	const legs = turn.phases.map(p => renderLegRow(p, maxDurationMs)).join('');
+/**
+ * The leg-by-leg waterfall for one turn: phase, model, verdict, duration and cost.
+ * Exported so the Session Steps Overview table (main.ts) can embed the exact same
+ * table under a matching turn's row instead of re-deriving its own — see
+ * `matchHydraFusionTurnsToChatTurns` in src/hydrafusion.ts for how rows are matched.
+ */
+export function renderLegsTable(phases: HydraFusionPhase[]): string {
+	const maxDurationMs = Math.max(...phases.map(p => p.durationMs), 0);
+	const legs = phases.map(p => renderLegRow(p, maxDurationMs)).join('');
+	return `<table class="hydra-table hydra-legs-table">
+<thead><tr>
+<th scope="col">Phase</th>
+<th scope="col">Model</th>
+<th scope="col">Verdict</th>
+<th scope="col">Duration</th>
+<th scope="col"><span class="hydra-sr-only">Relative duration</span></th>
+<th scope="col" title="Inference calls this leg made">Calls</th>
+<th scope="col">Input</th>
+<th scope="col">Output</th>
+<th scope="col">Cost</th>
+</tr></thead>
+<tbody>${legs}</tbody>
+</table>`;
+}
+
+/**
+ * One collapsed turn row that expands into its leg-by-leg waterfall.
+ *
+ * @param chatTurnNumber The matching row in the Session Steps Overview table below,
+ *   when `matchHydraFusionTurnsToChatTurns` could place this turn — renders a link
+ *   that scrolls to and expands that row so the same leg detail can be reached from
+ *   either place. `null` when no match was found (e.g. the chat turn carries no
+ *   timestamp), in which case the link is simply omitted.
+ */
+export function renderTurnRow(turn: HydraFusionTurn, index: number, chatTurnNumber: number | null = null): string {
 	const plan = turn.plannedPhases.length > 0 ? turn.plannedPhases.join(' › ') : null;
 	const skipped = plan && turn.plannedPhases.length > turn.phases.length
 		? ` (${turn.plannedPhases.length - turn.phases.length} planned leg${turn.plannedPhases.length - turn.phases.length === 1 ? '' : 's'} never ran)`
@@ -254,28 +281,16 @@ export function renderTurnRow(turn: HydraFusionTurn, index: number): string {
 <span class="hydra-pattern-badge ${patternClass(turn.pattern)}" title="${escapeHtml(patternTitle(turn.pattern))}">${escapeHtml(turn.pattern)}</span>
 <span class="hydra-turn-chain">${renderModelChain(turn)}</span>
 <span class="hydra-turn-metrics">
-<span title="Credits for this turn"><strong>${escapeHtml(formatAiu(turn.aiu))}</strong> AIU</span>
+<span title="Credits for this turn"><strong>${escapeHtml(formatFusionCost(turn.aiu))}</strong></span>
 <span title="Wall-clock time for the whole turn">${escapeHtml(formatFusionDuration(turn.durationMs))}</span>
 <span title="Router hops in this turn">${turn.phases.length} leg${turn.phases.length === 1 ? '' : 's'}</span>
+${chatTurnNumber !== null ? `<span class="hydra-jump-to-step" data-turn="${chatTurnNumber}" title="Jump to step #${chatTurnNumber} in the Session Steps Overview below" role="button" tabindex="0">⤵ step #${chatTurnNumber}</span>` : ''}
 </span>
 </summary>
 <div class="hydra-turn-body">
 ${plan ? `<div class="hydra-turn-plan">Planned: <code>${escapeHtml(plan)}</code>${escapeHtml(skipped)}</div>` : ''}
 ${turn.degradedReason ? `<div class="hydra-turn-degraded">⚠️ Degraded: ${escapeHtml(turn.degradedReason)}</div>` : ''}
-<table class="hydra-table hydra-legs-table">
-<thead><tr>
-<th scope="col">Phase</th>
-<th scope="col">Model</th>
-<th scope="col">Verdict</th>
-<th scope="col">Duration</th>
-<th scope="col"><span class="hydra-sr-only">Relative duration</span></th>
-<th scope="col" title="Inference calls this leg made">Calls</th>
-<th scope="col">Input</th>
-<th scope="col">Output</th>
-<th scope="col">AIU</th>
-</tr></thead>
-<tbody>${legs}</tbody>
-</table>
+${renderLegsTable(turn.phases)}
 </div>
 </details>`;
 }
@@ -283,8 +298,13 @@ ${turn.degradedReason ? `<div class="hydra-turn-degraded">⚠️ Degraded: ${esc
 /**
  * Renders the whole HydraFusion section, or an empty string when the session never
  * routed through it — which is the case for every session except HydraFusion CLI ones.
+ *
+ * @param chatTurnMatches Fusion turn index → matching `ChatTurn.turnNumber`, from
+ *   `matchHydraFusionTurnsToChatTurns`. Optional so direct callers (and existing
+ *   tests) can render the section on its own; omitting it just drops the
+ *   "jump to step" links from each turn row.
  */
-export function renderHydraFusionSection(summary: HydraFusionSummary | undefined): string {
+export function renderHydraFusionSection(summary: HydraFusionSummary | undefined, chatTurnMatches?: Map<number, number>): string {
 	if (!summary || summary.totalTurns === 0) { return ''; }
 
 	const modelCount = summary.models.length;
@@ -304,8 +324,8 @@ ${renderPhaseLedger(summary)}
 </div>
 <div class="hydra-panel hydra-turns-panel">
 <div class="hydra-panel-title">🧩 One turn in detail</div>
-<div class="hydra-panel-sub">Expand a turn to see each leg, what it decided, and what it cost. ● marks the leg whose output you actually received; ✗ marks a leg a judge rejected.</div>
-<div class="hydra-turns">${summary.turns.map((t, i) => renderTurnRow(t, i)).join('')}</div>
+<div class="hydra-panel-sub">Expand a turn to see each leg, what it decided, and what it cost. ● marks the leg whose output you actually received; ✗ marks a leg a judge rejected. The same legs also appear under their step in the Session Steps Overview below.</div>
+<div class="hydra-turns">${summary.turns.map((t, i) => renderTurnRow(t, i, chatTurnMatches?.get(i) ?? null)).join('')}</div>
 </div>
 </div>`;
 }

--- a/vscode-extension/src/webview/logviewer/hydraFusionSection.ts
+++ b/vscode-extension/src/webview/logviewer/hydraFusionSection.ts
@@ -106,7 +106,7 @@ function renderHeadlineCards(summary: HydraFusionSummary): string {
 	));
 
 	cards.push(renderCard(
-		'💳', 'Credits', formatFusionCost(summary.totalAiu),
+		'💳', 'Cost', formatFusionCost(summary.totalAiu),
 		`${summary.totalLegs} legs · ${summary.totalRequestCount} inference calls`,
 		'Cost of the AI credits the CLI itself reported (1 credit = $0.01), summed from each turn\'s rollup. Legs are router hops; inference calls are model round trips across all of them.',
 	));
@@ -284,7 +284,7 @@ export function renderTurnRow(turn: HydraFusionTurn, index: number, chatTurnNumb
 <span class="hydra-pattern-badge ${patternClass(turn.pattern)}" title="${escapeHtml(patternTitle(turn.pattern))}">${escapeHtml(turn.pattern)}</span>
 <span class="hydra-turn-chain">${renderModelChain(turn)}</span>
 <span class="hydra-turn-metrics">
-<span title="Credits for this turn"><strong>${escapeHtml(formatFusionCost(turn.aiu))}</strong></span>
+<span title="Cost for this turn"><strong>${escapeHtml(formatFusionCost(turn.aiu))}</strong></span>
 <span title="Wall-clock time for the whole turn">${escapeHtml(formatFusionDuration(turn.durationMs))}</span>
 <span title="Router hops in this turn">${turn.phases.length} leg${turn.phases.length === 1 ? '' : 's'}</span>
 ${canJumpToStep ? `<span class="hydra-jump-to-step" data-turn="${chatTurnNumber}" title="Jump to step #${chatTurnNumber} in the Session Steps Overview below" role="button" tabindex="0">⤵ step #${chatTurnNumber}</span>` : ''}

--- a/vscode-extension/src/webview/logviewer/main.ts
+++ b/vscode-extension/src/webview/logviewer/main.ts
@@ -5,9 +5,9 @@ import { escapeHtml, formatCompact, formatCost, formatFileSize, setCompactNumber
 import { getModelDisplayName } from '../../../../src/webview/shared/modelUtils';
 import type { McpToolUsage, ModeUsage, ToolCallUsage } from '../shared/types';
 import { buildTurnOverviewRows, hashModelToHue } from './turnsOverview';
-import { renderHydraFusionSection, renderLegsTable } from './hydraFusionSection';
+import { renderHydraFusionSection, renderLegsTable, formatFusionCost } from './hydraFusionSection';
 import { matchHydraFusionTurnsToChatTurns } from '../../../../src/hydrafusion';
-import type { HydraFusionPhase, HydraFusionSummary } from '../../../../src/hydrafusion';
+import type { HydraFusionSummary, HydraFusionTurn } from '../../../../src/hydrafusion';
 // CSS imported as text via esbuild
 import themeStyles from '../shared/theme.css';
 import styles from './styles.css';
@@ -1102,14 +1102,18 @@ function renderTurnsOverviewTable(data: SessionLogData, hydraTurnMatches?: Map<n
 	const hasLegs = rows.some(r => r.legs.length > 0);
 	const columnCount = 7 + (hasCached ? 1 : 0) + (hasCost ? 1 : 0);
 
-	// Reverse-map chat turn number → this turn's raw HydraFusion phases, so an
-	// expanded row can reuse the exact same leg table the HydraFusion section
-	// renders above, instead of re-deriving markup from the trimmed TurnOverviewLegRow.
-	const legPhasesByTurn = new Map<number, HydraFusionPhase[]>();
+	// Reverse-map chat turn number → this turn's matched HydraFusionTurn, so an expanded
+	// row can reuse the exact same leg table the HydraFusion section renders above
+	// (instead of re-deriving markup from the trimmed TurnOverviewLegRow) and show the
+	// same total: the turn's own rollup `aiu`, not a sum of the legs' individual costs,
+	// which `analyzeHydraFusionSession` can legitimately differ from (it prefers
+	// `session.fusion_completed.totalNanoAiu` and only falls back to summing legs when
+	// that rollup is missing — see buildTurn in src/hydrafusion.ts).
+	const hydraTurnByChatTurn = new Map<number, HydraFusionTurn>();
 	if (data.hydraFusion && hydraTurnMatches) {
 		for (const [hydraIndex, chatTurnNumber] of hydraTurnMatches) {
-			const phases = data.hydraFusion.turns[hydraIndex]?.phases;
-			if (phases) { legPhasesByTurn.set(chatTurnNumber, phases); }
+			const hydraTurn = data.hydraFusion.turns[hydraIndex];
+			if (hydraTurn) { hydraTurnByChatTurn.set(chatTurnNumber, hydraTurn); }
 		}
 	}
 
@@ -1132,12 +1136,13 @@ ${costCell(child.cost)}
 		const legToggle = row.legs.length > 0
 			? `<button type="button" class="turns-overview-leg-toggle" data-turn="${row.turnNumber}" aria-expanded="false" aria-label="Toggle HydraFusion legs for step #${row.turnNumber}" title="Show the HydraFusion legs behind this step">▸</button> `
 			: '';
-		const legsRow = row.legs.length > 0
+		const hydraTurn = hydraTurnByChatTurn.get(row.turnNumber);
+		const legsRow = row.legs.length > 0 && hydraTurn
 			? `<tr class="turns-overview-legs-row" data-parent-turn="${row.turnNumber}" style="display: none;">
 <td colspan="${columnCount}">
 <div class="turns-overview-legs-wrap">
-<div class="turns-overview-legs-caption">⚡ HydraFusion legs for step #${row.turnNumber} — total <strong>${escapeHtml(formatCost(row.legs.reduce((s, l) => s + l.costUsd, 0)))}</strong></div>
-${renderLegsTable(legPhasesByTurn.get(row.turnNumber) ?? [])}
+<div class="turns-overview-legs-caption">⚡ HydraFusion legs for step #${row.turnNumber} — total <strong>${escapeHtml(formatFusionCost(hydraTurn.aiu))}</strong></div>
+${renderLegsTable(hydraTurn.phases)}
 </div>
 </td>
 </tr>`

--- a/vscode-extension/src/webview/logviewer/main.ts
+++ b/vscode-extension/src/webview/logviewer/main.ts
@@ -1130,7 +1130,7 @@ ${costCell(child.cost)}
 <td class="turns-overview-actual" title="Estimated from text">~</td>
 </tr>`).join('');
 		const legToggle = row.legs.length > 0
-			? `<button type="button" class="turns-overview-leg-toggle" data-turn="${row.turnNumber}" aria-expanded="false" title="Show the HydraFusion legs behind this step">▸</button> `
+			? `<button type="button" class="turns-overview-leg-toggle" data-turn="${row.turnNumber}" aria-expanded="false" aria-label="Toggle HydraFusion legs for step #${row.turnNumber}" title="Show the HydraFusion legs behind this step">▸</button> `
 			: '';
 		const legsRow = row.legs.length > 0
 			? `<tr class="turns-overview-legs-row" data-parent-turn="${row.turnNumber}" style="display: none;">

--- a/vscode-extension/src/webview/logviewer/main.ts
+++ b/vscode-extension/src/webview/logviewer/main.ts
@@ -5,8 +5,9 @@ import { escapeHtml, formatCompact, formatCost, formatFileSize, setCompactNumber
 import { getModelDisplayName } from '../../../../src/webview/shared/modelUtils';
 import type { McpToolUsage, ModeUsage, ToolCallUsage } from '../shared/types';
 import { buildTurnOverviewRows, hashModelToHue } from './turnsOverview';
-import { renderHydraFusionSection } from './hydraFusionSection';
-import type { HydraFusionSummary } from '../../../../src/hydrafusion';
+import { renderHydraFusionSection, renderLegsTable } from './hydraFusionSection';
+import { matchHydraFusionTurnsToChatTurns } from '../../../../src/hydrafusion';
+import type { HydraFusionPhase, HydraFusionSummary } from '../../../../src/hydrafusion';
 // CSS imported as text via esbuild
 import themeStyles from '../shared/theme.css';
 import styles from './styles.css';
@@ -1084,14 +1085,33 @@ function renderModelOverviewBadge(model: string | null): string {
  * at a glance without opening every turn card. A row's model badge differing
  * from the one above it is flagged with ⇄ to spot model switches quickly.
  * Clicking a row scrolls to and briefly highlights the matching turn card.
+ *
+ * When a turn was routed through HydraFusion (`hydraTurnMatches` places it), its
+ * row also gets a ⚡ toggle that expands the same leg-by-leg table shown in the
+ * HydraFusion section above — see `matchHydraFusionTurnsToChatTurns`. This is the
+ * only difference from a plain session's table: everything else here runs exactly
+ * as before for the overwhelming majority of sessions, which never used the router.
  */
-function renderTurnsOverviewTable(data: SessionLogData): string {
+function renderTurnsOverviewTable(data: SessionLogData, hydraTurnMatches?: Map<number, number>): string {
 	if (data.turns.length === 0) { return ''; }
-	const rows = buildTurnOverviewRows(data.turns);
+	const rows = buildTurnOverviewRows(data.turns, data.hydraFusion, hydraTurnMatches);
 	const hasCached = rows.some(r => r.cached !== null);
 	const hasModelSwitches = rows.some((r, i) => i > 0 && r.model && rows[i - 1].model && r.model !== rows[i - 1].model);
 	const hasCost = rows.some(r => r.cost !== null || r.children.some(c => c.cost !== null));
 	const totalChildren = rows.reduce((sum, r) => sum + r.children.length, 0);
+	const hasLegs = rows.some(r => r.legs.length > 0);
+	const columnCount = 7 + (hasCached ? 1 : 0) + (hasCost ? 1 : 0);
+
+	// Reverse-map chat turn number → this turn's raw HydraFusion phases, so an
+	// expanded row can reuse the exact same leg table the HydraFusion section
+	// renders above, instead of re-deriving markup from the trimmed TurnOverviewLegRow.
+	const legPhasesByTurn = new Map<number, HydraFusionPhase[]>();
+	if (data.hydraFusion && hydraTurnMatches) {
+		for (const [hydraIndex, chatTurnNumber] of hydraTurnMatches) {
+			const phases = data.hydraFusion.turns[hydraIndex]?.phases;
+			if (phases) { legPhasesByTurn.set(chatTurnNumber, phases); }
+		}
+	}
 
 	const costCell = (cost: number | null): string => hasCost ? `<td class="count-cell">${cost !== null ? formatCost(cost) : '—'}</td>` : '';
 
@@ -1109,8 +1129,21 @@ ${hasCached ? '<td class="count-cell">—</td>' : ''}
 ${costCell(child.cost)}
 <td class="turns-overview-actual" title="Estimated from text">~</td>
 </tr>`).join('');
+		const legToggle = row.legs.length > 0
+			? `<button type="button" class="turns-overview-leg-toggle" data-turn="${row.turnNumber}" aria-expanded="false" title="Show the HydraFusion legs behind this step">▸</button> `
+			: '';
+		const legsRow = row.legs.length > 0
+			? `<tr class="turns-overview-legs-row" data-parent-turn="${row.turnNumber}" style="display: none;">
+<td colspan="${columnCount}">
+<div class="turns-overview-legs-wrap">
+<div class="turns-overview-legs-caption">⚡ HydraFusion legs for step #${row.turnNumber} — total <strong>${escapeHtml(formatCost(row.legs.reduce((s, l) => s + l.costUsd, 0)))}</strong></div>
+${renderLegsTable(legPhasesByTurn.get(row.turnNumber) ?? [])}
+</div>
+</td>
+</tr>`
+			: '';
 		return `<tr class="turns-overview-row${switched ? ' turns-overview-row-switch' : ''}" data-turn="${row.turnNumber}" title="Jump to turn #${row.turnNumber}">
-<td class="turns-overview-num">#${row.turnNumber}${switched ? ' <span class="overview-switch-icon" title="Model changed from the previous step">⇄</span>' : ''}</td>
+<td class="turns-overview-num">${legToggle}#${row.turnNumber}${switched ? ' <span class="overview-switch-icon" title="Model changed from the previous step">⇄</span>' : ''}</td>
 <td><span class="turn-mode" style="background: ${getModeColor(row.mode)};">${getModeIcon(row.mode)} ${escapeHtml(row.mode)}</span></td>
 <td>${renderModelOverviewBadge(row.model)}</td>
 <td class="count-cell">${formatCompact(row.input)}</td>
@@ -1119,7 +1152,7 @@ ${cachedCell}
 <td class="count-cell"><strong>${formatCompact(row.total)}</strong></td>
 ${costCell(row.cost)}
 <td class="turns-overview-actual" title="${row.isActual ? 'Actual API usage' : 'Estimated from text'}">${row.isActual ? '✓' : '~'}</td>
-</tr>${childRows}`;
+</tr>${childRows}${legsRow}`;
 	}).join('');
 
 	return `
@@ -1128,6 +1161,7 @@ ${costCell(row.cost)}
 <span>🧭 Session Steps Overview (${rows.length})</span>
 ${hasModelSwitches ? '<span class="overview-switch-note">⇄ marks a model change from the previous step</span>' : ''}
 ${totalChildren > 0 ? `<span class="overview-switch-note">🤖 ↳ marks a sub-agent/child session delegated from that step</span>` : ''}
+${hasLegs ? '<span class="overview-switch-note">⚡ expand a step to see the HydraFusion legs behind it</span>' : ''}
 </div>
 <div class="turns-overview-table-wrap">
 <table class="turns-overview-table">
@@ -1218,12 +1252,43 @@ e.preventDefault();
 });
 }
 
-/** Clicking a turns-overview row jumps to and briefly highlights the matching turn card. */
+/**
+ * Clicking a turns-overview row jumps to and briefly highlights the matching turn card.
+ * A row with HydraFusion legs also gets a ▸ toggle that expands them in place — its
+ * clicks are excluded here (via stopPropagation in its own handler below) so they
+ * don't also trigger the jump-to-turn-card behavior.
+ */
 function wireUpTurnsOverviewHandlers(): void {
 document.querySelectorAll<HTMLElement>('.turns-overview-row').forEach(row => {
-row.addEventListener('click', () => {
+row.addEventListener('click', (e) => {
+if ((e.target as HTMLElement).closest('.turns-overview-leg-toggle')) { return; }
 const turnNumber = parseInt(row.getAttribute('data-turn') || '0', 10);
 if (turnNumber > 0) { scrollAndFocusTurn(turnNumber); }
+});
+});
+
+document.querySelectorAll<HTMLElement>('.turns-overview-leg-toggle').forEach(toggle => {
+toggle.addEventListener('click', (e) => {
+e.stopPropagation();
+const turnNumber = toggle.getAttribute('data-turn') || '';
+const expanded = toggle.getAttribute('aria-expanded') === 'true';
+setOverviewLegsExpanded(turnNumber, !expanded);
+});
+});
+}
+
+/** Clicking (or activating with the keyboard) a HydraFusion turn's "jump to step" link scrolls to and expands its row in the Session Steps Overview table below. */
+function wireUpHydraFusionHandlers(): void {
+document.querySelectorAll<HTMLElement>('.hydra-jump-to-step').forEach(link => {
+const activate = (e: Event): void => {
+e.preventDefault();
+e.stopPropagation();
+const turnNumber = parseInt(link.getAttribute('data-turn') || '0', 10);
+if (turnNumber > 0) { scrollAndFocusOverviewRow(turnNumber); }
+};
+link.addEventListener('click', activate);
+link.addEventListener('keydown', (e) => {
+if ((e as KeyboardEvent).key === 'Enter' || (e as KeyboardEvent).key === ' ') { activate(e); }
 });
 });
 }
@@ -1254,6 +1319,7 @@ vscode.postMessage({ command: 'openRawFile' });
 
 wireUpToolCallHandlers();
 wireUpTurnsOverviewHandlers();
+wireUpHydraFusionHandlers();
 }
 
 // ── Entry-point renderers (signatures preserved) ─────────────────────────────
@@ -1475,6 +1541,12 @@ function renderLayout(data: SessionLogData): void {
 		modeSubLabel: modeStats.modeSubLabel,
 	};
 
+	// Computed once and shared by both renderers below so the HydraFusion section's
+	// "jump to step" links and the Session Steps Overview table's expandable legs
+	// agree on which turn is which. `undefined` for the overwhelming majority of
+	// sessions, which never used HydraFusion — both renderers treat that as "no legs".
+	const hydraTurnMatches = data.hydraFusion ? matchHydraFusionTurnsToChatTurns(data.turns, data.hydraFusion.turns) : undefined;
+
 	setHtml(root, `
 <style>${themeStyles}</style>
 <style>${styles}</style>
@@ -1490,9 +1562,9 @@ ${renderSessionActualUsage(
 	actualStats.aggregatedBreakdown,
 )}
 
-${renderHydraFusionSection(data.hydraFusion)}
+${renderHydraFusionSection(data.hydraFusion, hydraTurnMatches)}
 
-${renderTurnsOverviewTable(data)}
+${renderTurnsOverviewTable(data, hydraTurnMatches)}
 
 <div class="turns-header">
 <span>📝</span>
@@ -1524,6 +1596,26 @@ function scrollAndFocusTurn(turnNumber: number): void {
 	turnCard.focus({ preventScroll: true });
 	turnCard.scrollIntoView({ behavior: 'smooth', block: 'center' });
 	setTimeout(() => turnCard.classList.remove('turn-card-focused'), 2_000);
+}
+
+/** Shows or hides the HydraFusion legs nested under a Session Steps Overview row, syncing its toggle button. */
+function setOverviewLegsExpanded(turnNumber: string, expanded: boolean): void {
+	const toggle = document.querySelector<HTMLElement>(`.turns-overview-leg-toggle[data-turn="${turnNumber}"]`);
+	const legsRow = document.querySelector<HTMLElement>(`.turns-overview-legs-row[data-parent-turn="${turnNumber}"]`);
+	if (!toggle || !legsRow) { return; }
+	toggle.setAttribute('aria-expanded', String(expanded));
+	toggle.textContent = expanded ? '▾' : '▸';
+	legsRow.style.display = expanded ? '' : 'none';
+}
+
+/** Scrolls to and briefly highlights a Session Steps Overview row, expanding its legs if it has any. */
+function scrollAndFocusOverviewRow(turnNumber: number): void {
+	const row = document.querySelector<HTMLElement>(`.turns-overview-row:not(.turns-overview-child-row)[data-turn="${turnNumber}"]`);
+	if (!row) { return; }
+	setOverviewLegsExpanded(String(turnNumber), true);
+	row.classList.add('turns-overview-row-focused');
+	row.scrollIntoView({ behavior: 'smooth', block: 'center' });
+	setTimeout(() => row.classList.remove('turns-overview-row-focused'), 2_000);
 }
 
 function focusRequestedTurn(data: SessionLogData & { focusedTurnNumber?: number; }): void {

--- a/vscode-extension/src/webview/logviewer/styles.css
+++ b/vscode-extension/src/webview/logviewer/styles.css
@@ -1333,6 +1333,44 @@ details[open] > summary .collapse-arrow {
 	color: var(--text-secondary);
 }
 
+.turns-overview-row-focused {
+	background: color-mix(in srgb, var(--vscode-focusBorder, #3b82f6) 22%, transparent);
+}
+
+.turns-overview-leg-toggle {
+	background: transparent;
+	border: 1px solid var(--border-subtle);
+	border-radius: 4px;
+	color: var(--text-secondary);
+	cursor: pointer;
+	font-size: 9px;
+	line-height: 1;
+	padding: 2px 4px;
+	margin-right: 2px;
+}
+
+.turns-overview-leg-toggle:hover {
+	background: var(--bg-tertiary);
+	color: var(--text-primary);
+}
+
+.turns-overview-legs-row td {
+	background: var(--bg-tertiary);
+	padding: 10px 12px 12px 34px;
+	white-space: normal;
+}
+
+.turns-overview-legs-wrap {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+}
+
+.turns-overview-legs-caption {
+	font-size: 11px;
+	color: var(--text-secondary);
+}
+
 /* Session hierarchy card */
 .hierarchy-card-content {
 text-align: left;
@@ -1725,6 +1763,20 @@ span.hydra-bar.hydra-phase-other { background: var(--text-secondary); }
 	color: var(--text-secondary);
 	font-variant-numeric: tabular-nums;
 	white-space: nowrap;
+}
+
+.hydra-jump-to-step {
+	border: 1px solid var(--border-subtle);
+	border-radius: 5px;
+	padding: 1px 6px;
+	cursor: pointer;
+	font-variant-numeric: normal;
+}
+
+.hydra-jump-to-step:hover,
+.hydra-jump-to-step:focus-visible {
+	background: var(--bg-tertiary);
+	color: var(--text-primary);
 }
 
 .hydra-turn-body {

--- a/vscode-extension/src/webview/logviewer/turnsOverview.ts
+++ b/vscode-extension/src/webview/logviewer/turnsOverview.ts
@@ -3,6 +3,9 @@
 // unit-testable directly in Node, unlike main.ts itself which can only be
 // exercised through the headless webview interaction/visual-diff harnesses.
 
+import { aiuToUsd } from '../../../../src/hydrafusion';
+import type { HydraFusionSummary, HydraFusionTurn } from '../../../../src/hydrafusion';
+
 export type TurnOverviewPromptDetail = {
 	category: string;
 	label: string;
@@ -25,6 +28,8 @@ export type TurnOverviewSourceToolCall = {
 
 export type TurnOverviewSourceTurn = {
 	turnNumber: number;
+	/** ISO timestamp of the turn's user message, used only to match it against HydraFusion legs. */
+	timestamp?: string | null;
 	model: string | null;
 	mode: string;
 	inputTokensEstimate: number;
@@ -47,6 +52,19 @@ export type TurnOverviewChildRow = {
 	cost: number | null;
 };
 
+/** One HydraFusion leg nested under the turn whose prompt it answered — see `buildTurnLegRows`. */
+export type TurnOverviewLegRow = {
+	kind: string;
+	model: string;
+	verdict: string | null;
+	isFinalSource: boolean;
+	durationMs: number;
+	requestCount: number;
+	input: number;
+	output: number;
+	costUsd: number;
+};
+
 export type TurnOverviewRow = {
 	turnNumber: number;
 	model: string | null;
@@ -58,6 +76,8 @@ export type TurnOverviewRow = {
 	isActual: boolean;
 	cost: number | null;
 	children: TurnOverviewChildRow[];
+	/** HydraFusion legs behind this turn, when `matchHydraFusionTurnsToChatTurns` could place it. Empty otherwise. */
+	legs: TurnOverviewLegRow[];
 };
 
 /**
@@ -90,8 +110,37 @@ export function buildTurnChildRows(turn: TurnOverviewSourceTurn): TurnOverviewCh
 		});
 }
 
-/** Builds one overview row per turn, preferring actual API usage over the text-based estimate when available. */
-export function buildTurnOverviewRows(turns: TurnOverviewSourceTurn[]): TurnOverviewRow[] {
+/** Builds the leg rows for one HydraFusion turn, converting each leg's AIU cost to USD. */
+export function buildTurnLegRows(hydraTurn: HydraFusionTurn): TurnOverviewLegRow[] {
+	return hydraTurn.phases.map(p => ({
+		kind: p.kind, model: p.model, verdict: p.verdict, isFinalSource: p.isFinalSource,
+		durationMs: p.durationMs, requestCount: p.usage.requestCount,
+		input: p.usage.inputTokens, output: p.usage.outputTokens, costUsd: aiuToUsd(p.usage.aiu),
+	}));
+}
+
+/**
+ * Builds one overview row per turn, preferring actual API usage over the text-based estimate when available.
+ *
+ * @param hydraFusion The session's HydraFusion summary, when it used the router. Absent for the
+ *   overwhelming majority of sessions, in which case every row's `legs` is simply empty.
+ * @param hydraTurnMatches Fusion turn index → matching `ChatTurn.turnNumber`, from
+ *   `matchHydraFusionTurnsToChatTurns`. Callers compute this once and pass it to both this
+ *   function and `renderHydraFusionSection` so the two views agree on which turn is which.
+ */
+export function buildTurnOverviewRows(
+	turns: TurnOverviewSourceTurn[],
+	hydraFusion?: HydraFusionSummary,
+	hydraTurnMatches?: Map<number, number>,
+): TurnOverviewRow[] {
+	const legsByChatTurn = new Map<number, TurnOverviewLegRow[]>();
+	if (hydraFusion && hydraTurnMatches) {
+		for (const [hydraIndex, chatTurnNumber] of hydraTurnMatches) {
+			const hydraTurn = hydraFusion.turns[hydraIndex];
+			if (hydraTurn) { legsByChatTurn.set(chatTurnNumber, buildTurnLegRows(hydraTurn)); }
+		}
+	}
+
 	return turns.map(turn => {
 		const au = turn.actualUsage;
 		const isActual = !!au;
@@ -104,6 +153,7 @@ export function buildTurnOverviewRows(turns: TurnOverviewSourceTurn[]): TurnOver
 			turnNumber: turn.turnNumber, model: turn.model, mode: turn.mode, input, cached: getTurnCachedTokens(turn), output, total, isActual,
 			cost: turn.estimatedCost ?? null,
 			children: buildTurnChildRows(turn),
+			legs: legsByChatTurn.get(turn.turnNumber) ?? [],
 		};
 	});
 }

--- a/vscode-extension/test/unit/hydrafusion.test.ts
+++ b/vscode-extension/test/unit/hydrafusion.test.ts
@@ -441,6 +441,26 @@ describe('matchHydraFusionTurnsToChatTurns', () => {
 		assert.equal(matches.get(0), 1);
 	});
 
+	test('a chat turn with no timestamp is skipped permanently, not left blocking every later fusion turn', () => {
+		// Regression test: an earlier version broke out of the advancement loop on an
+		// unusable timestamp without moving past it, so chatIndex stayed pinned there —
+		// every subsequent fusion turn hit the same bad entry immediately and could never
+		// reach turn 3, even though it has a perfectly good timestamp.
+		const content = [
+			fusionTurnAt('f1', '2026-01-01T00:00:05.000Z'),
+			fusionTurnAt('f2', '2026-01-01T00:00:25.000Z'),
+		].join('\n');
+		const summary = analyzeHydraFusionSession(content)!;
+		const chatTurns = [
+			{ turnNumber: 1, timestamp: '2026-01-01T00:00:00.000Z' },
+			{ turnNumber: 2, timestamp: null },
+			{ turnNumber: 3, timestamp: '2026-01-01T00:00:20.000Z' },
+		];
+		const matches = matchHydraFusionTurnsToChatTurns(chatTurns, summary.turns);
+		assert.equal(matches.get(0), 1);
+		assert.equal(matches.get(1), 3);
+	});
+
 	test('returns an empty map for a session with no fusion turns', () => {
 		const chatTurns = [{ turnNumber: 1, timestamp: '2026-01-01T00:00:00.000Z' }];
 		assert.equal(matchHydraFusionTurnsToChatTurns(chatTurns, []).size, 0);

--- a/vscode-extension/test/unit/hydrafusion.test.ts
+++ b/vscode-extension/test/unit/hydrafusion.test.ts
@@ -409,6 +409,27 @@ describe('matchHydraFusionTurnsToChatTurns', () => {
 		assert.equal(matches.size, 0);
 	});
 
+	test('known limitation: attaches to a nearby non-fusion turn when the real trigger is missing from chatTurns entirely', () => {
+		// Unlike the "skips a chat turn a non-fusion model handled" case above, here chat turn 2
+		// is the ONLY turn available before f2 — there is no turn 3 in the list at all (e.g. it
+		// was dropped upstream during turn extraction). matchHydraFusionTurnsToChatTurns has no
+		// way to tell "the real trigger is missing" apart from "turn 2 is genuinely closest", so
+		// it attaches f2 there. Documented in the function's own doc comment as a known trade-off
+		// that would need a shared turn id to fully close.
+		const content = [
+			fusionTurnAt('f1', '2026-01-01T00:00:05.000Z'),
+			fusionTurnAt('f2', '2026-01-01T00:00:25.000Z'),
+		].join('\n');
+		const summary = analyzeHydraFusionSession(content)!;
+		const chatTurns = [
+			{ turnNumber: 1, timestamp: '2026-01-01T00:00:00.000Z' },
+			{ turnNumber: 2, timestamp: '2026-01-01T00:00:10.000Z' },
+		];
+		const matches = matchHydraFusionTurnsToChatTurns(chatTurns, summary.turns);
+		assert.equal(matches.get(0), 1);
+		assert.equal(matches.get(1), 2);
+	});
+
 	test('stops advancing at a chat turn with no timestamp rather than guessing past it', () => {
 		const content = fusionTurnAt('f1', '2026-01-01T00:00:20.000Z');
 		const summary = analyzeHydraFusionSession(content)!;

--- a/vscode-extension/test/unit/hydrafusion.test.ts
+++ b/vscode-extension/test/unit/hydrafusion.test.ts
@@ -430,7 +430,7 @@ describe('matchHydraFusionTurnsToChatTurns', () => {
 		assert.equal(matches.get(1), 2);
 	});
 
-	test('stops advancing at a chat turn with no timestamp rather than guessing past it', () => {
+	test('never matches a chat turn with no timestamp, even when it is otherwise the nearest one', () => {
 		const content = fusionTurnAt('f1', '2026-01-01T00:00:20.000Z');
 		const summary = analyzeHydraFusionSession(content)!;
 		const chatTurns = [

--- a/vscode-extension/test/unit/hydrafusion.test.ts
+++ b/vscode-extension/test/unit/hydrafusion.test.ts
@@ -2,8 +2,10 @@ import { describe, test } from 'node:test';
 import * as assert from 'node:assert/strict';
 
 import {
+	aiuToUsd,
 	analyzeHydraFusionSession,
 	containsHydraFusionEvents,
+	matchHydraFusionTurnsToChatTurns,
 	nanoAiuToAiu,
 } from '../../../src/hydrafusion';
 
@@ -346,5 +348,80 @@ describe('analyzeHydraFusionSession', () => {
 		const summary = analyzeHydraFusionSession(content)!;
 		assert.equal(summary.totalTurns, 2);
 		assert.deepEqual(summary.turns.map(t => t.phases[0].model), ['model-a', 'model-b']);
+	});
+});
+
+describe('aiuToUsd', () => {
+	test('converts AI credits to dollars at the documented $0.01-per-credit rate', () => {
+		assert.equal(aiuToUsd(14.72), 0.1472);
+		assert.equal(aiuToUsd(0), 0);
+	});
+});
+
+describe('matchHydraFusionTurnsToChatTurns', () => {
+	/** A minimal one-leg fusion turn, timestamped so matching tests control ordering directly. */
+	function fusionTurnAt(fusionId: string, timestamp: string): string {
+		return [
+			line('session.fusion_resolved', { fusionId, pattern: 'single', phasePlan: [{ kind: 'primary' }] }, timestamp),
+			line('assistant.fusion_phase_completed', { fusionId, phaseId: `${fusionId}:phase:0`, phaseKind: 'primary', model: 'm', usage: { totalNanoAiu: AIU } }, timestamp),
+			line('session.fusion_completed', { fusionId, finalSourcePhaseId: `${fusionId}:phase:0`, totalNanoAiu: AIU }, timestamp),
+		].join('\n');
+	}
+
+	test('matches each fusion turn to the last chat turn whose prompt preceded it', () => {
+		const content = [
+			fusionTurnAt('f1', '2026-01-01T00:00:05.000Z'),
+			fusionTurnAt('f2', '2026-01-01T00:00:15.000Z'),
+		].join('\n');
+		const summary = analyzeHydraFusionSession(content)!;
+		const chatTurns = [
+			{ turnNumber: 1, timestamp: '2026-01-01T00:00:00.000Z' },
+			{ turnNumber: 2, timestamp: '2026-01-01T00:00:10.000Z' },
+		];
+		const matches = matchHydraFusionTurnsToChatTurns(chatTurns, summary.turns);
+		assert.equal(matches.get(0), 1);
+		assert.equal(matches.get(1), 2);
+	});
+
+	test('skips a chat turn a non-fusion model handled, rather than mismatching the next fusion turn to it', () => {
+		// Turn 2 wasn't routed through HydraFusion (no fusion turn resolves between it and turn 3),
+		// so it must not absorb f1's match even though it's chronologically closest.
+		const content = [
+			fusionTurnAt('f1', '2026-01-01T00:00:05.000Z'),
+			fusionTurnAt('f2', '2026-01-01T00:00:25.000Z'),
+		].join('\n');
+		const summary = analyzeHydraFusionSession(content)!;
+		const chatTurns = [
+			{ turnNumber: 1, timestamp: '2026-01-01T00:00:00.000Z' },
+			{ turnNumber: 2, timestamp: '2026-01-01T00:00:10.000Z' },
+			{ turnNumber: 3, timestamp: '2026-01-01T00:00:20.000Z' },
+		];
+		const matches = matchHydraFusionTurnsToChatTurns(chatTurns, summary.turns);
+		assert.equal(matches.get(0), 1);
+		assert.equal(matches.get(1), 3);
+	});
+
+	test('leaves a fusion turn unmatched when no chat turn timestamp precedes it', () => {
+		const content = fusionTurnAt('f1', '2020-01-01T00:00:00.000Z');
+		const summary = analyzeHydraFusionSession(content)!;
+		const chatTurns = [{ turnNumber: 1, timestamp: '2026-01-01T00:00:00.000Z' }];
+		const matches = matchHydraFusionTurnsToChatTurns(chatTurns, summary.turns);
+		assert.equal(matches.size, 0);
+	});
+
+	test('stops advancing at a chat turn with no timestamp rather than guessing past it', () => {
+		const content = fusionTurnAt('f1', '2026-01-01T00:00:20.000Z');
+		const summary = analyzeHydraFusionSession(content)!;
+		const chatTurns = [
+			{ turnNumber: 1, timestamp: '2026-01-01T00:00:00.000Z' },
+			{ turnNumber: 2, timestamp: null },
+		];
+		const matches = matchHydraFusionTurnsToChatTurns(chatTurns, summary.turns);
+		assert.equal(matches.get(0), 1);
+	});
+
+	test('returns an empty map for a session with no fusion turns', () => {
+		const chatTurns = [{ turnNumber: 1, timestamp: '2026-01-01T00:00:00.000Z' }];
+		assert.equal(matchHydraFusionTurnsToChatTurns(chatTurns, []).size, 0);
 	});
 });

--- a/vscode-extension/test/unit/webview-hydraFusionSection.test.ts
+++ b/vscode-extension/test/unit/webview-hydraFusionSection.test.ts
@@ -217,6 +217,14 @@ describe('renderHydraFusionSection', () => {
 		assert.match(html, /hydra-jump-to-step" data-turn="3"/);
 		assert.match(html, /step #3/);
 	});
+
+	test('omits the jump-to-step link for an in-flight turn with no completed phases, even with a chat-turn match', () => {
+		// Resolved but nothing has completed yet — the overview row would have no legs to expand.
+		const inFlight = line('session.fusion_resolved', { fusionId: 'f', pattern: 'single', phasePlan: [{ kind: 'primary' }], syntheticModel: 'hydrafusion' });
+		const summary = analyzeHydraFusionSession(inFlight);
+		const html = renderHydraFusionSection(summary, new Map([[0, 1]]));
+		assert.ok(!html.includes('hydra-jump-to-step'));
+	});
 });
 
 describe('renderLegsTable', () => {

--- a/vscode-extension/test/unit/webview-hydraFusionSection.test.ts
+++ b/vscode-extension/test/unit/webview-hydraFusionSection.test.ts
@@ -1,13 +1,14 @@
 import { describe, test } from 'node:test';
 import * as assert from 'node:assert/strict';
 
-import { analyzeHydraFusionSession } from '../../../src/hydrafusion';
+import { analyzeHydraFusionSession, matchHydraFusionTurnsToChatTurns } from '../../../src/hydrafusion';
 import { setFormatLocale } from '../../src/webview/shared/formatUtils';
 import {
 	barWidthPercent,
-	formatAiu,
+	formatFusionCost,
 	formatFusionDuration,
 	renderHydraFusionSection,
+	renderLegsTable,
 } from '../../src/webview/logviewer/hydraFusionSection';
 
 // Pin the locale so decimal separators and grouping are deterministic regardless of
@@ -57,14 +58,14 @@ function renderCascade(overrides: { draftModel?: string } = {}): string {
 	return renderHydraFusionSection(analyzeHydraFusionSession(cascadeSession(overrides)));
 }
 
-describe('formatAiu', () => {
-	test('keeps two decimals for the sub-credit turns that routing produces', () => {
-		assert.equal(formatAiu(0.58), '0.58');
-		assert.equal(formatAiu(14.72), '14.72');
+describe('formatFusionCost', () => {
+	test('converts AIU credits to USD at the documented $0.01-per-credit rate', () => {
+		assert.equal(formatFusionCost(14.72), '$0.15');
+		assert.equal(formatFusionCost(192.25), '$1.92');
 	});
 
-	test('drops to one decimal once the number is large enough that two stop informing', () => {
-		assert.equal(formatAiu(2811.93338), '2,811.9');
+	test('rounds a sub-cent leg to the nearest cent rather than showing more precision than the app uses elsewhere', () => {
+		assert.equal(formatFusionCost(0.58), '$0.01');
 	});
 });
 
@@ -126,11 +127,12 @@ describe('renderHydraFusionSection', () => {
 		assert.match(html, /1 rejected · 0 accepted/);
 	});
 
-	test('separates review spend from the credits that bought the answer', () => {
+	test('separates review spend from the credits that bought the answer, shown in dollars rather than AIU', () => {
 		const html = renderCascade();
 		assert.match(html, /Review share/);
-		// draft 0.58 + judge 2.45 were superseded by the repair leg.
-		assert.match(html, /3\.03 of 14\.72 AIU/);
+		// draft 0.58 + judge 2.45 AIU were superseded by the repair leg, at $0.01 per credit.
+		assert.match(html, /\$0\.03 of \$0\.15/);
+		assert.ok(!html.includes('AIU'), 'AIU units should no longer appear now that costs are shown in dollars');
 	});
 
 	test('distinguishes router legs from inference calls', () => {
@@ -202,5 +204,36 @@ describe('renderHydraFusionSection', () => {
 		const html = renderHydraFusionSection(analyzeHydraFusionSession(single));
 		assert.ok(!html.includes('Judge rejections'));
 		assert.match(html, /0\.0%/); // compound rate: no turn used more than one model
+	});
+
+	test('omits the jump-to-step link when no chat-turn match is supplied', () => {
+		assert.ok(!renderCascade().includes('hydra-jump-to-step'));
+	});
+
+	test('links to the matching Session Steps Overview row when a chat-turn match is supplied', () => {
+		const summary = analyzeHydraFusionSession(cascadeSession());
+		const matches = new Map([[0, 3]]); // this session's one fusion turn matches chat step #3
+		const html = renderHydraFusionSection(summary, matches);
+		assert.match(html, /hydra-jump-to-step" data-turn="3"/);
+		assert.match(html, /step #3/);
+	});
+});
+
+describe('renderLegsTable', () => {
+	test('renders one row per leg with its phase, model, verdict, duration and cost', () => {
+		const summary = analyzeHydraFusionSession(cascadeSession());
+		const html = renderLegsTable(summary!.turns[0].phases);
+		assert.match(html, /hydra-phase-badge hydra-phase-repair">🛠️ repair/);
+		assert.match(html, /hydra-verdict hydra-verdict-reject">reject</);
+		assert.match(html, /gpt-5\.6-sol/);
+		assert.match(html, /mai-code-1\.1-flash/);
+		assert.match(html, /\$0\.12/); // the 11.69 AIU repair leg, at $0.01 per credit
+	});
+
+	test('is the exact table renderTurnRow embeds, so main.ts can reuse it for the matching overview row', () => {
+		const summary = analyzeHydraFusionSession(cascadeSession());
+		const sectionHtml = renderHydraFusionSection(summary);
+		const legsTableHtml = renderLegsTable(summary!.turns[0].phases);
+		assert.ok(sectionHtml.includes(legsTableHtml));
 	});
 });

--- a/vscode-extension/test/unit/webview-turnsOverview.test.ts
+++ b/vscode-extension/test/unit/webview-turnsOverview.test.ts
@@ -3,11 +3,13 @@ import * as assert from 'node:assert/strict';
 
 import {
 	buildTurnChildRows,
+	buildTurnLegRows,
 	buildTurnOverviewRows,
 	getTurnCachedTokens,
 	hashModelToHue,
 	type TurnOverviewSourceTurn,
 } from '../../src/webview/logviewer/turnsOverview';
+import type { HydraFusionSummary, HydraFusionTurn } from '../../../src/hydrafusion';
 
 function turn(overrides: Partial<TurnOverviewSourceTurn> = {}): TurnOverviewSourceTurn {
 	return {
@@ -18,6 +20,34 @@ function turn(overrides: Partial<TurnOverviewSourceTurn> = {}): TurnOverviewSour
 		outputTokensEstimate: 50,
 		thinkingTokensEstimate: 0,
 		...overrides,
+	};
+}
+
+/** A minimal one-leg HydraFusion turn for testing the legs correlation, independent of the parser. */
+function hydraTurn(overrides: Partial<HydraFusionTurn> = {}): HydraFusionTurn {
+	return {
+		fusionId: 'f', pattern: 'single', outcome: 'completed', degradedReason: null, policy: null,
+		routeSource: null, routingLatencyMs: null, plannedPhases: [], primaryModel: null,
+		secondaryModel: null, fallbackModel: null, finalSourceModel: 'gpt-4o',
+		phases: [{
+			phaseId: 'f:phase:0', kind: 'primary', role: 'solver', model: 'gpt-4o', status: 'succeeded',
+			verdict: null, durationMs: 1000, conversationScope: 'root',
+			usage: { requestCount: 1, inputTokens: 100, outputTokens: 20, cachedTokens: 0, cacheWriteTokens: 0, aiu: 5 },
+			isFinalSource: true, completedAt: null,
+		}],
+		handoffs: [], requestCount: 1, inputTokens: 100, outputTokens: 20, cachedTokens: 0, cacheWriteTokens: 0,
+		aiu: 5, reviewAiu: 0, durationMs: 1000, startedAt: null, completedAt: null, isCompound: false,
+		...overrides,
+	};
+}
+
+function hydraSummary(turns: HydraFusionTurn[]): HydraFusionSummary {
+	return {
+		turns, totalTurns: turns.length, patternCounts: [], compoundTurns: 0, compoundRatePercent: 0,
+		judgeAccepts: 0, judgeRejects: 0, judgeRejectionRatePercent: null, totalAiu: 0, reviewAiu: 0,
+		reviewSharePercent: 0, totalInputTokens: 0, totalOutputTokens: 0, totalCachedTokens: 0,
+		totalRequestCount: 0, totalLegs: 0, byModel: [], byPhaseKind: [], models: [], avgRoutingLatencyMs: null,
+		degradedTurns: 0, syntheticModel: null,
 	};
 }
 
@@ -142,6 +172,53 @@ describe('buildTurnOverviewRows', () => {
 		assert.equal(rows[0].children.length, 2);
 		assert.deepEqual(rows[0].children[0], { toolName: 'task', model: 'claude-sonnet-4-6', input: 500, output: 200, total: 700, cost: 0.05 });
 		assert.deepEqual(rows[0].children[1], { toolName: 'task', model: 'gpt-4o', input: 100, output: 40, total: 140, cost: null });
+	});
+
+	test('every row has an empty legs array for a plain session that never used HydraFusion', () => {
+		const rows = buildTurnOverviewRows([turn({ turnNumber: 1 }), turn({ turnNumber: 2 })]);
+		assert.deepEqual(rows[0].legs, []);
+		assert.deepEqual(rows[1].legs, []);
+	});
+
+	test('attaches legs only to the chat turn hydraTurnMatches places, leaving the rest empty', () => {
+		const summary = hydraSummary([hydraTurn()]);
+		const matches = new Map([[0, 2]]); // fusion turn 0 matches chat turn #2
+		const rows = buildTurnOverviewRows(
+			[turn({ turnNumber: 1, timestamp: '2026-01-01T00:00:00.000Z' }), turn({ turnNumber: 2, timestamp: '2026-01-01T00:00:05.000Z' })],
+			summary,
+			matches,
+		);
+		assert.deepEqual(rows[0].legs, []);
+		assert.equal(rows[1].legs.length, 1);
+		assert.equal(rows[1].legs[0].model, 'gpt-4o');
+	});
+
+	test('leaves every row without legs when hydraTurnMatches is omitted, even with a HydraFusion summary present', () => {
+		const summary = hydraSummary([hydraTurn()]);
+		const rows = buildTurnOverviewRows([turn({ turnNumber: 1 })], summary);
+		assert.deepEqual(rows[0].legs, []);
+	});
+});
+
+describe('buildTurnLegRows', () => {
+	test('maps each phase to a leg row, converting its AIU cost to USD', () => {
+		const rows = buildTurnLegRows(hydraTurn());
+		assert.deepEqual(rows, [{
+			kind: 'primary', model: 'gpt-4o', verdict: null, isFinalSource: true,
+			durationMs: 1000, requestCount: 1, input: 100, output: 20, costUsd: 0.05,
+		}]);
+	});
+
+	test('produces one row per leg, in the order the router ran them', () => {
+		const t = hydraTurn({
+			phases: [
+				{ phaseId: 'f:phase:0', kind: 'primary', role: 'solver', model: 'a', status: 'succeeded', verdict: null, durationMs: 1, conversationScope: 'root', usage: { requestCount: 1, inputTokens: 1, outputTokens: 1, cachedTokens: 0, cacheWriteTokens: 0, aiu: 1 }, isFinalSource: false, completedAt: null },
+				{ phaseId: 'f:judge', kind: 'judge', role: 'judge', model: 'b', status: 'succeeded', verdict: 'reject', durationMs: 2, conversationScope: 'review', usage: { requestCount: 1, inputTokens: 2, outputTokens: 2, cachedTokens: 0, cacheWriteTokens: 0, aiu: 2 }, isFinalSource: false, completedAt: null },
+			],
+		});
+		const rows = buildTurnLegRows(t);
+		assert.deepEqual(rows.map(r => r.kind), ['primary', 'judge']);
+		assert.equal(rows[1].verdict, 'reject');
 	});
 });
 


### PR DESCRIPTION
## Summary

- The HydraFusion Routing section on the session log viewer showed every leg's cost in AIU credits while the rest of the extension shows USD. All leg/turn/model/phase costs now render in dollars, converted from AIU at the documented $0.01-per-credit rate (`copilotPlans.json`'s `monthlyAiCreditsUsd` note). The underlying `HydraFusionSummary` AIU fields are unchanged — only the render layer converts, via a new `aiuToUsd()` in `src/hydrafusion.ts`.
- You can now reach a turn's HydraFusion leg detail from either view:
  - A new `matchHydraFusionTurnsToChatTurns()` correlates each fusion turn with the chat turn whose prompt triggered it, by timestamp (no assumption that every turn was routed, so it degrades gracefully on mixed sessions).
  - A matched row in the **Session Steps Overview** table gets a ⚡ toggle that expands the same leg-by-leg table shown in the HydraFusion section (extracted into a shared `renderLegsTable()` so both views render identical markup instead of duplicating it).
  - Each turn in the HydraFusion section's "One turn in detail" list gets a "jump to step" link that scrolls to and expands its matching row below.
- Everything here is additive and gated on a session's `hydraFusion` summary being present — a plain (non-HydraFusion) session's Session Steps Overview table renders exactly as before, with zero extra DOM or computation.

## Test plan

- [x] `npm run check-types` — clean
- [x] `npm run test:node` — all suites pass, including new coverage for `aiuToUsd`, `matchHydraFusionTurnsToChatTurns`, `buildTurnLegRows`, the updated dollar-cost assertions in `webview-hydraFusionSection.test.ts`, and the legs-correlation cases in `webview-turnsOverview.test.ts`
- [x] `npm run check:contract` — no new webview messages were added, contract still holds
- [x] `npm run check:interaction` — every control in the logviewer panel (including the new toggle and jump link) does something when clicked, headlessly
- [x] Rendered the `logviewer` fixture headlessly (via `visual-view-diff`) and manually drove the new toggle/jump-link interactions with Playwright: dollar costs render correctly, expanding a step shows its legs, and clicking a HydraFusion turn's jump link scrolls to and expands the matching row — zero console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018wsw9S9tVaVkqrb2X7JCdv

---
_Generated by [Claude Code](https://claude.ai/code/session_018wsw9S9tVaVkqrb2X7JCdv)_